### PR TITLE
Wishlist + Recently Viewed (persisted, shareable — no new deps)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,7 +44,7 @@ import Success from './pages/marketplace/Success';
 import Orders from './pages/account/Orders';
 import Addresses from './pages/account/Addresses';
 import AccountOrderDetail from './pages/account/OrderDetail';
-import Wishlist from './pages/account/Wishlist';
+import ShareWishlist from './pages/account/ShareWishlist';
 import { CartProvider } from './context/CartContext';
 import ProfileProvider from './context/ProfileContext';
 import ToastHost from './components/ui/ToastHost';
@@ -136,14 +136,8 @@ export default function App() {
                   </RequireAuth>
                 }
               />
-              <Route
-                path="/account/wishlist"
-                element={
-                  <RequireAuth>
-                    <Wishlist />
-                  </RequireAuth>
-                }
-              />
+              <Route path="/account/wishlist" element={<Wishlist />} />
+              <Route path="/share/wishlist" element={<ShareWishlist />} />
             </Route>
             <Route path="/login" element={<Login />} />
             <Route path="/auth/callback" element={<AuthCallback />} />

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { getCart } from '../lib/cart';
+import { getWishlist, subscribe as subWish, unsubscribe as unsubWish } from '../lib/wishlist';
 import { Link, NavLink } from 'react-router-dom';
 import UserMenu from './UserMenu';
 
@@ -8,6 +9,7 @@ const linkClass = ({ isActive }: { isActive: boolean }) =>
 
 export default function Navbar() {
   const [count, setCount] = useState(0);
+  const [wishCount, setWishCount] = useState(getWishlist().length);
   const [moreOpen, setMoreOpen] = useState(false);
   const moreRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -15,6 +17,11 @@ export default function Navbar() {
     update();
     const i = setInterval(update, 1000);
     return () => clearInterval(i);
+  }, []);
+  useEffect(() => {
+    const cb = (ids: string[]) => setWishCount(ids.length);
+    subWish(cb);
+    return () => unsubWish(cb);
   }, []);
   useEffect(() => {
     const onDoc = (e: MouseEvent) => {
@@ -90,7 +97,7 @@ export default function Navbar() {
       </div>
       <div style={{ marginLeft: 'auto', display: 'flex', gap: '16px', alignItems: 'center' }}>
         <NavLink to="/account/wishlist" className={linkClass}>
-          Wishlist
+          Wishlist {wishCount ? <span className="badge">{wishCount}</span> : null}
         </NavLink>
         <Link to="/marketplace/checkout" className="cart-link">
           Cart {count ? <span className="badge">{count}</span> : null}

--- a/web/src/components/ProductCard.tsx
+++ b/web/src/components/ProductCard.tsx
@@ -1,36 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { getNavatar } from '../lib/navatar';
-import { isFav, toggleFav, subscribe, unsubscribe } from '../lib/wishlist';
+import WishlistButton from './WishlistButton';
 
 export default function ProductCard({ product }: { product: any }) {
   const navatar = getNavatar();
-  const [fav, setFav] = useState(isFav(product.id));
-
-  useEffect(() => {
-    const cb = (ids: string[]) => setFav(ids.includes(product.id));
-    subscribe(cb);
-    return () => unsubscribe(cb);
-  }, [product.id]);
-
-  const onToggle = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    const next = toggleFav(product.id);
-    setFav(next);
-  };
 
   return (
     <div className="product-card">
       <div className="thumb" style={{ position: 'relative' }}>
         <img src={product.image} alt={product.name} />
-        <button
-          className="heart-btn icon-btn"
-          aria-label={fav ? 'Remove from wishlist' : 'Add to wishlist'}
-          aria-pressed={fav}
-          onClick={onToggle}
-        >
-          {fav ? '♥' : '♡'}
-        </button>
+        <WishlistButton id={product.id} />
         {navatar && (
           <img
             src={navatar}
@@ -51,4 +30,3 @@ export default function ProductCard({ product }: { product: any }) {
     </div>
   );
 }
-

--- a/web/src/components/RecentCarousel.tsx
+++ b/web/src/components/RecentCarousel.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { getRecent } from '../lib/recent';
+import { getProduct } from '../lib/products';
+
+export default function RecentCarousel() {
+  const [ids, setIds] = React.useState<string[]>(getRecent().slice(0, 12));
+
+  React.useEffect(() => {
+    const onStore = () => setIds(getRecent().slice(0, 12));
+    window.addEventListener('storage', onStore);
+    window.addEventListener('recent:update', onStore as any);
+    return () => {
+      window.removeEventListener('storage', onStore);
+      window.removeEventListener('recent:update', onStore as any);
+    };
+  }, []);
+
+  const items = ids
+    .map(id => getProduct(id))
+    .filter(Boolean)
+    .map(p => ({ id: p!.id, name: p!.name, img: (p as any).img || (p as any).image }));
+
+  if (!items.length) return null;
+
+  return (
+    <section className="panel" style={{ padding: '12px' }}>
+      <h3 style={{ margin: '0 0 8px' }}>Recently viewed</h3>
+      <div className="recent-row">
+        {items.map(it => (
+          <a key={it.id} href={`/marketplace/item?id=${it.id}`} className="recent-card" aria-label={it.name}>
+            <img src={it.img} alt="" />
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/WishlistButton.tsx
+++ b/web/src/components/WishlistButton.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { isWished, toggleWishlist, subscribe, unsubscribe } from '../lib/wishlist';
+import { useToast } from './ui/useToast';
+
+export default function WishlistButton({ id }: { id: string }) {
+  const [wished, setWished] = useState(isWished(id));
+  const toast = useToast();
+
+  useEffect(() => {
+    const cb = (ids: string[]) => setWished(ids.includes(id));
+    subscribe(cb);
+    return () => unsubscribe(cb);
+  }, [id]);
+
+  const onToggle = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const next = toggleWishlist(id);
+    setWished(next);
+    toast.info(next ? 'Added to wishlist' : 'Removed from wishlist');
+  };
+
+  return (
+    <button
+      className="heart-btn icon-btn"
+      aria-label={wished ? 'Remove from wishlist' : 'Add to wishlist'}
+      aria-pressed={wished}
+      onClick={onToggle}
+    >
+      {wished ? '♥' : '♡'}
+    </button>
+  );
+}

--- a/web/src/components/marketplace/ProductCard.tsx
+++ b/web/src/components/marketplace/ProductCard.tsx
@@ -1,37 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { getNavatar } from '../../lib/navatar';
 import type { Item } from '../../lib/catalog';
-import { isFav, toggleFav, subscribe, unsubscribe } from '../../lib/wishlist';
+import WishlistButton from '../WishlistButton';
 
 export default function ProductCard({ item }: { item: Item }) {
   const navatar = getNavatar();
-  const [fav, setFav] = useState(isFav(item.id));
-
-  useEffect(() => {
-    const cb = (ids: string[]) => setFav(ids.includes(item.id));
-    subscribe(cb);
-    return () => unsubscribe(cb);
-  }, [item.id]);
-
-  const onToggle = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    const next = toggleFav(item.id);
-    setFav(next);
-  };
-
   return (
     <div className="product-card">
       <div className="thumb" style={{ position: 'relative' }}>
         <img src={item.img} alt={item.name} />
-        <button
-          className="heart-btn icon-btn"
-          aria-label={fav ? 'Remove from wishlist' : 'Add to wishlist'}
-          aria-pressed={fav}
-          onClick={onToggle}
-        >
-          {fav ? '♥' : '♡'}
-        </button>
+        <WishlistButton id={item.id} />
         {navatar && (
           <img
             src={navatar}
@@ -52,4 +30,3 @@ export default function ProductCard({ item }: { item: Item }) {
     </div>
   );
 }
-

--- a/web/src/lib/recent.ts
+++ b/web/src/lib/recent.ts
@@ -1,0 +1,34 @@
+const KEY = 'nv_recent_v1';
+const LIMIT = 20;
+
+function read(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(KEY) || '[]');
+  } catch {
+    return [];
+  }
+}
+
+function write(ids: string[]) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(ids.slice(0, LIMIT)));
+  } catch {}
+  try {
+    window.dispatchEvent(new CustomEvent('recent:update', { detail: ids }));
+  } catch {}
+}
+
+export function pushRecent(id: string) {
+  const cur = read().filter(x => x !== id);
+  cur.unshift(id);
+  write(cur);
+  console.log('recent_view_push', { id });
+}
+
+export function getRecent(): string[] {
+  return read();
+}
+
+export function clearRecent() {
+  write([]);
+}

--- a/web/src/pages/account/ShareWishlist.tsx
+++ b/web/src/pages/account/ShareWishlist.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { importWishlist } from '../../lib/wishlist';
+import { getProduct } from '../../lib/products';
+import { useToast } from '../../components/ui/useToast';
+
+export default function ShareWishlist() {
+  const [sp] = useSearchParams();
+  const data = sp.get('data') || '';
+  const toast = useToast();
+
+  const ids = useMemo(() => importWishlist(data), [data]);
+
+  useEffect(() => {
+    console.log('wishlist_share_opened');
+    if (!ids.length) {
+      toast.error('Invalid share link');
+    }
+  }, [ids, toast]);
+
+  const items = ids
+    .map(id => getProduct(id))
+    .filter(Boolean);
+
+  if (!items.length) {
+    return (
+      <div className="page">
+        <h1>Shared Wishlist</h1>
+        <p>No items found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page">
+      <h1>Shared Wishlist</h1>
+      <div className="wishlist-grid">
+        {items.map(p => (
+          <a key={p!.id} href={`/marketplace/item?id=${p!.id}`}> 
+            <img src={(p as any).img} alt={p!.name} />
+            <div>{p!.name}</div>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/account/Wishlist.tsx
+++ b/web/src/pages/account/Wishlist.tsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import ProductCard from '../../components/marketplace/ProductCard';
-import { getWishlist, subscribe, unsubscribe } from '../../lib/wishlist';
+import { getWishlist, subscribe, unsubscribe, removeWish, exportWishlist } from '../../lib/wishlist';
 import { getProduct } from '../../lib/products';
 import { Item as CatItem } from '../../lib/catalog';
 import { useCart } from '../../context/CartContext';
+import { useNavigate } from 'react-router-dom';
 
 export default function WishlistPage() {
   const [ids, setIds] = useState<string[]>(getWishlist());
   const { add, openMiniCart } = useCart();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const cb = (next: string[]) => setIds(next);
@@ -43,6 +45,11 @@ export default function WishlistPage() {
     openMiniCart();
   };
 
+  const share = () => {
+    const enc = exportWishlist();
+    navigate(`/share/wishlist?data=${encodeURIComponent(enc)}`);
+  };
+
   if (items.length === 0) {
     return (
       <div className="page">
@@ -55,13 +62,14 @@ export default function WishlistPage() {
   return (
     <div className="page">
       <h1>Wishlist</h1>
+      <button onClick={share} style={{ marginBottom: '1rem' }}>Share my wishlist</button>
       <div className="wishlist-grid">
         {items.map(item => (
           <div key={item.id} style={{ position: 'relative' }}>
             <ProductCard item={item} />
             <div style={{ marginTop: '.5rem', display: 'flex', gap: '.5rem' }}>
-              <a href={`/marketplace/item?id=${item.id}`}>View</a>
-              <button onClick={() => handleAdd(item)}>Add</button>
+              <button onClick={() => handleAdd(item)}>Add to cart</button>
+              <button onClick={() => removeWish(item.id)}>Remove</button>
             </div>
           </div>
         ))}
@@ -69,4 +77,3 @@ export default function WishlistPage() {
     </div>
   );
 }
-

--- a/web/src/pages/marketplace/ProductDetail.tsx
+++ b/web/src/pages/marketplace/ProductDetail.tsx
@@ -3,20 +3,21 @@ import { useSearchParams, Link } from 'react-router-dom';
 import Gallery from '../../components/Gallery';
 import { Skeleton } from '../../components/ui/Skeleton';
 import { useToast } from '../../components/ui/useToast';
-import { getProduct } from '../../lib/products';
+import { getProduct, PRODUCTS } from '../../lib/products';
 import { addToCart } from '../../lib/cart';
 import RecoStrip from '../../components/RecoStrip';
-import { recommendFor, pushRecent, Item } from '../../lib/reco';
-import { PRODUCTS } from '../../lib/products';
+import { recommendFor, Item } from '../../lib/reco';
 import Stars from '../../components/Stars';
 import ReviewForm from '../../components/ReviewForm';
 import ReviewsList from '../../components/ReviewsList';
 import QAForm from '../../components/QAForm';
 import QAList from '../../components/QAList';
 import { ratingStats } from '../../lib/reviews';
-import { isFav, toggleFav, subscribe, unsubscribe } from '../../lib/wishlist';
 import Seo from '../../components/Seo';
 import ShareRow from '../../components/ShareRow';
+import WishlistButton from '../../components/WishlistButton';
+import { pushRecent } from '../../lib/recent';
+import RecentCarousel from '../../components/RecentCarousel';
 
 const allItems: Item[] = PRODUCTS.map(p => ({
   id: p.id,
@@ -34,7 +35,6 @@ export default function ProductDetail() {
   const [sp] = useSearchParams();
   const id = sp.get('id') || '';
   const product = getProduct(id);
-  const [fav, setFav] = useState(isFav(id));
   const toast = useToast();
   const [imgLoaded, setImgLoaded] = useState(false);
 
@@ -56,13 +56,6 @@ export default function ProductDetail() {
   useEffect(() => {
     if (product) pushRecent(product.id);
   }, [product?.id]);
-
-  useEffect(() => {
-    const cb = (ids: string[]) => setFav(ids.includes(id));
-    subscribe(cb);
-    return () => unsubscribe(cb);
-  }, [id]);
-
 
   const recos = product
     ? recommendFor(
@@ -129,14 +122,7 @@ export default function ProductDetail() {
         <div>
           <h1 style={{ display: 'flex', alignItems: 'center', gap: '.5rem' }}>
             {product.name}
-            <button
-              className="icon-btn"
-              aria-label={fav ? 'Remove from wishlist' : 'Add to wishlist'}
-              aria-pressed={fav}
-              onClick={() => setFav(toggleFav(product.id))}
-            >
-              {fav ? '♥' : '♡'}
-            </button>
+            <WishlistButton id={product.id} />
           </h1>
           <div style={{display:'flex', alignItems:'center', gap:8, marginTop:6}}>
             <Stars value={Math.round(stats.avg)} />
@@ -194,6 +180,7 @@ export default function ProductDetail() {
         </section>
       )}
       <RecoStrip title="For you" items={recos} source="detail" />
+      <RecentCarousel />
     </section>
   );
 }

--- a/web/src/pages/marketplace/index.tsx
+++ b/web/src/pages/marketplace/index.tsx
@@ -6,7 +6,7 @@ import { addToCart } from '../../lib/cart';
 import CategoryChips from '../../components/filters/CategoryChips';
 import PriceRange from '../../components/filters/PriceRange';
 import SortSelect from '../../components/filters/SortSelect';
-import Pagination from '../../components/Pagination';
+import RecentCarousel from '../../components/RecentCarousel';
 import { PRODUCTS } from '../../lib/products';
 import Seo from '../../components/Seo';
 import {
@@ -145,6 +145,7 @@ export default function MarketplacePage() {
           onChange={(min, max) => handleUpdate({ min, max })}
         />
       </div>
+      <RecentCarousel />
       {loading ? (
         <div className="grid">
           {Array.from({ length: 12 }).map((_, i) => (

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -632,3 +632,8 @@ input, textarea, select { width:100%; padding:10px 12px; border-radius:10px; bor
 .setting-block { background:var(--panel); border:1px solid var(--panel-b); border-radius:8px; padding:16px; display:flex; flex-direction:column; gap:8px; }
 .setting-block label { display:flex; align-items:center; gap:8px; }
 .quick-links { display:flex; flex-wrap:wrap; gap:12px; }
+
+.recent-row { display:flex; gap:8px; overflow-x:auto; padding-bottom:4px; }
+.recent-card { flex:0 0 auto; width:120px; border-radius:8px; overflow:hidden; }
+.recent-card img { width:100%; height:80px; object-fit:cover; display:block; }
+


### PR DESCRIPTION
## Summary
- implement persistent wishlist with shareable links and console telemetry
- add recent views tray with carousel component
- expose wishlist routes and navbar count badge

## Testing
- `npm run lint`
- `npm run build` *(fails: vite not found and dependency install blocked 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a2da0262bc8329b93a3fc888f870ba