### PR TITLE
Add support page and floating feedback button

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -10,6 +10,13 @@
   </head>
   <body>
     <div id="root"></div>
+    <form name="natur-feedback" data-netlify="true" netlify-honeypot="bot-field" hidden>
+      <input type="text" name="category" />
+      <textarea name="message"></textarea>
+      <input type="email" name="email" />
+      <input type="text" name="page" />
+      <input type="text" name="ua" />
+    </form>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,6 +25,7 @@ import FAQ from './pages/faq';
 import Privacy from './pages/privacy';
 import Terms from './pages/terms';
 import Contact from './pages/contact';
+import Support from './pages/support';
 import StoryStudioPage from './pages/story-studio';
 import AutoQuiz from './pages/auto-quiz';
 import Profile from './pages/Profile';
@@ -47,6 +48,7 @@ import Wishlist from './pages/account/Wishlist';
 import { CartProvider } from './context/CartContext';
 import ProfileProvider from './context/ProfileContext';
 import ToastHost from './components/ui/ToastHost';
+import FloatingFeedback from './components/FloatingFeedback';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import NotFound from './pages/errors/NotFound';
 import ServerError from './pages/errors/ServerError';
@@ -62,6 +64,7 @@ export default function App() {
       <CartProvider>
         <Suspense fallback={<div className="container" style={{ padding: '24px' }}>Loading...</div>}>
           <ToastHost />
+          <FloatingFeedback />
           <ErrorBoundary>
             <Routes>
             <Route element={<AppShell />}>
@@ -71,6 +74,7 @@ export default function App() {
               <Route path="/privacy" element={<Privacy />} />
               <Route path="/terms" element={<Terms />} />
               <Route path="/contact" element={<Contact />} />
+              <Route path="/support" element={<Support />} />
               <Route path="/story-studio" element={<StoryStudioPage />} />
               <Route path="/auto-quiz" element={<AutoQuiz />} />
               <Route path="/worlds" element={<Worlds />} />

--- a/web/src/components/FloatingFeedback.tsx
+++ b/web/src/components/FloatingFeedback.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useToast } from './ui/useToast';
+import { submitNetlifyForm } from '../lib/feedback';
+
+export default function FloatingFeedback() {
+  const [open, setOpen] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [form, setForm] = useState({
+    category: 'Bug',
+    message: '',
+    email: '',
+    'bot-field': '',
+  });
+  const loc = useLocation();
+  const toast = useToast();
+
+  if (loc.pathname.includes('checkout')) return null;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    try {
+      await submitNetlifyForm({
+        'form-name': 'natur-feedback',
+        category: form.category,
+        message: form.message,
+        email: form.email,
+        page: window.location.href,
+        ua: navigator.userAgent,
+        'bot-field': form['bot-field'],
+      });
+      setSent(true);
+      setForm({ category: 'Bug', message: '', email: '', 'bot-field': '' });
+      toast.success("Thanks! We'll get back to you.", 3000);
+      setTimeout(() => {
+        setSent(false);
+        setOpen(false);
+      }, 3000);
+    } catch {
+      toast.error("Couldn't send feedback—try again.");
+    }
+  };
+
+  return (
+    <>
+      <button className="nv-feedback-btn" onClick={() => setOpen(o => !o)} aria-label="Feedback">
+        Feedback
+      </button>
+      <div className={`nv-feedback-panel${open ? ' open' : ''}`}>
+        {sent ? (
+          <p>Thanks! We'll get back to you.</p>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <input type="hidden" name="form-name" value="natur-feedback" />
+            <p hidden>
+              <label>
+                Don’t fill this out: <input name="bot-field" value={form['bot-field']} onChange={handleChange} />
+              </label>
+            </p>
+            <div className="field">
+              <label>
+                Category
+                <select name="category" value={form.category} onChange={handleChange}>
+                  <option>Bug</option>
+                  <option>Feature</option>
+                  <option>Order issue</option>
+                  <option>Other</option>
+                </select>
+              </label>
+            </div>
+            <div className="field">
+              <label>
+                Message
+                <textarea name="message" required maxLength={2000} value={form.message} onChange={handleChange} rows={3}></textarea>
+              </label>
+            </div>
+            <div className="field">
+              <label>
+                Email (optional)
+                <input type="email" name="email" value={form.email} onChange={handleChange} />
+              </label>
+            </div>
+            <small style={{ opacity: 0.7, display: 'block', marginBottom: '8px' }}>
+              We only use this info to respond.
+            </small>
+            <button className="button" type="submit">Send</button>
+          </form>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -82,6 +82,9 @@ export default function Navbar() {
             <NavLink to="/contact" className="menu-item" onClick={() => setMoreOpen(false)}>
               Contact
             </NavLink>
+            <NavLink to="/support" className="menu-item" onClick={() => setMoreOpen(false)}>
+              Support
+            </NavLink>
           </div>
         )}
       </div>

--- a/web/src/lib/feedback.ts
+++ b/web/src/lib/feedback.ts
@@ -1,0 +1,15 @@
+export function buildFormPayload(fields: Record<string, string>) {
+  return Object.entries(fields)
+    .map(([k, v]) => encodeURIComponent(k) + '=' + encodeURIComponent(v))
+    .join('&');
+}
+
+export async function submitNetlifyForm(fields: Record<string, string>) {
+  const body = buildFormPayload(fields);
+  const res = await fetch('/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  if (!res.ok) throw new Error('Request failed');
+}

--- a/web/src/pages/support.tsx
+++ b/web/src/pages/support.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import Seo from '../components/Seo';
+import { useToast } from '../components/ui/useToast';
+import { submitNetlifyForm } from '../lib/feedback';
+
+export default function Support() {
+  const [sent, setSent] = useState(false);
+  const [form, setForm] = useState({
+    category: 'Bug',
+    message: '',
+    email: '',
+    'bot-field': '',
+  });
+  const toast = useToast();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    try {
+      await submitNetlifyForm({
+        'form-name': 'natur-feedback',
+        category: form.category,
+        message: form.message,
+        email: form.email,
+        page: window.location.href,
+        ua: navigator.userAgent,
+        'bot-field': form['bot-field'],
+      });
+      setSent(true);
+      setForm({ category: 'Bug', message: '', email: '', 'bot-field': '' });
+      setTimeout(() => setSent(false), 3000);
+    } catch {
+      toast.error("Couldn't send feedback—try again.");
+    }
+  };
+
+  return (
+    <main className="page">
+      <Seo title="Support – Naturverse" description="Send feedback or get help." />
+      <h1>Support</h1>
+      {sent ? (
+        <p>Thanks! We'll get back to you.</p>
+      ) : (
+        <form onSubmit={handleSubmit}>
+          <input type="hidden" name="form-name" value="natur-feedback" />
+          <p hidden>
+            <label>
+              Don’t fill this out: <input name="bot-field" value={form['bot-field']} onChange={handleChange} />
+            </label>
+          </p>
+          <div className="field">
+            <label>
+              Category
+              <select name="category" value={form.category} onChange={handleChange}>
+                <option>Bug</option>
+                <option>Feature</option>
+                <option>Order issue</option>
+                <option>Other</option>
+              </select>
+            </label>
+          </div>
+          <div className="field">
+            <label>
+              Message
+              <textarea name="message" required maxLength={2000} value={form.message} onChange={handleChange}></textarea>
+            </label>
+          </div>
+          <div className="field">
+            <label>
+              Email (optional)
+              <input type="email" name="email" value={form.email} onChange={handleChange} />
+            </label>
+          </div>
+          <small style={{ opacity: 0.7 }}>We only use this info to respond.</small>
+          <div style={{ marginTop: '8px' }}>
+            <button className="button" type="submit">Send</button>
+          </div>
+        </form>
+      )}
+    </main>
+  );
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -341,8 +341,50 @@ body {
   .icon-btn { appearance: none; background: transparent; border: 0; cursor: pointer; }
   .icon-btn[aria-pressed="true"] { color: #ef4444; }
 
-  .field-error { color:#ef4444; font-size:12px; margin-top:4px; }
-  .field { display:flex; flex-direction:column; gap:4px; }
+.field-error { color:#ef4444; font-size:12px; margin-top:4px; }
+.field { display:flex; flex-direction:column; gap:4px; }
+
+/* Floating feedback button */
+.nv-feedback-btn {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  cursor: pointer;
+  z-index: 50;
+}
+
+.nv-feedback-panel {
+  position: fixed;
+  right: 16px;
+  bottom: 72px;
+  width: 260px;
+  background: var(--panel);
+  border: 1px solid var(--panel-b);
+  border-radius: 8px;
+  padding: 12px;
+  opacity: 0;
+  transform: translateY(8px);
+  pointer-events: none;
+  transition: opacity .2s ease, transform .2s ease;
+  z-index: 50;
+}
+
+.nv-feedback-panel.open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+html.reduced-motion .nv-feedback-panel {
+  transition: none;
+  transform: none;
+}
   .row { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
   @media (max-width:640px){ .row { grid-template-columns:1fr; } }
 


### PR DESCRIPTION
## Summary
- add Netlify-backed Support page at `/support`
- introduce floating feedback button with slide-up form
- share submission helpers for encoding and posting form data

## Testing
- `npm --prefix web run lint`
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d6a4e27c8329a156f2b915b66dfb