### PR TITLE
feat: add AI story and quiz generators

### DIFF
--- a/web/functions/generate-quiz.ts
+++ b/web/functions/generate-quiz.ts
@@ -1,0 +1,47 @@
+import type { Handler } from "@netlify/functions";
+
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod !== "POST") {
+      return { statusCode: 405, body: "Method Not Allowed" };
+    }
+    const { passage, objective = "Check reading comprehension for ages 8-10." } = JSON.parse(event.body || "{}" );
+
+    if (!process.env.OPENAI_API_KEY) {
+      return { statusCode: 500, body: "Missing OPENAI_API_KEY" };
+    }
+
+    const system = `You create kid-safe multiple-choice quizzes (3–5 questions).\nEach question:\n- has 1 correct answer and 3 distractors\n- is short and clear\nReturn strict JSON:\n{\n  "questions": [\n    {\n      "q": "string",\n      "choices": ["A","B","C","D"],\n      "answerIndex": 0,\n      "why": "one-sentence rationale"\n    }\n  ]\n}`;
+
+    const user = `Make a quiz for this passage and objective.\nObjective: ${objective}\nPassage: """${passage}"""`;
+
+    const resp = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: process.env.OPENAI_MODEL || "gpt-4o-mini",
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: user },
+        ],
+        temperature: 0.4,
+        response_format: { type: "json_object" },
+        max_tokens: 900,
+      }),
+    });
+
+    if (!resp.ok) {
+      const errText = await resp.text();
+      return { statusCode: 500, body: `OpenAI error: ${errText}` };
+    }
+
+    const data = await resp.json();
+    const json = JSON.parse(data.choices?.[0]?.message?.content || `{"questions":[]}`);
+    return { statusCode: 200, body: JSON.stringify(json) };
+  } catch (e: any) {
+    return { statusCode: 500, body: e?.message || "Server error" };
+  }
+};

--- a/web/functions/generate-story.ts
+++ b/web/functions/generate-story.ts
@@ -1,0 +1,52 @@
+import type { Handler } from "@netlify/functions";
+
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod !== "POST") {
+      return { statusCode: 405, body: "Method Not Allowed" };
+    }
+    const { topic, age = 8, tone = "curious", length = 450 } = JSON.parse(event.body || "{}" );
+
+    if (!process.env.OPENAI_API_KEY) {
+      return { statusCode: 500, body: "Missing OPENAI_API_KEY" };
+    }
+
+    // Simple safety and guardrails
+    const system = `You are a kids' nature storyteller. \
+Keep content G-rated, friendly, and factual. \
+No scary or violent content. Vocabulary appropriate for ages ${age}. \
+Write in ${tone} tone. Keep it around ${length} words. \
+End with a positive reflection question.`;
+
+    const user = `Write a short story about: ${topic}.\nInclude 3 short sections with headings.\nTitle it.`;
+
+    // Call OpenAI Chat Completions (Responses API compatible prompt)
+    const resp = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: process.env.OPENAI_MODEL || "gpt-4o-mini",
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: user },
+        ],
+        temperature: 0.8,
+        max_tokens: 1200,
+      }),
+    });
+
+    if (!resp.ok) {
+      const errText = await resp.text();
+      return { statusCode: 500, body: `OpenAI error: ${errText}` };
+    }
+
+    const data = await resp.json();
+    const text = data.choices?.[0]?.message?.content?.trim() || "No story generated.";
+    return { statusCode: 200, body: JSON.stringify({ story: text }) };
+  } catch (e: any) {
+    return { statusCode: 500, body: e?.message || "Server error" };
+  }
+};

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,8 @@ import Arcade from "@/pages/zones/Arcade";
 import Community from "@/pages/zones/Community";
 import Lesson from "@/pages/naturversity/Lesson";
 import About from "@/pages/About";
+import StoryStudioPage from "@/pages/story-studio";
+import AutoQuiz from "@/pages/auto-quiz";
 
 import Profile from "@/pages/Profile";
 import NotFound from "@/pages/NotFound";
@@ -35,6 +37,8 @@ export default function App() {
           <Route path="/login" element={<Login />} />
           <Route path="/auth/callback" element={<AuthCallback />} />
           <Route path="/about" element={<About />} />
+          <Route path="/story-studio" element={<StoryStudioPage />} />
+          <Route path="/auto-quiz" element={<AutoQuiz />} />
           <Route path="/worlds" element={<Worlds />} />
           <Route path="/worlds/:slug" element={<World />} />
           <Route

--- a/web/src/pages/Zones.tsx
+++ b/web/src/pages/Zones.tsx
@@ -71,6 +71,18 @@ export default function ZonesHub() {
           emoji="⚙️"
         />
       </div>
+      <ul className="mt-8 space-y-2 list-disc pl-5">
+        <li>
+          <a href="/story-studio" className="text-blue-300 underline">
+            Story Studio (AI)
+          </a>
+        </li>
+        <li>
+          <a href="/auto-quiz" className="text-blue-300 underline">
+            Auto-Quiz (AI)
+          </a>
+        </li>
+      </ul>
     </main>
   );
 }

--- a/web/src/pages/auto-quiz.tsx
+++ b/web/src/pages/auto-quiz.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+
+type Q = { q: string; choices: string[]; answerIndex: number; why: string };
+
+export default function AutoQuiz() {
+  const [passage, setPassage] = useState("Rainforests are layered habitats with a canopy that captures most sunlight…");
+  const [loading, setLoading] = useState(false);
+  const [qs, setQs] = useState<Q[]>([]);
+  const [answers, setAnswers] = useState<number[]>([]);
+
+  async function generate() {
+    setLoading(true);
+    setQs([]);
+    setAnswers([]);
+    const res = await fetch("/.netlify/functions/generate-quiz", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ passage }),
+    });
+    const json = await res.json();
+    const out: Q[] = json.questions || [];
+    setQs(out);
+    setAnswers(new Array(out.length).fill(-1));
+    setLoading(false);
+  }
+
+  function select(i: number, choice: number) {
+    const next = [...answers];
+    next[i] = choice;
+    setAnswers(next);
+  }
+
+  const score = qs.reduce((acc, q, i) => acc + (answers[i] === q.answerIndex ? 1 : 0), 0);
+
+  return (
+    <div className="container" style={{ maxWidth: 840, margin: "0 auto", padding: "2rem" }}>
+      <h1>Auto-Quiz</h1>
+      <p>Paste a short passage; get ready-to-use MCQs.</p>
+
+      <textarea
+        value={passage}
+        onChange={(e) => setPassage(e.target.value)}
+        rows={6}
+        style={{ width: "100%", marginBottom: 12 }}
+      />
+      <button onClick={generate} disabled={loading}>
+        {loading ? "Generating…" : "Generate Quiz"}
+      </button>
+
+      {qs.length > 0 && (
+        <div style={{ marginTop: 24 }}>
+          {qs.map((q, i) => (
+            <div
+              key={i}
+              style={{
+                marginBottom: 16,
+                paddingBottom: 16,
+                borderBottom: "1px solid rgba(255,255,255,0.15)",
+              }}
+            >
+              <strong>
+                {i + 1}. {q.q}
+              </strong>
+              <div style={{ marginTop: 8, display: "grid", gap: 6 }}>
+                {q.choices.map((c, j) => (
+                  <label key={j} style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                    <input
+                      type="radio"
+                      name={`q${i}`}
+                      checked={answers[i] === j}
+                      onChange={() => select(i, j)}
+                    />
+                    <span>{c}</span>
+                  </label>
+                ))}
+              </div>
+              {answers[i] >= 0 && (
+                <div style={{ marginTop: 8, fontStyle: "italic" }}>
+                  {answers[i] === q.answerIndex
+                    ? "✅ Correct!"
+                    : `❌ The answer is "${q.choices[q.answerIndex]}".`} {q.why}
+                </div>
+              )}
+            </div>
+          ))}
+          <h3>
+            Your score: {score}/{qs.length}
+          </h3>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/story-studio.tsx
+++ b/web/src/pages/story-studio.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+
+export default function StoryStudio() {
+  const [topic, setTopic] = useState("A tiny dragon who loves rainforests");
+  const [age, setAge] = useState(8);
+  const [tone, setTone] = useState("curious");
+  const [loading, setLoading] = useState(false);
+  const [story, setStory] = useState("");
+
+  async function generate() {
+    setLoading(true);
+    setStory("");
+    const res = await fetch("/.netlify/functions/generate-story", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ topic, age, tone, length: 500 }),
+    });
+    const json = await res.json();
+    setStory(json.story || "No story.");
+    setLoading(false);
+  }
+
+  return (
+    <div className="container" style={{ maxWidth: 840, margin: "0 auto", padding: "2rem" }}>
+      <h1>Story Studio</h1>
+      <p>Create kid-safe, nature-themed stories.</p>
+
+      <label>Topic</label>
+      <input
+        value={topic}
+        onChange={(e) => setTopic(e.target.value)}
+        style={{ width: "100%", marginBottom: 12 }}
+      />
+
+      <div style={{ display: "flex", gap: 12, marginBottom: 12 }}>
+        <label>
+          Age
+          <input
+            type="number"
+            min={5}
+            max={12}
+            value={age}
+            onChange={(e) => setAge(parseInt(e.target.value || "8"))}
+            style={{ marginLeft: 8, width: 80 }}
+          />
+        </label>
+        <label>
+          Tone
+          <select
+            value={tone}
+            onChange={(e) => setTone(e.target.value)}
+            style={{ marginLeft: 8 }}
+          >
+            <option>curious</option>
+            <option>adventurous</option>
+            <option>gentle</option>
+            <option>funny</option>
+          </select>
+        </label>
+      </div>
+
+      <button onClick={generate} disabled={loading}>
+        {loading ? "Generating…" : "Make Story"}
+      </button>
+
+      {story && (
+        <article
+          style={{
+            whiteSpace: "pre-wrap",
+            marginTop: 24,
+            background: "rgba(0,0,0,0.2)",
+            padding: 16,
+            borderRadius: 8,
+          }}
+        >
+          {story}
+        </article>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Netlify functions to generate kid-friendly stories and quizzes with OpenAI
- create Story Studio and Auto-Quiz pages
- wire up routes and zones page links

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0d39c77648329b95194abfad41880