### PR TITLE
Fix Netlify paths so deploy uses /web/dist (not /web/web/dist)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,16 +1,17 @@
 [build]
-base = "web"
-command = "npm install --no-audit --no-fund && npm run build"
-publish = "web/dist"
+  base    = "web"
+  command = "npm install --no-audit --no-fund && npm run build"
+  publish = "dist"              # <<< was web/dist, caused /web/web/dist
 
 [functions]
-directory = "web/functions"
-node_bundler = "esbuild"
+  directory    = "functions"    # <<< was web/functions, caused /web/web/functions
+  node_bundler = "esbuild"
 
 [[plugins]]
-package = "@netlify/plugin-functions-install-core"
+  package = "@netlify/plugin-functions-install-core"
 
+# SPA redirect (unchanged)
 [[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
+  from = "/*"
+  to   = "/index.html"
+  status = 200


### PR DESCRIPTION
## Summary
- fix Netlify config to use paths relative to `web` base directory
- publish `dist` and deploy functions from `functions` to avoid doubled `web/`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a36a295e9c8329bef5d6f91bc5ba4b