### PR TITLE
Add settings page with theme and data controls

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import AppShell from './components/AppShell';
 import Home from './pages/Home';
@@ -13,7 +13,8 @@ import MusicZone from './pages/zones/MusicZone';
 import EcoLab from './pages/zones/EcoLab';
 import StoryStudio from './pages/zones/StoryStudio';
 import Parents from './pages/zones/Parents';
-import Settings from './pages/zones/Settings';
+import ZoneSettings from './pages/zones/Settings';
+import Settings from './pages/settings';
 import WellnessZone from './pages/zones/Wellness';
 import CreatorLab from './pages/zones/CreatorLab';
 import Arcade from './pages/zones/arcade';
@@ -49,8 +50,13 @@ import ToastHost from './components/ui/ToastHost';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import NotFound from './pages/errors/NotFound';
 import ServerError from './pages/errors/ServerError';
+import { applyThemeFromStorage, applyReducedMotionFromStorage } from './lib/prefs';
 
 export default function App() {
+  useEffect(() => {
+    applyThemeFromStorage();
+    applyReducedMotionFromStorage();
+  }, []);
   return (
     <ProfileProvider>
       <CartProvider>
@@ -75,7 +81,8 @@ export default function App() {
               <Route path="/zones/eco-lab" element={<EcoLab />} />
               <Route path="/zones/story-studio" element={<StoryStudio />} />
               <Route path="/zones/parents" element={<Parents />} />
-              <Route path="/zones/settings" element={<Settings />} />
+              <Route path="/zones/settings" element={<ZoneSettings />} />
+              <Route path="/settings" element={<Settings />} />
               <Route path="/zones/wellness" element={<WellnessZone />} />
               <Route path="/zones/creator-lab" element={<CreatorLab />} />
               <Route path="/zones/arcade" element={<Arcade />} />

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -70,6 +70,9 @@ export default function Navbar() {
             <NavLink to="/faq" className="menu-item" onClick={() => setMoreOpen(false)}>
               FAQ
             </NavLink>
+            <NavLink to="/settings" className="menu-item" onClick={() => setMoreOpen(false)}>
+              Settings
+            </NavLink>
             <NavLink to="/privacy" className="menu-item" onClick={() => setMoreOpen(false)}>
               Privacy
             </NavLink>

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -79,6 +79,9 @@ export default function UserMenu() {
           <Link className="menu-item" to="/profile" onClick={() => setOpen(false)}>
             Profile
           </Link>
+          <Link className="menu-item" to="/settings" onClick={() => setOpen(false)}>
+            Settings
+          </Link>
           <Link
             className="menu-item"
             to="/account/orders"

--- a/web/src/lib/dataExport.ts
+++ b/web/src/lib/dataExport.ts
@@ -1,0 +1,41 @@
+const BASE_KEYS = ['natur_cart', 'natur_orders', 'natur_profile', 'navatar'];
+const PREFIXES = ['naturversity_', 'wellness_'];
+
+function collectKeys(): string[] {
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i);
+    if (!k) continue;
+    if (BASE_KEYS.includes(k) || PREFIXES.some(p => k.startsWith(p))) {
+      keys.push(k);
+    }
+  }
+  return keys;
+}
+
+export function exportData() {
+  const data: Record<string, unknown> = {};
+  for (const k of collectKeys()) {
+    const v = localStorage.getItem(k);
+    if (v !== null) {
+      try {
+        data[k] = JSON.parse(v);
+      } catch {
+        data[k] = v;
+      }
+    }
+  }
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'naturverse-data.json';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function clearData() {
+  for (const k of collectKeys()) {
+    localStorage.removeItem(k);
+  }
+}

--- a/web/src/lib/prefs.ts
+++ b/web/src/lib/prefs.ts
@@ -1,0 +1,42 @@
+export type ThemePref = 'light' | 'dark' | 'system';
+
+function applyTheme(theme: 'light' | 'dark') {
+  document.documentElement.dataset.theme = theme;
+}
+
+export function getTheme(): ThemePref {
+  return (localStorage.getItem('theme') as 'light' | 'dark') || 'system';
+}
+
+export function setTheme(t: ThemePref) {
+  if (t === 'system') {
+    localStorage.removeItem('theme');
+    applyThemeFromStorage();
+  } else {
+    localStorage.setItem('theme', t);
+    applyTheme(t);
+  }
+}
+
+export function applyThemeFromStorage() {
+  const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
+  const theme = stored ?? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  applyTheme(theme);
+}
+
+export function getReducedMotion(): boolean {
+  return localStorage.getItem('reducedMotion') === 'true';
+}
+
+export function setReducedMotion(on: boolean) {
+  localStorage.setItem('reducedMotion', on ? 'true' : 'false');
+  applyReducedMotion(on);
+}
+
+export function applyReducedMotion(on: boolean) {
+  document.documentElement.classList.toggle('reduced-motion', on);
+}
+
+export function applyReducedMotionFromStorage() {
+  applyReducedMotion(getReducedMotion());
+}

--- a/web/src/pages/settings.tsx
+++ b/web/src/pages/settings.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  ThemePref,
+  getTheme,
+  setTheme,
+  getReducedMotion,
+  setReducedMotion,
+} from '../lib/prefs';
+import { exportData, clearData } from '../lib/dataExport';
+
+export default function Settings() {
+  const [theme, setThemeState] = useState<ThemePref>(getTheme());
+  const [reduced, setReduced] = useState<boolean>(getReducedMotion());
+
+  const changeTheme = (t: ThemePref) => {
+    setThemeState(t);
+    setTheme(t);
+  };
+
+  const changeReduced = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setReduced(e.target.checked);
+    setReducedMotion(e.target.checked);
+  };
+
+  const handleExport = () => {
+    exportData();
+  };
+
+  const handleClear = () => {
+    if (confirm('Clear local data?')) {
+      clearData();
+      window.location.reload();
+    }
+  };
+
+  return (
+    <main className="container settings-page">
+      <h1>Settings</h1>
+
+      <section className="setting-block">
+        <h2>Theme</h2>
+        <label>
+          <input
+            type="radio"
+            name="theme"
+            value="light"
+            checked={theme === 'light'}
+            onChange={() => changeTheme('light')}
+          />
+          Light
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="theme"
+            value="dark"
+            checked={theme === 'dark'}
+            onChange={() => changeTheme('dark')}
+          />
+          Dark
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="theme"
+            value="system"
+            checked={theme === 'system'}
+            onChange={() => changeTheme('system')}
+          />
+          System
+        </label>
+      </section>
+
+      <section className="setting-block">
+        <h2>Motion</h2>
+        <label>
+          <input
+            type="checkbox"
+            checked={reduced}
+            onChange={changeReduced}
+          />
+          Reduce motion
+        </label>
+      </section>
+
+      <section className="setting-block">
+        <h2>Data</h2>
+        <button className="button" onClick={handleExport}>
+          Export my data
+        </button>
+        <button
+          className="button"
+          style={{ background: 'var(--danger)', color: 'var(--bg)' }}
+          onClick={handleClear}
+        >
+          Clear local data
+        </button>
+      </section>
+
+      <nav className="quick-links">
+        <Link to="/account/orders">Orders</Link>
+        <Link to="/profile">Profile</Link>
+        <Link to="/privacy">Privacy</Link>
+        <Link to="/terms">Terms</Link>
+        <Link to="/contact">Contact</Link>
+      </nav>
+    </main>
+  );
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -93,8 +93,8 @@ body { background: var(--bg); color: var(--text); }
   box-sizing: border-box;
 }
 
-/* Hard-disable animations & transitions everywhere */
-* {
+/* Reduced motion toggle */
+html.reduced-motion * {
   animation: none !important;
   transition: none !important;
 }
@@ -586,3 +586,7 @@ input, textarea, select { width:100%; padding:10px 12px; border-radius:10px; bor
 .site-footer { padding:32px 16px; background:rgba(10,16,32,.8); border-top:1px solid rgba(255,255,255,.1); }
 .site-footer .footer-links, .site-footer .footer-social { display:flex; flex-wrap:wrap; gap:12px; justify-content:center; }
 .site-footer .footer-links { margin-bottom:12px; }
+.settings-page { display:grid; gap:24px; padding:24px 0; }
+.setting-block { background:var(--panel); border:1px solid var(--panel-b); border-radius:8px; padding:16px; display:flex; flex-direction:column; gap:8px; }
+.setting-block label { display:flex; align-items:center; gap:8px; }
+.quick-links { display:flex; flex-wrap:wrap; gap:12px; }


### PR DESCRIPTION
## Summary
- add `/settings` page for theme, reduced motion and data management
- persist preferences in `localStorage` and apply on load
- allow exporting or clearing local data
- surface settings link in nav menus

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c189af588329a5a684aaead84dbb