### PR TITLE
Order history & details pages (localStorage) + explorer links (no new deps)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,6 +35,7 @@ import MarketplacePage from './pages/marketplace/MarketplacePage';
 import CartPage from './pages/marketplace/cart';
 import CheckoutPage from './pages/marketplace/checkout';
 import OrdersPage from './pages/marketplace/orders';
+import OrderDetailPage from './pages/marketplace/order';
 import ItemPage from './pages/marketplace/item';
 import ReviewPage from './pages/marketplace/review';
 import { CartProvider } from './context/CartContext';
@@ -174,6 +175,7 @@ export default function App() {
             <Route path="/marketplace/item" element={<ItemPage />} />
             <Route path="/marketplace/checkout" element={<CheckoutPage />} />
             <Route path="/marketplace/orders" element={<OrdersPage />} />
+            <Route path="/marketplace/orders/:id" element={<OrderDetailPage />} />
             <Route path="*" element={<NotFound />} />
             </Routes>
             {/* global styles */}

--- a/web/src/lib/orders.ts
+++ b/web/src/lib/orders.ts
@@ -1,18 +1,62 @@
-export type Receipt = {
-  id: string;                    // timestamp or tx hash
-  ts: number;                    // Date.now()
+export type NaturLine = {
+  id: string;
+  name: string;
+  qty: number;
+  priceNatur: number; // unit price
+  meta?: Record<string, any>;
+};
+
+export type NaturOrder = {
+  id: string; // ulid-ish or tx hash fallback
+  createdAt: number; // epoch ms
   totalNatur: number;
-  items: { id:string; name:string; qty:number; priceNatur:number }[];
+  lines: NaturLine[];
   txHash?: string;
+  network?: string; // e.g. "Polygon Amoy"
+  address?: string; // buyer address
 };
 
 const KEY = 'natur_orders';
 
-export function loadOrders(): Receipt[] {
-  try { return JSON.parse(localStorage.getItem(KEY) || '[]'); } catch { return []; }
+export function loadOrders(): NaturOrder[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
 }
 
-export function saveOrder(r: Receipt) {
-  const all = loadOrders();
-  localStorage.setItem(KEY, JSON.stringify([r, ...all]));
+export function saveOrders(list: NaturOrder[]) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(list));
+  } catch {}
 }
+
+export function getOrder(id: string): NaturOrder | undefined {
+  return loadOrders().find((o) => o.id === id);
+}
+
+export function addOrder(o: NaturOrder) {
+  const list = loadOrders();
+  list.unshift(o);
+  saveOrders(list);
+}
+
+export function fmtDate(ts: number) {
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return '';
+  }
+}
+
+export function explorerUrl(txHash?: string) {
+  if (!txHash) return '';
+  const base = import.meta.env.VITE_BLOCK_EXPLORER || '';
+  // Accept either ".../" or empty; fall back to hash only
+  return base ? `${base.replace(/\/+$/, '')}/tx/${txHash}` : '';
+}
+

--- a/web/src/pages/marketplace/checkout.tsx
+++ b/web/src/pages/marketplace/checkout.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../lib/wallet';
 import FaucetHelp from '../../components/FaucetHelp';
 import { formatToken, naturUsdApprox } from '../../lib/pricing';
-import { saveOrder } from '../../lib/orders';
+import { addOrder } from '../../lib/orders';
 
 const EXPLORER = import.meta.env.VITE_BLOCK_EXPLORER as string | undefined;
 const MERCHANT = import.meta.env.VITE_MERCHANT_ADDRESS as string;
@@ -123,17 +123,18 @@ const CheckoutPage: React.FC = () => {
       const tx = await transferNatur(signer, MERCHANT, need);
       await tx.wait();
 
-      saveOrder({
+      addOrder({
         id: tx.hash || String(Date.now()),
-        ts: Date.now(),
+        createdAt: Date.now(),
         totalNatur,
-        items: items.map((i) => ({
+        lines: items.map((i) => ({
           id: i.id,
           name: i.name,
           qty: i.qty,
           priceNatur: i.priceNatur,
         })),
         txHash: tx.hash,
+        address,
       });
 
       clear();

--- a/web/src/pages/marketplace/order.tsx
+++ b/web/src/pages/marketplace/order.tsx
@@ -1,0 +1,87 @@
+import React, { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { getOrder, fmtDate, explorerUrl } from '../../lib/orders';
+import { fmtNatur } from '../../lib/money';
+
+export default function OrderDetailPage() {
+  const { id = '' } = useParams();
+  const order = useMemo(() => getOrder(id), [id]);
+
+  if (!order) {
+    return (
+      <section>
+        <a href="/marketplace/orders">← Back to Orders</a>
+        <h1>Order not found</h1>
+        <p>We couldn’t find that order in this browser.</p>
+      </section>
+    );
+  }
+
+  const txUrl = explorerUrl(order.txHash);
+
+  return (
+    <section>
+      <a href="/marketplace/orders">← Back to Orders</a>
+      <h1>Order {order.id}</h1>
+      <p style={{ opacity: 0.9 }}>
+        {fmtDate(order.createdAt)} · {order.network || '—'}
+      </p>
+
+      <h2>Items</h2>
+      <div
+        style={{ display: 'grid', gap: '.5rem', margin: '0.5rem 0 1rem' }}
+      >
+        {order.lines.map((l) => (
+          <div
+            key={l.id}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr auto auto',
+              gap: '.75rem',
+              padding: '.5rem .75rem',
+              background: 'rgba(255,255,255,.04)',
+              borderRadius: 10,
+            }}
+          >
+            <div>
+              <div style={{ fontWeight: 600 }}>{l.name}</div>
+              <small style={{ opacity: 0.8 }}>Unit {fmtNatur(l.priceNatur)}</small>
+            </div>
+            <div style={{ justifySelf: 'end' }}>Qty {l.qty}</div>
+            <div style={{ justifySelf: 'end', fontWeight: 600 }}>
+              {fmtNatur(l.qty * l.priceNatur)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <h2>Total</h2>
+      <p style={{ fontWeight: 700 }}>{fmtNatur(order.totalNatur)}</p>
+
+      <h2>Transaction</h2>
+      {order.txHash ? (
+        <p>
+          Hash: <code>{order.txHash}</code>
+          <br />
+          {txUrl && (
+            <a href={txUrl} target="_blank" rel="noreferrer">
+              View on Explorer ↗
+            </a>
+          )}
+        </p>
+      ) : (
+        <p>No transaction hash recorded.</p>
+      )}
+
+      {order.address && (
+        <>
+          <h2>Buyer</h2>
+          <p>
+            <small>Wallet:</small> <code>{order.address}</code>
+          </p>
+        </>
+      )}
+    </section>
+  );
+}
+

--- a/web/src/pages/marketplace/orders.tsx
+++ b/web/src/pages/marketplace/orders.tsx
@@ -1,45 +1,51 @@
-import React from 'react';
-import { loadOrders } from '../../lib/orders';
-
-const EXP = import.meta.env.VITE_BLOCK_EXPLORER as string | undefined;
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { loadOrders, fmtDate } from '../../lib/orders';
+import { fmtNatur } from '../../lib/money';
 
 export default function OrdersPage() {
-  const orders = loadOrders();
-
-  if (!orders.length) {
-    return (
-      <section>
-        <h1>Your orders</h1>
-        <p>No orders yet.</p>
-        <a href="/marketplace">Shop the marketplace</a>
-      </section>
-    );
-  }
-
+  const orders = useMemo(() => loadOrders(), []);
   return (
     <section>
-      <h1>Your orders</h1>
-      <ul>
-        {orders.map(o => (
-          <li key={o.id} style={{margin:'1rem 0', padding:'1rem', border:'1px solid #2a3355', borderRadius:8}}>
-            <div><strong>Total:</strong> {o.totalNatur.toFixed(2)} NATUR</div>
-            <div><strong>Date:</strong> {new Date(o.ts).toLocaleString()}</div>
-            <details style={{marginTop:'.5rem'}}>
-              <summary>Items</summary>
-              <ul>
-                {o.items.map(i => (
-                  <li key={i.id}>{i.name} × {i.qty} — {(i.priceNatur*i.qty).toFixed(2)} NATUR</li>
-                ))}
-              </ul>
-            </details>
-            {o.txHash && EXP ? (
-              <div style={{marginTop:'.5rem'}}>
-                <a href={`${EXP}/tx/${o.txHash}`} target="_blank" rel="noreferrer">View on explorer</a>
+      <a href="/marketplace">← Back to Marketplace</a>
+      <h1>My Orders</h1>
+
+      {orders.length === 0 ? (
+        <p>
+          No orders yet. After a successful NATUR payment,
+          your orders will appear here.
+        </p>
+      ) : (
+        <div style={{ display: 'grid', gap: '0.75rem', marginTop: '1rem' }}>
+          {orders.map((o) => (
+            <Link
+              key={o.id}
+              to={`/marketplace/orders/${encodeURIComponent(o.id)}`}
+              style={{
+                padding: '0.9rem 1rem',
+                background: 'rgba(255,255,255,.04)',
+                borderRadius: 12,
+                textDecoration: 'none',
+                color: 'inherit',
+                display: 'grid',
+                gridTemplateColumns: '1fr auto',
+                gap: '.5rem',
+              }}
+            >
+              <div>
+                <div style={{ fontWeight: 600 }}>Order {o.id.slice(0, 8)}…</div>
+                <div style={{ opacity: 0.8, fontSize: '.9rem' }}>
+                  {fmtDate(o.createdAt)} · {o.network || '—'}
+                </div>
               </div>
-            ) : null}
-          </li>
-        ))}
-      </ul>
+              <div style={{ alignSelf: 'center', fontWeight: 600 }}>
+                {fmtNatur(o.totalNatur)}
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
     </section>
   );
 }
+


### PR DESCRIPTION
## Summary
- implement localStorage order storage with explorer links
- add My Orders and Order detail pages with totals and transaction info
- record orders after checkout and wire routes

## Testing
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a193debc448329b96c918b9e27901a