### PR TITLE
Marketplace search, filters, sort, and pagination (no new deps)

### DIFF
--- a/web/src/components/Pagination.tsx
+++ b/web/src/components/Pagination.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+type Props = {
+  page: number;
+  pages: number;
+  onChange: (p: number) => void;
+};
+
+export default function Pagination({ page, pages, onChange }: Props) {
+  if (pages <= 1) return null;
+
+  const go = (p: number) => {
+    if (p < 1 || p > pages || p === page) return;
+    onChange(p);
+  };
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowRight') { e.preventDefault(); go(page + 1); }
+    if (e.key === 'ArrowLeft') { e.preventDefault(); go(page - 1); }
+  };
+
+  const maxButtons = 5;
+  let start = Math.max(1, page - 2);
+  let end = Math.min(pages, start + maxButtons - 1);
+  if (end - start < maxButtons - 1) start = Math.max(1, end - maxButtons + 1);
+  const nums = [];
+  for (let i = start; i <= end; i++) nums.push(i);
+  const showStart = start > 1;
+  const showEnd = end < pages;
+
+  return (
+    <nav className="pagination" aria-label="Pagination" onKeyDown={handleKey} tabIndex={0}>
+      <button onClick={() => go(page - 1)} disabled={page === 1} aria-label="Previous page">Prev</button>
+      {showStart && (
+        <>
+          <button onClick={() => go(1)} aria-current={page === 1 ? 'page' : undefined}>1</button>
+          {start > 2 && <span className="ellipsis">…</span>}
+        </>
+      )}
+      {nums.map(n => (
+        <button key={n} onClick={() => go(n)} aria-current={n === page ? 'page' : undefined}>{n}</button>
+      ))}
+      {showEnd && (
+        <>
+          {end < pages - 1 && <span className="ellipsis">…</span>}
+          <button onClick={() => go(pages)} aria-current={page === pages ? 'page' : undefined}>{pages}</button>
+        </>
+      )}
+      <button onClick={() => go(page + 1)} disabled={page === pages} aria-label="Next page">Next</button>
+    </nav>
+  );
+}

--- a/web/src/components/filters/CategoryChips.tsx
+++ b/web/src/components/filters/CategoryChips.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+type Props = {
+  categories: string[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+};
+
+export default function CategoryChips({ categories, selected, onChange }: Props) {
+  const toggle = (cat: string) => {
+    const set = new Set(selected);
+    if (set.has(cat)) set.delete(cat); else set.add(cat);
+    onChange(Array.from(set));
+  };
+
+  return (
+    <div className="chip-row">
+      {categories.map(cat => (
+        <button
+          key={cat}
+          type="button"
+          className="chip"
+          aria-pressed={selected.includes(cat)}
+          onClick={() => toggle(cat)}
+        >
+          {cat}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/filters/PriceRange.tsx
+++ b/web/src/components/filters/PriceRange.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+
+type Props = {
+  min: number;
+  max: number;
+  onChange: (min: number, max: number) => void;
+};
+
+export default function PriceRange({ min, max, onChange }: Props) {
+  const [minVal, setMinVal] = useState<string>(String(min || ''));
+  const [maxVal, setMaxVal] = useState<string>(max === Infinity ? '' : String(max));
+
+  useEffect(() => { setMinVal(String(min || '')); }, [min]);
+  useEffect(() => { setMaxVal(max === Infinity ? '' : String(max)); }, [max]);
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      let m1 = parseFloat(minVal);
+      let m2 = parseFloat(maxVal);
+      if (isNaN(m1) || m1 < 0) m1 = 0;
+      if (isNaN(m2) || m2 < 0) m2 = Infinity;
+      onChange(m1, m2);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [minVal, maxVal, onChange]);
+
+  return (
+    <div className="price-range">
+      <input
+        type="number"
+        placeholder="Min"
+        value={minVal}
+        onChange={e => setMinVal(e.target.value)}
+        min="0"
+      />
+      <span>–</span>
+      <input
+        type="number"
+        placeholder="Max"
+        value={maxVal}
+        onChange={e => setMaxVal(e.target.value)}
+        min="0"
+      />
+    </div>
+  );
+}

--- a/web/src/components/filters/SortSelect.tsx
+++ b/web/src/components/filters/SortSelect.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import type { Sort } from '../../lib/catalogFilter';
+
+type Props = {
+  value: Sort;
+  onChange: (v: Sort) => void;
+};
+
+export default function SortSelect({ value, onChange }: Props) {
+  return (
+    <select className="sort-select" value={value} onChange={e => onChange(e.target.value as Sort)}>
+      <option value="relevance">Relevance</option>
+      <option value="price_asc">Price: Low to High</option>
+      <option value="price_desc">Price: High to Low</option>
+      <option value="newest">Newest</option>
+    </select>
+  );
+}

--- a/web/src/lib/catalogFilter.ts
+++ b/web/src/lib/catalogFilter.ts
@@ -1,0 +1,100 @@
+export type Sort = 'relevance' | 'price_asc' | 'price_desc' | 'newest';
+
+export interface FilterState {
+  q: string;
+  cats: string[];
+  min: number;
+  max: number;
+  sort: Sort;
+  page: number;
+}
+
+export interface Item {
+  id: string;
+  name: string;
+  description?: string;
+  tags?: string[];
+  category: string;
+  price: number;
+  createdAt: number;
+  popularity?: number;
+  [key: string]: any;
+}
+
+function scoreItem(item: Item, q: string): number {
+  if (!q) return 0;
+  const term = q.toLowerCase();
+  let score = 0;
+  if (item.name.toLowerCase().includes(term)) score += 2;
+  if (item.description && item.description.toLowerCase().includes(term)) score += 1;
+  if (item.tags && item.tags.some(t => t.toLowerCase().includes(term))) score += 1;
+  return score;
+}
+
+export function applyFilters(items: Item[], { q, cats, min, max, sort }: FilterState) {
+  const withScore = items
+    .map(item => ({ item, score: scoreItem(item, q) }))
+    .filter(entry => (q ? entry.score > 0 : true))
+    .filter(entry => (cats.length ? cats.includes(entry.item.category) : true))
+    .filter(entry => entry.item.price >= min && entry.item.price <= max);
+
+  const sorted = withScore.sort((a, b) => {
+    switch (sort) {
+      case 'price_asc':
+        return a.item.price - b.item.price;
+      case 'price_desc':
+        return b.item.price - a.item.price;
+      case 'newest':
+        return b.item.createdAt - a.item.createdAt;
+      default: {
+        if (b.score !== a.score) return b.score - a.score;
+        const popA = a.item.popularity ?? 0;
+        const popB = b.item.popularity ?? 0;
+        if (popB !== popA) return popB - popA;
+        return b.item.createdAt - a.item.createdAt;
+      }
+    }
+  });
+
+  return sorted.map(s => s.item);
+}
+
+export function slicePage(items: Item[], page: number, size: number) {
+  const total = items.length;
+  const pages = Math.max(1, Math.ceil(total / size));
+  const p = Math.min(Math.max(1, page), pages);
+  const start = (p - 1) * size;
+  const pageItems = items.slice(start, start + size);
+  return { pageItems, total, pages };
+}
+
+export function parseQuery(search: string): FilterState {
+  const sp = new URLSearchParams(search); // search may start with '?'
+  const q = sp.get('q') || '';
+  const cats = sp.get('cats') ? sp.get('cats')!.split(',').filter(Boolean) : [];
+  const min = parseFloat(sp.get('min') || '0');
+  const maxRaw = sp.get('max');
+  const max = maxRaw === null ? Infinity : parseFloat(maxRaw);
+  const sort = (sp.get('sort') as Sort) || 'relevance';
+  const page = parseInt(sp.get('page') || '1', 10);
+  return {
+    q,
+    cats,
+    min: isNaN(min) || min < 0 ? 0 : min,
+    max: isNaN(max) || max < 0 ? Infinity : max,
+    sort,
+    page: isNaN(page) || page < 1 ? 1 : page,
+  };
+}
+
+export function stringifyQuery(state: FilterState): string {
+  const sp = new URLSearchParams();
+  if (state.q) sp.set('q', state.q);
+  if (state.cats.length) sp.set('cats', state.cats.join(','));
+  if (state.min > 0) sp.set('min', String(state.min));
+  if (state.max !== Infinity) sp.set('max', String(state.max));
+  if (state.sort !== 'relevance') sp.set('sort', state.sort);
+  if (state.page > 1) sp.set('page', String(state.page));
+  const s = sp.toString();
+  return s ? `?${s}` : '';
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -455,3 +455,86 @@ body {
   gap: 12px;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
 }
+/* Marketplace filters and pagination */
+.filters-bar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+@media (min-width: 768px) {
+  .filters-bar {
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    padding: 0.5rem 0;
+    z-index: 10;
+  }
+}
+.filters-bar input[type="search"] {
+  flex: 1;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--panel-b);
+  background: var(--panel);
+  color: inherit;
+}
+.sort-select {
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--panel-b);
+  background: var(--panel);
+  color: inherit;
+}
+.filters-side {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 1rem;
+}
+.chip {
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-b);
+  background: var(--panel);
+  cursor: pointer;
+}
+.chip[aria-pressed="true"] {
+  background: var(--accent);
+  color: var(--bg);
+}
+.price-range {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.price-range input {
+  width: 80px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  border: 1px solid var(--panel-b);
+  background: var(--panel);
+  color: inherit;
+}
+.pagination {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  margin: 1rem 0;
+}
+.pagination button {
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--panel-b);
+  background: var(--panel);
+  color: inherit;
+}
+.pagination button[aria-current="page"] {
+  background: var(--accent);
+  color: var(--bg);
+}
+.pagination .ellipsis {
+  display: flex;
+  align-items: center;
+  padding: 0 4px;
+}


### PR DESCRIPTION
## Summary
- add catalogFilter helpers for searching, sorting, pagination, and URL state
- introduce filter UI components and pagination controls
- overhaul marketplace page with debounced search, category/price filters, sort options, and URL-synced pagination

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)
- `npm ci` (fails: package.json and lockfile out of sync)


------
https://chatgpt.com/codex/tasks/task_e_68a2a66ce99483298a85a2a39d476254