### PR TITLE
chore: stabilize netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,7 @@ node_bundler = "esbuild"
 
 [build.environment]
   NODE_VERSION = "20"
+  NPM_FLAGS = "--no-audit --no-fund --legacy-peer-deps"
 
 [[redirects]]
 from = "/api/*"

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,4 +1,8 @@
 registry=https://registry.npmjs.org/
-always-auth=false
+strict-ssl=true
 fund=false
 audit=false
+legacy-peer-deps=true
+fetch-retry-maxtimeout=600000
+fetch-timeout=600000
+

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,10 @@
   "name": "naturverse-web",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=20",
+    "npm": ">=9"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- lock npm to public registry and relax checks
- pin node/npm versions for Netlify
- expose node & npm engine requirements

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0fcab4c50832996e6c4db0b216f05