### PR TITLE
Persist avatar upload and refresh navatar display

### DIFF
--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { getMyProfile, getPublicAvatarUrl } from "@/lib/avatar";
+import { supabase } from "@/supabaseClient";
+import { fetchAvatar } from "@/lib/avatar";
 
 export default function Navbar() {
   const [email, setEmail] = useState<string | null>(null);
@@ -8,9 +9,15 @@ export default function Navbar() {
 
   useEffect(() => {
     (async () => {
-      const prof = await getMyProfile();
-      setEmail(prof?.email ?? null);
-      setAvatarUrl(getPublicAvatarUrl(prof?.avatar_path));
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+      setEmail(user.email ?? null);
+      try {
+        const url = await fetchAvatar(user.id);
+        setAvatarUrl(url);
+      } catch {
+        // ignore
+      }
     })();
   }, []);
 
@@ -30,3 +37,4 @@ export default function Navbar() {
     </nav>
   );
 }
+

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -1,69 +1,89 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { supabase } from "@/supabaseClient";
-import { getMyProfile, getPublicAvatarUrl, uploadNavatar } from "@/lib/avatar";
+import { uploadAvatar, fetchAvatar } from "@/lib/avatar";
 
 export default function Profile() {
   const [email, setEmail] = useState<string>("");
-  const [avatarPath, setAvatarPath] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string>("");
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [file, setFile] = useState<File | null>(null);
   const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
+  // On mount, get the current user + current avatar
   useEffect(() => {
     (async () => {
-      const prof = await getMyProfile();
-      setEmail(prof?.email ?? "");
-      setAvatarPath(prof?.avatar_path ?? null);
-      setAvatarUrl(getPublicAvatarUrl(prof?.avatar_path));
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+      setUserId(user.id);
+      setEmail(user.email ?? "");
+      try {
+        const url = await fetchAvatar(user.id);
+        setAvatarUrl(url);
+      } catch {
+        // ignore – empty avatar is fine
+      }
     })();
   }, []);
 
-  const onPick = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0] ?? null;
-    setFile(f);
-    // show immediate preview
-    setPreviewUrl(f ? URL.createObjectURL(f) : null);
-  };
-
-  const onSave = async () => {
+  function onChooseFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
     if (!file) return;
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+  }
+
+  async function onSave() {
+    if (!userId || !inputRef.current?.files?.[0]) return;
     setSaving(true);
     try {
-      const newPath = await uploadNavatar(file);
-      setAvatarPath(newPath);
-      setAvatarUrl(getPublicAvatarUrl(newPath)); // new public URL + cache bust
-      setPreviewUrl(null); // we now have a real URL
+      const file = inputRef.current.files[0];
+      const { url } = await uploadAvatar(file, userId);
+      // Reflect immediately
+      setAvatarUrl(url);
+      setPreviewUrl(null);
       alert("Navatar updated");
-    } catch (err: any) {
-      console.error(err);
-      alert(err?.message ?? "Failed to update Navatar");
+    } catch (e: any) {
+      alert(e.message ?? "Failed to update Navatar");
     } finally {
       setSaving(false);
+      // Reset file input so the same image can be reselected if desired
+      if (inputRef.current) inputRef.current.value = "";
     }
-  };
-
-  const shownSrc = previewUrl || avatarUrl || "/avatar-placeholder.png";
+  }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center text-center">
-      <img
-        src={shownSrc}
-        alt="navatar"
-        className="h-32 w-32 rounded-full object-cover shadow-md border border-white/10"
-      />
-      <p className="mt-4 font-medium">{email}</p>
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="w-full max-w-md rounded-xl bg-black/20 backdrop-blur p-6 text-center shadow-lg border border-white/10">
+        <div className="mb-4 flex justify-center">
+          {/* Avatar figure – fixed size, always cropped */}
+          <img
+            src={previewUrl ?? avatarUrl ?? "/avatar-placeholder.png"}
+            alt="navatar"
+            className="h-28 w-28 rounded-full object-cover ring-2 ring-white/20 shadow"
+          />
+        </div>
 
-      <div className="mt-4 flex items-center gap-3">
-        <input type="file" accept="image/*" onChange={onPick} />
-        <button
-          onClick={onSave}
-          disabled={saving || !file}
-          className="px-3 py-1.5 rounded bg-sky-600 text-white disabled:opacity-50"
-        >
-          {saving ? "Saving..." : "Save Navatar"}
-        </button>
+        <div className="text-white/90 font-medium">{email}</div>
+
+        <div className="mt-4 flex items-center gap-2 justify-center">
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            onChange={onChooseFile}
+            className="text-sm file:mr-3 file:rounded-md file:border-0 file:bg-white/80 file:px-3 file:py-2 file:text-sm file:font-semibold hover:file:bg-white"
+          />
+          <button
+            onClick={onSave}
+            disabled={!previewUrl || saving}
+            className="rounded-md bg-sky-500/90 px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {saving ? "Saving…" : "Save Navatar"}
+          </button>
+        </div>
       </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- add helpers to upload and fetch avatars with public URLs
- update profile page to preview, upload and persist navatar
- fetch saved avatar in navbar thumbnail

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0bf315270832995673e019ee00017