### PR TITLE
feat: add arcade rewards shop with coin tracking

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,6 +28,7 @@ import NotFound from './pages/NotFound';
 import EcoRunner from './pages/zones/arcade/eco-runner';
 import MemoryMatch from './pages/zones/arcade/memory-match';
 import WordBuilder from './pages/zones/arcade/word-builder';
+import ArcadeShop from './pages/zones/arcade/shop';
 import { RequireAuth, useSession } from './lib/auth';
 
 export default function App() {
@@ -129,6 +130,7 @@ export default function App() {
           <Route path="/zones/arcade/eco-runner" element={<EcoRunner />} />
           <Route path="/zones/arcade/memory-match" element={<MemoryMatch />} />
           <Route path="/zones/arcade/word-builder" element={<WordBuilder />} />
+          <Route path="/zones/arcade/shop" element={<ArcadeShop />} />
           <Route
             path="/zones/community"
             element={

--- a/web/src/lib/coins.ts
+++ b/web/src/lib/coins.ts
@@ -1,0 +1,36 @@
+// Sum coins saved by any game using keys like "nv:<game>:coins".
+// Spending is tracked separately so we never mutate game saves.
+const COIN_KEY_MATCH = /^nv:.*:coins$/;
+const SPENT_KEY = "nv:spent:coins";
+
+export function getPerGameTotal(): number {
+  let total = 0;
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i)!;
+    if (COIN_KEY_MATCH.test(k)) total += Number(localStorage.getItem(k) || 0);
+  }
+  return total;
+}
+
+export function getSpent(): number {
+  return Number(localStorage.getItem(SPENT_KEY) || 0);
+}
+
+export function getAvailableCoins(): number {
+  return Math.max(0, getPerGameTotal() - getSpent());
+}
+
+export function trySpend(cost: number): boolean {
+  const avail = getAvailableCoins();
+  if (cost > avail) return false;
+  localStorage.setItem(SPENT_KEY, String(getSpent() + cost));
+  return true;
+}
+
+// helpers to mark owned cosmetic items
+export function isOwned(id: string): boolean {
+  return localStorage.getItem(`nv:owned:${id}`) === "1";
+}
+export function setOwned(id: string, v = true) {
+  localStorage.setItem(`nv:owned:${id}`, v ? "1" : "0");
+}

--- a/web/src/pages/zones/arcade/index.tsx
+++ b/web/src/pages/zones/arcade/index.tsx
@@ -1,17 +1,27 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { getAvailableCoins } from "../../../lib/coins";
 
 export default function Arcade() {
   const bestEasy = localStorage.getItem("nv:mm:best:easy");
   const bestMed  = localStorage.getItem("nv:mm:best:medium");
   const bestHard = localStorage.getItem("nv:mm:best:hard");
-  const coins    = localStorage.getItem("nv:coins") || "0";
+  const [coins, setCoins] = useState(0);
 
   function fmt(s: string){ const n=Number(s); const m=Math.floor(n/60).toString().padStart(2,"0"); const sec=Math.floor(n%60).toString().padStart(2,"0"); return `${m}:${sec}`; }
+
+  useEffect(() => {
+    setCoins(getAvailableCoins());
+    const i = setInterval(() => setCoins(getAvailableCoins()), 800);
+    return () => clearInterval(i);
+  }, []);
 
   return (
     <div style={{ maxWidth: 860, margin: "0 auto", padding: "2rem 1rem" }}>
       <h1>Arcade</h1>
+      <p style={{margin:"6px 0 14px"}}>
+        Your coins: <strong>🪙 {coins}</strong> — <Link to="/zones/arcade/shop">open Rewards Shop</Link>
+      </p>
       <p>Quick brain-boost games. First mini‑game ships now!</p>
 
       <ul>
@@ -21,19 +31,15 @@ export default function Arcade() {
   Best: {bestEasy ? `Easy ${fmt(bestEasy)} ` : ""}
         {bestMed ? `• Medium ${fmt(bestMed)} ` : ""}
         {bestHard ? `• Hard ${fmt(bestHard)} ` : ""}
-  <br/>🪙 Coins: {coins}
   </p>
         </li>
         <li>
           <Link to="/zones/arcade/word-builder">Word Builder</Link> — make words from daily letters.
           <div style={{opacity:.9}}>
             Best score today: {localStorage.getItem("nv:wb:best:" + ["nature","ocean","forest"][Math.floor(Date.now()/86400000)%3]) || "—"}
-            &nbsp;•&nbsp; 🪙 Coins: {localStorage.getItem("nv:wb:coins") || localStorage.getItem("nv:wb:coins") || "0"}
           </div>
         </li>
-        <li>
-          <Link to="/zones/arcade/eco-runner">Eco Runner</Link> — jump to collect 🌿 & 🪙, dodge hazards.
-        </li>
+        <li><Link to="/zones/arcade/eco-runner">Eco Runner</Link> — jump, collect, dodge.</li>
       </ul>
 
       <p style={{ marginTop: "2rem" }}>

--- a/web/src/pages/zones/arcade/shop.tsx
+++ b/web/src/pages/zones/arcade/shop.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { getAvailableCoins, trySpend, isOwned, setOwned } from "../../../lib/coins";
+
+type Item = { id: string; name: string; cost: number; desc: string };
+
+const ITEMS: Item[] = [
+  { id: "theme-aurora", name: "Aurora Theme", cost: 8,  desc: "Glow trails & aurora bg" },
+  { id: "theme-jungle", name: "Jungle Theme",  cost: 6,  desc: "Leaf particles + sfx" },
+  { id: "emote-sparkle", name: "Sparkle Emote", cost: 4, desc: "Celebrate wins ✨" },
+  { id: "badge-explorer", name: "Explorer Badge", cost: 3, desc: "Profile flair 🧭" },
+];
+
+export default function ArcadeShop() {
+  const [coins, setCoins] = useState(0);
+  const [toast, setToast] = useState<string | null>(null);
+  const refresh = () => setCoins(getAvailableCoins());
+
+  useEffect(() => {
+    refresh();
+    const i = setInterval(refresh, 800); // reflect new coins after games
+    return () => clearInterval(i);
+  }, []);
+
+  function buy(it: Item) {
+    if (isOwned(it.id)) { setToast("Already owned!"); return; }
+    if (!trySpend(it.cost)) { setToast("Not enough coins yet! Play more 😄"); return; }
+    setOwned(it.id, true);
+    refresh();
+    setToast(`Purchased ${it.name}!`);
+    setTimeout(() => setToast(null), 1800);
+  }
+
+  return (
+    <div style={{maxWidth: 960, margin:"0 auto", padding:"1rem"}}>
+      <div style={{display:"flex", justifyContent:"space-between", alignItems:"center", marginBottom:8}}>
+        <h1 style={{margin:0}}>🛍️ Rewards Shop</h1>
+        <Link to="/zones/arcade">← Back to Arcade</Link>
+      </div>
+      <p style={{opacity:.9}}>Earn 🪙 by playing mini-games. Spend them on fun cosmetics.</p>
+
+      <div style={{display:"flex", gap:16, alignItems:"center", margin:"8px 0 16px"}}>
+        <div style={{fontWeight:700}}>Your Coins:</div>
+        <div style={{padding:"4px 10px", borderRadius:8, background:"#13233a"}}>🪙 {coins}</div>
+        {toast && <div style={{marginLeft:8, opacity:.9}}>{toast}</div>}
+      </div>
+
+      <div style={{display:"grid", gridTemplateColumns:"repeat(auto-fill,minmax(220px,1fr))", gap:16}}>
+        {ITEMS.map(it => {
+          const owned = isOwned(it.id);
+          return (
+            <div key={it.id} style={{background:"#0e1b2f", borderRadius:12, padding:14, border:"1px solid #1c3557"}}>
+              <div style={{display:"flex", justifyContent:"space-between", marginBottom:6}}>
+                <strong>{owned ? `✅ ${it.name}` : it.name}</strong>
+                <span>🪙 {it.cost}</span>
+              </div>
+              <div style={{opacity:.9, minHeight:36}}>{it.desc}</div>
+              <button
+                disabled={owned}
+                onClick={() => buy(it)}
+                style={{marginTop:10, padding:"6px 10px", borderRadius:8, border:"1px solid #27486f", background:"#13233a", color:"#eaf2ff", cursor: owned ? "default":"pointer"}}
+              >
+                {owned ? "Owned" : "Buy"}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- track and spend game coins via localStorage helpers
- add Rewards Shop page to buy cosmetic items
- show live coin total on Arcade hub with link to shop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a1472116188329874ca141804e1fd5