### PR TITLE
chore: streamline web build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,12 @@
 [build]
-base = "web"
-command = "npm ci --no-audit --no-fund && npm run build"
-publish = "dist"
-functions = "functions"
+  base = "web"
+  command = "npm install --no-audit --no-fund && npm run build"
+  publish = "dist"
+
+[functions]
+  directory = "functions"
 
 [[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,0 @@
-{
-	"name": "naturverse-web",
-	"version": "1.0.0",
-	"lockfileVersion": 3,
-	"requires": true,
-	"packages": {}
-}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,0 @@
-{
-	"type": "module",
-	"scripts": {
-		"dev": "cd web && vite",
-		"build": "cd web && vite build",
-		"preview": "cd web && vite preview --port 5173 --strictPort"
-	}
-}

--- a/web/package.json
+++ b/web/package.json
@@ -1,22 +1,25 @@
 {
   "name": "naturverse-web",
   "private": true,
-  "engines": { "node": ">=20" },
+  "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 8080",
-    "lint": "echo \"(eslint not configured)\""
+    "preview": "vite preview --port 8080"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.45.4",
+    "ethers": "^6.15.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.1",
-    "@supabase/supabase-js": "^2.45.0",
-    "ethers": "^6.15.0"
+    "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-react-swc": "^3.7.0",
     "typescript": "^5.5.4",
-    "vite": "^5.4.19"
+    "vite": "^5.4.0"
   }
 }

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -1,0 +1,12 @@
+{
+  "name": "Naturverse",
+  "short_name": "Naturverse",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0ea5e9",
+  "icons": [
+    { "src": "/favicon-512.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/favicon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/web/src/lib/search.ts
+++ b/web/src/lib/search.ts
@@ -1,9 +1,8 @@
 import { PRODUCTS } from './products'
 
-export type SearchItem = { id: string; title: string; description?: string }
-export const seedProducts: SearchItem[] = [
-  { id: 'sample-1', title: 'Natur Tee' },
-  { id: 'sample-2', title: 'Natur Hoodie' }
+export const seedProducts = [
+  { id: 'demo-1', name: 'Natur Tee', price: 2500, tags: ['apparel'] },
+  { id: 'demo-2', name: 'Natur Bottle', price: 1900, tags: ['gear'] }
 ]
 
 export type SearchResultItem = {

--- a/web/src/pages/marketplace/index.tsx
+++ b/web/src/pages/marketplace/index.tsx
@@ -19,6 +19,8 @@ import {
 import { useLocation, useNavigate } from 'react-router-dom';
 import { seedProducts } from '../../lib/search';
 
+const items = seedProducts; // or your mapped PRODUCTS fallback
+
 const allItems = PRODUCTS.map(p => ({
   id: p.id,
   name: p.name,
@@ -39,10 +41,6 @@ export default function MarketplacePage() {
   const [pageSize, setPageSize] = useState(() => (window.innerWidth < 640 ? 12 : 24));
   const toast = useToast();
   const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    seedProducts;
-  }, []);
 
   useEffect(() => {
     const onResize = () => setPageSize(window.innerWidth < 640 ? 12 : 24);


### PR DESCRIPTION
## Summary
- scope web as only app package for Netlify and SPA routing
- simplify web package.json and remove root package files
- export seedProducts and reference in marketplace page
- fix missing favicon manifest

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden for @types/react)*
- `npm run build` *(fails: vite not found due to install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68a3371988f883299a48cc5f3bd39131