### PR TITLE
chore: revert 3D deps for now and use fallback to restore green deploy

### DIFF
--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,4 +1,0 @@
-legacy-peer-deps=true
-fund=false
-audit=false
-save-exact=true

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,16 +8,12 @@
       "name": "naturverse-web",
       "version": "1.0.0",
       "dependencies": {
-        "@babel/runtime": "^7.25.0",
-        "@react-three/drei": "9.105.6",
-        "@react-three/fiber": "8.15.22",
         "@supabase/supabase-js": "^2.5.0",
         "@tanstack/react-query": "^5",
         "hono": "^4.3.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^7.8.0",
-        "three": "0.160.0"
+        "react-router-dom": "^7.8.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.12",
@@ -2660,24 +2656,7 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/three": {
-      "version": "0.160.1",
-      "resolved": "",
-      "integrity": ""
-    },
-    "node_modules/@react-three/fiber": {
-      "version": "8.15.12",
-      "resolved": "",
-      "integrity": ""
     }
   },
-  "dependencies": {
-    "three": {
-      "version": "^0.160.1"
-    },
-    "@react-three/fiber": {
-      "version": "^8.15.12"
-    }
-  }
+  "dependencies": {}
 }

--- a/web/package.json
+++ b/web/package.json
@@ -10,16 +10,12 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@babel/runtime": "^7.25.0",
-    "@react-three/drei": "9.92.7",
-    "@react-three/fiber": "8.15.16",
     "@supabase/supabase-js": "^2.5.0",
     "@tanstack/react-query": "^5",
     "hono": "^4.3.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.8.0",
-    "three": "0.160.1"
+    "react-router-dom": "^7.8.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from "react";
+import React from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Navbar } from "@/components/Navbar";
 import ImmersiveBackground from "@/components/ImmersiveBackground";
@@ -28,8 +28,6 @@ import NotFound from "@/pages/NotFound";
 import { RequireAuth } from "@/lib/auth";
 import IslandHubFallback from "@/components/IslandHubFallback";
 
-const IslandHub3D = lazy(() => import("./components/IslandHub3D"));
-
 export default function App() {
   return (
     <BrowserRouter>
@@ -45,14 +43,7 @@ export default function App() {
           <Route path="/auto-quiz" element={<AutoQuiz />} />
           <Route path="/worlds" element={<Worlds />} />
           <Route path="/worlds/:slug" element={<World />} />
-          <Route
-            path="/hub"
-            element={
-              <Suspense fallback={<IslandHubFallback />}>
-                <IslandHub3D />
-              </Suspense>
-            }
-          />
+          <Route path="/hub" element={<IslandHubFallback />} />
           <Route
             path="/zones"
             element={

--- a/web/src/pages/world-hub.tsx
+++ b/web/src/pages/world-hub.tsx
@@ -1,10 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Link } from "react-router-dom";
-import useWebGLSupport from "@/hooks/useWebGLSupport";
-import useReducedMotion from "@/hooks/useReducedMotion";
-import IslandHub3D from "@/components/IslandHub3D";
 import IslandHubFallback from "@/components/IslandHubFallback";
-import { invalidate } from "@react-three/fiber";
 
 interface PortalMeta {
   key: string;
@@ -23,18 +19,9 @@ const portals: PortalMeta[] = [
 ];
 
 export default function WorldHub() {
-  const webgl = useWebGLSupport();
-  const reduced = useReducedMotion();
-  const [active, setActive] = useState<string | null>(null);
-
   useEffect(() => {
-    document.title = "Naturverse Hub (3D Beta)";
+    document.title = "Naturverse Hub";
   }, []);
-
-  const handleActive = (k: string | null) => {
-    setActive(k);
-    if (reduced) invalidate();
-  };
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-12">
@@ -44,27 +31,19 @@ export default function WorldHub() {
       <div className="mt-4 w-full flex flex-col items-center">
         <div className="relative w-full max-w-[1100px]">
           <div className="relative w-full" style={{ paddingTop: "56.25%" }}>
-            {webgl ? (
-              <IslandHub3D reduced={reduced} active={active} onActiveChange={handleActive} />
-            ) : (
-              <IslandHubFallback />
-            )}
-            {webgl && (
-              <div className="absolute inset-0 pointer-events-none">
-                {portals.map((p) => (
-                  <Link
-                    key={p.key}
-                    to={p.route}
-                    className="pointer-events-auto absolute text-xs text-white"
-                    style={{ top: p.top, left: p.left, transform: "translate(-50%, -50%)" }}
-                    onFocus={() => handleActive(p.key)}
-                    onBlur={() => handleActive(null)}
-                  >
-                    {p.label}
-                  </Link>
-                ))}
-              </div>
-            )}
+            <IslandHubFallback />
+            <div className="absolute inset-0 pointer-events-none">
+              {portals.map((p) => (
+                <Link
+                  key={p.key}
+                  to={p.route}
+                  className="pointer-events-auto absolute text-xs text-white"
+                  style={{ top: p.top, left: p.left, transform: "translate(-50%, -50%)" }}
+                >
+                  {p.label}
+                </Link>
+              ))}
+            </div>
           </div>
         </div>
         <div className="mt-4 flex flex-wrap justify-center gap-4 text-xs text-white/80">

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,14 +11,7 @@ export default defineConfig({
       "@assets": path.resolve(__dirname, "src/assets"),
     },
   },
-  optimizeDeps: {
-    include: ["three", "@react-three/fiber", "@react-three/drei"],
-  },
   build: {
-    rollupOptions: {
-      // In case some lib tries to import babel helpers via path
-      external: ["@babel/runtime/helpers/esm/extends"],
-    },
     // helps some “cannot resolve entry chunk” issues when code-splitting
     sourcemap: false,
   },


### PR DESCRIPTION
## Summary
- remove Three.js-related dependencies and config entries
- direct `/hub` route and world hub page to 2D fallback
- drop repo-specific npm registry configuration for Netlify compatibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ee36f96483298bab803db074a042