### PR TITLE
feat(zones): add Zones hub and section routes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,14 @@ import AuthCallback from "@/pages/AuthCallback";
 import Worlds from "@/pages/Worlds";
 import World from "@/pages/World";
 import AppHome from "@/pages/AppHome";
+import ZonesHub from "@/pages/ZonesHub";
+import Naturversity from "@/pages/zones/Naturversity";
+import Music from "@/pages/zones/Music";
+import Wellness from "@/pages/zones/Wellness";
+import MakerLab from "@/pages/zones/MakerLab";
+import Arcade from "@/pages/zones/Arcade";
+import Library from "@/pages/zones/Library";
+
 import Profile from "@/pages/Profile";
 import NotFound from "@/pages/NotFound";
 import { RequireAuth } from "@/lib/auth";
@@ -22,6 +30,13 @@ export default function App() {
           <Route path="/auth/callback" element={<AuthCallback />} />
           <Route path="/worlds" element={<Worlds />} />
           <Route path="/worlds/:slug" element={<World />} />
+          <Route path="/zones" element={<ZonesHub />} />
+          <Route path="/zones/naturversity" element={<Naturversity />} />
+          <Route path="/zones/music" element={<Music />} />
+          <Route path="/zones/wellness" element={<Wellness />} />
+          <Route path="/zones/maker-lab" element={<MakerLab />} />
+          <Route path="/zones/arcade" element={<Arcade />} />
+          <Route path="/zones/library" element={<Library />} />
           <Route
             path="/app"
             element={

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -24,6 +24,7 @@ export const Navbar: React.FC = () => {
         <div className="flex-1" />
         <NavLink to="/" className={linkClass} end>Home</NavLink>
         <NavLink to="/worlds" className={linkClass}>Worlds</NavLink>
+        <NavLink to="/zones" className={linkClass}>Zones</NavLink>
         <NavLink to="/app" className={linkClass}>App</NavLink>
         <NavLink to="/profile" className={linkClass}>Profile</NavLink>
         {email && (

--- a/web/src/pages/ZonesHub.tsx
+++ b/web/src/pages/ZonesHub.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const zones = [
+  { slug: "naturversity", title: "Naturversity", blurb: "Guided lessons, quests, and projects." },
+  { slug: "music", title: "Music Zone", blurb: "Songs, soundscapes, and rhythm games." },
+  { slug: "wellness", title: "Wellness Zone", blurb: "Breathing, mindfulness, and movement." },
+  { slug: "maker-lab", title: "Maker Lab", blurb: "Crafts, experiments, and build-along activities." },
+  { slug: "arcade", title: "Arcade", blurb: "Mini-games and challenges." },
+  { slug: "library", title: "Library", blurb: "Stories, lore, and knowledge base." },
+];
+
+export default function ZonesHub() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold mb-6">Explore Zones</h1>
+      <ul className="grid sm:grid-cols-2 gap-4">
+        {zones.map(z => (
+          <li key={z.slug} className="rounded-lg border border-white/10 bg-white/5 p-4">
+            <h2 className="text-xl font-semibold">{z.title}</h2>
+            <p className="text-white/80 mt-1">{z.blurb}</p>
+            <Link to={`/zones/${z.slug}`} className="inline-block mt-3 text-sky-300 hover:text-sky-200 underline">
+              Enter
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/web/src/pages/zones/Arcade.tsx
+++ b/web/src/pages/zones/Arcade.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+export default function Arcade() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold">Arcade</h1>
+      <p className="text-white/80 mt-2">Mini-games and challenges.</p>
+      <ul className="list-disc ml-6 mt-6 text-white/70">
+        <li>Memory match (animal cards)</li>
+        <li>Whack-a-weed (click speed)</li>
+        <li>Quiz sprint (timed multiple choice)</li>
+      </ul>
+    </main>
+  );
+}

--- a/web/src/pages/zones/Library.tsx
+++ b/web/src/pages/zones/Library.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+export default function Library() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold">Library</h1>
+      <p className="text-white/80 mt-2">Stories, lore, and knowledge base.</p>
+      <ul className="list-disc ml-6 mt-6 text-white/70">
+        <li>Story cards (read mode)</li>
+        <li>Glossary (animals, plants, places)</li>
+        <li>"Ask Turian" Q&A (later with AI)</li>
+      </ul>
+    </main>
+  );
+}

--- a/web/src/pages/zones/MakerLab.tsx
+++ b/web/src/pages/zones/MakerLab.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+export default function MakerLab() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold">Maker Lab</h1>
+      <p className="text-white/80 mt-2">Crafts, experiments, build-alongs.</p>
+      <ul className="list-disc ml-6 mt-6 text-white/70">
+        <li>Project cards (supplies + steps)</li>
+        <li>Photo upload or "I made this!" button</li>
+        <li>Safety tips component</li>
+      </ul>
+    </main>
+  );
+}

--- a/web/src/pages/zones/Music.tsx
+++ b/web/src/pages/zones/Music.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+export default function Music() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold">Music Zone</h1>
+      <p className="text-white/80 mt-2">Songs, soundscapes, rhythm games.</p>
+      <ul className="list-disc ml-6 mt-6 text-white/70">
+        <li>Audio player + playlist</li>
+        <li>Beat pad / simple sequencer</li>
+        <li>"Nature sounds" mixer</li>
+      </ul>
+    </main>
+  );
+}

--- a/web/src/pages/zones/Naturversity.tsx
+++ b/web/src/pages/zones/Naturversity.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export default function Naturversity() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold">Naturversity</h1>
+      <p className="text-white/80 mt-2">Guided lessons, quests, and projects.</p>
+      <section className="mt-6 space-y-2 text-white/70">
+        <p>Next steps:</p>
+        <ul className="list-disc ml-6">
+          <li>Lesson list component (units → lessons → activities)</li>
+          <li>Progress tracking (local first; Supabase later)</li>
+          <li>Badge system (complete quests → badges)</li>
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/web/src/pages/zones/Wellness.tsx
+++ b/web/src/pages/zones/Wellness.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+export default function Wellness() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold">Wellness Zone</h1>
+      <p className="text-white/80 mt-2">Breathing, mindfulness, movement.</p>
+      <ul className="list-disc ml-6 mt-6 text-white/70">
+        <li>Breathing timer (circle expand/contract)</li>
+        <li>Short guided audios</li>
+        <li>Stretch cards</li>
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add /zones hub with links to sections
- scaffold Naturversity, Music, Wellness, Maker Lab, Arcade, and Library pages
- wire Zones into navbar and app routes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c544c470832985376a8de885873d