### PR TITLE
feat: add shipping and promo code to checkout

### DIFF
--- a/web/src/lib/orders.ts
+++ b/web/src/lib/orders.ts
@@ -18,6 +18,8 @@ export type NaturLine = {
   meta?: Record<string, any>;
 };
 
+import type { ShippingMethodId } from "./pricing";
+
 export type NaturOrder = {
   id: string; // ulid-ish or tx hash fallback
   createdAt: number; // epoch ms
@@ -27,6 +29,9 @@ export type NaturOrder = {
   network?: string; // e.g. "Polygon Amoy"
   address?: string; // buyer address
   shipping: Shipping;
+  shippingMethod: ShippingMethodId;
+  discount?: { code: string; amount: number };
+  totals: { items: number; shipping: number; discount: number; grandTotal: number };
 };
 
 const KEY = 'natur_orders';

--- a/web/src/lib/pricing.ts
+++ b/web/src/lib/pricing.ts
@@ -26,3 +26,21 @@ export function naturUsdApprox(naturAmount: number, rateEnv?: string): string | 
 export function clamp(n: number, min: number, max: number) {
   return Math.max(min, Math.min(max, n));
 }
+
+export type ShippingMethodId = "standard" | "expedited";
+
+export const SHIPPING_PRICES: Record<ShippingMethodId, number> = {
+  standard: 0,
+  expedited: 2.5,
+};
+
+export function calcDiscountNATUR(code: string, itemsSubtotal: number) {
+  if (code.trim().toUpperCase() === "WELCOME10") {
+    return Math.min(itemsSubtotal * 0.1, 20);
+  }
+  return 0;
+}
+
+export function formatNatur(n: number) {
+  return `${n.toFixed(2)} NATUR`;
+}

--- a/web/src/lib/storage.ts
+++ b/web/src/lib/storage.ts
@@ -1,0 +1,9 @@
+export const getJSON = <T>(k: string, d: T): T => {
+  try {
+    return JSON.parse(localStorage.getItem(k) || "") as T;
+  } catch {
+    return d;
+  }
+};
+export const setJSON = (k: string, v: any) => localStorage.setItem(k, JSON.stringify(v));
+

--- a/web/src/pages/marketplace/order.tsx
+++ b/web/src/pages/marketplace/order.tsx
@@ -1,11 +1,16 @@
 import React, { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { getOrder, fmtDate, explorerUrl } from '../../lib/orders';
-import { fmtNatur } from '../../lib/money';
+import { formatNatur, ShippingMethodId } from '../../lib/pricing';
 
 export default function OrderDetailPage() {
   const { id = '' } = useParams();
   const order = useMemo(() => getOrder(id), [id]);
+
+  const shipLabels: Record<ShippingMethodId, string> = {
+    standard: 'Standard',
+    expedited: 'Expedited',
+  };
 
   if (!order) {
     return (
@@ -45,22 +50,42 @@ export default function OrderDetailPage() {
           >
             <div>
               <div style={{ fontWeight: 600 }}>{l.name}</div>
-              <small style={{ opacity: 0.8 }}>Unit {fmtNatur(l.priceNatur)}</small>
+              <small style={{ opacity: 0.8 }}>Unit {formatNatur(l.priceNatur)}</small>
             </div>
             <div style={{ justifySelf: 'end' }}>Qty {l.qty}</div>
             <div style={{ justifySelf: 'end', fontWeight: 600 }}>
-              {fmtNatur(l.qty * l.priceNatur)}
+              {formatNatur(l.qty * l.priceNatur)}
             </div>
           </div>
         ))}
       </div>
 
-        <h2>Total</h2>
-        <p style={{ fontWeight: 700 }}>{fmtNatur(order.totalNatur)}</p>
+        <h2>Totals</h2>
+        <div className="totals" style={{ marginBottom: '1rem' }}>
+          <div className="row">
+            <span>Items</span>
+            <span>{formatNatur(order.totals?.items ?? order.totalNatur)}</span>
+          </div>
+          <div className="row">
+            <span>Shipping ({shipLabels[order.shippingMethod] || ''})</span>
+            <span>{formatNatur(order.totals?.shipping ?? 0)}</span>
+          </div>
+          {order.totals?.discount ? (
+            <div className="row">
+              <span>Discount</span>
+              <span>-{formatNatur(order.totals.discount)}</span>
+            </div>
+          ) : null}
+          <div className="row grand">
+            <span>Total</span>
+            <span>{formatNatur(order.totals?.grandTotal ?? order.totalNatur)}</span>
+          </div>
+        </div>
 
         {order.shipping && (
           <>
             <h2>Shipping</h2>
+            <p>{shipLabels[order.shippingMethod] || ''}</p>
             <p style={{ whiteSpace: 'pre-line' }}>
               {order.shipping.fullName}
               {'\n'}

--- a/web/src/pages/marketplace/orders.tsx
+++ b/web/src/pages/marketplace/orders.tsx
@@ -1,10 +1,14 @@
 import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { loadOrders, fmtDate } from '../../lib/orders';
-import { fmtNatur } from '../../lib/money';
+import { formatNatur, ShippingMethodId } from '../../lib/pricing';
 
 export default function OrdersPage() {
   const orders = useMemo(() => loadOrders(), []);
+  const shipLabels: Record<ShippingMethodId, string> = {
+    standard: 'Standard',
+    expedited: 'Expedited',
+  };
   return (
     <section>
       <a href="/marketplace">← Back to Marketplace</a>
@@ -35,11 +39,12 @@ export default function OrdersPage() {
               <div>
                 <div style={{ fontWeight: 600 }}>Order {o.id.slice(0, 8)}…</div>
                 <div style={{ opacity: 0.8, fontSize: '.9rem' }}>
-                  {fmtDate(o.createdAt)} · {o.network || '—'}
+                  {fmtDate(o.createdAt)} · {o.network || '—'} ·
+                  {shipLabels[o.shippingMethod as ShippingMethodId] || ''}
                 </div>
               </div>
               <div style={{ alignSelf: 'center', fontWeight: 600 }}>
-                {fmtNatur(o.totalNatur)}
+                {formatNatur(o.totals?.grandTotal ?? o.totalNatur)}
               </div>
             </Link>
           ))}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -212,3 +212,9 @@ body {
   .row { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
   @media (max-width:640px){ .row { grid-template-columns:1fr; } }
 
+.totals { display:grid; gap:6px; }
+.totals .row{ display:flex; justify-content:space-between; }
+.totals .grand{ font-weight:700; font-size:1.1rem; }
+.promo-chip{ display:inline-flex; align-items:center; gap:8px; padding:4px 8px; border-radius:999px; background:rgba(255,255,255,.08); }
+.error{ color:#ef4444; font-size:12px; margin-top:4px; }
+


### PR DESCRIPTION
## Summary
- add shipping method options, promo code logic, and live totals to checkout
- persist selections and apply on payment and order history
- add storage helpers and styling for promo and totals sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b9bba4e08329a40787af8ec1d3b4