### PR TITLE
chore: configure netlify build and deps

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,16 +1,17 @@
 [build]
-base = "web"
-command = "npm install --no-audit --no-fund && npm run build"
-publish = "dist"            # publish *inside* /web
-functions = "functions"     # functions live in /web/functions
+  base = "web"
+  publish = "web/dist"
+  command = "npm install --no-audit --no-fund && npm run build"
 
 [functions]
-node_bundler = "esbuild"
+  directory = "web/functions"
+  node_bundler = "esbuild"
 
 [[plugins]]
-package = "@netlify/plugin-functions-install-core"
+  package = "@netlify/plugin-functions-install-core"
 
+# SPA fallback
 [[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/web/package.json
+++ b/web/package.json
@@ -1,30 +1,27 @@
 {
   "name": "naturverse-web",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
-  "engines": {
-    "node": ">=20"
-  },
+  "engines": { "node": ">=20" },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
-    "lint": "echo \"lint skipped\""
+    "preview": "vite preview --port 8080",
+    "lint": "echo \"(lint disabled)\""
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.45.3",
-    "ethers": "^6.13.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",
-    "tslib": "^2.6.3"
+    "ethers": "^6.13.2",
+    "@noble/hashes": "^1.4.0",
+    "@noble/curves": "^1.4.0",
+    "@adraffy/ens-normalize": "^1.10.1",
+    "aes-js": "^4.0.0-beta.5"
   },
   "devDependencies": {
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
+    "vite": "^5.4.10",
     "@vitejs/plugin-react": "^4.3.1",
-    "typescript": "^5.5.4",
-    "vite": "^5.4.10"
+    "typescript": "^5.5.4"
   }
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- point Netlify build to `web` directory and bundle functions from `web/functions`
- simplify `web/package.json` and add required ethers-related deps
- ensure Vite uses React plugin with sourcemaps

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden fetching packages)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a372ec1c0c83298b08656800d7f176