### PR TITLE
Command Palette (⌘K) + Site Search (no new deps)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -53,6 +53,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import NotFound from './pages/errors/NotFound';
 import ServerError from './pages/errors/ServerError';
 import { applyThemeFromStorage, applyReducedMotionFromStorage } from './lib/prefs';
+import CommandPalette from './components/CommandPalette';
 
 export default function App() {
   useEffect(() => {
@@ -65,6 +66,7 @@ export default function App() {
         <Suspense fallback={<div className="container" style={{ padding: '24px' }}>Loading...</div>}>
           <ToastHost />
           <FloatingFeedback />
+          <CommandPalette />
           <ErrorBoundary>
             <Routes>
             <Route element={<AppShell />}>

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { search, getRecent, remember, getBaseItems, SearchItem } from '../lib/search';
+import { useNavigate } from 'react-router-dom';
+
+export default function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [items, setItems] = useState<SearchItem[]>([]);
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const tag = target.tagName;
+      const isInput = tag === 'INPUT' || tag === 'TEXTAREA' || (target as any).isContentEditable;
+      if ((e.key === 'k' && (e.metaKey || e.ctrlKey)) || (e.key === '/' && !isInput)) {
+        e.preventDefault();
+        setOpen(true);
+      } else if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    const onOpen = () => setOpen(true);
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('nv_palette_open', onOpen as any);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('nv_palette_open', onOpen as any);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      const rec = getRecent();
+      setItems(rec.length ? rec : getBaseItems().slice(0, 5));
+      setQuery('');
+      setActive(0);
+      setTimeout(() => inputRef.current?.focus(), 0);
+      console.log('cmd_opened');
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (!query) {
+      const rec = getRecent();
+      setItems(rec.length ? rec : getBaseItems().slice(0, 5));
+      setActive(0);
+      return;
+    }
+    const res = search(query);
+    setItems(res);
+    console.log('cmd_search', { q: query, results: res.length });
+  }, [query, open]);
+
+  const flat = items;
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive(a => Math.min(a + 1, flat.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive(a => Math.max(a - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const item = flat[active];
+      if (item) select(item);
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    } else if (e.key === 'Tab') {
+      e.preventDefault();
+    }
+  }
+
+  function select(item: SearchItem) {
+    setOpen(false);
+    remember(item.path);
+    navigate(item.path);
+    console.log('cmd_navigate', { path: item.path });
+  }
+
+  function highlight(text: string) {
+    if (!query) return text;
+    const q = query.toLowerCase();
+    const i = text.toLowerCase().indexOf(q);
+    if (i === -1) return text;
+    return (
+      <>
+        {text.slice(0, i)}<mark>{text.slice(i, i + q.length)}</mark>{text.slice(i + q.length)}
+      </>
+    );
+  }
+
+  const grouped: Record<string, SearchItem[]> = {};
+  if (query) {
+    items.forEach(i => {
+      (grouped[i.kind] ||= []).push(i);
+    });
+  } else {
+    grouped['recent'] = items;
+  }
+
+  const order = query ? ['product', 'page', 'account'] : ['recent'];
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="palette-backdrop" onClick={() => setOpen(false)}>
+      <div
+        className="palette"
+        role="dialog"
+        aria-modal="true"
+        onClick={e => e.stopPropagation()}
+      >
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Search the Naturverse…"
+          aria-label="Search"
+        />
+        {order.map(key => {
+          const arr = grouped[key];
+          if (!arr || !arr.length) return null;
+          const header = key === 'product' ? 'Products' : key === 'page' ? 'Pages' : key === 'account' ? 'Account' : 'Recent';
+          return (
+            <div className="palette-group" key={key}>
+              <div className="palette-header">{header}</div>
+              {arr.map((item, idx) => {
+                const iIdx = flat.indexOf(item);
+                return (
+                  <div
+                    key={item.id}
+                    className={
+                      'palette-item' + (iIdx === active ? ' active' : '')
+                    }
+                    onMouseEnter={() => setActive(iIdx)}
+                    onMouseDown={e => {
+                      e.preventDefault();
+                      select(item);
+                    }}
+                  >
+                    <div style={{ flex: 1 }}>
+                      <div>{highlight(item.title)}</div>
+                      <div className="muted small">{item.subtitle || item.path}</div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { getCart } from '../lib/cart';
 import { getWishlist, subscribe as subWish, unsubscribe as unsubWish } from '../lib/wishlist';
 import { Link, NavLink } from 'react-router-dom';
 import UserMenu from './UserMenu';
+import SearchBar from './SearchBar';
 
 const linkClass = ({ isActive }: { isActive: boolean }) =>
   (isActive ? 'nav-active' : undefined);
@@ -96,6 +97,7 @@ export default function Navbar() {
         )}
       </div>
       <div style={{ marginLeft: 'auto', display: 'flex', gap: '16px', alignItems: 'center' }}>
+        <SearchBar />
         <NavLink to="/account/wishlist" className={linkClass}>
           Wishlist {wishCount ? <span className="badge">{wishCount}</span> : null}
         </NavLink>

--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function SearchBar() {
+  const open = () => {
+    try {
+      window.dispatchEvent(new CustomEvent('nv_palette_open'));
+    } catch {}
+  };
+  return (
+    <button className="menu-btn" onClick={open}>
+      Search (⌘K)
+    </button>
+  );
+}
+

--- a/web/src/lib/search.ts
+++ b/web/src/lib/search.ts
@@ -1,0 +1,114 @@
+export type SearchItem = {
+  id: string;
+  kind: 'page' | 'product' | 'account';
+  title: string;
+  subtitle?: string;
+  path: string;
+  keywords?: string[];
+};
+
+import { PRODUCTS } from './products';
+
+const BASE_ITEMS: SearchItem[] = [
+  { id: 'home', kind: 'page', title: 'Home', path: '/' },
+  { id: 'worlds', kind: 'page', title: 'Worlds', path: '/worlds' },
+  { id: 'zones', kind: 'page', title: 'Zones', path: '/zones' },
+  { id: 'arcade', kind: 'page', title: 'Arcade', path: '/zones/arcade' },
+  { id: 'marketplace', kind: 'page', title: 'Marketplace', path: '/marketplace' },
+  { id: 'checkout', kind: 'page', title: 'Checkout', path: '/marketplace/checkout' },
+  { id: 'support', kind: 'page', title: 'Support', path: '/support' },
+  { id: 'about', kind: 'page', title: 'About', path: '/about' },
+  { id: 'faq', kind: 'page', title: 'FAQ', path: '/faq' },
+  { id: 'privacy', kind: 'page', title: 'Privacy', path: '/privacy' },
+  { id: 'terms', kind: 'page', title: 'Terms', path: '/terms' },
+  { id: 'profile', kind: 'account', title: 'Profile', path: '/profile' },
+  { id: 'orders', kind: 'account', title: 'Orders', path: '/account/orders' },
+  { id: 'addresses', kind: 'account', title: 'Addresses', path: '/account/addresses' },
+  { id: 'wishlist', kind: 'account', title: 'Wishlist', path: '/account/wishlist' },
+  { id: 'settings', kind: 'account', title: 'Settings', path: '/settings' },
+];
+
+export function getBaseItems(): SearchItem[] {
+  return BASE_ITEMS;
+}
+
+export function getProductItems(): SearchItem[] {
+  return PRODUCTS.map(p => ({
+    id: `product-${p.id}`,
+    kind: 'product' as const,
+    title: p.name,
+    subtitle: p.category,
+    path: `/marketplace/item?id=${p.id}`,
+    keywords: [p.category.toLowerCase()],
+  }));
+}
+
+function norm(str: string) {
+  return str
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '');
+}
+
+export function score(query: string, item: SearchItem): number {
+  const q = norm(query.trim());
+  if (!q) return 0;
+  const t = norm(item.title);
+  const sub = norm(item.subtitle || '');
+  const keys = (item.keywords || []).map(norm);
+  let s = 0;
+  if (t.startsWith(q)) s += 50;
+  else if (t.includes(q)) s += 40;
+  if (sub.startsWith(q)) s += 20;
+  else if (sub.includes(q)) s += 10;
+  if (keys.some(k => k.startsWith(q))) s += 15;
+  else if (keys.some(k => k.includes(q))) s += 5;
+  return Math.min(100, s);
+}
+
+export function search(query: string): SearchItem[] {
+  const all = [...getBaseItems(), ...getProductItems()];
+  return all
+    .map(i => ({ item: i, s: score(query, i) }))
+    .filter(r => r.s > 0)
+    .sort((a, b) => b.s - a.s)
+    .slice(0, 20)
+    .map(r => r.item);
+}
+
+const RECENT_KEY = 'nv_recent_cmd_v1';
+const RECENT_LIMIT = 8;
+
+function readRecent(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+  } catch {
+    return [];
+  }
+}
+
+function writeRecent(paths: string[]) {
+  try {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(paths.slice(0, RECENT_LIMIT)));
+  } catch {}
+}
+
+export function remember(path: string) {
+  const cur = readRecent().filter(p => p !== path);
+  cur.unshift(path);
+  writeRecent(cur);
+}
+
+export function getRecent(): SearchItem[] {
+  const paths = readRecent();
+  const all = [...getBaseItems(), ...getProductItems()];
+  return paths
+    .map(p => all.find(i => i.path === p))
+    .filter(Boolean) as SearchItem[];
+}
+
+// utility to ensure product items loaded (no-op for static data)
+export function seedProducts() {
+  getProductItems();
+}
+

--- a/web/src/pages/marketplace/index.tsx
+++ b/web/src/pages/marketplace/index.tsx
@@ -17,6 +17,7 @@ import {
   FilterState,
 } from '../../lib/catalogFilter';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { seedProducts } from '../../lib/search';
 
 const allItems = PRODUCTS.map(p => ({
   id: p.id,
@@ -38,6 +39,10 @@ export default function MarketplacePage() {
   const [pageSize, setPageSize] = useState(() => (window.innerWidth < 640 ? 12 : 24));
   const toast = useToast();
   const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    seedProducts();
+  }, []);
 
   useEffect(() => {
     const onResize = () => setPageSize(window.innerWidth < 640 ? 12 : 24);

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -637,3 +637,12 @@ input, textarea, select { width:100%; padding:10px 12px; border-radius:10px; bor
 .recent-card { flex:0 0 auto; width:120px; border-radius:8px; overflow:hidden; }
 .recent-card img { width:100%; height:80px; object-fit:cover; display:block; }
 
+.palette-backdrop { position:fixed; inset:0; background:rgba(0,0,0,.45); backdrop-filter: blur(3px); z-index:10000; }
+.palette { margin:6vh auto; max-width:720px; background:rgba(14,18,30,.98); border:1px solid rgba(255,255,255,.14); border-radius:14px; overflow:hidden; }
+.palette input { width:100%; padding:14px 16px; border:0; outline:none; background:rgba(255,255,255,.04); color:#fff; }
+.palette-group { padding:6px 0; } .palette-header { padding:8px 12px; opacity:.7; font-size:12px; }
+.palette-item { padding:10px 12px; display:flex; gap:10px; align-items:center; cursor:pointer; }
+.palette-item:hover, .palette-item.active { background:rgba(255,255,255,.08); }
+.palette-item mark { background:none; color:#00d1ff; }
+@media (prefers-reduced-motion: reduce){ .palette-backdrop{ backdrop-filter:none; } }
+


### PR DESCRIPTION
## Summary
- Add client-side search utils for pages and products
- Provide global command palette with keyboard navigation and recent items
- Wire navbar search button, palette mount, product seeding, and styles

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite: not found)*
- `npm --prefix web install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd7593708329885b9a6ae075f778