### PR TITLE
feat: add local recommendations and cross-sell strips

### DIFF
--- a/web/src/components/RecoStrip.tsx
+++ b/web/src/components/RecoStrip.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import type { Item } from "../lib/reco";
+
+export default function RecoStrip({ title, items, source }: { title:string; items:Item[]; source:string }) {
+  React.useEffect(() => {
+    if (items?.length) {
+      console.log('reco_view', { source, count: items.length });
+    }
+  }, [items, source]);
+
+  if (!items?.length) return null;
+  return (
+    <section className="panel" style={{ padding:"12px" }}>
+      <div style={{ display:"flex", justifyContent:"space-between", alignItems:"center", marginBottom:8 }}>
+        <h3 style={{ margin:0 }}>{title}</h3>
+        <a href="/marketplace" className="button alt" style={{ padding:"4px 8px" }}>See all</a>
+      </div>
+      <div className="reco-row">
+        {items.map(it => (
+          <a
+            key={it.id}
+            className="reco-card"
+            href={`/marketplace/item?id=${it.id}`}
+            aria-label={it.name}
+            onClick={() => console.log('reco_click', { id: it.id, source })}
+          >
+            <img src={it.image} alt="" loading="lazy" />
+            <div className="reco-name">{it.name}</div>
+            <div className="reco-price">{it.price.toFixed(2)} NATUR</div>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/src/lib/reco.ts
+++ b/web/src/lib/reco.ts
@@ -1,0 +1,46 @@
+export type Item = { id:string; name:string; price:number; category:string; image:string; createdAt:number };
+const KEY = "natur_recent_v1";
+const LIMIT = 20;
+
+export function loadRecent(): string[] {
+  try { return JSON.parse(localStorage.getItem(KEY) || "[]"); } catch { return []; }
+}
+export function saveRecent(ids: string[]) { localStorage.setItem(KEY, JSON.stringify(ids.slice(0, LIMIT))); }
+
+export function pushRecent(id: string) {
+  const cur = loadRecent().filter(x => x !== id);
+  cur.unshift(id);
+  saveRecent(cur);
+  // broadcast
+  try { window.dispatchEvent(new StorageEvent("storage", { key: KEY, newValue: JSON.stringify(cur) })); } catch {}
+  console.log('recent_push', { id });
+}
+
+export function recentItems(all: Item[]): Item[] {
+  const map = new Map(all.map(i => [i.id, i]));
+  return loadRecent().map(id => map.get(id)).filter(Boolean) as Item[];
+}
+
+/** Recommend by same category and price closeness (±30%), fallback to newest in category. */
+export function recommendFor(item: Item, all: Item[], take=8): Item[] {
+  const pool = all.filter(p => p.id !== item.id && p.category === item.category);
+  const close = pool
+    .map(p => ({ p, diff: Math.abs(p.price - item.price) / Math.max(1, item.price) }))
+    .sort((a,b)=> a.diff - b.diff);
+  let out = close.filter(x => x.diff <= 0.3).map(x => x.p);
+  if (out.length < take) {
+    const remainder = pool
+      .filter(p => !out.includes(p))
+      .sort((a,b)=> b.createdAt - a.createdAt);
+    out = out.concat(remainder);
+  }
+  return out.slice(0, take);
+}
+
+/** Recommend from a set of categories (for cart/success). */
+export function recommendForCats(cats: string[], all: Item[], take=6): Item[] {
+  const set = new Set(cats);
+  const pool = all.filter(p => set.has(p.category));
+  const newest = pool.sort((a,b)=> b.createdAt - a.createdAt);
+  return newest.slice(0, take);
+}

--- a/web/src/pages/marketplace/OrderSuccess.tsx
+++ b/web/src/pages/marketplace/OrderSuccess.tsx
@@ -2,6 +2,18 @@ import React, { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { getOrder, fmtDate, explorerUrl } from '../../lib/orders';
 import { formatNatur, ShippingMethodId } from '../../lib/pricing';
+import RecoStrip from '../../components/RecoStrip';
+import { recommendForCats, Item } from '../../lib/reco';
+import { PRODUCTS } from '../../lib/products';
+
+const allItems: Item[] = PRODUCTS.map(p => ({
+  id: p.id,
+  name: p.name,
+  price: p.baseNatur,
+  category: p.category,
+  image: p.img,
+  createdAt: p.createdAt,
+}));
 
 export default function OrderSuccess() {
   const { id = '' } = useParams();
@@ -26,6 +38,19 @@ export default function OrderSuccess() {
   }
 
   const txUrl = explorerUrl(order.txHash);
+  const cats = useMemo(() => {
+    return Array.from(
+      new Set(
+        order.lines
+          .map(l => {
+            const pid = l.id.split('::')[0];
+            return PRODUCTS.find(p => p.id === pid)?.category;
+          })
+          .filter(Boolean) as string[],
+      ),
+    );
+  }, [order]);
+  const recos = recommendForCats(cats, allItems, 6);
 
   return (
     <section>
@@ -128,6 +153,7 @@ export default function OrderSuccess() {
           </button>
         </div>
       </div>
+      <RecoStrip title="You might also like" items={recos} source="success" />
     </section>
   );
 }

--- a/web/src/pages/marketplace/ProductDetail.tsx
+++ b/web/src/pages/marketplace/ProductDetail.tsx
@@ -1,8 +1,20 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import Gallery from '../../components/Gallery';
 import { getProduct } from '../../lib/products';
 import { useCart } from '../../context/CartContext';
+import RecoStrip from '../../components/RecoStrip';
+import { recommendFor, pushRecent, Item } from '../../lib/reco';
+import { PRODUCTS } from '../../lib/products';
+
+const allItems: Item[] = PRODUCTS.map(p => ({
+  id: p.id,
+  name: p.name,
+  price: p.baseNatur,
+  category: p.category,
+  image: p.img,
+  createdAt: p.createdAt,
+}));
 
 const DEF_SIZES = ['XS','S','M','L','XL'];
 const DEF_MATERIALS = ['Cotton','Recycled','Premium'];
@@ -20,6 +32,25 @@ export default function ProductDetail() {
   const [size, setSize] = useState<string>(sizes[0]);
   const [material, setMaterial] = useState<string>(materials[0]);
   const [qty, setQty] = useState(1);
+
+  useEffect(() => {
+    if (product) pushRecent(product.id);
+  }, [product?.id]);
+
+  const recos = product
+    ? recommendFor(
+        {
+          id: product.id,
+          name: product.name,
+          price: product.baseNatur,
+          category: product.category,
+          image: images[0],
+          createdAt: product.createdAt,
+        },
+        allItems,
+        8,
+      )
+    : [];
 
   if (!product) {
     return (
@@ -75,6 +106,7 @@ export default function ProductDetail() {
           </div>
         </div>
       </div>
+      <RecoStrip title="For you" items={recos} source="detail" />
     </section>
   );
 }

--- a/web/src/pages/marketplace/cart.tsx
+++ b/web/src/pages/marketplace/cart.tsx
@@ -7,6 +7,18 @@ import {
   encodeCartToQuery,
   decodeCartFromQuery,
 } from '../../lib/cartPersist';
+import RecoStrip from '../../components/RecoStrip';
+import { recommendForCats, Item } from '../../lib/reco';
+import { PRODUCTS } from '../../lib/products';
+
+const allItems: Item[] = PRODUCTS.map(p => ({
+  id: p.id,
+  name: p.name,
+  price: p.baseNatur,
+  category: p.category,
+  image: p.img,
+  createdAt: p.createdAt,
+}));
 
 export default function CartPage() {
   const navigate = useNavigate();
@@ -36,6 +48,18 @@ export default function CartPage() {
       </section>
     );
   }
+
+  const cats = Array.from(
+    new Set(
+      items
+        .map(l => {
+          const pid = l.id.split('::')[0];
+          return PRODUCTS.find(p => p.id === pid)?.category;
+        })
+        .filter(Boolean) as string[],
+    ),
+  );
+  const recos = recommendForCats(cats, allItems, 6);
 
   return (
     <section>
@@ -67,6 +91,7 @@ export default function CartPage() {
             Share cart
           </button>
         </div>
+      <RecoStrip title="You might also like" items={recos} source="cart" />
     </section>
   );
 }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -312,3 +312,31 @@ body {
 .actions { display:flex; gap: 8px; flex-wrap: wrap }
 .form-grid { display:grid; gap:12px; grid-template-columns:1fr 1fr }
 @media (max-width:640px){ .form-grid { grid-template-columns:1fr } }
+
+.reco-row {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}
+.reco-card {
+  display: grid;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 12px;
+  background: rgba(255,255,255,.04);
+  text-decoration: none;
+  color: inherit;
+}
+.reco-card img {
+  width: 100%;
+  height: 140px;
+  object-fit: cover;
+  border-radius: 8px;
+  background:#0b0f1c;
+}
+.reco-name { font-size: 14px; line-height: 1.3; }
+.reco-price { font-weight: 700; font-size: 14px; opacity: .95; }
+@media (max-width: 640px) {
+  .reco-card img { height: 120px; }
+}


### PR DESCRIPTION
## Summary
- add localStorage-backed recommendation helpers and telemetry
- show reusable recommendation strips across marketplace pages
- style responsive product strips

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c91f63f08329bb68c8babb2f2381