### PR TITLE
fix: export seedProducts

### DIFF
--- a/web/src/lib/search.ts
+++ b/web/src/lib/search.ts
@@ -15,10 +15,13 @@ const BASE_ITEMS: SearchItem[] = [
   { id: 'orders', kind: 'account', title: 'Orders', path: '/account/orders' },
 ];
 
+let productCache: SearchItem[] | null = null;
+
 function getProductItems(): SearchItem[] {
+  if (productCache) return productCache;
   try {
     const { PRODUCTS } = require('./products');
-    return (PRODUCTS ?? []).map((p: any) => ({
+    productCache = (PRODUCTS ?? []).map((p: any) => ({
       id: `prod-${p.id}`,
       kind: 'product' as const,
       title: p.name,
@@ -26,9 +29,14 @@ function getProductItems(): SearchItem[] {
       path: `/marketplace/item?id=${p.id}`,
       keywords: [p.category.toLowerCase()],
     }));
+    return productCache;
   } catch {
     return [];
   }
+}
+
+export function seedProducts() {
+  productCache = getProductItems();
 }
 
 export function getBaseItems(): SearchItem[] {


### PR DESCRIPTION
## Summary
- export `seedProducts` from search utilities and cache products

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix web run lint` *(fails: ESLint couldn't find config)*
- `cd web && npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f3c982e88329955736fece4ecd7d