### PR TITLE
Marketplace upgrade: product detail + live Navatar preview, add-to-cart from item page (no new deps)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,6 +35,7 @@ import MarketplacePage from './pages/marketplace/MarketplacePage';
 import CartPage from './pages/marketplace/cart';
 import CheckoutPage from './pages/marketplace/checkout';
 import OrdersPage from './pages/marketplace/orders';
+import ItemPage from './pages/marketplace/item';
 import { CartProvider } from './context/CartContext';
 import ProfileProvider from './context/ProfileContext';
 
@@ -168,6 +169,7 @@ export default function App() {
             />
             <Route path="/marketplace" element={<MarketplacePage />} />
             <Route path="/marketplace/cart" element={<CartPage />} />
+            <Route path="/marketplace/item" element={<ItemPage />} />
             <Route path="/marketplace/checkout" element={<CheckoutPage />} />
             <Route path="/marketplace/orders" element={<OrdersPage />} />
             <Route path="*" element={<NotFound />} />

--- a/web/src/context/CartContext.tsx
+++ b/web/src/context/CartContext.tsx
@@ -7,6 +7,7 @@ export type CartItem = {
   qty: number;
   options?: Record<string, string>;
   imageUrl?: string;
+  meta?: Record<string, unknown>;
 };
 
 type CartState = {

--- a/web/src/lib/navatar.ts
+++ b/web/src/lib/navatar.ts
@@ -35,3 +35,12 @@ export const getNavatarUrl = async (): Promise<string | null> => {
 
   return null;
 };
+
+// Tries localStorage first; can be expanded to fetch from Supabase later.
+export function getNavatarSrc(): string | null {
+  try {
+    const fromLocal = localStorage.getItem('navatar_url');
+    if (fromLocal) return fromLocal;
+  } catch {}
+  return null;
+}

--- a/web/src/lib/products.ts
+++ b/web/src/lib/products.ts
@@ -1,58 +1,48 @@
 export type Product = {
   id: string;
-  slug: string;
-  family: "printable" | "merch";
   name: string;
-  priceNatur: number; // base
-  thumb: string;
-  variants?: {
-    // key -> allowed values (string arrays)
-    size?: string[];
-    color?: string[];
-    pack?: string[];
+  baseNatur: number; // price per unit in NATUR
+  img: string; // base product image (used as preview background)
+  options: {
+    sizes: { key: string; label: string; multiplier: number }[];
+    materials?: { key: string; label: string; multiplier: number }[];
   };
 };
 
 export const PRODUCTS: Product[] = [
   {
-    id: "poster-rainforest",
-    slug: "poster-rainforest",
-    family: "printable",
-    name: "Rainforest Poster",
-    priceNatur: 120,
-    thumb: "/assets/market/poster-rainforest.jpg",
-    variants: { size: ["A4", "A3"] }
+    id: 'plush-classic',
+    name: 'Turian Plush',
+    baseNatur: 50,
+    img: '/assets/market/plush.png',
+    options: {
+      sizes: [
+        { key: 's', label: 'Small (8\")', multiplier: 1 },
+        { key: 'm', label: 'Medium (12\")', multiplier: 1.5 },
+        { key: 'l', label: 'Large (16\")', multiplier: 2 },
+      ],
+      materials: [
+        { key: 'std', label: 'Standard', multiplier: 1 },
+        { key: 'xl', label: 'Extra-soft', multiplier: 1.2 },
+      ],
+    },
   },
   {
-    id: "sticker-pack",
-    slug: "sticker-pack",
-    family: "printable",
-    name: "Navatar Stickers",
-    priceNatur: 60,
-    thumb: "/assets/market/sticker-pack.jpg",
-    variants: { pack: ["10", "25", "50"] }
+    id: 'tee-kids',
+    name: 'Kids Tee',
+    baseNatur: 25,
+    img: '/assets/market/tee.png',
+    options: {
+      sizes: [
+        { key: 's', label: 'S', multiplier: 1 },
+        { key: 'm', label: 'M', multiplier: 1.05 },
+        { key: 'l', label: 'L', multiplier: 1.1 },
+      ],
+    },
   },
-  {
-    id: "tee-classic",
-    slug: "tee-classic",
-    family: "merch",
-    name: "Classic Tee",
-    priceNatur: 350,
-    thumb: "/assets/market/tee-classic.jpg",
-    variants: { size: ["XS","S","M","L","XL"], color: ["Black","White","Navy"] }
-  },
-  {
-    id: "sweatshirt-cozy",
-    slug: "sweatshirt-cozy",
-    family: "merch",
-    name: "Cozy Sweatshirt",
-    priceNatur: 540,
-    thumb: "/assets/market/sweatshirt-cozy.jpg",
-    variants: { size: ["XS","S","M","L","XL"], color: ["Black","White","Navy"] }
-  }
 ];
 
-export function getProductBySlug(slug: string) {
-  return PRODUCTS.find(p => p.slug === slug) || null;
+export function getProduct(id: string) {
+  return PRODUCTS.find(p => p.id === id);
 }
 

--- a/web/src/pages/marketplace/MarketplacePage.tsx
+++ b/web/src/pages/marketplace/MarketplacePage.tsx
@@ -1,32 +1,20 @@
-import React from "react";
-import { useCart } from "../../context/CartContext";
-import { Link } from "react-router-dom";
-
-const mockProducts = [
-  { id: "1", name: "Navatar Plushie", price: 25, image: "/plushie.png" },
-  { id: "2", name: "Turian Hoodie", price: 50, image: "/hoodie.png" },
-  { id: "3", name: "Natur Token Mug", price: 15, image: "/mug.png" },
-  { id: "4", name: "Wellness Blanket", price: 40, image: "/blanket.png" },
-];
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { PRODUCTS } from '../../lib/products';
 
 const MarketplacePage: React.FC = () => {
-  const { add } = useCart();
-
   return (
     <div className="p-8">
       <h1 className="text-3xl font-bold mb-6">Marketplace</h1>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-        {mockProducts.map((p) => (
+        {PRODUCTS.map(p => (
           <div key={p.id} className="border rounded-lg p-4 flex flex-col items-center">
-            <img src={p.image} alt={p.name} className="w-32 h-32 object-contain mb-4" />
+            <img src={p.img} alt={p.name} className="w-32 h-32 object-contain mb-4" />
             <h2 className="font-semibold">{p.name}</h2>
-            <p>{p.price} NATUR</p>
-            <button
-              onClick={() => add({ id: p.id, name: p.name, priceNatur: p.price, qty: 1, imageUrl: p.image })}
-              className="mt-2 bg-green-600 text-white px-3 py-1 rounded"
-            >
-              Add to Cart
-            </button>
+            <p>{p.baseNatur} NATUR</p>
+            <a href={`/marketplace/item?id=${p.id}`} className="mt-2 bg-green-600 text-white px-3 py-1 rounded">
+              Customize
+            </a>
           </div>
         ))}
       </div>

--- a/web/src/pages/marketplace/item.tsx
+++ b/web/src/pages/marketplace/item.tsx
@@ -1,0 +1,113 @@
+import React, { useMemo, useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { getProduct, Product } from '../../lib/products';
+import { getNavatarSrc } from '../../lib/navatar';
+import { useCart } from '../../context/CartContext';
+
+type Sel = { size: string; material?: string; qty: number };
+
+function priceNatur(p: Product, sel: Sel) {
+  const sizeMul = p.options.sizes.find(s => s.key === sel.size)?.multiplier ?? 1;
+  const matMul  = p.options.materials?.find(m => m.key === sel.material)?.multiplier ?? 1;
+  return p.baseNatur * sizeMul * matMul * sel.qty;
+}
+
+export default function ItemPage() {
+  const [sp] = useSearchParams();            // ?id=plush-classic
+  const nav = useNavigate();
+  const id  = sp.get('id') || '';
+  const product = getProduct(id);
+
+  const { add } = useCart();
+  const [sel, setSel] = useState<Sel>({ size: product?.options.sizes[0]?.key || 's', material: product?.options.materials?.[0]?.key, qty: 1 });
+
+  const total = useMemo(() => product ? priceNatur(product, sel) : 0, [product, sel]);
+  const navatar = getNavatarSrc();
+
+  if (!product) {
+    return (
+      <section>
+        <h1>Product not found</h1>
+        <a href="/marketplace">Back to Marketplace</a>
+      </section>
+    );
+  }
+
+  const addToCart = () => {
+    const lineId = `${product.id}-${sel.size}-${sel.material || 'na'}`;
+    add({
+      id: lineId,
+      name: `${product.name} • ${sel.size}${sel.material ? ' • ' + sel.material : ''}`,
+      qty: sel.qty,
+      priceNatur: priceNatur(product, { ...sel, qty: 1 }), // unit price
+      meta: { productId: product.id, size: sel.size, material: sel.material }
+    });
+    nav('/marketplace/cart');
+  };
+
+  return (
+    <section>
+      <a href="/marketplace">← Back to Marketplace</a>
+      <div style={{display:'grid', gridTemplateColumns:'minmax(280px,1fr) 1fr', gap:'1.5rem', alignItems:'start', marginTop:'1rem'}}>
+        <div>
+          <div className="preview">
+            {/* product base image */}
+            {product.img ? <img src={product.img} alt="" className="base" /> : <div className="base placeholder" />}
+            {/* navatar overlay */}
+            {navatar ? <img src={navatar} alt="Navatar" className="overlay" /> : <div className="overlay placeholder">Add your Navatar to Profile</div>}
+          </div>
+          <small style={{opacity:.8}}>Preview is illustrative; final production rendering may vary.</small>
+        </div>
+
+        <div>
+          <h1>{product.name}</h1>
+          <p><strong>Price:</strong> {total.toFixed(2)} NATUR</p>
+
+          <div style={{marginTop:'1rem'}}>
+            <label>Size:&nbsp;</label>
+            <select
+              value={sel.size}
+              onChange={e => setSel(s => ({ ...s, size: e.target.value }))}
+            >
+              {product.options.sizes.map(s => (
+                <option key={s.key} value={s.key}>{s.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {product.options.materials?.length ? (
+            <div style={{marginTop:'0.75rem'}}>
+              <label>Material:&nbsp;</label>
+              <select
+                value={sel.material}
+                onChange={e => setSel(s => ({ ...s, material: e.target.value }))}
+              >
+                {product.options.materials.map(m => (
+                  <option key={m.key} value={m.key}>{m.label}</option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          <div style={{marginTop:'0.75rem'}}>
+            <label>Quantity:&nbsp;</label>
+            <button onClick={() => setSel(s => ({ ...s, qty: Math.max(1, s.qty-1) }))}>–</button>
+            <span style={{padding:'0 .5rem'}}>{sel.qty}</span>
+            <button onClick={() => setSel(s => ({ ...s, qty: s.qty+1 }))}>+</button>
+          </div>
+
+          <div style={{marginTop:'1rem'}}>
+            <button onClick={addToCart}>Add to cart</button>
+          </div>
+
+          {!navatar && (
+            <p style={{marginTop:'0.75rem', opacity:.9}}>
+              Tip: set your Navatar on the <a href="/profile">Profile</a> page to see it in the preview.
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/web/src/styles/marketplace.css
+++ b/web/src/styles/marketplace.css
@@ -14,3 +14,20 @@
   max-width: 95%;
   padding: 16px;
 }
+
+.preview {
+  position: relative; width: 100%; max-width: 520px; aspect-ratio: 1/1; border-radius: 16px;
+  background: radial-gradient(120% 120% at 0% 0%, rgba(255,255,255,.06), rgba(0,0,0,.2));
+  overflow: hidden; box-shadow: 0 10px 30px rgba(0,0,0,.25);
+}
+.preview .base { width:100%; height:100%; object-fit: cover; display:block; filter: saturate(1.05) contrast(1.05); }
+.preview .base.placeholder { background:#1b2440; }
+.preview .overlay {
+  position:absolute; inset:auto 10% 8% 10%; object-fit: contain; opacity:.95;
+  filter: drop-shadow(0 4px 12px rgba(0,0,0,.35));
+}
+.preview .overlay.placeholder {
+  display:flex; align-items:center; justify-content:center;
+  position:absolute; inset:10% 10% 8% 10%; color:#cbd5ff; background:rgba(255,255,255,.04);
+  border:1px dashed rgba(203,213,255,.25); border-radius:12px; font-size:.9rem; text-align:center; padding:.5rem;
+}


### PR DESCRIPTION
## Summary
- replace product catalog with light data and helper lookup
- add local-storage Navatar helper and item page with live preview and cart integration
- wire up marketplace routes and preview styles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a18fe9bd6083299b03a5249855234f