### PR TITLE
Fix Netlify paths: publish and functions relative to base="web"

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,14 +1,14 @@
-# netlify.toml  (root)
+# netlify.toml
 
 [build]
   base    = "web"
   command = "npm install --no-audit --no-fund && npm run build"
-  publish = "web/dist"
+  publish = "dist"         # was "web/dist" — wrong with base set
 
 [functions]
-  directory = "web/functions"
+  directory = "functions"  # was "web/functions" — wrong with base set
 
-# Force SPA fallback for Vite/React routes
+# SPA fallback for client routes
 [[redirects]]
   from = "/*"
   to   = "/index.html"


### PR DESCRIPTION
SUMMARY
Deploys are failing because the resolved config points to /opt/build/repo/web/web/dist and /opt/build/repo/web/web/functions. With base = "web" in netlify.toml, publish and functions must be relative to that base, not prefixed with web/. This PR corrects the paths so Netlify deploys from /opt/build/repo/web/dist and uses /opt/build/repo/web/functions.

CHANGES
	1.	Update netlify.toml at the repo root:

# netlify.toml

[build]
  base    = "web"
  command = "npm install --no-audit --no-fund && npm run build"
  publish = "dist"         # was "web/dist" — wrong with base set

[functions]
  directory = "functions"  # was "web/functions" — wrong with base set

# SPA fallback for client routes
[[redirects]]
  from = "/*"
  to   = "/index.html"
  status = 200

[build.environment]
  NODE_VERSION = "20"
  NPM_FLAGS    = "--no-audit --no-fund"

No dependency changes; Vite’s default outDir is dist, so the folder will exist after npm run build.

ACCEPTANCE
	•	Netlify “Resolved config” shows:
	•	base: /opt/build/repo/web
	•	publish: /opt/build/repo/web/dist
	•	functionsDirectory: /opt/build/repo/web/functions
	•	Build completes (vite build runs) and the site serves normally (no blank screen).
	•	Functions (if present) are detected instead of “non-existing directory: web/functions”.

NOTES
If any local overrides were added in the Netlify UI, ensure “Base directory” is web, “Publish directory” is dist, and “Functions directory” is functions (all relative).

------
https://chatgpt.com/codex/tasks/task_e_68a2f848e10c8329849fe90d9391221a