### PR TITLE
feat: add Turian tips and shimmer hero heading

### DIFF
--- a/web/functions/generate-tips.ts
+++ b/web/functions/generate-tips.ts
@@ -1,0 +1,63 @@
+import type { Handler } from "@netlify/functions";
+
+const fallback = {
+  tips: [
+    "Try a 60-second nature breath.",
+    "Spot three leaf shapes today.",
+    "Ask a 'why' about any animal!",
+    "Draw your tiny world."
+  ]
+};
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, body: "Method Not Allowed" };
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return { statusCode: 200, body: JSON.stringify(fallback) };
+  }
+
+  try {
+    const resp = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: process.env.OPENAI_MODEL || "gpt-4o-mini",
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are Turian the Durian, a playful, kid-safe guide for a nature-learning app. Reply with 3–5 short, friendly tips (max ~16 words each). Keep G-rated, curious, encouraging. JSON only: { \"tips\": [\"...\"] }.",
+          },
+          {
+            role: "user",
+            content: "Make tips about exploration, kind learning, and quick activities.",
+          },
+        ],
+        temperature: 0.6,
+        max_tokens: 200,
+        response_format: { type: "json_object" },
+      }),
+    });
+
+    if (!resp.ok) {
+      return { statusCode: 200, body: JSON.stringify(fallback) };
+    }
+
+    const data = await resp.json();
+    const text = data.choices?.[0]?.message?.content;
+    const parsed = JSON.parse(text || "{}");
+    const tips = Array.isArray(parsed.tips) ? parsed.tips : [];
+    if (!tips.length) {
+      return { statusCode: 200, body: JSON.stringify(fallback) };
+    }
+    return { statusCode: 200, body: JSON.stringify({ tips }) };
+  } catch {
+    return { statusCode: 200, body: JSON.stringify(fallback) };
+  }
+};
+

--- a/web/src/components/TurianHero.tsx
+++ b/web/src/components/TurianHero.tsx
@@ -15,11 +15,29 @@ export default function TurianHero() {
           0% { transform: translateY(0) rotate(0deg); }
           100% { transform: translateY(-8px) rotate(1.5deg); }
         }
+        @keyframes nv-shimmer {
+          from { background-position: -200% 0; }
+          to { background-position: 200% 0; }
+        }
+        .nv-shimmer {
+          background: linear-gradient(90deg, rgba(255,255,255,0.95), rgba(255,255,255,0.6), rgba(255,255,255,0.95));
+          background-clip: text;
+          -webkit-background-clip: text;
+          color: transparent;
+        }
       `}</style>
       <div className="mx-auto max-w-6xl flex flex-col items-center gap-12 md:flex-row md:justify-between">
         <div className="max-w-[560px] w-full text-center md:text-left flex flex-col items-center md:items-start bg-black/20 md:bg-transparent rounded-lg p-4 md:p-0">
           <h1 className="text-4xl sm:text-5xl font-bold leading-tight text-white">
-            Meet Turian the Durian 🍈⚡
+            <span
+              className="nv-shimmer"
+              style={{
+                animation: reduced ? "none" : "nv-shimmer 6s linear infinite",
+                backgroundSize: "200% 100%"
+              }}
+            >
+              Meet Turian the Durian 🍈⚡
+            </span>
           </h1>
           <p className="mt-4 text-lg text-white/90">
             Your playful guide to nature quests, stories, and mini-labs.

--- a/web/src/components/TurianTips.tsx
+++ b/web/src/components/TurianTips.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from "react";
+import useReducedMotion from "@/hooks/useReducedMotion";
+
+const localTips = [
+  "Try a 60-second nature breath.",
+  "Spot three leaf shapes today.",
+  "Ask a 'why' about any animal!",
+  "Draw your tiny world."
+];
+
+export default function TurianTips() {
+  const reduced = useReducedMotion();
+  const [show, setShow] = useState(() => localStorage.getItem("show-tips") !== "false");
+  const [tips, setTips] = useState<string[]>(localTips);
+  const [idx, setIdx] = useState(0);
+  const [fade, setFade] = useState(false);
+
+  useEffect(() => {
+    const handler = () => setShow(localStorage.getItem("show-tips") !== "false");
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, []);
+
+  useEffect(() => {
+    if (!show) return;
+    const schedule = (cb: () => void) =>
+      ("requestIdleCallback" in window
+        ? (window as any).requestIdleCallback(cb)
+        : setTimeout(cb, 200));
+    schedule(async () => {
+      try {
+        const resp = await fetch("/.netlify/functions/generate-tips", { method: "POST" });
+        const data = await resp.json();
+        if (Array.isArray(data.tips) && data.tips.length) {
+          setTips(data.tips);
+        } else {
+          setTips(localTips);
+        }
+      } catch {
+        setTips(localTips);
+      }
+    });
+  }, [show]);
+
+  useEffect(() => {
+    if (reduced || tips.length <= 1) return;
+    const id = setInterval(() => {
+      setFade(true);
+      setTimeout(() => {
+        setIdx((i) => (i + 1) % tips.length);
+        setFade(false);
+      }, 250);
+    }, 8000);
+    return () => clearInterval(id);
+  }, [reduced, tips]);
+
+  if (!show) return null;
+
+  return (
+    <div className="mx-auto mt-4 w-full max-w-[720px] rounded-lg border border-white/10 bg-black/40 p-4 text-white">
+      <div className="mb-1 flex items-center gap-2 text-sm font-semibold text-white/90">
+        <span role="img" aria-label="Turian">🍈</span>
+        <span>Turian says</span>
+      </div>
+      <p
+        aria-live="polite"
+        className={`${fade && !reduced ? "opacity-0" : "opacity-100"}`}
+        style={{ transition: reduced ? "none" : "opacity 250ms" }}
+      >
+        {tips[idx]}
+      </p>
+    </div>
+  );
+}
+

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import TurianHero from "@/components/TurianHero";
+import TurianTips from "@/components/TurianTips";
 
 export default function Home() {
   return (
     <main className="flex flex-col">
       <TurianHero />
+      <TurianTips />
       <div className="mx-auto max-w-5xl w-full px-4 pb-12">
         <section className="mt-8">
           <article>

--- a/web/src/pages/zones/Settings.tsx
+++ b/web/src/pages/zones/Settings.tsx
@@ -87,6 +87,22 @@ export default function Settings() {
       </div>
 
       <div className="rounded-lg border border-white/10 bg-white/5 p-4 mt-6">
+        <h2 className="text-xl font-semibold text-white">Turian Tips</h2>
+        <label className="text-white/80 mt-1 block">
+          <input
+            type="checkbox"
+            defaultChecked={localStorage.getItem("show-tips") !== "false"}
+            onChange={(e) => {
+              localStorage.setItem("show-tips", e.target.checked ? "true" : "false");
+              window.dispatchEvent(new StorageEvent("storage"));
+            }}
+            style={{ marginRight: 8 }}
+          />
+          Show tips from Turian
+        </label>
+      </div>
+
+      <div className="rounded-lg border border-white/10 bg-white/5 p-4 mt-6">
         <h2 className="text-xl font-semibold text-white">Motion</h2>
         <label className="text-white/80">
           <input


### PR DESCRIPTION
## Summary
- add `generate-tips` Netlify function for AI-powered tip generation with graceful fallback
- introduce `TurianTips` component with idle tip fetching, rotation, motion-aware fades, and storage-driven visibility
- enhance hero heading with motion-safe shimmer and add settings toggle to show/hide tips

## Testing
- `cd web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0dfff4be48329937d5e98856bd81d