### PR TITLE
Add runtime guardrails: ErrorBoundary, boot diagnostics, sourcemaps, and no-cache headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,16 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+# Disable cache for HTML during recovery
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cache-Control = "no-store, no-cache, must-revalidate"
+
+# Allow sourcemaps to be fetched
+[[headers]]
+  for = "/assets/*.map"
+  [headers.values]
+    Cache-Control = "no-store, no-cache, must-revalidate"
+    Access-Control-Allow-Origin = "*"

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,13 +8,20 @@ import "./styles/app.css";
 import "./styles/themes.css";
 import { applyTheme, onThemeChange } from "./lib/theme";
 import { ThemeProvider } from './context/ThemeContext';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 applyTheme();
 onThemeChange(() => applyTheme());
 
+try {
+  console.info('[Naturverse] boot:start', { ts: new Date().toISOString(), env: import.meta.env.MODE });
+  localStorage.setItem('naturverse_boot', new Date().toISOString());
+} catch {}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
         <ThemeProvider>
           <AuthProvider>
             <App />
@@ -22,8 +29,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           </AuthProvider>
         </ThemeProvider>
       </BrowserRouter>
-    </React.StrictMode>
-  );
+    </ErrorBoundary>
+  </React.StrictMode>
+);
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    sourcemap: true,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- enable Vite sourcemaps for easier debugging
- wrap app with global ErrorBoundary and log crashes
- disable caching and allow sourcemaps via Netlify headers
- add boot diagnostics to log first paint

## Testing
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a30b342ca88329b8a0e10ca082770d