### PR TITLE
Stabilize Netlify build & fix seedProducts export

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,14 @@
 [build]
   base = "web"
-  command = "npm ci --no-audit --no-fund && npm run build"
   publish = "dist"
+  functions = "functions"
+  command = "npm install --no-audit --no-fund && npm run build"
 
-[functions]
-  directory = "web/functions"
+[build.environment]
+  NODE_VERSION = "20"
+  NPM_FLAGS = "--no-audit --no-fund"
 
+# Single-page app fallback
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,3 +1,4 @@
+legacy-peer-deps=true
 audit=false
 fund=false
-progress=false
+@supabase:registry=https://registry.npmjs.org/

--- a/web/src/lib/search.ts
+++ b/web/src/lib/search.ts
@@ -1,3 +1,25 @@
+import { PRODUCTS } from './products';
+
+export type SearchableItem = {
+  id: string;
+  title: string;
+  description?: string;
+  priceNatur?: number;
+  tags?: string[];
+  image?: string;
+};
+
+export function seedProducts(): SearchableItem[] {
+  return PRODUCTS.map(p => ({
+    id: p.id,
+    title: p.name ?? `Item ${p.id}`,
+    description: '',
+    priceNatur: p.baseNatur ?? 0,
+    tags: p.category ? [p.category] : [],
+    image: p.img,
+  }));
+}
+
 export type SearchItem = {
   id: string;
   kind: 'page' | 'product' | 'account';
@@ -6,8 +28,6 @@ export type SearchItem = {
   path: string;
   keywords?: string[];
 };
-
-import { PRODUCTS } from './products';
 
 const BASE_ITEMS: SearchItem[] = [
   { id: 'home', kind: 'page', title: 'Home', path: '/' },
@@ -31,8 +51,6 @@ function getProductItems(): SearchItem[] {
   }));
   return productCache;
 }
-
-export const seedProducts = () => PRODUCTS;
 
 export function getBaseItems(): SearchItem[] {
   return BASE_ITEMS;

--- a/web/src/pages/marketplace/index.tsx
+++ b/web/src/pages/marketplace/index.tsx
@@ -17,7 +17,7 @@ import {
   FilterState,
 } from '../../lib/catalogFilter';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { seedProducts } from '@/lib/search';
+import { seedProducts } from '../../lib/search';
 
 const allItems = PRODUCTS.map(p => ({
   id: p.id,


### PR DESCRIPTION
## Summary
- Configure Netlify to install dependencies and build from `/web`, set publish and functions folders, and specify Node 20
- Add per-app `.npmrc` to suppress audit/peer-dep noise and use Supabase registry
- Export `seedProducts` and related types, and fix marketplace import

## Testing
- ⚠️ `npm install --no-audit --no-fund` (hung, aborted)
- ❌ `npm run build` (missing vite after install failure)
- ❌ `npm test` (no test script)


------
https://chatgpt.com/codex/tasks/task_e_68a3082fdfc48329885eb41ec891d9ad