### PR TITLE
Navatar Previews in Marketplace Catalog

### DIFF
--- a/web/src/components/ProductCard.tsx
+++ b/web/src/components/ProductCard.tsx
@@ -1,0 +1,28 @@
+import { getNavatar } from '../lib/navatar';
+
+export default function ProductCard({ product }: { product: any }) {
+  const navatar = getNavatar();
+  return (
+    <div className="product-card">
+      <div className="thumb" style={{ position: 'relative' }}>
+        <img src={product.image} alt={product.name} />
+        {navatar && (
+          <img
+            src={navatar.image}
+            alt="navatar"
+            style={{
+              position: 'absolute',
+              bottom: 0,
+              right: 0,
+              width: '35%',
+              borderRadius: '50%',
+              border: '2px solid #fff',
+            }}
+          />
+        )}
+      </div>
+      <h3>{product.name}</h3>
+      <p>{product.price} NATUR</p>
+    </div>
+  );
+}

--- a/web/src/lib/navatar.ts
+++ b/web/src/lib/navatar.ts
@@ -1,9 +1,22 @@
+export type Navatar = { id: string; image: string };
+
+export function getNavatar(): Navatar | null {
+  try {
+    const raw = localStorage.getItem('natur_navatar');
+    if (raw) return JSON.parse(raw) as Navatar;
+  } catch {
+    // ignore parse errors
+  }
+  return null;
+}
+
 export const getNavatarUrl = async (): Promise<string | null> => {
-  // 1) localStorage preview (set by Profile page when choosing file)
+  const nav = getNavatar();
+  if (nav?.image) return nav.image;
+
   const local = localStorage.getItem('navatar_preview');
   if (local) return local;
 
-  // 2) Supabase users table (optional—wrapped in try so no build issues)
   try {
     const { createClient } = await import('@supabase/supabase-js');
     const sb = createClient(

--- a/web/src/pages/marketplace/ProductDetailPage.tsx
+++ b/web/src/pages/marketplace/ProductDetailPage.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { getNavatar } from '../../lib/navatar';
+
+export default function ProductDetailPage({ product }: { product: any }) {
+  const navatar = getNavatar();
+  const [showNavatar, setShowNavatar] = useState(false);
+
+  return (
+    <div className="page">
+      <h1>{product.name}</h1>
+      <div style={{ position: 'relative', width: 300 }}>
+        <img src={product.image} alt={product.name} style={{ width: '100%' }} />
+        {navatar && showNavatar && (
+          <img
+            src={navatar.image}
+            alt="navatar"
+            style={{ position: 'absolute', bottom: 0, right: 0, width: '40%', borderRadius: '50%' }}
+          />
+        )}
+      </div>
+      <p>{product.description}</p>
+      <label>
+        <input
+          type="checkbox"
+          checked={showNavatar}
+          onChange={(e) => setShowNavatar(e.target.checked)}
+        />
+        Preview with my Navatar
+      </label>
+    </div>
+  );
+}

--- a/web/src/styles/ui.css
+++ b/web/src/styles/ui.css
@@ -36,3 +36,5 @@ a{color:inherit}
 .summary { margin-top: 16px; padding: 12px; border: 1px solid rgba(255,255,255,.1); border-radius: 8px; }
 .orders { list-style: none; padding: 0; }
 .order { display: grid; grid-template-columns: 1fr auto auto; gap: 12px; padding: 12px 0; border-bottom: 1px solid rgba(255,255,255,.08); }
+.product-card{border:1px solid rgba(255,255,255,.1);padding:12px;border-radius:8px}
+.product-card .thumb img{width:100%;border-radius:6px}


### PR DESCRIPTION
## Summary
- add helper to get stored navatar
- display user's navatar on product cards
- add product detail page with optional navatar preview

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a16d4064208329bc9768ad0bc8ccf4