### PR TITLE
Account Settings hub — Address Book (CRUD), Order Detail, Navbar user menu + Sign Out (no new deps)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,9 @@ import ProductDetail from './pages/marketplace/ProductDetail';
 import Checkout from './pages/marketplace/Checkout';
 import Success from './pages/marketplace/Success';
 import Orders from './pages/account/Orders';
+import Addresses from './pages/account/Addresses';
+import AccountOrderDetail from './pages/account/OrderDetail';
+import Wishlist from './pages/account/Wishlist';
 import { CartProvider } from './context/CartContext';
 import ProfileProvider from './context/ProfileContext';
 
@@ -44,40 +47,40 @@ export default function App() {
   return (
     <ProfileProvider>
       <CartProvider>
-        <Suspense fallback={<div className="container" style={{padding:'24px'}}>Loading...</div>}>
+        <Suspense fallback={<div className="container" style={{ padding: '24px' }}>Loading...</div>}>
           <Routes>
-          <Route element={<AppShell />}>
-            <Route path="/" element={<Home />} />
-            <Route path="/about" element={<About />} />
-            <Route path="/story-studio" element={<StoryStudioPage />} />
-            <Route path="/auto-quiz" element={<AutoQuiz />} />
-            <Route path="/worlds" element={<Worlds />} />
-            <Route path="/worlds/:slug" element={<World />} />
-            <Route path="/zones" element={<ZonesHub />} />
-            <Route path="/zones/naturversity" element={<Naturversity />} />
-            <Route path="/zones/music" element={<MusicZone />} />
-            <Route path="/zones/eco-lab" element={<EcoLab />} />
-            <Route path="/zones/story-studio" element={<StoryStudio />} />
-            <Route path="/zones/parents" element={<Parents />} />
-            <Route path="/zones/settings" element={<Settings />} />
-            <Route path="/zones/wellness" element={<WellnessZone />} />
-            <Route path="/zones/creator-lab" element={<CreatorLab />} />
-            <Route path="/zones/arcade" element={<Arcade />} />
-            <Route path="/zones/arcade/eco-runner" element={<EcoRunner />} />
-            <Route path="/zones/arcade/memory-match" element={<MemoryMatch />} />
-            <Route path="/zones/arcade/word-builder" element={<WordBuilder />} />
-            <Route path="/zones/arcade/shop" element={<ArcadeShop />} />
-            <Route path="/zones/community" element={<Community />} />
-            <Route path="/naturversity/lesson/:id" element={<Lesson />} />
-            <Route path="/app" element={<AppHome />} />
-            <Route
-              path="/profile"
-              element={
-                <RequireAuth>
-                  <Profile />
-                </RequireAuth>
-              }
-            />
+            <Route element={<AppShell />}>
+              <Route path="/" element={<Home />} />
+              <Route path="/about" element={<About />} />
+              <Route path="/story-studio" element={<StoryStudioPage />} />
+              <Route path="/auto-quiz" element={<AutoQuiz />} />
+              <Route path="/worlds" element={<Worlds />} />
+              <Route path="/worlds/:slug" element={<World />} />
+              <Route path="/zones" element={<ZonesHub />} />
+              <Route path="/zones/naturversity" element={<Naturversity />} />
+              <Route path="/zones/music" element={<MusicZone />} />
+              <Route path="/zones/eco-lab" element={<EcoLab />} />
+              <Route path="/zones/story-studio" element={<StoryStudio />} />
+              <Route path="/zones/parents" element={<Parents />} />
+              <Route path="/zones/settings" element={<Settings />} />
+              <Route path="/zones/wellness" element={<WellnessZone />} />
+              <Route path="/zones/creator-lab" element={<CreatorLab />} />
+              <Route path="/zones/arcade" element={<Arcade />} />
+              <Route path="/zones/arcade/eco-runner" element={<EcoRunner />} />
+              <Route path="/zones/arcade/memory-match" element={<MemoryMatch />} />
+              <Route path="/zones/arcade/word-builder" element={<WordBuilder />} />
+              <Route path="/zones/arcade/shop" element={<ArcadeShop />} />
+              <Route path="/zones/community" element={<Community />} />
+              <Route path="/naturversity/lesson/:id" element={<Lesson />} />
+              <Route path="/app" element={<AppHome />} />
+              <Route
+                path="/profile"
+                element={
+                  <RequireAuth>
+                    <Profile />
+                  </RequireAuth>
+                }
+              />
               <Route path="/marketplace" element={<MarketplacePage />} />
               <Route path="/marketplace/cart" element={<CartPage />} />
               <Route path="/marketplace/item" element={<ProductDetail />} />
@@ -85,11 +88,42 @@ export default function App() {
               <Route path="/marketplace/success" element={<Success />} />
               <Route path="/marketplace/orders" element={<OrdersPage />} />
               <Route path="/marketplace/orders/:id" element={<OrderDetailPage />} />
-              <Route path="/account/orders" element={<Orders />} />
-            <Route path="*" element={<NotFound />} />
-          </Route>
-          <Route path="/login" element={<Login />} />
-          <Route path="/auth/callback" element={<AuthCallback />} />
+              <Route
+                path="/account/orders"
+                element={
+                  <RequireAuth>
+                    <Orders />
+                  </RequireAuth>
+                }
+              />
+              <Route
+                path="/account/orders/:id"
+                element={
+                  <RequireAuth>
+                    <AccountOrderDetail />
+                  </RequireAuth>
+                }
+              />
+              <Route
+                path="/account/addresses"
+                element={
+                  <RequireAuth>
+                    <Addresses />
+                  </RequireAuth>
+                }
+              />
+              <Route
+                path="/account/wishlist"
+                element={
+                  <RequireAuth>
+                    <Wishlist />
+                  </RequireAuth>
+                }
+              />
+              <Route path="*" element={<NotFound />} />
+            </Route>
+            <Route path="/login" element={<Login />} />
+            <Route path="/auth/callback" element={<AuthCallback />} />
           </Routes>
         </Suspense>
         {/* global styles */}

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { getCart } from '../lib/cart';
 import { Link, NavLink } from 'react-router-dom';
+import UserMenu from './UserMenu';
 
 const linkClass = ({ isActive }: { isActive: boolean }) =>
   (isActive ? 'nav-active' : undefined);
@@ -8,23 +9,47 @@ const linkClass = ({ isActive }: { isActive: boolean }) =>
 export default function Navbar() {
   const [count, setCount] = useState(0);
   useEffect(() => {
-    const update = () => setCount(getCart().reduce((s,l)=> s+l.qty, 0));
+    const update = () => setCount(getCart().reduce((s, l) => s + l.qty, 0));
     update();
-    const i = setInterval(update, 1000); // simple polling; replace later with event bus
+    const i = setInterval(update, 1000);
     return () => clearInterval(i);
   }, []);
   return (
-    <nav style={{display:'flex',gap:'16px',alignItems:'center',padding:'12px 16px',background:'rgba(10,16,32,.8)',borderBottom:'1px solid rgba(255,255,255,.1)'}}>
-      <NavLink end to="/" className={linkClass}>Home</NavLink>
-      <NavLink to="/worlds" className={linkClass}>Worlds</NavLink>
-      <NavLink to="/zones" className={linkClass}>Zones</NavLink>
-      <NavLink to="/zones/arcade" className={linkClass}>Arcade</NavLink>
-      <NavLink to="/marketplace" className={linkClass}>Marketplace</NavLink>
-      <NavLink to="/account" className={linkClass}>Account</NavLink>
-      <NavLink to="/account/wishlist" className={linkClass}>Wishlist</NavLink>
-      <Link to="/marketplace/checkout" className="cart-link">
-        Cart {count ? <span className="badge">{count}</span> : null}
-      </Link>
+    <nav
+      style={{
+        display: 'flex',
+        gap: '16px',
+        alignItems: 'center',
+        padding: '12px 16px',
+        background: 'rgba(10,16,32,.8)',
+        borderBottom: '1px solid rgba(255,255,255,.1)',
+      }}
+    >
+      <NavLink end to="/" className={linkClass}>
+        Home
+      </NavLink>
+      <NavLink to="/worlds" className={linkClass}>
+        Worlds
+      </NavLink>
+      <NavLink to="/zones" className={linkClass}>
+        Zones
+      </NavLink>
+      <NavLink to="/zones/arcade" className={linkClass}>
+        Arcade
+      </NavLink>
+      <NavLink to="/marketplace" className={linkClass}>
+        Marketplace
+      </NavLink>
+      <div style={{ marginLeft: 'auto', display: 'flex', gap: '16px', alignItems: 'center' }}>
+        <NavLink to="/account/wishlist" className={linkClass}>
+          Wishlist
+        </NavLink>
+        <Link to="/marketplace/checkout" className="cart-link">
+          Cart {count ? <span className="badge">{count}</span> : null}
+        </Link>
+        <UserMenu />
+      </div>
     </nav>
   );
 }
+

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { supabase } from '../supabaseClient';
+import { getNavatar } from '../lib/navatar';
+
+export default function UserMenu() {
+  const [open, setOpen] = useState(false);
+  const [avatar, setAvatar] = useState<string | null>(null);
+  const [initials, setInitials] = useState<string | null>(null);
+  const nav = useNavigate();
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setAvatar(getNavatar());
+    supabase.auth.getUser().then(({ data }) => {
+      const name = (data.user?.user_metadata?.full_name || data.user?.email || '')
+        .trim();
+      if (name) {
+        const parts = name.split(/\s+/);
+        const init =
+          parts.length > 1
+            ? parts[0][0] + parts[1][0]
+            : name.slice(0, 2);
+        setInitials(init.toUpperCase());
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDoc);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, []);
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+    nav('/');
+  };
+
+  return (
+    <div className="menu" ref={ref}>
+      <button className="menu-btn" onClick={() => setOpen(!open)}>
+        {avatar ? (
+          <img
+            src={avatar}
+            alt=""
+            style={{ width: 32, height: 32, borderRadius: '50%' }}
+          />
+        ) : initials ? (
+          <div
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              background: 'rgba(255,255,255,.12)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontWeight: 700,
+            }}
+          >
+            {initials}
+          </div>
+        ) : (
+          'Account'
+        )}
+      </button>
+      {open && (
+        <div className="menu-pop">
+          <Link className="menu-item" to="/profile" onClick={() => setOpen(false)}>
+            Profile
+          </Link>
+          <Link
+            className="menu-item"
+            to="/account/orders"
+            onClick={() => setOpen(false)}
+          >
+            Orders
+          </Link>
+          <Link
+            className="menu-item"
+            to="/account/addresses"
+            onClick={() => setOpen(false)}
+          >
+            Addresses
+          </Link>
+          <Link
+            className="menu-item"
+            to="/account/wishlist"
+            onClick={() => setOpen(false)}
+          >
+            Wishlist
+          </Link>
+          <button className="menu-item" onClick={signOut}>
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/web/src/lib/addresses.ts
+++ b/web/src/lib/addresses.ts
@@ -1,0 +1,55 @@
+export type Address = {
+  id: string;
+  name: string;
+  line1: string;
+  line2?: string;
+  city: string;
+  region?: string;
+  postal?: string;
+  country: string;
+  phone?: string;
+  isDefault?: boolean;
+};
+
+const KEY = 'natur_addresses_v1';
+
+function save(list: Address[]) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(list));
+  } catch {}
+}
+
+export function getAddresses(): Address[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed as Address[];
+  } catch {}
+  return [];
+}
+
+export function saveAddress(addr: Omit<Address, 'id'> & { id?: string }): Address {
+  const list = getAddresses();
+  const id = addr.id || crypto.randomUUID();
+  const next: Address = { ...addr, id };
+  if (next.isDefault) {
+    list.forEach((a) => (a.isDefault = false));
+  }
+  const idx = list.findIndex((a) => a.id === id);
+  if (idx >= 0) list[idx] = next; else list.push(next);
+  save(list);
+  return next;
+}
+
+export function removeAddress(id: string): void {
+  const list = getAddresses().filter((a) => a.id !== id);
+  save(list);
+}
+
+export function setDefault(id: string): void {
+  const list = getAddresses();
+  list.forEach((a) => (a.isDefault = a.id === id));
+  save(list);
+}
+

--- a/web/src/pages/account/Addresses.tsx
+++ b/web/src/pages/account/Addresses.tsx
@@ -1,93 +1,82 @@
 import React, { useState } from 'react';
-import { getAddresses, upsertAddress, deleteAddress, setDefaultAddress } from '../../lib/account';
-import type { Address } from '../../lib/types';
+import {
+  Address,
+  getAddresses,
+  saveAddress,
+  removeAddress,
+  setDefault,
+} from '../../lib/addresses';
 
-const EMAIL_RE = /^\S+@\S+\.\S+$/;
-const US_POSTAL = /^\d{5}(-\d{4})?$/;
-
-const emptyAddress = (): Address => ({
-  id: crypto.randomUUID(),
-  fullName: '',
-  email: '',
-  phone: '',
-  address1: '',
-  address2: '',
+const emptyAddress: Address = {
+  id: '',
+  name: '',
+  line1: '',
   city: '',
-  state: '',
-  postal: '',
-  country: 'US',
-});
+  country: '',
+};
 
 export default function Addresses() {
-  const [book, setBook] = useState(getAddresses());
+  const [list, setList] = useState<Address[]>(getAddresses());
   const [editing, setEditing] = useState<Address | null>(null);
 
-  const refresh = () => setBook(getAddresses());
+  const refresh = () => setList(getAddresses());
 
-  const startAdd = () => setEditing(emptyAddress());
+  const startAdd = () => setEditing({ ...emptyAddress });
   const startEdit = (a: Address) => setEditing(a);
 
   const save = (addr: Address) => {
-    upsertAddress(addr);
+    const saved = saveAddress(addr);
+    if (saved.isDefault) setDefault(saved.id);
+    alert('Saved');
     refresh();
     setEditing(null);
   };
 
   const del = (id: string) => {
     if (confirm('Delete this address?')) {
-      deleteAddress(id);
+      removeAddress(id);
       refresh();
     }
   };
 
   const makeDefault = (id: string) => {
-    setDefaultAddress(id);
+    setDefault(id);
     refresh();
   };
 
-  if (editing) {
-    return (
-      <section>
-        <a href="/account/addresses">← Back</a>
-        <h1>{book.list.find((a) => a.id === editing.id) ? 'Edit Address' : 'Add Address'}</h1>
-        <AddressForm initial={editing} onSave={save} onCancel={() => setEditing(null)} />
-      </section>
-    );
-  }
-
   return (
-    <section>
-      <a href="/account">← Back to Account</a>
+    <section className="page-container">
       <h1>Address Book</h1>
-      <button onClick={startAdd}>Add Address</button>
-      {book.list.length === 0 ? (
-        <p>No addresses saved.</p>
+      {editing ? (
+        <AddressForm
+          initial={editing}
+          onSave={save}
+          onCancel={() => setEditing(null)}
+        />
       ) : (
-        <div style={{ display: 'grid', gap: '1rem', marginTop: '1rem' }}>
-          {book.list.map((a) => (
-            <div
-              key={a.id}
-              style={{
-                border: '1px solid rgba(255,255,255,.12)',
-                borderRadius: 8,
-                padding: '0.75rem',
-              }}
-            >
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                <strong>{a.fullName}</strong>
-                {book.defaultId === a.id && <span className="badge default">Default</span>}
+        <button onClick={startAdd}>Add address</button>
+      )}
+
+      {list.length === 0 ? (
+        <p>No addresses yet.</p>
+      ) : (
+        <div className="addr-grid" style={{ marginTop: '1rem' }}>
+          {list.map((a) => (
+            <div className="addr-card" key={a.id}>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <strong>{a.name}</strong>
+                {a.isDefault && <span className="badge-default">Default</span>}
               </div>
               <div style={{ whiteSpace: 'pre-line', marginTop: 4 }}>
-                {a.address1}
-                {a.address2 ? `\n${a.address2}` : ''}
-                {`\n${a.city}, ${a.state} ${a.postal}`}
+                {a.line1}
+                {a.line2 ? `\n${a.line2}` : ''}
+                {`\n${a.city}${a.region ? ', ' + a.region : ''} ${a.postal || ''}`}
                 {`\n${a.country}`}
-                {`\n${a.email}`}
                 {a.phone ? `\n${a.phone}` : ''}
               </div>
-              <div className="actions" style={{ marginTop: 8 }}>
-                {book.defaultId !== a.id && (
-                  <button onClick={() => makeDefault(a.id)}>Set default</button>
+              <div className="actions" style={{ marginTop: 8, display: 'flex', gap: 8 }}>
+                {!a.isDefault && (
+                  <button onClick={() => makeDefault(a.id)}>Make default</button>
                 )}
                 <button onClick={() => startEdit(a)}>Edit</button>
                 <button onClick={() => del(a.id)}>Delete</button>
@@ -107,132 +96,64 @@ interface FormProps {
 }
 
 function AddressForm({ initial, onSave, onCancel }: FormProps) {
-  const [value, setValue] = useState<Address>(initial);
-  const [touched, setTouched] = useState<Record<keyof Address, boolean>>({
-    id: false,
-    fullName: false,
-    email: false,
-    phone: false,
-    address1: false,
-    address2: false,
-    city: false,
-    state: false,
-    postal: false,
-    country: false,
-  });
+  const [value, setValue] = useState<Address>({ ...initial });
 
-  const setField = (field: keyof Address) => (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  const set = (field: keyof Address) => (
+    e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    const v = e.target.value.replace(/\s+/g, ' ').trimStart();
+    const v = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
     setValue({ ...value, [field]: v });
   };
-  const blur = (field: keyof Address) => () =>
-    setTouched((t) => ({ ...t, [field]: true }));
-
-  const errors: Record<keyof Address, string> = {
-    id: '',
-    fullName: value.fullName.trim() ? '' : 'Required',
-    email: EMAIL_RE.test(value.email) ? '' : 'Invalid email',
-    phone: '',
-    address1: value.address1.trim() ? '' : 'Required',
-    address2: '',
-    city: value.city.trim() ? '' : 'Required',
-    state: value.state.trim() ? '' : 'Required',
-    postal:
-      value.country === 'US'
-        ? US_POSTAL.test(value.postal) ? '' : 'Invalid postal code'
-        : value.postal.trim() ? '' : 'Required',
-    country: value.country.trim() ? '' : 'Required',
-  };
-  const valid = Object.values(errors).every((e) => !e);
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!valid) {
-      alert('Please fix errors before saving.');
-      setTouched(
-        Object.keys(touched).reduce(
-          (a, k) => ({ ...a, [k]: true }),
-          {} as Record<keyof Address, boolean>
-        )
-      );
+    if (!value.name || !value.line1 || !value.city || !value.country) {
+      alert('Please fill required fields.');
       return;
     }
     onSave(value);
   };
 
   return (
-    <form onSubmit={submit} className="form-grid" style={{ maxWidth: 420 }}>
-      <input
-        placeholder="Full name"
-        value={value.fullName}
-        onChange={setField('fullName')}
-        onBlur={blur('fullName')}
-        data-invalid={touched.fullName && !!errors.fullName}
-      />
-      <input
-        placeholder="Email"
-        value={value.email}
-        onChange={setField('email')}
-        onBlur={blur('email')}
-        data-invalid={touched.email && !!errors.email}
-      />
-      <input
-        placeholder="Phone (optional)"
-        value={value.phone || ''}
-        onChange={setField('phone')}
-        onBlur={blur('phone')}
-      />
-      <select
-        value={value.country}
-        onChange={setField('country')}
-        onBlur={blur('country')}
-        data-invalid={touched.country && !!errors.country}
-      >
-        <option value="">Country</option>
-        <option value="US">United States</option>
-        <option value="CA">Canada</option>
-        <option value="Other">Other</option>
-      </select>
+    <form onSubmit={submit} className="form-grid" style={{ maxWidth: 420, marginTop: '1rem' }}>
+      <input placeholder="Name" value={value.name} onChange={set('name')} />
       <input
         placeholder="Address line 1"
-        value={value.address1}
-        onChange={setField('address1')}
-        onBlur={blur('address1')}
-        data-invalid={touched.address1 && !!errors.address1}
+        value={value.line1}
+        onChange={set('line1')}
       />
       <input
         placeholder="Address line 2"
-        value={value.address2 || ''}
-        onChange={setField('address2')}
-        onBlur={blur('address2')}
+        value={value.line2 || ''}
+        onChange={set('line2')}
       />
+      <input placeholder="City" value={value.city} onChange={set('city')} />
       <input
-        placeholder="City"
-        value={value.city}
-        onChange={setField('city')}
-        onBlur={blur('city')}
-        data-invalid={touched.city && !!errors.city}
-      />
-      <input
-        placeholder="State"
-        value={value.state}
-        onChange={setField('state')}
-        onBlur={blur('state')}
-        data-invalid={touched.state && !!errors.state}
+        placeholder="Region"
+        value={value.region || ''}
+        onChange={set('region')}
       />
       <input
         placeholder="Postal code"
-        value={value.postal}
-        onChange={setField('postal')}
-        onBlur={blur('postal')}
-        data-invalid={touched.postal && !!errors.postal}
+        value={value.postal || ''}
+        onChange={set('postal')}
       />
+      <input
+        placeholder="Country"
+        value={value.country}
+        onChange={set('country')}
+      />
+      <input placeholder="Phone" value={value.phone || ''} onChange={set('phone')} />
+      <label style={{ display: 'flex', alignItems: 'center', gap: 6, gridColumn: '1/3' }}>
+        <input
+          type="checkbox"
+          checked={value.isDefault || false}
+          onChange={set('isDefault')}
+        />
+        Default
+      </label>
       <div className="actions" style={{ gridColumn: '1/3', marginTop: 8 }}>
-        <button type="submit" disabled={!valid}>
-          Save
-        </button>
+        <button type="submit">Save</button>
         <button type="button" onClick={onCancel}>
           Cancel
         </button>
@@ -240,3 +161,4 @@ function AddressForm({ initial, onSave, onCancel }: FormProps) {
     </form>
   );
 }
+

--- a/web/src/pages/account/OrderDetail.tsx
+++ b/web/src/pages/account/OrderDetail.tsx
@@ -1,133 +1,67 @@
-import React, { useMemo } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
-import { getOrderById, reorder } from '../../lib/account';
-import { explorerUrl } from '../../lib/orders';
-import { formatNatur } from '../../lib/pricing';
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { getOrders } from '../../lib/orders';
 
 export default function OrderDetail() {
   const { id = '' } = useParams();
-  const order = useMemo(() => getOrderById(id), [id]);
-  const nav = useNavigate();
+  const order = getOrders().find((o) => o.id === id);
 
   if (!order) {
     return (
-      <section>
-        <a href="/account/orders">← Back to Orders</a>
+      <section className="page-container">
+        <Link to="/account/orders">← Back to Orders</Link>
         <h1>Order not found</h1>
-        <p>We couldn’t find that order in this browser.</p>
       </section>
     );
   }
 
-  const doReorder = () => {
-    reorder(order);
-    const added = order.lines.reduce((s, l) => s + l.qty, 0);
-    alert(`Re-added ${added} items to your cart.`);
-    nav('/marketplace/cart');
-  };
-
-  const shipLabels: Record<string, string> = {
-    standard: 'Standard',
-    expedited: 'Expedited',
-  };
-  const txUrl = explorerUrl(order.txHash);
-
   return (
-    <section>
-      <a href="/account/orders">← Back to Orders</a>
-      <h1>Order {order.id}</h1>
-      <p style={{ opacity: 0.9 }}>{new Date(order.createdAt).toLocaleString()}</p>
+    <section className="page-container">
+      <Link to="/account/orders">← Back to Orders</Link>
+      <h1>Order #{order.id.slice(0, 8)}</h1>
+      <p className="muted" style={{ marginBottom: '1rem' }}>
+        {new Date(order.createdAt).toLocaleString()} • ${order.amounts.total.toFixed(2)}
+      </p>
+
+      <h2>Contact</h2>
+      <p>{order.email}</p>
+
+      <h2>Shipping</h2>
+      <p>{order.shippingName}<br />{order.shippingAddress}</p>
 
       <h2>Items</h2>
       <table className="table">
         <thead>
           <tr>
-            <th>Name</th>
-            <th>Variant</th>
+            <th>Item</th>
             <th>Qty</th>
             <th>Unit</th>
-            <th>Line</th>
+            <th>Total</th>
           </tr>
         </thead>
         <tbody>
           {order.lines.map((l) => (
             <tr key={l.id}>
-              <td>{l.name}</td>
-              <td>{l.meta?.variant || ''}</td>
+              <td>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  {l.image && (
+                    <img
+                      src={l.image}
+                      alt=""
+                      style={{ width: 40, height: 40, objectFit: 'cover', borderRadius: 4 }}
+                    />
+                  )}
+                  {l.name}
+                </div>
+              </td>
               <td>{l.qty}</td>
-              <td>{formatNatur(l.priceNatur)}</td>
-              <td>{formatNatur(l.priceNatur * l.qty)}</td>
+              <td>${l.price.toFixed(2)}</td>
+              <td>${(l.price * l.qty).toFixed(2)}</td>
             </tr>
           ))}
         </tbody>
       </table>
-
-      <h2>Totals</h2>
-      <table className="table">
-        <tbody>
-          <tr>
-            <td>Items</td>
-            <td>{formatNatur(order.totals?.items ?? order.totalNatur)}</td>
-          </tr>
-          {order.totals?.shipping !== undefined && (
-            <tr>
-              <td>Shipping ({shipLabels[order.shippingMethod] || ''})</td>
-              <td>{formatNatur(order.totals.shipping)}</td>
-            </tr>
-          )}
-          {order.totals?.discount && (
-            <tr>
-              <td>Discount</td>
-              <td>-{formatNatur(order.totals.discount)}</td>
-            </tr>
-          )}
-          <tr>
-            <td>Grand total</td>
-            <td>{formatNatur(order.totals?.grandTotal ?? order.totalNatur)}</td>
-          </tr>
-        </tbody>
-      </table>
-
-      {order.shipping && (
-        <>
-          <h2>Shipping</h2>
-          <p>{shipLabels[order.shippingMethod] || ''}</p>
-          <p style={{ whiteSpace: 'pre-line' }}>
-            {order.shipping.fullName}
-            {'\n'}
-            {order.shipping.address1}
-            {order.shipping.address2 ? `\n${order.shipping.address2}` : ''}
-            {'\n'}
-            {order.shipping.city}, {order.shipping.state} {order.shipping.postal}
-            {'\n'}
-            {order.shipping.country}
-            {'\n'}
-            {order.shipping.email}
-            {order.shipping.phone ? `\n${order.shipping.phone}` : ''}
-          </p>
-        </>
-      )}
-
-      {order.txHash && (
-        <>
-          <h2>Transaction</h2>
-          <p>
-            Hash: <code>{order.txHash}</code>
-            <br />
-            {txUrl && (
-              <a href={txUrl} target="_blank" rel="noreferrer">
-                View on Explorer ↗
-              </a>
-            )}
-          </p>
-        </>
-      )}
-
-      <div className="actions" style={{ marginTop: '1rem' }}>
-        <button onClick={doReorder}>Reorder</button>
-        <Link to="/account/orders">Go to Orders</Link>
-        <Link to="/marketplace">Continue Shopping</Link>
-      </div>
     </section>
   );
 }
+

--- a/web/src/pages/account/Orders.tsx
+++ b/web/src/pages/account/Orders.tsx
@@ -4,24 +4,44 @@ import { Link } from 'react-router-dom';
 export default function Orders() {
   const list = getOrders();
   return (
-    <div className="container" style={{padding:'24px'}}>
+    <div className="container" style={{ padding: '24px' }}>
       <h1>Your Orders</h1>
       {!list.length ? (
-        <p>No orders yet. <Link to="/marketplace" style={{color:'#7fe3ff'}}>Go shop</Link>.</p>
+        <p>
+          No orders yet.{' '}
+          <Link to="/marketplace" style={{ color: '#7fe3ff' }}>
+            Go shop
+          </Link>
+          .
+        </p>
       ) : (
         <div className="panel">
-          {list.map((o,i)=>(
-            <div key={i} className="order">
-              <div className="muted small">{new Date(o.createdAt).toLocaleString()}</div>
-              <div><strong>#{o.id.slice(0,8)}</strong> • {o.lines.length} item(s) • <strong>${o.amounts.total.toFixed(2)}</strong></div>
-              <div className="muted small">{o.shippingName} — {o.shippingAddress}</div>
-              <div className="thumbs">
-                {o.lines.slice(0,6).map((l,j)=> l.image ? <img key={j} src={l.image} alt="" /> : <div key={j} className="ph"/> )}
+          {list.map((o, i) => (
+            <Link key={i} to={`/account/orders/${o.id}`} className="order">
+              <div className="muted small">
+                {new Date(o.createdAt).toLocaleString()}
               </div>
-            </div>
+              <div>
+                <strong>#{o.id.slice(0, 8)}</strong> • {o.lines.length} item(s) •{' '}
+                <strong>${o.amounts.total.toFixed(2)}</strong>
+              </div>
+              <div className="muted small">
+                {o.shippingName} — {o.shippingAddress}
+              </div>
+              <div className="thumbs">
+                {o.lines.slice(0, 6).map((l, j) =>
+                  l.image ? (
+                    <img key={j} src={l.image} alt="" />
+                  ) : (
+                    <div key={j} className="ph" />
+                  )
+                )}
+              </div>
+            </Link>
           ))}
         </div>
       )}
     </div>
   );
 }
+

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -562,3 +562,11 @@ input, textarea, select { width:100%; padding:10px 12px; border-radius:10px; bor
 .rev { padding:10px 0; border-bottom:1px dashed rgba(255,255,255,.1); }
 .muted { opacity:.8; }
 .small { font-size:12px; }
+.menu { position:relative }
+.menu-btn { display:flex; align-items:center; gap:8px; border:1px solid rgba(255,255,255,.18); background:rgba(255,255,255,.06); border-radius:999px; padding:6px 10px; }
+.menu-pop { position:absolute; right:0; top:calc(100% + 8px); min-width:200px; background:rgba(12,16,30,.98); border:1px solid rgba(255,255,255,.14); border-radius:12px; padding:8px; box-shadow:0 8px 28px rgba(0,0,0,.4); }
+.menu-item { display:flex; align-items:center; gap:8px; padding:8px 10px; border-radius:8px; }
+.menu-item:hover { background:rgba(255,255,255,.06); }
+.badge-default { background:#00d1ff; color:#08121f; border-radius:999px; padding:2px 8px; font-weight:800; font-size:12px; }
+.addr-card { padding:12px; border:1px solid rgba(255,255,255,.12); border-radius:12px; background:rgba(255,255,255,.04); }
+.addr-grid { display:grid; gap:12px; grid-template-columns:repeat(auto-fill, minmax(260px, 1fr)); }


### PR DESCRIPTION
## Summary
- implement address helpers and default handling
- add account address book CRUD UI and order detail page
- introduce user menu in navbar and protect account routes with RequireAuth

## Testing
- `npm test` (fails: Missing script: "test")
- `npm --prefix web run lint`
- `npm run build` (fails: sh: 1: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a2b13dcd508329b7198ec1f18143eb