### PR TITLE
Add local wishlist with navbar badge

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,12 +38,15 @@ import ItemPage from './pages/marketplace/item';
 import ReviewPage from './pages/marketplace/review';
 import { CartProvider } from './context/CartContext';
 import ProfileProvider from './context/ProfileContext';
+import { WishlistProvider } from './context/WishlistContext';
+import WishlistPage from './pages/marketplace/Wishlist';
 
 export default function App() {
   return (
     <ProfileProvider>
       <CartProvider>
-        <Routes>
+        <WishlistProvider>
+          <Routes>
           <Route element={<AppShell />}> 
             <Route path="/" element={<Home />} />
             <Route path="/about" element={<About />} />
@@ -165,16 +168,18 @@ export default function App() {
             <Route path="/marketplace/review" element={<ReviewPage />} />
             <Route path="/marketplace/item" element={<ItemPage />} />
             <Route path="/marketplace/checkout" element={<CheckoutPage />} />
+            <Route path="/marketplace/wishlist" element={<WishlistPage />} />
             <Route path="/marketplace/orders" element={<OrdersPage />} />
             <Route path="/marketplace/orders/:id" element={<OrderDetailPage />} />
             <Route path="*" element={<NotFound />} />
           </Route>
           <Route path="/login" element={<Login />} />
           <Route path="/auth/callback" element={<AuthCallback />} />
-        </Routes>
-        {/* global styles */}
-        <link rel="stylesheet" href="/src/styles/ui.css" />
-        <link rel="stylesheet" href="/src/styles/marketplace.css" />
+          </Routes>
+          {/* global styles */}
+          <link rel="stylesheet" href="/src/styles/ui.css" />
+          <link rel="stylesheet" href="/src/styles/marketplace.css" />
+        </WishlistProvider>
       </CartProvider>
     </ProfileProvider>
   );

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { useWishlist } from '../context/WishlistContext';
+import { useNavigate } from 'react-router-dom';
 
 const linkClass = ({ isActive }: { isActive: boolean }) =>
   isActive ? 'nav-active' : undefined;
 
 export default function Navbar() {
   const { user, signOut } = useAuth();
+  const { ids } = useWishlist();
+  const navigate = useNavigate();
 
   const navatar = (() => {
     try {
@@ -24,6 +28,17 @@ export default function Navbar() {
       <NavLink to="/marketplace" className={linkClass}>Marketplace</NavLink>
       <NavLink to="/marketplace/cart" className={linkClass}>Cart</NavLink>
       <NavLink to="/marketplace/orders" className={linkClass}>Orders</NavLink>
+      <button
+        className="icon-btn"
+        style={{ position: 'relative' }}
+        onClick={() => navigate('/marketplace/wishlist')}
+        aria-label="Wishlist"
+      >
+        ♥
+        {ids.length > 0 && (
+          <span className="badge">{ids.length > 9 ? '9+' : ids.length}</span>
+        )}
+      </button>
 
       <div style={{ marginLeft: 'auto', display: 'flex', gap: '.75rem', alignItems: 'center' }}>
         {user ? (

--- a/web/src/context/WishlistContext.tsx
+++ b/web/src/context/WishlistContext.tsx
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+export type WishlistContext = {
+  ids: string[];
+  has: (id: string) => boolean;
+  toggle: (id: string) => void;
+  add: (id: string) => void;
+  remove: (id: string) => void;
+  clear: () => void;
+};
+
+const WishlistCtx = createContext<WishlistContext | undefined>(undefined);
+
+export const WishlistProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [ids, setIds] = useState<string[]>(() => {
+    try {
+      const raw = localStorage.getItem('natur_wishlist');
+      return raw ? JSON.parse(raw) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  const persist = (next: string[] | ((prev: string[]) => string[])) => {
+    setIds(prev => {
+      const value = typeof next === 'function' ? (next as (p: string[]) => string[])(prev) : next;
+      try { localStorage.setItem('natur_wishlist', JSON.stringify(value)); } catch {}
+      return value;
+    });
+  };
+
+  const add = (id: string) => persist(prev => (prev.includes(id) ? prev : [...prev, id]));
+  const remove = (id: string) => persist(prev => prev.filter(x => x !== id));
+  const toggle = (id: string) => persist(prev => (prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]));
+  const has = (id: string) => ids.includes(id);
+  const clear = () => persist([]);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === 'natur_wishlist') {
+        try {
+          const raw = e.newValue;
+          setIds(raw ? JSON.parse(raw) : []);
+        } catch {
+          setIds([]);
+        }
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  return (
+    <WishlistCtx.Provider value={{ ids, add, remove, toggle, has, clear }}>
+      {children}
+    </WishlistCtx.Provider>
+  );
+};
+
+export const useWishlist = () => {
+  const ctx = useContext(WishlistCtx);
+  if (!ctx) throw new Error('useWishlist must be used within WishlistProvider');
+  return ctx;
+};
+

--- a/web/src/pages/marketplace/MarketplacePage.tsx
+++ b/web/src/pages/marketplace/MarketplacePage.tsx
@@ -1,14 +1,29 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { PRODUCTS } from '../../lib/products';
+import { useWishlist } from '../../context/WishlistContext';
 
 const MarketplacePage: React.FC = () => {
+  const { toggle, has } = useWishlist();
   return (
     <div className="p-8">
       <h1 className="text-3xl font-bold mb-6">Marketplace</h1>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
         {PRODUCTS.map(p => (
-          <div key={p.id} className="border rounded-lg p-4 flex flex-col items-center">
+          <div key={p.id} className="border rounded-lg p-4 flex flex-col items-center" style={{ position: 'relative' }}>
+            <button
+              className="icon-btn"
+              aria-pressed={has(p.id)}
+              aria-label={has(p.id) ? 'Remove from wishlist' : 'Add to wishlist'}
+              onClick={e => {
+                e.stopPropagation();
+                e.preventDefault();
+                toggle(p.id);
+              }}
+              style={{ position: 'absolute', top: 8, right: 8 }}
+            >
+              {has(p.id) ? '♥' : '♡'}
+            </button>
             <img src={p.img} alt={p.name} className="w-32 h-32 object-contain mb-4" />
             <h2 className="font-semibold">{p.name}</h2>
             <p>{p.baseNatur} NATUR</p>

--- a/web/src/pages/marketplace/Wishlist.tsx
+++ b/web/src/pages/marketplace/Wishlist.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useWishlist } from '../../context/WishlistContext';
+import { getProduct } from '../../lib/products';
+import { useCart } from '../../context/CartContext';
+
+export default function WishlistPage() {
+  const { ids, remove } = useWishlist();
+  const { add } = useCart();
+
+  const products = ids.map(id => getProduct(id)).filter(Boolean);
+
+  const addToCart = (id: string) => {
+    const p = getProduct(id);
+    if (!p) return;
+    add({ id: p.id, name: p.name, priceNatur: p.baseNatur, qty: 1 });
+  };
+
+  if (products.length === 0) {
+    return (
+      <div className="p-8">
+        <h1>Wishlist</h1>
+        <p>Nothing saved yet—browse the catalog.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8">
+      <h1>Wishlist</h1>
+      <div className="flex flex-col gap-4 mt-4">
+        {products.map(p => (
+          <div key={p!.id} className="flex items-center gap-4 border rounded p-4">
+            <Link to={`/marketplace/item?id=${p!.id}`} className="shrink-0">
+              <img src={p!.img} alt={p!.name} className="w-20 h-20 object-contain" />
+            </Link>
+            <div className="flex-1">
+              <Link to={`/marketplace/item?id=${p!.id}`} className="font-semibold">
+                {p!.name}
+              </Link>
+              <div>{p!.baseNatur} NATUR</div>
+            </div>
+            <button onClick={() => addToCart(p!.id)} className="bg-green-600 text-white px-3 py-1 rounded">
+              Add to cart
+            </button>
+            <button
+              onClick={() => remove(p!.id)}
+              className="ml-2 text-sm text-red-500 underline"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/web/src/pages/marketplace/item.tsx
+++ b/web/src/pages/marketplace/item.tsx
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { getProduct, Product } from '../../lib/products';
 import { getNavatarSrc } from '../../lib/navatar';
 import { useCart } from '../../context/CartContext';
+import { useWishlist } from '../../context/WishlistContext';
 
 type Sel = { size: string; material?: string; qty: number };
 
@@ -19,6 +20,7 @@ export default function ItemPage() {
   const product = getProduct(id);
 
   const { add } = useCart();
+  const { toggle, has } = useWishlist();
   const [sel, setSel] = useState<Sel>({ size: product?.options.sizes[0]?.key || 's', material: product?.options.materials?.[0]?.key, qty: 1 });
 
   const total = useMemo(() => product ? priceNatur(product, sel) : 0, [product, sel]);
@@ -60,7 +62,17 @@ export default function ItemPage() {
         </div>
 
         <div>
-          <h1>{product.name}</h1>
+          <h1 style={{ display: 'flex', alignItems: 'center', gap: '.5rem' }}>
+            {product.name}
+            <button
+              className="icon-btn"
+              aria-pressed={has(product.id)}
+              aria-label={has(product.id) ? 'Remove from wishlist' : 'Add to wishlist'}
+              onClick={() => toggle(product.id)}
+            >
+              {has(product.id) ? '♥' : '♡'}
+            </button>
+          </h1>
           <p><strong>Price:</strong> {total.toFixed(2)} NATUR</p>
 
           <div style={{marginTop:'1rem'}}>

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -198,3 +198,12 @@ body {
   font-weight: 700;
 }
 
+.badge {
+  position: absolute; top: -6px; right: -6px;
+  min-width: 18px; height: 18px; padding: 0 4px;
+  border-radius: 999px; font-size: 11px; line-height: 18px;
+  background: #ef4444; color: #fff; font-weight: 700;
+}
+.icon-btn { appearance: none; background: transparent; border: 0; cursor: pointer; }
+.icon-btn[aria-pressed="true"] { color: #ef4444; }
+


### PR DESCRIPTION
## Summary
- add Wishlist context persisted to localStorage with multi-tab sync
- expose wishlist page and provider in app routes
- show wishlist badge in navbar with heart toggles on catalog and items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1b3a3612c83299632f61591e5a977