### PR TITLE
feat: add auth context and navbar session handling

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import ImmersiveBackground from './components/ImmersiveBackground';
 import Home from './pages/Home';
@@ -29,7 +29,7 @@ import EcoRunner from './pages/zones/arcade/eco-runner';
 import MemoryMatch from './pages/zones/arcade/memory-match';
 import WordBuilder from './pages/zones/arcade/word-builder';
 import ArcadeShop from './pages/zones/arcade/shop';
-import { RequireAuth, useSession } from './lib/auth';
+import { RequireAuth } from './context/AuthContext';
 import TopBar from './components/TopBar';
 import MarketplacePage from './pages/marketplace/MarketplacePage';
 import CartPage from './pages/marketplace/cart';
@@ -42,14 +42,13 @@ import { CartProvider } from './context/CartContext';
 import ProfileProvider from './context/ProfileContext';
 
 export default function App() {
-  const { session } = useSession();
   return (
-    <BrowserRouter>
+    <>
       <ImmersiveBackground />
       <ProfileProvider>
         <CartProvider>
           <div className="min-h-screen">
-            <Navbar email={session?.user.email} />
+            <Navbar />
             <TopBar />
             <Routes>
             <Route path="/" element={<Home />} />
@@ -184,6 +183,6 @@ export default function App() {
           </div>
         </CartProvider>
       </ProfileProvider>
-    </BrowserRouter>
+    </>
   );
 }

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -1,35 +1,45 @@
-import { NavLink } from 'react-router-dom';
-import { useCart } from '../context/CartContext';
+import React from 'react';
+import { useAuth } from '../context/AuthContext';
 
-export default function Navbar({ email }: { email?: string | null }) {
-  const { items } = useCart();
-  const count = items.reduce((n, i) => n + i.qty, 0);
+export default function Navbar() {
+  const { user, signOut } = useAuth();
+
+  const navatar = (() => {
+    try { return localStorage.getItem('navatar_url'); } catch { return null; }
+  })();
 
   return (
-    <div className="nv-wrap">
-      <nav className="nv-nav">
-        <NavLink to="/" className="brand" end>
-          The Naturverse
-        </NavLink>
-          <NavLink to="/worlds">Worlds</NavLink>
-          <NavLink to="/zones">Zones</NavLink>
-          <div className="nv-spacer" />
-          <a href="/marketplace">Marketplace</a>
-          <a href="/marketplace/cart" className="cart-link">
-            Cart{count > 0 ? <span className="cart-badge">{count}</span> : null}
-          </a>
-          <a href="/marketplace/review">Review</a>
-          <a href="/marketplace/orders">Orders</a>
-          {email ? (
-            <>
-              <NavLink to="/app">App</NavLink>
-              <NavLink to="/profile">Profile</NavLink>
-              <a href="/.netlify/functions/signout">Sign out</a>
-            </>
-          ) : (
-            <NavLink to="/login">Sign in</NavLink>
-          )}
-      </nav>
-    </div>
+    <nav className="nav">
+      <a href="/">Home</a>
+      <a href="/zones">Zones</a>
+      <a href="/marketplace">Marketplace</a>
+      <a href="/marketplace/cart">Cart</a>
+      <a href="/marketplace/orders">Orders</a>
+
+      <div style={{marginLeft:'auto', display:'flex', gap:'.75rem', alignItems:'center'}}>
+        {user ? (
+          <>
+            <a href="/profile" style={{display:'inline-flex', alignItems:'center', gap:'.5rem'}}>
+              {navatar ? (
+                <img src={navatar} alt="Navatar" width={28} height={28}
+                     style={{borderRadius:'50%', objectFit:'cover'}} />
+              ) : (
+                <div style={{
+                  width:28, height:28, borderRadius:'50%',
+                  background:'rgba(255,255,255,.12)', display:'grid', placeItems:'center', fontSize:12
+                }}>
+                  {user.email?.[0]?.toUpperCase() || 'U'}
+                </div>
+              )}
+              <span>Profile</span>
+            </a>
+            <button onClick={signOut}>Sign out</button>
+          </>
+        ) : (
+          <a href="/#signin">Sign in</a>
+        )}
+      </div>
+    </nav>
   );
 }
+

--- a/web/src/context/AuthContext.tsx
+++ b/web/src/context/AuthContext.tsx
@@ -1,0 +1,108 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { supabase } from '../supabaseClient';
+
+type AuthState = {
+  loading: boolean;
+  session: any | null;
+  user: any | null;
+  signOut: () => Promise<void>;
+  setNavatarLocal: (url: string | null) => void;
+};
+
+const Ctx = createContext<AuthState | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const nav = useNavigate();
+  const loc = useLocation();
+  const [loading, setLoading] = useState(true);
+  const [session, setSession] = useState<any | null>(null);
+  const [user, setUser] = useState<any | null>(null);
+
+  const setNavatarLocal = (url: string | null) => {
+    try {
+      if (url) localStorage.setItem('navatar_url', url);
+      else localStorage.removeItem('navatar_url');
+    } catch {}
+  };
+
+  // Initial load + URL cleanup (handles magic-link fragments)
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      setSession(data.session ?? null);
+      setUser(data.session?.user ?? null);
+      setLoading(false);
+
+      // If magic link appended params, clean them and route to /app by default
+      const hash = window.location.hash || '';
+      const looksLikeToken = /access_token=|type=recovery|type=signup|type=invite/.test(hash);
+      if (looksLikeToken) {
+        // Clean hash to avoid multiple sign-ins on refresh
+        history.replaceState({}, document.title, window.location.pathname + window.location.search);
+        // Redirect target: if already on /profile /app keep it; else go to /app
+        if (!loc.pathname.startsWith('/app') && !loc.pathname.startsWith('/profile')) {
+          nav('/app', { replace: true });
+        }
+      }
+    })();
+
+    // Subscribe to auth changes
+    const { data: sub } = supabase.auth.onAuthStateChange(async (event, sess) => {
+      setSession(sess ?? null);
+      setUser(sess?.user ?? null);
+      if (event === 'SIGNED_OUT') {
+        setNavatarLocal(null);
+        // If leaving a protected page, go home
+        if (window.location.pathname.startsWith('/app') || window.location.pathname.startsWith('/profile')) {
+          nav('/', { replace: true });
+        }
+      }
+      if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED' || event === 'USER_UPDATED') {
+        // Optional: fetch profile row to mirror avatar_url
+        try {
+          const uid = sess?.user?.id;
+          if (uid) {
+            const { data: rows } = await supabase.from('users').select('avatar_url').eq('id', uid).limit(1).maybeSingle();
+            if (rows?.avatar_url) setNavatarLocal(rows.avatar_url);
+          }
+        } catch {}
+      }
+    });
+
+    return () => sub?.subscription?.unsubscribe();
+  }, [nav, loc.pathname]);
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  const value = useMemo<AuthState>(() => ({
+    loading, session, user, signOut, setNavatarLocal
+  }), [loading, session, user]);
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+};
+
+export const useAuth = () => {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+};
+
+// Route guard
+export const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { loading, user } = useAuth();
+  if (loading) return <div style={{padding:'2rem'}}>Loading…</div>;
+  if (!user) {
+    return (
+      <div style={{padding:'2rem'}}>
+        <h1>Sign in required</h1>
+        <p>Please sign in with your magic link, then return here.</p>
+        <a href="/">Go to Home</a>
+      </div>
+    );
+  }
+  return <>{children}</>;
+};
+

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from 'react-router-dom';
 import App from "./App";
+import { AuthProvider } from './context/AuthContext';
 import "./styles/app.css";
 import "./styles/themes.css";
 import { applyTheme, onThemeChange } from "./lib/theme";
@@ -10,6 +12,10 @@ onThemeChange(() => applyTheme());
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { supabase } from '../supabaseClient';
 import { uploadAvatar, fetchAvatar } from '../lib/avatar';
+import { useAuth } from '../context/AuthContext';
 
 export default function Profile() {
   const [email, setEmail] = useState<string>("");
@@ -9,6 +10,7 @@ export default function Profile() {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const { setNavatarLocal } = useAuth();
 
   // On mount, get the current user + current avatar
   useEffect(() => {
@@ -20,6 +22,7 @@ export default function Profile() {
       try {
         const url = await fetchAvatar(user.id);
         setAvatarUrl(url);
+        if (url) setNavatarLocal(url);
       } catch {
         // ignore – empty avatar is fine
       }
@@ -39,7 +42,8 @@ export default function Profile() {
     try {
       const file = inputRef.current.files[0];
       const { url } = await uploadAvatar(file, userId);
-      // Reflect immediately
+      // Mirror to localStorage so Navbar & previews can use it immediately
+      setNavatarLocal(url);
       setAvatarUrl(url);
       setPreviewUrl(null);
       alert("Navatar updated");
@@ -58,9 +62,11 @@ export default function Profile() {
         <div className="mb-4 flex justify-center">
           {/* Avatar figure – fixed size, always cropped */}
           <img
-            src={previewUrl ?? avatarUrl ?? "/avatar-placeholder.png"}
-            alt="navatar"
-            className="h-28 w-28 rounded-full object-cover ring-2 ring-white/20 shadow"
+            src={previewUrl || avatarUrl || '/avatar-placeholder.png'}
+            alt="Navatar"
+            width={128}
+            height={128}
+            style={{ width:128, height:128, borderRadius:'50%', objectFit:'cover', background:'#111' }}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- add `AuthContext` to centralize Supabase session handling and navatar mirroring
- wrap application with `AuthProvider` and protect routes with `RequireAuth`
- enhance navbar and profile to reflect auth state and persist navatar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19724ac348329a2d0b8da73b7097e