### PR TITLE
Lock deps and configure Netlify build & functions bundling

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,15 @@
 [build]
-  command   = "npm ci && npm run build"
-  publish   = "web/dist"
-  functions = "web/functions"
+base = "web"
+publish = "web/dist"
+functions = "web/functions"
+command = "npm install --no-audit --no-fund && npm run build"
 
 [functions]
-  node_bundler = "esbuild"
+# Use esbuild so ESM and TS get bundled cleanly
+node_bundler = "esbuild"
 
-# keep the SPA redirect
+# SPA fallback
 [[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+from = "/*"
+to = "/index.html"
+status = 200

--- a/web/functions/package.json
+++ b/web/functions/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "dependencies": {
+    "ethers": "^6.13.2"
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,32 +1,27 @@
 {
   "name": "naturverse-web",
-  "version": "1.0.0",
   "private": true,
+  "version": "0.0.0",
   "type": "module",
+  "engines": { "node": ">=20" },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --port 8080",
-    "lint": "eslint src --ext .ts,.tsx"
-  },
-  "engines": {
-    "node": ">=20"
+    "lint": "eslint ."
   },
   "dependencies": {
-    "@supabase/supabase-js": "2.45.4",
-    "ethers": "^6.13.2",
+    "@supabase/supabase-js": "2.45.0",
+    "clsx": "2.1.1",
+    "ethers": "6.13.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router-dom": "6.26.2",
-    "@noble/hashes": "^1.4.0",
-    "@noble/curves": "^1.4.0",
-    "@adraffy/ens-normalize": "^1.10.1",
-    "aes-js": "^4.0.0-beta.5"
+    "zustand": "4.5.4"
   },
   "devDependencies": {
-    "@types/react": "18.3.5",
+    "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
-    "@vitejs/plugin-react": "4.3.3",
+    "@vitejs/plugin-react": "4.3.1",
     "eslint": "9.9.0",
     "typescript": "5.5.4",
     "vite": "5.4.10"


### PR DESCRIPTION
## Summary
- Scope all app dependencies to `web/package.json` with Node 20 engine and streamlined scripts
- Provide a minimal `web/functions/package.json` so Netlify picks up function deps
- Configure Netlify build to install deps and bundle functions from `/web`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fsupabase-js)*
- `npm run build` *(fails: vite: not found)*
- `npm run lint` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_68a358df9404832991ad85cc1b54400d