### PR TITLE
feat: support avatar uploads

### DIFF
--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -1,24 +1,45 @@
-import { Link, useNavigate } from "react-router-dom";
-import { useAuth } from "@/auth/session";
-import { supabase } from "@/supabaseClient";
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '@/auth/session';
+import { supabase } from '@/supabaseClient';
+import { useEffect, useState } from 'react';
 
 export default function Navbar() {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      if (!user) return;
+      const { data } = await supabase
+        .from('users')
+        .select('avatar_url')
+        .eq('id', user.id)
+        .single();
+      setAvatarUrl(data?.avatar_url ?? null);
+    })();
+  }, [user]);
 
   async function logout() {
     await supabase.auth.signOut();
-    navigate("/", { replace: true });
+    navigate('/', { replace: true });
   }
 
   return (
     <nav className="nav">
-      <Link to="/" className="brand">Naturverse</Link>
+      <Link to="/" className="brand">
+        Naturverse
+      </Link>
       <div className="spacer" />
       {user ? (
         <>
           <Link to="/app">App</Link>
           <Link to="/profile">Profile</Link>
+          <img
+            src={avatarUrl || 'https://dummyimage.com/40x40/101a38/ffffff&text=N'}
+            alt="avatar"
+            style={{ width: 32, height: 32, borderRadius: '50%' }}
+          />
           <button onClick={logout}>Sign out</button>
         </>
       ) : (

--- a/web/src/lib/avatar.ts
+++ b/web/src/lib/avatar.ts
@@ -1,35 +1,51 @@
-// Avatar upload helpers for Naturverse
-import { SupabaseClient } from '@supabase/supabase-js';
-
-export function getFileExt(name: string): string {
-  return name.split('.').pop()?.toLowerCase() || '';
+/* Avatar helpers for Supabase Storage */
+export function getFileExt(name: string) {
+  const i = name.lastIndexOf('.');
+  return i === -1 ? '' : name.slice(i + 1).toLowerCase();
 }
 
 export async function uploadAvatar(
-  supabase: SupabaseClient,
+  supabase: any,
   userId: string,
   file: File
 ): Promise<{ publicUrl: string; path: string }> {
-  const ext = getFileExt(file.name);
-  const filename = crypto.randomUUID() + '.' + ext;
+  const ext = getFileExt(file.name) || 'png';
+  const filename = `${crypto.randomUUID()}.${ext}`;
   const path = `avatars/${userId}/${filename}`;
-  const { error: upErr } = await supabase.storage
+
+  const { error: upErr } = await supabase
+    .storage
     .from('avatars')
     .upload(path, file, { upsert: true, contentType: file.type });
+
   if (upErr) throw upErr;
-  const { data } = supabase.storage.from('avatars').getPublicUrl(path);
+
+  const { data } = supabase
+    .storage
+    .from('avatars')
+    .getPublicUrl(path);
+
   return { publicUrl: data.publicUrl, path };
 }
 
 export async function removeAvatarIfExists(
-  supabase: SupabaseClient,
-  priorUrlOrPath?: string | null
-): Promise<void> {
-  if (!priorUrlOrPath) return;
-  let storagePath = priorUrlOrPath;
-  const idx = priorUrlOrPath.indexOf('/object/public/');
-  if (idx !== -1) {
-    storagePath = priorUrlOrPath.substring(idx + '/object/public/'.length);
-  }
+  supabase: any,
+  existingPathOrUrl?: string | null
+) {
+  if (!existingPathOrUrl) return;
+
+  // Prefer storage path (avatars/uid/filename). If a URL was stored, convert it.
+  const toPath = (input: string) => {
+    if (input.startsWith('http')) {
+      const idx = input.indexOf('/object/public/');
+      return idx === -1 ? '' : input.slice(idx + '/object/public/'.length);
+    }
+    return input;
+  };
+
+  const storagePath = toPath(existingPathOrUrl);
+  if (!storagePath) return;
+
+  // Ignore not-found
   await supabase.storage.from('avatars').remove([storagePath]).catch(() => {});
 }


### PR DESCRIPTION
## Summary
- add Supabase Storage avatar helpers
- enable uploading/saving avatars on Profile page with preview
- show user avatar in navbar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `node --env-file ../.env --input-type=module -e "import { createClient } from '@supabase/supabase-js'; const supabase = createClient(process.env.VITE_SUPABASE_URL, process.env.VITE_SUPABASE_ANON_KEY); const { data, error } = await supabase.from('users').select('avatar_url, avatar_path').limit(1); console.log(JSON.stringify({data,error}, null, 2));"` *(fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0aec2f79c8329a76db2986a81f960