### PR TITLE
feat(shell): navbar + routes + protected pages

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,33 +1,46 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import { AuthProvider, useAuth } from "@/auth/session";
-import Landing from "@/pages/Landing";     // your static landing page
+import React from "react";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Navbar } from "@/components/Navbar";
+import Home from "@/pages/Landing";         // <- use your existing landing component name
 import Login from "@/pages/Login";
 import AuthCallback from "@/pages/AuthCallback";
+import Worlds from "@/pages/Worlds";
+import World from "@/pages/World";
 import AppHome from "@/pages/AppHome";
 import Profile from "@/pages/Profile";
-import Navbar from "@/components/Navbar";
-
-function Protected({ children }: { children: JSX.Element }) {
-  const { user, loading } = useAuth();
-  if (loading) return <div style={{ padding: 24, color: "white" }}>Loading…</div>;
-  if (!user) return <Navigate to="/login" replace />;
-  return children;
-}
+import NotFound from "@/pages/NotFound";
+import { RequireAuth } from "@/lib/auth";
 
 export default function App() {
   return (
-    <AuthProvider>
-      <BrowserRouter>
+    <BrowserRouter>
+      <div className="min-h-screen bg-gradient-to-br from-[#0b1020] via-[#101a38] to-[#1e2046]">
         <Navbar />
         <Routes>
-          <Route path="/" element={<Landing />} />
+          <Route path="/" element={<Home />} />
           <Route path="/login" element={<Login />} />
           <Route path="/auth/callback" element={<AuthCallback />} />
-          <Route path="/app" element={<Protected><AppHome /></Protected>} />
-          <Route path="/profile" element={<Protected><Profile /></Protected>} />
-          <Route path="*" element={<Navigate to="/" replace />} />
+          <Route path="/worlds" element={<Worlds />} />
+          <Route path="/worlds/:slug" element={<World />} />
+          <Route
+            path="/app"
+            element={
+              <RequireAuth>
+                <AppHome />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/profile"
+            element={
+              <RequireAuth>
+                <Profile />
+              </RequireAuth>
+            }
+          />
+          <Route path="*" element={<NotFound />} />
         </Routes>
-      </BrowserRouter>
-    </AuthProvider>
+      </div>
+    </BrowserRouter>
   );
 }

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -1,40 +1,37 @@
-import { Link } from "react-router-dom";
-import { useEffect, useState } from "react";
+import React from "react";
+import { Link, NavLink } from "react-router-dom";
 import { supabase } from "@/supabaseClient";
-import { fetchAvatar } from "@/lib/avatar";
 
-export default function Navbar() {
-  const [email, setEmail] = useState<string | null>(null);
-  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+const linkClass = ({ isActive }: { isActive: boolean }) =>
+  `px-3 py-2 rounded-md text-sm font-medium ${isActive ? "bg-white/10 text-white" : "text-white/80 hover:text-white"}`;
 
-  useEffect(() => {
-    (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) return;
-      setEmail(user.email ?? null);
-      try {
-        const url = await fetchAvatar(user.id);
-        setAvatarUrl(url);
-      } catch {
-        // ignore
-      }
-    })();
+export const Navbar: React.FC = () => {
+  const [email, setEmail] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setEmail(data.user?.email ?? null));
   }, []);
 
-  return (
-    <nav className="flex items-center gap-3 p-3">
-      <Link to="/">Naturverse</Link>
-      <Link to="/app">App</Link>
-      <Link to="/profile">Profile</Link>
-      <div className="ml-auto flex items-center gap-2">
-        <img
-          src={avatarUrl || "/avatar-placeholder.png"}
-          alt="navatar"
-          className="h-8 w-8 rounded-full object-cover border border-white/10"
-        />
-        {email && <span className="text-xs opacity-80">{email}</span>}
-      </div>
-    </nav>
-  );
-}
+  async function signOut() {
+    await supabase.auth.signOut();
+    window.location.href = "/";
+  }
 
+  return (
+    <header className="w-full sticky top-0 z-30 bg-black/30 backdrop-blur border-b border-white/10">
+      <nav className="mx-auto max-w-5xl flex items-center gap-2 px-4 h-14">
+        <Link to="/" className="text-white font-semibold">Naturverse</Link>
+        <div className="flex-1" />
+        <NavLink to="/" className={linkClass} end>Home</NavLink>
+        <NavLink to="/worlds" className={linkClass}>Worlds</NavLink>
+        <NavLink to="/app" className={linkClass}>App</NavLink>
+        <NavLink to="/profile" className={linkClass}>Profile</NavLink>
+        {email && (
+          <button onClick={signOut} className="ml-2 px-3 py-2 rounded-md text-sm font-medium text-white/80 hover:text-white">
+            Sign out
+          </button>
+        )}
+      </nav>
+    </header>
+  );
+};

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { supabase } from "@/supabaseClient";
+
+export function useSession() {
+  const [session, setSession] = React.useState<Awaited<ReturnType<typeof supabase.auth.getSession>>["data"]["session"] | null>(null);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let mounted = true;
+    supabase.auth.getSession().then(({ data }) => {
+      if (mounted) {
+        setSession(data.session ?? null);
+        setLoading(false);
+      }
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => setSession(s));
+    return () => {
+      mounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+  return { session, loading };
+}
+
+export const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { session, loading } = useSession();
+  const location = useLocation();
+  if (loading) return null;
+  if (!session) return <Navigate to="/login" state={{ from: location }} replace />;
+  return <>{children}</>;
+};

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import { createRoot } from "react-dom/client";
+import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/app.css";
 
-const el = document.getElementById("root")!;
-createRoot(el).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );

--- a/web/src/pages/AppHome.tsx
+++ b/web/src/pages/AppHome.tsx
@@ -1,11 +1,12 @@
-import { useAuth } from "@/auth/session";
+import React from "react";
 
 export default function AppHome() {
-  const { user } = useAuth();
   return (
-    <div className="page">
-      <h1>Welcome back{user ? `, ${user.email}` : ""}!</h1>
-      <p>This is your app home. From here we’ll link to Profile, Worlds, etc.</p>
-    </div>
+    <main className="mx-auto max-w-5xl px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold">Welcome back!</h1>
+      <p className="text-white/80 mt-2">
+        This is your app home. From here we’ll link to your Profile, Worlds, progress, etc.
+      </p>
+    </main>
   );
 }

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,39 +1,35 @@
-import { useState } from "react";
+import React from "react";
 import { supabase } from "@/supabaseClient";
 
 export default function Login() {
-  const [email, setEmail] = useState("");
-  const [sending, setSending] = useState(false);
-  const [msg, setMsg] = useState<string | null>(null);
+  const [email, setEmail] = React.useState("");
+  const [sending, setSending] = React.useState(false);
 
   async function sendLink(e: React.FormEvent) {
     e.preventDefault();
     setSending(true);
-    setMsg(null);
-    const redirectTo = `${window.location.origin}/auth/callback`;
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: { emailRedirectTo: redirectTo },
-    });
+    const { error } = await supabase.auth.signInWithOtp({ email, options: { emailRedirectTo: `${location.origin}/auth/callback` }});
     setSending(false);
-    if (error) { setMsg(error.message); return; }
-    setMsg("Magic link sent! Check your email.");
+    if (error) alert(error.message);
+    else alert("Magic link sent!");
   }
 
   return (
-    <div className="page">
-      <h1>Sign in</h1>
-      <form onSubmit={sendLink}>
+    <main className="mx-auto max-w-md px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold mb-4">Sign in</h1>
+      <form onSubmit={sendLink} className="space-y-3">
         <input
-          type="email"
+          className="w-full rounded-md border border-white/20 bg-black/30 p-2 text-white"
           placeholder="you@example.com"
           value={email}
           onChange={(e)=>setEmail(e.target.value)}
+          type="email"
           required
         />
-        <button disabled={sending}>{sending ? "Sending…" : "Send magic link"}</button>
+        <button disabled={sending} className="w-full rounded-md bg-sky-500/90 py-2 font-semibold">
+          {sending ? "Sending…" : "Send magic link"}
+        </button>
       </form>
-      {msg && <p>{msg}</p>}
-    </div>
+    </main>
   );
 }

--- a/web/src/pages/NotFound.tsx
+++ b/web/src/pages/NotFound.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export default function NotFound() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-20 text-center text-white">
+      <h1 className="text-4xl font-bold">404</h1>
+      <p className="mt-2 text-white/80">That page wandered off into the forest.</p>
+      <Link to="/" className="inline-block mt-6 text-sky-300 underline">Go Home</Link>
+    </main>
+  );
+}

--- a/web/src/pages/World.tsx
+++ b/web/src/pages/World.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { useParams, Link } from "react-router-dom";
+
+export default function World() {
+  const { slug } = useParams();
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10 text-white">
+      <Link to="/worlds" className="text-sky-300 underline">← Back to Worlds</Link>
+      <h1 className="text-3xl font-bold mt-4 capitalize">{(slug ?? "").replace(/-/g, " ")}</h1>
+      <p className="mt-2 text-white/80">
+        This is a placeholder page for <strong>{slug}</strong>. We’ll add real scenes, maps and activities here.
+      </p>
+    </main>
+  );
+}

--- a/web/src/pages/Worlds.tsx
+++ b/web/src/pages/Worlds.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const worlds = [
+  { slug: "tropical-rainforest", title: "Tropical Rainforest", blurb: "Explore lush rainforests with Turian." },
+  { slug: "ocean-adventures", title: "Ocean Adventures", blurb: "Dive into crystal-clear waters." },
+  { slug: "magical-stories", title: "Magical Stories", blurb: "Read stories of transformation and nature’s magic." },
+  { slug: "brain-challenge", title: "Brain Challenge", blurb: "Test your knowledge with fun quizzes!" },
+];
+
+export default function Worlds() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold mb-6">Explore Amazing Worlds</h1>
+      <ul className="grid sm:grid-cols-2 gap-4">
+        {worlds.map(w => (
+          <li key={w.slug} className="rounded-lg border border-white/10 bg-white/5 p-4">
+            <h2 className="text-xl font-semibold">{w.title}</h2>
+            <p className="text-white/80 mt-1">{w.blurb}</p>
+            <Link to={`/worlds/${w.slug}`} className="inline-block mt-3 text-sky-300 hover:text-sky-200 underline">
+              Enter
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add sticky Navbar with Home, Worlds, App, Profile and sign-out
- protect `/app` and `/profile` via `RequireAuth`
- add Worlds hub, world detail, login, and 404 pages
- centralize routing through `App` with new pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c1d181dc8329a1eafdbe05de0f29