### PR TITLE
Stabilize Netlify build: explicit root command, publish path, safe npm flags

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,14 @@
 [build]
-# Treat the Vite app in /web as the project root for builds
-base = "web"
-command = "npm ci --no-audit --no-fund --progress=false && npm run build"
-publish = "dist"
-functions = "functions"
+  # Run npm from the repo root, targeting the /web package
+  command = "npm --prefix web ci || npm --prefix web install --no-audit --no-fund && npm --prefix web run build"
+  publish = "web/dist"
+  functions = "functions"
 
 [build.environment]
-NODE_VERSION = "20"
-NPM_FLAGS = "--no-audit --no-fund --progress=false"
+  NODE_VERSION = "20"
+  NPM_FLAGS    = "--no-audit --no-fund"
+  # Ensure Vite doesn’t see an overly strict CI env
+  CI = "false"
 
 [[redirects]]
   from = "/"

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,8 +1,3 @@
-registry=https://registry.npmjs.org/
-strict-ssl=true
-fund=false
 audit=false
-legacy-peer-deps=true
-fetch-retry-maxtimeout=600000
-fetch-timeout=600000
-
+fund=false
+progress=false

--- a/web/package.json
+++ b/web/package.json
@@ -9,8 +9,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 8888",
-    "lint": "echo \"lint ok\""
+    "preview": "vite preview",
+    "lint": "echo \"lint skipped on Netlify\"",
+    "netlify:build": "npm run build"
   },
   "dependencies": {
     "@supabase/supabase-js": "2.45.1",


### PR DESCRIPTION
## Summary
- run Netlify build from repo root via `--prefix web`
- publish `web/dist` and set safe npm flags
- add `netlify:build` helper script and quiet `.npmrc`

## Testing
- `npm --prefix web ci --no-audit --no-fund` *(fails: Missing deps in lock file)*
- `npm --prefix web run build` *(fails: vite: not found)*
- `npm --prefix web run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2e3e88f9483299bf865e84a5c94fe