### PR TITLE
feat: scaffold rainforest world page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,11 @@ import OceanWorld from './pages/OceanWorld';
 import DesertWorld from './pages/DesertWorld';
 import Stories from './pages/Stories';
 import Quizzes from './pages/Quizzes';
+import Rainforest from './pages/Rainforest';
+import Plants from './pages/rainforest/Plants';
+import Animals from './pages/rainforest/Animals';
+import Ecosystem from './pages/rainforest/Ecosystem';
+import Quiz from './pages/rainforest/Quiz';
 
 export default function App() {
   const location = useLocation();
@@ -25,6 +30,11 @@ export default function App() {
         <Route path="/app" element={<ProtectedRoute><AppHome /></ProtectedRoute>} />
         <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
         <Route path="/map" element={<ProtectedRoute><MapHub /></ProtectedRoute>} />
+        <Route path="/rainforest" element={<Rainforest />} />
+        <Route path="/rainforest/plants" element={<Plants />} />
+        <Route path="/rainforest/animals" element={<Animals />} />
+        <Route path="/rainforest/ecosystem" element={<Ecosystem />} />
+        <Route path="/rainforest/quiz" element={<Quiz />} />
         <Route path="/worlds/rainforest" element={<ProtectedRoute><RainforestWorld /></ProtectedRoute>} />
         <Route path="/worlds/ocean" element={<ProtectedRoute><OceanWorld /></ProtectedRoute>} />
         <Route path="/worlds/desert" element={<ProtectedRoute><DesertWorld /></ProtectedRoute>} />

--- a/web/src/pages/Landing.tsx
+++ b/web/src/pages/Landing.tsx
@@ -10,7 +10,7 @@ export default function Landing() {
         <article>
           <h2>Explore Amazing Worlds</h2>
           <ul>
-            <li><a href="/map#rainforest">Tropical Rainforest</a></li>
+            <li><a href="/rainforest">Tropical Rainforest</a></li>
             <li><a href="/map#ocean">Ocean Adventures</a></li>
             <li><a href="/map#stories">Magical Stories</a></li>
             <li><a href="/map#quizzes">Brain Challenge</a></li>

--- a/web/src/pages/Rainforest.tsx
+++ b/web/src/pages/Rainforest.tsx
@@ -1,0 +1,33 @@
+import { Link } from 'react-router-dom';
+
+export default function Rainforest() {
+  const cards = [
+    { title: 'Plants', emoji: '🌱', description: 'Learn about rainforest plants', href: '/rainforest/plants' },
+    { title: 'Animals', emoji: '🐒', description: 'Meet amazing animals', href: '/rainforest/animals' },
+    { title: 'Ecosystem', emoji: '🌳', description: 'Explore how everything works together', href: '/rainforest/ecosystem' },
+    { title: 'Quizzes', emoji: '🧠', description: 'Test your rainforest knowledge', href: '/rainforest/quiz' },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-green-900 to-green-500 text-white">
+      <header className="p-4">
+        <Link to="/" className="underline">Back to Home</Link>
+      </header>
+      <main className="flex flex-col items-center px-4">
+        <h1 className="text-4xl md:text-5xl font-bold text-center mt-2">Tropical Rainforest</h1>
+        <p className="mt-2 text-center text-lg">Discover amazing plants and animals with Turian!</p>
+        <div className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-4xl">
+          {cards.map(card => (
+            <div key={card.title} className="bg-white text-gray-800 rounded-xl shadow-md p-6 flex flex-col items-center text-center transform transition hover:scale-105">
+              <div className="text-4xl mb-2">{card.emoji}</div>
+              <h2 className="text-2xl font-semibold mb-2">{card.title}</h2>
+              <p className="mb-4">{card.description}</p>
+              <Link to={card.href} className="cta">Start</Link>
+            </div>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}
+

--- a/web/src/pages/rainforest/Animals.tsx
+++ b/web/src/pages/rainforest/Animals.tsx
@@ -1,0 +1,7 @@
+export default function Animals() {
+  return (
+    <div className="p-4">
+      <h1>Placeholder for Animals</h1>
+    </div>
+  );
+}

--- a/web/src/pages/rainforest/Ecosystem.tsx
+++ b/web/src/pages/rainforest/Ecosystem.tsx
@@ -1,0 +1,7 @@
+export default function Ecosystem() {
+  return (
+    <div className="p-4">
+      <h1>Placeholder for Ecosystem</h1>
+    </div>
+  );
+}

--- a/web/src/pages/rainforest/Plants.tsx
+++ b/web/src/pages/rainforest/Plants.tsx
@@ -1,0 +1,7 @@
+export default function Plants() {
+  return (
+    <div className="p-4">
+      <h1>Placeholder for Plants</h1>
+    </div>
+  );
+}

--- a/web/src/pages/rainforest/Quiz.tsx
+++ b/web/src/pages/rainforest/Quiz.tsx
@@ -1,0 +1,7 @@
+export default function Quiz() {
+  return (
+    <div className="p-4">
+      <h1>Placeholder for Quiz</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Tropical Rainforest page with gradient layout, cards, and start links
- add placeholder pages for plants, animals, ecosystem, and quiz
- wire up /rainforest routes and update landing link

## Testing
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a7e45dc8832988f50405a05e7ac3