### PR TITLE
Fix broken @/context/CartContext imports (use relative paths)

### DIFF
--- a/web/src/components/CartBadge.tsx
+++ b/web/src/components/CartBadge.tsx
@@ -3,7 +3,7 @@ import { useCart } from '../context/CartContext';
 
 export default function CartBadge() {
   const { items } = useCart();
-  const count = items.reduce((n, i) => n + i.quantity, 0);
+  const count = items.reduce((n, i) => n + i.qty, 0);
   return (
     <Link to="/marketplace/checkout" style={{ position: 'relative' }}>
       🛒

--- a/web/src/lib/orders.ts
+++ b/web/src/lib/orders.ts
@@ -2,7 +2,7 @@ export type NaturOrder = {
   id: string;
   ts: number;
   address?: string;
-  items: { id: string; name: string; qty: number; price: number }[];
+  items: { id: string; name: string; qty: number; priceNatur: number }[];
   subtotal: number;
   fee: number;
   total: number;

--- a/web/src/pages/marketplace/CheckoutPage.tsx
+++ b/web/src/pages/marketplace/CheckoutPage.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { useCart } from "@/context/CartContext";
-import { useNavigate } from "react-router-dom";
+import React, { useEffect, useMemo, useState } from 'react';
+import { useCart } from '../../context/CartContext';
+import { useNavigate } from 'react-router-dom';
 import {
   connectWallet,
   ensureCorrectChain,
@@ -9,9 +9,9 @@ import {
   getNaturMeta,
   getNativeBalance,
   transferNatur,
-} from "@/lib/wallet";
-import FaucetHelp from "@/components/FaucetHelp";
-import { formatToken, naturUsdApprox } from "@/lib/pricing";
+} from '../../lib/wallet';
+import FaucetHelp from '../../components/FaucetHelp';
+import { formatToken, naturUsdApprox } from '../../lib/pricing';
 
 const EXPLORER = import.meta.env.VITE_BLOCK_EXPLORER as string | undefined;
 const MERCHANT = import.meta.env.VITE_MERCHANT_ADDRESS as string;
@@ -19,7 +19,7 @@ const NATUR_USD_RATE = import.meta.env.VITE_NATUR_USD_RATE as string | undefined
 
 const CheckoutPage: React.FC = () => {
   const nav = useNavigate();
-  const { items, subtotal, clearCart } = useCart();
+  const { items, totalNatur: cartTotal, clear } = useCart();
 
   const [address, setAddress] = useState<string | null>(null);
   const [chainOk, setChainOk] = useState(false);
@@ -32,8 +32,8 @@ const CheckoutPage: React.FC = () => {
   const [showFaucet, setShowFaucet] = useState(false);
 
   const totalNatur = useMemo(
-    () => Number((Math.round(subtotal * 100) / 100).toFixed(2)),
-    [subtotal]
+    () => Number((Math.round(cartTotal * 100) / 100).toFixed(2)),
+    [cartTotal]
   );
   const totalUsd = naturUsdApprox(totalNatur, NATUR_USD_RATE);
 
@@ -130,13 +130,13 @@ const CheckoutPage: React.FC = () => {
         items: items.map((i) => ({
           id: i.id,
           name: i.name,
-          qty: i.quantity,
-          price: i.price,
+          qty: i.qty,
+          priceNatur: i.priceNatur,
         })),
-        subtotal: subtotal,
+        subtotal: cartTotal,
         fee: 0,
         total: need,
-        status: "Paid" as const,
+        status: 'Paid' as const,
         txHash: tx.hash,
       };
       try {
@@ -144,7 +144,7 @@ const CheckoutPage: React.FC = () => {
         localStorage.setItem("natur_orders", JSON.stringify([order, ...existing]));
       } catch {}
 
-      clearCart();
+      clear();
       nav(`/marketplace/orders/${id}`);
       if (EXPLORER) window.open(`${EXPLORER}/tx/${tx.hash}`, "_blank");
     } catch (e: any) {
@@ -167,9 +167,9 @@ const CheckoutPage: React.FC = () => {
             {items.map((i) => (
               <li key={i.id} className="flex justify-between border-b py-2">
                 <span>
-                  {i.name} × {i.quantity}
+                  {i.name} × {i.qty}
                 </span>
-                <span>{(i.price * i.quantity).toFixed(2)} {naturSymbol}</span>
+                <span>{(i.priceNatur * i.qty).toFixed(2)} {naturSymbol}</span>
               </li>
             ))}
           </ul>

--- a/web/src/pages/marketplace/MarketplacePage.tsx
+++ b/web/src/pages/marketplace/MarketplacePage.tsx
@@ -10,7 +10,7 @@ const mockProducts = [
 ];
 
 const MarketplacePage: React.FC = () => {
-  const { addItem } = useCart();
+  const { add } = useCart();
 
   return (
     <div className="p-8">
@@ -22,7 +22,7 @@ const MarketplacePage: React.FC = () => {
             <h2 className="font-semibold">{p.name}</h2>
             <p>{p.price} NATUR</p>
             <button
-              onClick={() => addItem(p)}
+              onClick={() => add({ id: p.id, name: p.name, priceNatur: p.price, qty: 1, imageUrl: p.image })}
               className="mt-2 bg-green-600 text-white px-3 py-1 rounded"
             >
               Add to Cart


### PR DESCRIPTION
## Summary
- refactor cart context to use local storage and expose add/remove/clear with totalNatur
- switch marketplace components to new cart API and relative imports
- replace legacy alias imports in checkout page

## Testing
- `npm run lint`
- `npm install` *(fails: 403 Forbidden to registry)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a189c18a748329b149210cecd9c46a