### PR TITLE
feat: composite product previews in cart and orders

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -178,6 +178,7 @@ export default function App() {
             </Routes>
             {/* global styles */}
             <link rel="stylesheet" href="/src/styles/ui.css" />
+            <link rel="stylesheet" href="/src/styles/marketplace.css" />
           </div>
         </CartProvider>
       </ProfileProvider>

--- a/web/src/context/CartContext.tsx
+++ b/web/src/context/CartContext.tsx
@@ -8,6 +8,7 @@ export type CartItem = {
   qty: number;
   options?: Record<string, string>;
   thumb?: string;
+  previewUrl?: string;
   navatar?: { id: string; image: string } | null;
 };
 type Cart = {
@@ -51,7 +52,16 @@ export default function CartProvider({ children }: { children: React.ReactNode }
             (x) => x.id === item.id && JSON.stringify(x.options || {}) === JSON.stringify(item.options || {})
           );
           return i
-            ? prev.map((x) => (x === i ? { ...x, qty: x.qty + item.qty, navatar: item.navatar } : x))
+            ? prev.map((x) =>
+                x === i
+                  ? {
+                      ...x,
+                      qty: x.qty + item.qty,
+                      navatar: item.navatar,
+                      previewUrl: item.previewUrl,
+                    }
+                  : x
+              )
             : [...prev, item];
         }),
       remove: (id) => setItems((prev) => prev.filter((x) => x.id !== id)),

--- a/web/src/lib/composite.ts
+++ b/web/src/lib/composite.ts
@@ -1,0 +1,50 @@
+export type ComposeBox = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+};
+
+export async function composePreview({
+  baseUrl,
+  avatarUrl,
+  box,
+}: {
+  baseUrl: string;
+  avatarUrl: string;
+  box: ComposeBox;
+}): Promise<string> {
+  try {
+    const baseImg = await loadImage(baseUrl);
+    const blob = await fetch(avatarUrl, { mode: 'cors' }).then((r) => r.blob());
+    const localUrl = URL.createObjectURL(blob);
+    const avatarImg = await loadImage(localUrl);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = baseImg.width;
+    canvas.height = baseImg.height;
+    const ctx = canvas.getContext('2d')!;
+    ctx.drawImage(baseImg, 0, 0);
+    ctx.drawImage(
+      avatarImg,
+      box.left * canvas.width,
+      box.top * canvas.height,
+      box.width * canvas.width,
+      box.height * canvas.height
+    );
+    URL.revokeObjectURL(localUrl);
+    return canvas.toDataURL('image/png');
+  } catch {
+    return baseUrl;
+  }
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.crossOrigin = 'anonymous';
+    img.src = src;
+  });
+}

--- a/web/src/pages/marketplace/CartPage.tsx
+++ b/web/src/pages/marketplace/CartPage.tsx
@@ -29,27 +29,12 @@ export default function CartPage() {
               {cart.items.map((i) => (
                 <tr key={i.id}>
                   <td>
-                    <div style={{ position: 'relative', display: 'inline-block', marginRight: 8 }}>
+                    <div style={{ display: 'inline-block', marginRight: 8 }}>
                       <img
-                        src={i.thumb}
+                        src={i.previewUrl || i.thumb}
                         alt=""
-                        style={{ width: 36, height: 36, borderRadius: 6 }}
+                        className="preview-thumb"
                       />
-                      {i.navatar?.image && (
-                        <img
-                          src={i.navatar.image}
-                          alt="navatar"
-                          style={{
-                            position: 'absolute',
-                            bottom: -4,
-                            right: -4,
-                            width: 24,
-                            height: 24,
-                            borderRadius: '50%',
-                            border: '2px solid #fff',
-                          }}
-                        />
-                      )}
                     </div>
                     {i.name}
                     {i.options && (

--- a/web/src/pages/marketplace/OrderDetailPage.tsx
+++ b/web/src/pages/marketplace/OrderDetailPage.tsx
@@ -36,15 +36,22 @@ export default function OrderDetailPage() {
       <h3 style={{ marginTop: 16 }}>Items</h3>
       <ul>
         {o.items.map((i) => (
-          <li key={i.id}>
-            {i.name} × {i.qty} — {(i.price * i.qty).toFixed(2)} NATUR
-            {i.options && (
-              <small style={{ marginLeft: 8, opacity: 0.8 }}>
-                {Object.entries(i.options)
-                  .map(([k, v]) => `${k}: ${v}`)
-                  .join(", ")}
-              </small>
-            )}
+          <li key={i.id} className="cart-line">
+            <img
+              src={i.previewUrl || i.thumb}
+              alt=""
+              className="preview-thumb"
+            />
+            <div>
+              {i.name} × {i.qty} — {(i.price * i.qty).toFixed(2)} NATUR
+              {i.options && (
+                <small style={{ marginLeft: 8, opacity: 0.8 }}>
+                  {Object.entries(i.options)
+                    .map(([k, v]) => `${k}: ${v}`)
+                    .join(", ")}
+                </small>
+              )}
+            </div>
           </li>
         ))}
       </ul>

--- a/web/src/pages/marketplace/OrdersPage.tsx
+++ b/web/src/pages/marketplace/OrdersPage.tsx
@@ -26,15 +26,22 @@ export default function OrdersPage() {
               <small>{new Date(o.createdAt).toLocaleString()}</small>
               <div className="items">
                 {o.items.map((it: any, i: number) => (
-                  <div key={i}>
-                    {it.qty} × {it.name}
-                    {it.options && (
-                      <small style={{ marginLeft: 8, opacity: 0.8 }}>
-                        {Object.entries(it.options)
-                          .map(([k, v]) => `${k}: ${v}`)
-                          .join(", ")}
-                      </small>
-                    )}
+                  <div key={i} className="cart-line">
+                    <img
+                      src={it.previewUrl || it.thumb}
+                      alt=""
+                      className="preview-thumb"
+                    />
+                    <div>
+                      {it.qty} × {it.name}
+                      {it.options && (
+                        <small style={{ marginLeft: 8, opacity: 0.8 }}>
+                          {Object.entries(it.options)
+                            .map(([k, v]) => `${k}: ${v}`)
+                            .join(", ")}
+                        </small>
+                      )}
+                    </div>
                   </div>
                 ))}
               </div>

--- a/web/src/pages/marketplace/ProductPage.tsx
+++ b/web/src/pages/marketplace/ProductPage.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from "react-router-dom";
 import { getProductBySlug } from "../../lib/products";
 import { useCart } from "../../context/CartContext";
 import { useProfile } from "../../context/ProfileContext";
+import { composePreview } from "../../lib/composite";
 
 export default function ProductPage() {
   const { slug } = useParams();
@@ -20,7 +21,20 @@ export default function ProductPage() {
   const [opts, setOpts] = React.useState<Record<string, string>>(defaults);
   const set = (k: string, v: string) => setOpts((prev) => ({ ...prev, [k]: v }));
 
-  const handleAdd = () => {
+  const handleAdd = async () => {
+    const box = { top: 0.2, left: 0.2, width: 0.6, height: 0.6 };
+    let previewUrl = product.thumb;
+    if (profile?.avatarUrl) {
+      try {
+        previewUrl = await composePreview({
+          baseUrl: product.thumb,
+          avatarUrl: profile.avatarUrl,
+          box,
+        });
+      } catch {
+        /* ignore */
+      }
+    }
     add({
       id: product.id,
       name: product.name,
@@ -28,6 +42,7 @@ export default function ProductPage() {
       qty: 1,
       options: opts,
       thumb: product.thumb,
+      previewUrl,
     });
     alert("Added to cart");
   };

--- a/web/src/pages/marketplace/checkout.tsx
+++ b/web/src/pages/marketplace/checkout.tsx
@@ -40,15 +40,22 @@ export default function Checkout() {
       <h1>Checkout</h1>
       <ul>
         {cart.items.map((line, i) => (
-          <li key={i}>
-            {line.qty} × {line.name} — {line.price.toFixed(2)} NATUR
-            {line.options && (
-              <small style={{ marginLeft: 8, opacity: 0.8 }}>
-                {Object.entries(line.options)
-                  .map(([k, v]) => `${k}: ${v}`)
-                  .join(", ")}
-              </small>
-            )}
+          <li key={i} className="cart-line">
+            <img
+              src={line.previewUrl || line.thumb}
+              alt=""
+              className="preview-thumb"
+            />
+            <div>
+              {line.qty} × {line.name} — {line.price.toFixed(2)} NATUR
+              {line.options && (
+                <small style={{ marginLeft: 8, opacity: 0.8 }}>
+                  {Object.entries(line.options)
+                    .map(([k, v]) => `${k}: ${v}`)
+                    .join(", ")}
+                </small>
+              )}
+            </div>
           </li>
         ))}
       </ul>

--- a/web/src/styles/marketplace.css
+++ b/web/src/styles/marketplace.css
@@ -1,0 +1,6 @@
+.preview-thumb {
+  width: 96px;
+  height: 96px;
+  object-fit: cover;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- composite Navatar and product art into a single preview via canvas
- store preview images on cart items and persist them into orders
- show generated previews throughout cart, checkout, and order history

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)

------
https://chatgpt.com/codex/tasks/task_e_68a1780d22bc8329b455f1181313ddcc