### PR TITLE
Cart → Review step (pre-checkout) + price utils + navbar links (no new deps)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,7 @@ import CartPage from './pages/marketplace/cart';
 import CheckoutPage from './pages/marketplace/checkout';
 import OrdersPage from './pages/marketplace/orders';
 import ItemPage from './pages/marketplace/item';
+import ReviewPage from './pages/marketplace/review';
 import { CartProvider } from './context/CartContext';
 import ProfileProvider from './context/ProfileContext';
 
@@ -169,6 +170,7 @@ export default function App() {
             />
             <Route path="/marketplace" element={<MarketplacePage />} />
             <Route path="/marketplace/cart" element={<CartPage />} />
+            <Route path="/marketplace/review" element={<ReviewPage />} />
             <Route path="/marketplace/item" element={<ItemPage />} />
             <Route path="/marketplace/checkout" element={<CheckoutPage />} />
             <Route path="/marketplace/orders" element={<OrdersPage />} />

--- a/web/src/components/CartLine.tsx
+++ b/web/src/components/CartLine.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fmtNatur } from '../lib/money';
+
+export type Line = {
+  id: string;
+  name: string;
+  qty: number;
+  priceNatur: number; // unit price
+  meta?: Record<string, any>;
+};
+
+type Props = {
+  line: Line;
+  onInc?: () => void;
+  onDec?: () => void;
+  onRemove?: () => void;
+};
+
+export default function CartLine({ line, onInc, onDec, onRemove }: Props) {
+  const subtotal = line.priceNatur * line.qty;
+  return (
+    <div style={{
+      display:'grid', gridTemplateColumns:'1fr auto auto', gap:'0.75rem',
+      padding:'0.75rem 1rem', background:'rgba(255,255,255,.04)', borderRadius:12
+    }}>
+      <div>
+        <div style={{fontWeight:600}}>{line.name}</div>
+        <div style={{opacity:.8, fontSize:'.9rem'}}>
+          Unit: {fmtNatur(line.priceNatur)} • Subtotal: {fmtNatur(subtotal)}
+        </div>
+      </div>
+      <div style={{display:'flex', alignItems:'center', gap:'.5rem'}}>
+        <button onClick={onDec} aria-label="decrease">–</button>
+        <span>{line.qty}</span>
+        <button onClick={onInc} aria-label="increase">+</button>
+      </div>
+      <div style={{display:'flex', alignItems:'center', gap:'.5rem', justifyContent:'flex-end'}}>
+        <button onClick={onRemove}>Remove</button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -11,23 +11,24 @@ export default function Navbar({ email }: { email?: string | null }) {
         <NavLink to="/" className="brand" end>
           The Naturverse
         </NavLink>
-        <NavLink to="/worlds">Worlds</NavLink>
-        <NavLink to="/zones">Zones</NavLink>
-        <NavLink to="/marketplace">Marketplace</NavLink>
-        <NavLink to="/marketplace/cart" className="cart-link">
-          Cart{count > 0 ? <span className="cart-badge">{count}</span> : null}
-        </NavLink>
-        <NavLink to="/marketplace/orders">Orders</NavLink>
-        <div className="nv-spacer" />
-        {email ? (
-          <>
-            <NavLink to="/app">App</NavLink>
-            <NavLink to="/profile">Profile</NavLink>
-            <a href="/.netlify/functions/signout">Sign out</a>
-          </>
-        ) : (
-          <NavLink to="/login">Sign in</NavLink>
-        )}
+          <NavLink to="/worlds">Worlds</NavLink>
+          <NavLink to="/zones">Zones</NavLink>
+          <div className="nv-spacer" />
+          <a href="/marketplace">Marketplace</a>
+          <a href="/marketplace/cart" className="cart-link">
+            Cart{count > 0 ? <span className="cart-badge">{count}</span> : null}
+          </a>
+          <a href="/marketplace/review">Review</a>
+          <a href="/marketplace/orders">Orders</a>
+          {email ? (
+            <>
+              <NavLink to="/app">App</NavLink>
+              <NavLink to="/profile">Profile</NavLink>
+              <a href="/.netlify/functions/signout">Sign out</a>
+            </>
+          ) : (
+            <NavLink to="/login">Sign in</NavLink>
+          )}
       </nav>
     </div>
   );

--- a/web/src/context/CartContext.tsx
+++ b/web/src/context/CartContext.tsx
@@ -10,13 +10,15 @@ export type CartItem = {
   meta?: Record<string, unknown>;
 };
 
-type CartState = {
-  items: CartItem[];
-  add(item: CartItem): void;
-  remove(id: string): void;
-  clear(): void;
-  totalNatur: number;
-};
+  type CartState = {
+    items: CartItem[];
+    add(item: CartItem): void;
+    remove(id: string): void;
+    clear(): void;
+    inc(id: string): void;
+    dec(id: string): void;
+    totalNatur: number;
+  };
 
 const CartContext = createContext<CartState | undefined>(undefined);
 
@@ -52,15 +54,31 @@ export const CartProvider: React.FC<{ children: React.ReactNode }> = ({ children
     persist(next);
   };
 
-  const remove = (id: string) => persist(prev => prev.filter(i => i.id !== id));
-  const clear = () => persist([]);
+    const remove = (id: string) => persist(prev => prev.filter(i => i.id !== id));
+    const clear = () => persist([]);
 
-  const totalNatur = useMemo(
-    () => items.reduce((sum, i) => sum + i.priceNatur * i.qty, 0),
-    [items]
-  );
+    const inc = (id: string) => {
+      const line = items.find(i => i.id === id);
+      if (!line) return;
+      add({ ...line, qty: 1 });
+    };
 
-  const value = useMemo(() => ({ items, add, remove, clear, totalNatur }), [items, totalNatur]);
+    const dec = (id: string) => {
+      const line = items.find(i => i.id === id);
+      if (!line) return;
+      if (line.qty <= 1) remove(id);
+      else add({ ...line, qty: -1 });
+    };
+
+    const totalNatur = useMemo(
+      () => items.reduce((sum, i) => sum + i.priceNatur * i.qty, 0),
+      [items]
+    );
+
+    const value = useMemo(
+      () => ({ items, add, remove, clear, inc, dec, totalNatur }),
+      [items, totalNatur]
+    );
 
   return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
 };

--- a/web/src/lib/money.ts
+++ b/web/src/lib/money.ts
@@ -1,0 +1,9 @@
+export function natur(n: number) {
+  // Ensure non-negative, clamp tiny floats, 2 dp display
+  const v = Math.max(0, Number.isFinite(n) ? n : 0);
+  return Number(v.toFixed(2));
+}
+
+export function fmtNatur(n: number) {
+  return `${natur(n).toFixed(2)} NATUR`;
+}

--- a/web/src/pages/marketplace/cart.tsx
+++ b/web/src/pages/marketplace/cart.tsx
@@ -1,21 +1,12 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import CartLine from '../../components/CartLine';
+import { fmtNatur } from '../../lib/money';
 import { useCart } from '../../context/CartContext';
 
 export default function CartPage() {
-  const { items, remove, add, clear, totalNatur } = useCart();
-
-  const dec = (id: string) => {
-    const line = items.find(i => i.id === id);
-    if (!line) return;
-    if (line.qty <= 1) remove(id);
-    else add({ ...line, qty: -1 }); // add negative qty handled in CartProvider
-  };
-
-  const inc = (id: string) => {
-    const line = items.find(i => i.id === id);
-    if (!line) return;
-    add({ ...line, qty: 1 });
-  };
+  const navigate = useNavigate();
+  const { items, inc, dec, remove, clear, totalNatur } = useCart();
 
   if (!items.length) {
     return (
@@ -30,31 +21,23 @@ export default function CartPage() {
   return (
     <section>
       <h1>Your cart</h1>
-      <table>
-        <thead>
-          <tr><th>Item</th><th>Qty</th><th>Price (NATUR)</th><th></th></tr>
-        </thead>
-        <tbody>
-          {items.map(i => (
-            <tr key={i.id}>
-              <td>{i.name}</td>
-              <td>
-                <button onClick={() => dec(i.id)} aria-label="decrease">–</button>
-                <span style={{padding:'0 .5rem'}}>{i.qty}</span>
-                <button onClick={() => inc(i.id)} aria-label="increase">+</button>
-              </td>
-              <td>{(i.priceNatur * i.qty).toFixed(2)}</td>
-              <td><button onClick={() => remove(i.id)}>Remove</button></td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div style={{display:'grid', gap:'.75rem', margin:'1rem 0'}}>
+        {items.map(line => (
+          <CartLine
+            key={line.id}
+            line={line}
+            onInc={() => inc(line.id)}
+            onDec={() => dec(line.id)}
+            onRemove={() => remove(line.id)}
+          />
+        ))}
+      </div>
 
-      <p style={{marginTop:'1rem'}}><strong>Total:</strong> {totalNatur.toFixed(2)} NATUR</p>
+      <p style={{marginTop:'1rem'}}><strong>Total:</strong> {fmtNatur(totalNatur)}</p>
 
-      <div style={{marginTop:'1rem'}}>
-        <a href="/marketplace/checkout">Proceed to checkout</a>
-        <button onClick={clear} style={{marginLeft:'.75rem'}}>Clear cart</button>
+      <div style={{marginTop:'1rem', display:'flex', gap:'.75rem'}}>
+        <button onClick={() => navigate('/marketplace/review')}>Review & details</button>
+        <button onClick={clear}>Clear cart</button>
       </div>
     </section>
   );

--- a/web/src/pages/marketplace/review.tsx
+++ b/web/src/pages/marketplace/review.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import CartLine from '../../components/CartLine';
+import { fmtNatur, natur } from '../../lib/money';
+import { useCart } from '../../context/CartContext';
+
+type Buyer = { name: string; email: string };
+
+function loadBuyer(): Buyer {
+  try {
+    const raw = localStorage.getItem('buyer_info');
+    if (raw) return JSON.parse(raw);
+  } catch {}
+  return { name: '', email: '' };
+}
+
+export default function ReviewPage() {
+  const nav = useNavigate();
+  const { items, inc, dec, remove, totalNatur } = useCart();
+  const [buyer, setBuyer] = useState<Buyer>(loadBuyer());
+  const [touched, setTouched] = useState(false);
+
+  const valid = useMemo(() => {
+    const hasItems = items.length > 0;
+    const okName = buyer.name.trim().length >= 2;
+    const okEmail = /\S+@\S+\.\S+/.test(buyer.email);
+    return hasItems && okName && okEmail;
+  }, [items, buyer]);
+
+  useEffect(() => {
+    try { localStorage.setItem('buyer_info', JSON.stringify(buyer)); } catch {}
+  }, [buyer]);
+
+  const fees = natur(totalNatur * 0.00); // fee placeholder (0% for now)
+  const grand = natur(totalNatur + fees);
+
+  return (
+    <section>
+      <a href="/marketplace">← Back to Marketplace</a>
+      <h1>Review & details</h1>
+
+      {items.length === 0 ? (
+        <p>Your cart is empty. <a href="/marketplace">Browse products</a></p>
+      ) : (
+        <>
+          <div style={{display:'grid', gap:'.75rem', margin:'1rem 0'}}>
+            {items.map(line => (
+              <CartLine
+                key={line.id}
+                line={line}
+                onInc={() => inc(line.id)}
+                onDec={() => dec(line.id)}
+                onRemove={() => remove(line.id)}
+              />
+            ))}
+          </div>
+
+          <div style={{margin:'1rem 0', display:'grid', gap:'.25rem', justifyContent:'start'}}>
+            <div><strong>Items:</strong> {fmtNatur(totalNatur)}</div>
+            <div><strong>Fees:</strong> {fmtNatur(fees)}</div>
+            <div><strong>Total:</strong> {fmtNatur(grand)}</div>
+          </div>
+
+          <div style={{marginTop:'1rem'}}>
+            <h2>Buyer</h2>
+            <div style={{display:'grid', gap:'.5rem', maxWidth:420}}>
+              <input
+                placeholder="Full name"
+                value={buyer.name}
+                onChange={e => setBuyer({ ...buyer, name: e.target.value })}
+                onBlur={() => setTouched(true)}
+              />
+              <input
+                placeholder="Email (for receipt)"
+                value={buyer.email}
+                onChange={e => setBuyer({ ...buyer, email: e.target.value })}
+                onBlur={() => setTouched(true)}
+              />
+              {!valid && touched && (
+                <small style={{color:'#fca5a5'}}>Please enter a name and valid email.</small>
+              )}
+            </div>
+          </div>
+
+          <div style={{marginTop:'1rem', display:'flex', gap:'.75rem'}}>
+            <button onClick={() => nav('/marketplace/cart')}>Edit cart</button>
+            <button
+              disabled={!valid}
+              onClick={() => nav('/marketplace/checkout')}
+              title={!valid ? 'Complete buyer details first' : 'Continue'}
+            >
+              Continue to NATUR payment
+            </button>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add NATUR price helpers for consistent formatting
- introduce reusable `CartLine` and review page capturing buyer details pre-checkout
- expose quantity helpers, wire review route, navbar links, and cart "Review & details" CTA

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a191e7c1848329bd654f68a183bfa2