### PR TITLE
feat(3d): lightweight React Three Fiber “Floating Island Hub” with motion-safe behavior and non-WebGL fallback; new /hub route

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,8 @@
     "@supabase/supabase-js": "^2.5.0",
     "@tanstack/react-query": "^5",
     "hono": "^4.3.7",
+    "three": "^0.164.0",
+    "@react-three/fiber": "^9.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.0"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,6 +23,7 @@ import Lesson from "@/pages/naturversity/Lesson";
 import About from "@/pages/About";
 import StoryStudioPage from "@/pages/story-studio";
 import AutoQuiz from "@/pages/auto-quiz";
+import WorldHub from "@/pages/world-hub";
 
 import Profile from "@/pages/Profile";
 import NotFound from "@/pages/NotFound";
@@ -43,6 +44,7 @@ export default function App() {
           <Route path="/auto-quiz" element={<AutoQuiz />} />
           <Route path="/worlds" element={<Worlds />} />
           <Route path="/worlds/:slug" element={<World />} />
+          <Route path="/hub" element={<WorldHub />} />
           <Route
             path="/zones"
             element={

--- a/web/src/components/IslandHub3D.tsx
+++ b/web/src/components/IslandHub3D.tsx
@@ -1,0 +1,157 @@
+import React, { useMemo, useRef } from "react";
+import { Canvas, useFrame, invalidate } from "@react-three/fiber";
+import * as THREE from "three";
+import { useNavigate } from "react-router-dom";
+
+interface Props {
+  reduced: boolean;
+  active?: string | null;
+  onActiveChange?: (key: string | null) => void;
+}
+
+const portalData = [
+  {
+    key: "naturversity",
+    color: "#7dd3fc",
+    position: [-1.2, 0.5, 0.8],
+    route: "/zones/naturversity",
+  },
+  {
+    key: "music",
+    color: "#a78bfa",
+    position: [1.3, 0.4, -0.5],
+    route: "/zones/music",
+  },
+  {
+    key: "wellness",
+    color: "#34d399",
+    position: [0.6, 0.5, 1.2],
+    route: "/zones/wellness",
+  },
+  {
+    key: "creator",
+    color: "#f472b6",
+    position: [-0.7, 0.4, -1.2],
+    route: "/zones/creator-lab",
+  },
+];
+
+function Island({ reduced }: { reduced: boolean }) {
+  const mesh = useRef<THREE.Mesh>(null!);
+  const geometry = useMemo(() => {
+    const geo = new THREE.IcosahedronGeometry(1.4, 1);
+    const pos = geo.attributes.position as THREE.BufferAttribute;
+    const vec = new THREE.Vector3();
+    for (let i = 0; i < pos.count; i++) {
+      vec.fromBufferAttribute(pos, i);
+      const n = Math.sin(vec.x * 12.9898 + vec.y * 78.233 + vec.z * 37.719) * 43758.5453;
+      const offset = (n - Math.floor(n)) * 0.15;
+      vec.addScaledVector(vec.normalize(), offset);
+      pos.setXYZ(i, vec.x, vec.y, vec.z);
+    }
+    pos.needsUpdate = true;
+    geo.computeVertexNormals();
+    return geo;
+  }, []);
+
+  useFrame((state, delta) => {
+    if (reduced) return;
+    mesh.current.rotation.y += 0.08 * delta;
+    mesh.current.position.y = Math.sin(state.clock.elapsedTime * 0.5) * 0.08;
+  });
+
+  return (
+    <mesh ref={mesh} geometry={geometry} position={[0, 0, 0]}>
+      <meshStandardMaterial color="#93c5fd" metalness={0} roughness={0.9} />
+    </mesh>
+  );
+}
+
+function Trees() {
+  const group = useRef<THREE.Group>(null!);
+  const positions = useMemo(() => [
+    [0.8, 0.7, 0.2],
+    [-0.6, 0.6, -0.4],
+    [0.2, 0.8, -0.5],
+    [-0.3, 0.7, 0.6],
+    [0.4, 0.6, 0.5],
+  ], []);
+  return (
+    <group ref={group}>
+      {positions.map((p, i) => {
+        const color = i % 2 === 0 ? "#34d399" : "#38d9a9";
+        return (
+          <group key={i} position={p as any}>
+            <mesh position={[0, 0.2, 0]}>
+              <cylinderGeometry args={[0.05, 0.06, 0.4, 6]} />
+              <meshStandardMaterial color="#92400e" />
+            </mesh>
+            <mesh position={[0, 0.55, 0]}>
+              <coneGeometry args={[0.25, 0.6, 6]} />
+              <meshStandardMaterial color={color} />
+            </mesh>
+          </group>
+        );
+      })}
+    </group>
+  );
+}
+
+function Water() {
+  return (
+    <mesh position={[0, -1.1, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+      <circleGeometry args={[3, 40]} />
+      <meshBasicMaterial color="#0ea5e9" transparent opacity={0.15} />
+    </mesh>
+  );
+}
+
+function Portal({ data, active, reduced, onActive }: { data: any; active: boolean; reduced: boolean; onActive: (key: string | null) => void; }) {
+  const ref = useRef<THREE.Mesh>(null!);
+  const navigate = useNavigate();
+  useFrame(() => {
+    if (ref.current) {
+      const target = active ? 1.08 : 1;
+      ref.current.scale.setScalar(THREE.MathUtils.lerp(ref.current.scale.x, target, 0.1));
+    }
+  });
+  return (
+    <mesh
+      ref={ref}
+      position={data.position as any}
+      onPointerOver={(e) => { e.stopPropagation(); onActive(data.key); if (reduced) invalidate(); }}
+      onPointerOut={(e) => { e.stopPropagation(); onActive(null); if (reduced) invalidate(); }}
+      onClick={(e) => { e.stopPropagation(); navigate(data.route); }}
+    >
+      <torusGeometry args={[0.3, 0.02, 8, 24]} />
+      <meshStandardMaterial color={data.color} />
+    </mesh>
+  );
+}
+
+export default function IslandHub3D({ reduced, active, onActiveChange }: Props) {
+  return (
+    <Canvas
+      dpr={[1, 1.5]}
+      gl={{ antialias: true, alpha: true, powerPreference: "high-performance" }}
+      camera={{ position: [0, 2.2, 5], fov: 50 }}
+      frameloop={reduced ? "demand" : "always"}
+    >
+      <ambientLight intensity={0.5} />
+      <hemisphereLight intensity={0.7} />
+      <directionalLight intensity={0.8} position={[5, 5, 5]} />
+      <Island reduced={reduced} />
+      <Water />
+      <Trees />
+      {portalData.map((p) => (
+        <Portal
+          key={p.key}
+          data={p}
+          active={active === p.key}
+          reduced={reduced}
+          onActive={(k) => onActiveChange?.(k)}
+        />
+      ))}
+    </Canvas>
+  );
+}

--- a/web/src/components/IslandHubFallback.tsx
+++ b/web/src/components/IslandHubFallback.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const portals = [
+  { key: "naturversity", color: "#7dd3fc", route: "/zones/naturversity", label: "Naturversity" },
+  { key: "music", color: "#a78bfa", route: "/zones/music", label: "Music" },
+  { key: "wellness", color: "#34d399", route: "/zones/wellness", label: "Wellness" },
+  { key: "creator", color: "#f472b6", route: "/zones/creator-lab", label: "Creator Lab" },
+];
+
+export default function IslandHubFallback() {
+  return (
+    <div className="w-full flex flex-col items-center gap-6">
+      <svg
+        role="img"
+        aria-label="Floating island illustration"
+        width="300"
+        height="200"
+        viewBox="0 0 300 200"
+      >
+        <ellipse cx="150" cy="150" rx="130" ry="30" fill="#0ea5e9" opacity="0.15" />
+        <polygon points="150,60 50,140 250,140" fill="#93c5fd" />
+      </svg>
+      <p className="text-sm text-white/80 text-center">
+        3D is disabled on this device—using a lightweight view.
+      </p>
+      <div className="flex flex-wrap justify-center gap-3">
+        {portals.map((p) => (
+          <Link
+            key={p.key}
+            to={p.route}
+            className="px-4 py-2 rounded-full text-sm font-medium text-black"
+            style={{ background: p.color }}
+          >
+            {p.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -31,6 +31,9 @@ export const Navbar: React.FC = () => {
         <NavLink to="/zones" className={linkClass}>
           Zones
         </NavLink>
+        <NavLink to="/hub" className={linkClass}>
+          3D Hub (beta)
+        </NavLink>
         <NavLink to="/about" className={linkClass}>
           About
         </NavLink>

--- a/web/src/hooks/useWebGLSupport.ts
+++ b/web/src/hooks/useWebGLSupport.ts
@@ -1,0 +1,20 @@
+import { useMemo } from "react";
+
+let cached: boolean | null = null;
+
+function detectWebGL(): boolean {
+  if (cached !== null) return cached;
+  if (typeof window === "undefined") return false;
+  try {
+    const canvas = document.createElement("canvas");
+    const gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
+    cached = !!gl;
+  } catch {
+    cached = false;
+  }
+  return cached;
+}
+
+export default function useWebGLSupport(): boolean {
+  return useMemo(() => detectWebGL(), []);
+}

--- a/web/src/pages/world-hub.tsx
+++ b/web/src/pages/world-hub.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import useWebGLSupport from "@/hooks/useWebGLSupport";
+import useReducedMotion from "@/hooks/useReducedMotion";
+import IslandHub3D from "@/components/IslandHub3D";
+import IslandHubFallback from "@/components/IslandHubFallback";
+import { invalidate } from "@react-three/fiber";
+
+interface PortalMeta {
+  key: string;
+  label: string;
+  color: string;
+  route: string;
+  top: string;
+  left: string;
+}
+
+const portals: PortalMeta[] = [
+  { key: "naturversity", label: "Naturversity", color: "#7dd3fc", route: "/zones/naturversity", top: "35%", left: "60%" },
+  { key: "music", label: "Music", color: "#a78bfa", route: "/zones/music", top: "40%", left: "30%" },
+  { key: "wellness", label: "Wellness", color: "#34d399", route: "/zones/wellness", top: "55%", left: "70%" },
+  { key: "creator", label: "Creator Lab", color: "#f472b6", route: "/zones/creator-lab", top: "58%", left: "40%" },
+];
+
+export default function WorldHub() {
+  const webgl = useWebGLSupport();
+  const reduced = useReducedMotion();
+  const [active, setActive] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.title = "Naturverse Hub (3D Beta)";
+  }, []);
+
+  const handleActive = (k: string | null) => {
+    setActive(k);
+    if (reduced) invalidate();
+  };
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-12">
+      <Link to="/zones" className="text-sm text-blue-300 hover:underline">
+        ← Back to zones
+      </Link>
+      <div className="mt-4 w-full flex flex-col items-center">
+        <div className="relative w-full max-w-[1100px]">
+          <div className="relative w-full" style={{ paddingTop: "56.25%" }}>
+            {webgl ? (
+              <IslandHub3D reduced={reduced} active={active} onActiveChange={handleActive} />
+            ) : (
+              <IslandHubFallback />
+            )}
+            {webgl && (
+              <div className="absolute inset-0 pointer-events-none">
+                {portals.map((p) => (
+                  <Link
+                    key={p.key}
+                    to={p.route}
+                    className="pointer-events-auto absolute text-xs text-white"
+                    style={{ top: p.top, left: p.left, transform: "translate(-50%, -50%)" }}
+                    onFocus={() => handleActive(p.key)}
+                    onBlur={() => handleActive(null)}
+                  >
+                    {p.label}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="mt-4 flex flex-wrap justify-center gap-4 text-xs text-white/80">
+          {portals.map((p) => (
+            <div key={p.key} className="flex items-center gap-1">
+              <span className="w-3 h-3 rounded-full" style={{ background: p.color }} />
+              <span>{p.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add `three` and `@react-three/fiber` dependencies
- create WebGL detection hook, 3D hub scene, and SVG fallback
- expose new `/hub` route with navbar link and reduce-motion support

## Testing
- `npm test`
- `npm run build` *(fails: Rollup failed to resolve import "@react-three/fiber" due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e447740483299ed557ac4551e44c