### PR TITLE
Fix Netlify build/deploy with root base dir and web package

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+registry=https://registry.npmjs.org/
 fund=false
 audit=false
 engine-strict=false

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,3 @@
+All Netlify functions should be placed here.
+Dependencies must be declared in `web/package.json`.
+Netlify will bundle with esbuild using that manifest.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,16 +1,15 @@
+## Netlify config
 [build]
-base = "web"
-command = "npm install && npm run build"
-publish = "web/dist"
+  base    = ""
+  command = "npm install --prefix web && npm run build --prefix web"
+  publish = "web/dist"
 
 [functions]
-directory = "web/functions"
-node_bundler = "esbuild"
-
-[[plugins]]
-package = "@netlify/plugin-functions-install-core"
+  directory    = "functions"
+  node_bundler = "esbuild"
+  included_files = ["functions/**"]
 
 [[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
+  from = "/*"
+  to   = "/index.html"
+  status = 200

--- a/web/package.json
+++ b/web/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
-    "lint": "echo \"skip lint for now\""
+    "preview": "vite preview"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.4",


### PR DESCRIPTION
## Summary
- configure Netlify to run web build from repo root and bundle functions
- clean up web package scripts and add root .npmrc registry
- document Netlify functions directory

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3d945ec1c83299ea2b2f6cd69e6ef