### PR TITLE
chore: stabilize netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,10 @@ command = "npm ci --no-audit --no-fund && npm run build"
 publish = "dist"
 functions = "functions"
 
+[build.environment]
+NODE_VERSION = "20"
+NPM_FLAGS = "--no-audit --no-fund"
+
 [[redirects]]
 from = "/*"
 to = "/index.html"

--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>The Naturverse</title>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <!-- Removed apple-touch-icon / favicon-192.png / manifest to stop runtime icon errors -->
     <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
   </head>

--- a/web/package.json
+++ b/web/package.json
@@ -10,18 +10,16 @@
     "lint": "echo \"(no eslint config yet)\" && exit 0"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.45.0",
-    "ethers": "^6.15.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-router-dom": "^6.23.0"
+    "@supabase/supabase-js": "2.45.0",
+    "ethers": "6.15.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-router-dom": "6.23.0"
   },
   "devDependencies": {
-    "@types/react": "^18.2.66",
-    "@types/react-dom": "^18.2.22",
-    "@vitejs/plugin-react": "^4.3.1",
-    "typescript": "^5.4.0",
-    "vite": "^5.4.0"
+    "@vitejs/plugin-react": "4.3.1",
+    "typescript": "5.4.5",
+    "vite": "5.4.0"
   },
   "engines": {
     "node": ">=20"

--- a/web/src/lib/search.ts
+++ b/web/src/lib/search.ts
@@ -83,3 +83,6 @@ export function getRecent(): SearchResultItem[] {
     return [];
   }
 }
+
+export { seedProducts };
+

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,5 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  build: { sourcemap: true }
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    sourcemap: true,
+  },
 });


### PR DESCRIPTION
## Summary
- pin web dependencies and include @vitejs/plugin-react
- update vite config and Netlify build settings
- clean SPA entry and export `seedProducts`

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fsupabase-js)*
- `npm run build` *(fails: vite: not found)*

## Checklist
- [x] Update netlify.toml (root) as provided
- [x] Replace /web/package.json with provided content
- [x] Replace /web/vite.config.ts with provided content
- [x] Ensure /web/index.html script points to /src/main.tsx and (optionally) remove manifest for now
- [x] Ensure /web/src/lib/search.ts exports seedProducts
- [ ] Run cd web && rm -rf node_modules package-lock.json && npm install && npm run build locally
- [ ] Commit the new /web/package-lock.json and push


------
https://chatgpt.com/codex/tasks/task_e_68a345d923d883299737e504f643bcac