### PR TITLE
feat: add immersive background and motion settings

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Navbar } from "@/components/Navbar";
+import ImmersiveBackground from "@/components/ImmersiveBackground";
 import Home from "@/pages/Landing";
 import Login from "@/pages/Login";
 import AuthCallback from "@/pages/AuthCallback";
@@ -30,7 +31,8 @@ import { RequireAuth } from "@/lib/auth";
 export default function App() {
   return (
     <BrowserRouter>
-      <div className="min-h-screen bg-gradient-to-br from-[#0b1020] via-[#101a38] to-[#1e2046]">
+      <ImmersiveBackground />
+      <div className="min-h-screen">
         <Navbar />
         <Routes>
           <Route path="/" element={<Home />} />

--- a/web/src/components/ImmersiveBackground/GradientBackdrop.tsx
+++ b/web/src/components/ImmersiveBackground/GradientBackdrop.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export default function GradientBackdrop() {
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: -3,
+        background:
+          "radial-gradient(1200px 800px at 20% 10%, rgba(62,132,199,0.35), transparent 60%), radial-gradient(1000px 700px at 80% 30%, rgba(119,201,146,0.35), transparent 60%), linear-gradient(180deg, #0b1220 0%, #0a0f1a 60%, #090e18 100%)",
+      }}
+    />
+  );
+}

--- a/web/src/components/ImmersiveBackground/StarfieldCanvas.tsx
+++ b/web/src/components/ImmersiveBackground/StarfieldCanvas.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useRef } from "react";
+
+type Star = { x: number; y: number; z: number; r: number; s: number };
+
+function makeStars(w: number, h: number, count: number): Star[] {
+  const stars: Star[] = [];
+  for (let i = 0; i < count; i++) {
+    stars.push({
+      x: Math.random() * w,
+      y: Math.random() * h,
+      z: Math.random() * 0.6 + 0.4, // depth
+      r: Math.random() * 0.7 + 0.3, // radius
+      s: Math.random() * 0.4 + 0.1, // speed
+    });
+  }
+  return stars;
+}
+
+export default function StarfieldCanvas({ enabled }: { enabled: boolean }) {
+  const ref = useRef<HTMLCanvasElement | null>(null);
+  const starsRef = useRef<Star[]>([]);
+  const rafRef = useRef<number | null>(null);
+  const lastRef = useRef(0);
+
+  useEffect(() => {
+    const canvas = ref.current!;
+    const ctx = canvas.getContext("2d", { alpha: true })!;
+    let w = (canvas.width = window.innerWidth);
+    let h = (canvas.height = window.innerHeight);
+    starsRef.current = makeStars(w, h, Math.min(220, Math.floor((w * h) / 18000)));
+
+    const onResize = () => {
+      w = (canvas.width = window.innerWidth);
+      h = (canvas.height = window.innerHeight);
+      starsRef.current = makeStars(w, h, Math.min(220, Math.floor((w * h) / 18000)));
+    };
+    window.addEventListener("resize", onResize);
+
+    const render = (t: number) => {
+      if (!enabled) return;
+      const dt = Math.min(33, t - lastRef.current || 16);
+      lastRef.current = t;
+      ctx.clearRect(0, 0, w, h);
+
+      // subtle parallax based on mouse
+      const mx = (window as any).__nv_mx ?? 0;
+      const my = (window as any).__nv_my ?? 0;
+
+      for (const s of starsRef.current) {
+        s.x += s.s * s.z * 0.3;
+        if (s.x > w + 2) s.x = -2;
+
+        const px = s.x + mx * (1 - s.z) * 8;
+        const py = s.y + my * (1 - s.z) * 8;
+
+        ctx.globalAlpha = 0.5 + 0.5 * s.z;
+        ctx.beginPath();
+        ctx.arc(px, py, s.r, 0, Math.PI * 2);
+        ctx.fillStyle = "rgba(255,255,255,0.9)";
+        ctx.fill();
+      }
+      rafRef.current = requestAnimationFrame(render);
+    };
+
+    if (enabled) {
+      rafRef.current = requestAnimationFrame(render);
+    }
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      window.removeEventListener("resize", onResize);
+    };
+  }, [enabled]);
+
+  useEffect(() => {
+    const move = (e: MouseEvent) => {
+      (window as any).__nv_mx = e.clientX / window.innerWidth - 0.5;
+      (window as any).__nv_my = e.clientY / window.innerHeight - 0.5;
+    };
+    if (enabled) window.addEventListener("mousemove", move);
+    return () => window.removeEventListener("mousemove", move);
+  }, [enabled]);
+
+  return (
+    <canvas
+      ref={ref}
+      aria-hidden
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: -2,
+        width: "100vw",
+        height: "100vh",
+        opacity: enabled ? 0.8 : 0,
+        transition: "opacity 300ms ease",
+      }}
+    />
+  );
+}

--- a/web/src/components/ImmersiveBackground/VignetteOverlay.tsx
+++ b/web/src/components/ImmersiveBackground/VignetteOverlay.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export default function VignetteOverlay() {
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: -1,
+        pointerEvents: "none",
+        background:
+          "radial-gradient(1200px 600px at 50% -10%, rgba(255,255,255,0.04), transparent 60%), radial-gradient(1600px 900px at 50% 100%, rgba(0,0,0,0.35), transparent 60%)",
+        mixBlendMode: "normal",
+      }}
+    />
+  );
+}

--- a/web/src/components/ImmersiveBackground/index.tsx
+++ b/web/src/components/ImmersiveBackground/index.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from "react";
+import useReducedMotion from "@/hooks/useReducedMotion";
+import GradientBackdrop from "./GradientBackdrop";
+import VignetteOverlay from "./VignetteOverlay";
+import StarfieldCanvas from "./StarfieldCanvas";
+
+/**
+ * Modes:
+ *   - "off": only gradient + vignette
+ *   - "canvas": adds starfield (disabled if reduced motion)
+ *
+ * Setting stored in localStorage "immersive-mode"
+ */
+export default function ImmersiveBackground() {
+  const reduced = useReducedMotion();
+  const [mode, setMode] = useState<"off" | "canvas">("canvas");
+
+  useEffect(() => {
+    const fromLS =
+      (localStorage.getItem("immersive-mode") as "off" | "canvas" | null) ||
+      "canvas";
+    setMode(fromLS);
+    const onStorage = () => {
+      const v = (localStorage.getItem("immersive-mode") as any) || "canvas";
+      setMode(v === "off" ? "off" : "canvas");
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const canvasOn = mode === "canvas" && !reduced;
+
+  return (
+    <>
+      <GradientBackdrop />
+      <StarfieldCanvas enabled={canvasOn} />
+      <VignetteOverlay />
+    </>
+  );
+}

--- a/web/src/hooks/useReducedMotion.ts
+++ b/web/src/hooks/useReducedMotion.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+/** Reads both OS prefers-reduced-motion and our app's localStorage flag "reduce-motion" */
+export default function useReducedMotion() {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const fromOS = !!media.matches;
+    const fromApp = localStorage.getItem("reduce-motion") === "true";
+    setReduced(fromOS || fromApp);
+
+    const handler = () =>
+      setReduced(
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches ||
+          localStorage.getItem("reduce-motion") === "true"
+      );
+    media.addEventListener?.("change", handler);
+    window.addEventListener("storage", handler);
+    return () => {
+      media.removeEventListener?.("change", handler);
+      window.removeEventListener("storage", handler);
+    };
+  }, []);
+
+  return reduced;
+}

--- a/web/src/pages/zones/Settings.tsx
+++ b/web/src/pages/zones/Settings.tsx
@@ -7,7 +7,6 @@ type Scale = "normal" | "large";
 export default function Settings() {
   const [theme, setTheme] = useState<Theme>(() => (localStorage.getItem("theme") as Theme) || "light");
   const [scale, setScale] = useState<Scale>(() => (localStorage.getItem("textScale") as Scale) || "normal");
-  const [reduce, setReduce] = useState(() => localStorage.getItem("reduceMotion") === "1");
 
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
@@ -19,13 +18,8 @@ export default function Settings() {
     localStorage.setItem("textScale", scale);
   }, [scale]);
 
-  useEffect(() => {
-    document.body.classList.toggle("reduce-motion", reduce);
-    localStorage.setItem("reduceMotion", reduce ? "1" : "0");
-  }, [reduce]);
-
   return (
-    <main className="mx-auto max-w-5xl px-4 py-10 text-white">
+    <main className="page-container mx-auto max-w-5xl py-10 text-white">
       <Breadcrumbs
         items={[
           { label: "Naturverse" },
@@ -73,13 +67,40 @@ export default function Settings() {
         </div>
       </section>
 
-      <section className="mt-6 rounded-lg border border-white/10 bg-white/5 p-4">
-        <h2 className="text-xl font-semibold">Accessibility</h2>
-        <label className="mt-3 flex items-center gap-2">
-          <input type="checkbox" checked={reduce} onChange={(e) => setReduce(e.target.checked)} />
-          Reduce motion
+      <div className="rounded-lg border border-white/10 bg-white/5 p-4 mt-6">
+        <h2 className="text-xl font-semibold text-white">Immersive Background</h2>
+        <p className="text-white/70 mt-1">Choose backdrop visuals. Starfield disables automatically if “Reduce motion” is on.</p>
+        <div className="mt-3 flex gap-3">
+          <button
+            onClick={() => { localStorage.setItem("immersive-mode", "off"); window.dispatchEvent(new StorageEvent("storage")); }}
+            className="rounded-md bg-white/10 px-3 py-2"
+          >
+            Off
+          </button>
+          <button
+            onClick={() => { localStorage.setItem("immersive-mode", "canvas"); window.dispatchEvent(new StorageEvent("storage")); }}
+            className="rounded-md bg-sky-600 px-3 py-2"
+          >
+            Starfield
+          </button>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-white/10 bg-white/5 p-4 mt-6">
+        <h2 className="text-xl font-semibold text-white">Motion</h2>
+        <label className="text-white/80">
+          <input
+            type="checkbox"
+            defaultChecked={localStorage.getItem("reduce-motion") === "true"}
+            onChange={(e) => {
+              localStorage.setItem("reduce-motion", e.target.checked ? "true" : "false");
+              window.dispatchEvent(new StorageEvent("storage"));
+            }}
+            style={{ marginRight: 8 }}
+          />
+          Reduce motion (fewer animations)
         </label>
-      </section>
+      </div>
     </main>
   );
 }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -4,7 +4,11 @@
 --bg-2:#101a38;
 --text:#eaf2ff;
 --accent:#91f2ff;
+--nv-page-pad:1rem;
 }
+@media (min-width: 640px) { :root { --nv-page-pad: 1.25rem; } }
+@media (min-width: 1024px) { :root { --nv-page-pad: 2rem; } }
+.page-container { padding: var(--nv-page-pad); }
 
 *,
 *::before,


### PR DESCRIPTION
## Summary
- add reduced-motion hook and immersive background with gradient, starfield, and vignette
- expose immersive background and motion preferences in settings
- introduce responsive page padding variable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0dabd1e9483299a155fa39b4b4241