### PR TITLE
feat: persist navatar through checkout and orders

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,7 @@ import Customize from './pages/marketplace/customize';
 import CartPage from './pages/marketplace/CartPage';
 import OrdersPage from './pages/marketplace/OrdersPage';
 import OrderDetailPage from './pages/marketplace/OrderDetailPage';
+import Checkout from './pages/marketplace/checkout';
 import CartProvider from './context/CartContext';
 
 export default function App() {
@@ -168,6 +169,7 @@ export default function App() {
             <Route path="/marketplace" element={<MarketplaceHome />} />
             <Route path="/marketplace/customize/:sku" element={<Customize />} />
             <Route path="/marketplace/cart" element={<CartPage />} />
+            <Route path="/marketplace/checkout" element={<Checkout />} />
             <Route path="/marketplace/orders" element={<OrdersPage />} />
             <Route path="/marketplace/orders/:id" element={<OrderDetailPage />} />
             <Route path="*" element={<NotFound />} />

--- a/web/src/pages/marketplace/CartPage.tsx
+++ b/web/src/pages/marketplace/CartPage.tsx
@@ -1,9 +1,12 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { useCart } from '../../context/CartContext';
+import { PRODUCTS } from './index';
 
 export default function CartPage() {
   const nav = useNavigate();
   const cart = useCart();
+
+  const getProductThumb = (id: string) => PRODUCTS.find((p) => p.sku === id)?.thumb || '';
   return (
     <div className="page">
       <h1>Cart</h1>
@@ -29,13 +32,28 @@ export default function CartPage() {
               {cart.items.map((i) => (
                 <tr key={i.id}>
                   <td>
-                    {i.thumb && (
+                    <div style={{ position: 'relative', display: 'inline-block', marginRight: 8 }}>
                       <img
-                        src={i.thumb}
+                        src={getProductThumb(i.id)}
                         alt=""
-                        style={{ width: 36, height: 36, marginRight: 8, borderRadius: 6 }}
+                        style={{ width: 36, height: 36, borderRadius: 6 }}
                       />
-                    )}
+                      {i.navatar?.image && (
+                        <img
+                          src={i.navatar.image}
+                          alt="navatar"
+                          style={{
+                            position: 'absolute',
+                            bottom: -4,
+                            right: -4,
+                            width: 24,
+                            height: 24,
+                            borderRadius: '50%',
+                            border: '2px solid #fff',
+                          }}
+                        />
+                      )}
+                    </div>
                     {i.name}
                   </td>
                   <td>

--- a/web/src/pages/marketplace/OrdersPage.tsx
+++ b/web/src/pages/marketplace/OrdersPage.tsx
@@ -1,26 +1,36 @@
-import { Link } from 'react-router-dom';
-import { listOrders } from '../../lib/orders';
-
 export default function OrdersPage() {
-  const orders = listOrders();
+  const orders = JSON.parse(localStorage.getItem('natur_orders') || '[]');
+  if (!orders.length) return <p>No orders yet.</p>;
+
   return (
     <div className="page">
       <h1>Your Orders</h1>
-      {orders.length === 0 && <p>No orders yet.</p>}
       <ul className="orders">
-        {orders.map((o) => (
+        {orders.map((o: any) => (
           <li key={o.id} className="order">
-            <div>
-              <b>{o.status}</b> • {new Date(o.ts).toLocaleString()}
-              <div style={{ opacity: 0.8 }}>
-                {o.items.map((i) => `${i.name}×${i.qty}`).join(', ')}
+            <div className="left">
+              {o.navatar?.image ? (
+                <img
+                  src={o.navatar.image}
+                  alt="navatar"
+                  style={{ width: 48, height: 48, borderRadius: '50%', border: '2px solid #fff' }}
+                />
+              ) : (
+                <div style={{ width: 48, height: 48, borderRadius: '50%', background: '#222' }} />
+              )}
+            </div>
+            <div className="right">
+              <div>
+                <strong>#{o.id}</strong> — {o.totalNatur} NATUR
               </div>
-            </div>
-            <div>
-              <b>{o.total.toFixed(2)} NATUR</b>
-            </div>
-            <div>
-              <Link to={`/marketplace/orders/${o.id}`}>View →</Link>
+              <small>{new Date(o.createdAt).toLocaleString()}</small>
+              <div className="items">
+                {o.items.map((it: any, i: number) => (
+                  <div key={i}>
+                    {it.qty} × {it.name}
+                  </div>
+                ))}
+              </div>
             </div>
           </li>
         ))}

--- a/web/src/pages/marketplace/checkout.tsx
+++ b/web/src/pages/marketplace/checkout.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useCart } from '../../context/CartContext';
+
+export default function Checkout() {
+  const cart = useCart();
+  const [order, setOrder] = useState<any | null>(null);
+
+  const handlePay = () => {
+    const o = cart.placeOrder(cart.total);
+    setOrder(o);
+  };
+
+  if (order) {
+    return (
+      <div className="page">
+        <div className="success">
+          <h2>Order confirmed 🎉</h2>
+          {order.navatar?.image && (
+            <div style={{ margin: '10px 0' }}>
+              <small>Navatar used:</small>
+              <br />
+              <img
+                src={order.navatar.image}
+                alt="Navatar used"
+                style={{ width: 64, height: 64, borderRadius: '50%', border: '2px solid #fff' }}
+              />
+            </div>
+          )}
+          <p>Order #{order.id}</p>
+          <p>Total: {order.totalNatur} NATUR</p>
+          <Link to="/marketplace/orders">View order history</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page">
+      <h1>Checkout</h1>
+      <p>Total: {cart.total.toFixed(2)} NATUR</p>
+      <button onClick={handlePay} disabled={cart.items.length === 0}>
+        Pay now
+      </button>
+    </div>
+  );
+}

--- a/web/src/styles/ui.css
+++ b/web/src/styles/ui.css
@@ -34,7 +34,9 @@ a{color:inherit}
 .cart { width:100%; border-collapse: collapse; }
 .cart th, .cart td { padding:10px; border-bottom: 1px solid rgba(255,255,255,.08); }
 .summary { margin-top: 16px; padding: 12px; border: 1px solid rgba(255,255,255,.1); border-radius: 8px; }
-.orders { list-style: none; padding: 0; }
-.order { display: grid; grid-template-columns: 1fr auto auto; gap: 12px; padding: 12px 0; border-bottom: 1px solid rgba(255,255,255,.08); }
+.orders { list-style:none; padding:0; }
+.order { display:flex; gap:12px; padding:12px; border:1px solid rgba(255,255,255,.08); border-radius:8px; margin-bottom:10px; }
+.cart-line { display:flex; gap:10px; align-items:center; }
+.thumb { width:72px; height:72px; object-fit:cover; border-radius:6px; }
 .product-card{border:1px solid rgba(255,255,255,.1);padding:12px;border-radius:8px}
 .product-card .thumb img{width:100%;border-radius:6px}


### PR DESCRIPTION
## Summary
- attach active Navatar to cart items and orders via CartContext
- show Navatar overlays in cart and order history
- add checkout page with confirmation view preserving Navatar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a16f657ce883299d74f6ae629edd73