### PR TITLE
chore: add Netlify Functions dependencies

### DIFF
--- a/web/functions/package.json
+++ b/web/functions/package.json
@@ -2,8 +2,14 @@
   "name": "naturverse-functions",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
+    "@supabase/supabase-js": "^2.45.4",
     "ethers": "^6.13.2",
-    "@supabase/supabase-js": "^2.45.4"
+    "openai": "^4.53.2",
+    "zod": "^3.23.8",
+    "node-fetch": "^3.3.2"
   }
 }


### PR DESCRIPTION
## Summary
- ensure Netlify Functions package specifies Node 18 runtime
- add OpenAI, Zod, and node-fetch dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-fetch)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3f1f91f688329b554d598c35fe955