### PR TITLE
feat: add global coins header and theme system

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,6 +30,7 @@ import MemoryMatch from './pages/zones/arcade/memory-match';
 import WordBuilder from './pages/zones/arcade/word-builder';
 import ArcadeShop from './pages/zones/arcade/shop';
 import { RequireAuth, useSession } from './lib/auth';
+import TopBar from './components/TopBar';
 
 export default function App() {
   const { session } = useSession();
@@ -38,6 +39,7 @@ export default function App() {
       <ImmersiveBackground />
       <div className="min-h-screen">
         <Navbar email={session?.user.email} />
+        <TopBar />
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/login" element={<Login />} />

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+
+function getTotalCoins(): number {
+  // Sum all nv::coins keys like we did in the shop util
+  let total = 0;
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i)!;
+    if (/^nv:.*:coins$/.test(k)) total += Number(localStorage.getItem(k) || 0);
+  }
+  return total - Number(localStorage.getItem("nv:spent:coins") || 0);
+}
+
+export default function TopBar() {
+  const [coins, setCoins] = useState(getTotalCoins());
+  const loc = useLocation();
+  useEffect(() => {
+    const i = setInterval(() => setCoins(getTotalCoins()), 800);
+    return () => clearInterval(i);
+  }, []);
+  return (
+    <div
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 20,
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "10px 14px",
+        background: "rgba(3,10,20,.55)",
+        backdropFilter: "blur(8px)",
+        borderBottom: "1px solid rgba(255,255,255,.06)",
+      }}
+    >
+      <Link to="/" style={{ fontWeight: 800, letterSpacing: ".02em" }}>
+        Naturverse
+      </Link>
+      <div style={{ marginLeft: "auto" }} />
+      <Link to="/zones/arcade" style={{ opacity: 0.9 }}>
+        Arcade
+      </Link>
+      <Link to="/zones/arcade/shop" style={{ opacity: 0.9 }}>
+        Shop
+      </Link>
+      <span
+        style={{
+          padding: "4px 10px",
+          border: "1px solid rgba(255,255,255,.12)",
+          borderRadius: 999,
+        }}
+      >
+        🪙 {coins}
+      </span>
+    </div>
+  );
+}

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -1,0 +1,18 @@
+export function isOwned(id: string): boolean {
+  return localStorage.getItem(`nv:owned:${id}`) === "1";
+}
+export type ThemeId = "theme-aurora" | "theme-jungle" | "theme-none";
+export function getActiveTheme(): ThemeId {
+  if (isOwned("theme-aurora")) return "theme-aurora";
+  if (isOwned("theme-jungle")) return "theme-jungle";
+  return "theme-none";
+}
+export function applyTheme() {
+  const t = getActiveTheme();
+  document.body.setAttribute("data-theme", t);
+}
+export function onThemeChange(cb: () => void) {
+  const handler = () => cb();
+  window.addEventListener("storage", handler);
+  return () => window.removeEventListener("storage", handler);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/app.css";
+import "./styles/themes.css";
+import { applyTheme, onThemeChange } from "./lib/theme";
+
+applyTheme();
+onThemeChange(() => applyTheme());
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/web/src/pages/zones/arcade/shop.tsx
+++ b/web/src/pages/zones/arcade/shop.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { getAvailableCoins, trySpend, isOwned, setOwned } from "../../../lib/coins";
+import { applyTheme } from "../../../lib/theme";
 
 type Item = { id: string; name: string; cost: number; desc: string };
 
@@ -27,6 +28,7 @@ export default function ArcadeShop() {
     if (!trySpend(it.cost)) { setToast("Not enough coins yet! Play more 😄"); return; }
     setOwned(it.id, true);
     refresh();
+    applyTheme();
     setToast(`Purchased ${it.name}!`);
     setTimeout(() => setToast(null), 1800);
   }
@@ -58,10 +60,37 @@ export default function ArcadeShop() {
               <button
                 disabled={owned}
                 onClick={() => buy(it)}
-                style={{marginTop:10, padding:"6px 10px", borderRadius:8, border:"1px solid #27486f", background:"#13233a", color:"#eaf2ff", cursor: owned ? "default":"pointer"}}
+                style={{
+                  marginTop: 10,
+                  padding: "6px 10px",
+                  borderRadius: 8,
+                  border: "1px solid #27486f",
+                  background: "#13233a",
+                  color: "#eaf2ff",
+                  cursor: owned ? "default" : "pointer",
+                }}
               >
                 {owned ? "Owned" : "Buy"}
               </button>
+              {it.id.startsWith("theme-") && (
+                <button
+                  style={{
+                    marginLeft: 8,
+                    padding: "6px 10px",
+                    borderRadius: 8,
+                    border: "1px solid #27486f",
+                    background: "#0f1d33",
+                    color: "#eaf2ff",
+                  }}
+                  onClick={() => {
+                    localStorage.setItem("nv:owned:" + it.id, "1");
+                    applyTheme();
+                    setTimeout(() => {}, 0);
+                  }}
+                >
+                  Preview
+                </button>
+              )}
             </div>
           );
         })}

--- a/web/src/styles/themes.css
+++ b/web/src/styles/themes.css
@@ -1,0 +1,27 @@
+/* base */
+:root { --bg0:#070e1a; --bg1:#0d1626; --ink:#eaf2ff; }
+body { background: linear-gradient(180deg, var(--bg0), var(--bg1)); color: var(--ink); }
+
+/* AURORA */
+body[data-theme="theme-aurora"]::before {
+content:""; position:fixed; inset:-20% -10% auto -10%; height:60%;
+background: radial-gradient(60% 80% at 20% 30%, rgba(91,243,255,.25), transparent 60%),
+radial-gradient(50% 70% at 80% 20%, rgba(151,255,175,.18), transparent 60%),
+radial-gradient(50% 70% at 50% 80%, rgba(163,131,255,.18), transparent 60%);
+filter: blur(28px); pointer-events:none; z-index:-1; animation: auroraFloat 14s ease-in-out infinite alternate;
+}
+@keyframes auroraFloat { from { transform: translateY(0px); } to { transform: translateY(-16px); } }
+
+/* JUNGLE */
+body[data-theme="theme-jungle"]::before {
+content:""; position:fixed; inset:0; pointer-events:none; z-index:-1;
+background:
+radial-gradient(40% 60% at 15% 20%, rgba(38,121,84,.25), transparent 60%),
+radial-gradient(40% 60% at 85% 30%, rgba(66,161,110,.18), transparent 60%),
+radial-gradient(50% 50% at 60% 80%, rgba(24,72,50,.20), transparent 60%),
+linear-gradient(180deg, #04120d, #0a1a12);
+filter: blur(18px);
+}
+
+/* Optional panel polish */
+.cardish { background: rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08); border-radius:12px; }


### PR DESCRIPTION
## Summary
- add theme utilities and styles for Aurora and Jungle backgrounds
- introduce sticky TopBar with live coin count and quick links
- apply theme changes after purchases and preview themes in shop

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)

------
https://chatgpt.com/codex/tasks/task_e_68a14f1e4f508329a90abe069b4d0e47