### PR TITLE
feat(web): add Tailwind UI foundation

### DIFF
--- a/web/postcss.config.cjs
+++ b/web/postcss.config.cjs
@@ -1,3 +1,6 @@
 module.exports = {
-  plugins: {},
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,21 @@
-:root { color-scheme: light dark; }
-* { box-sizing: border-box; }
-html, body, #root { height: 100%; margin: 0; }
-body { font-family: system-ui, Arial, sans-serif; }
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Light/Dark design tokens */
+:root {
+  --bg: 255 255 255;   /* white */
+  --fg: 17 24 39;      /* slate-900 */
+}
+.dark {
+  --bg: 17 24 39;      /* slate-900 */
+  --fg: 241 245 249;   /* slate-100 */
+}
+
+html, body, #root { height: 100%; }
+body { @apply antialiased; background-color: rgb(var(--bg)); color: rgb(var(--fg)); }
+
+/* Handy primitives */
+.container-prose { @apply prose max-w-none dark:prose-invert; }
+.card { @apply rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900; }
+.btn { @apply inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-brand text-white hover:opacity-90 transition; }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,10 +1,53 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}"
+    "./src/**/*.{ts,tsx,js,jsx}"
   ],
+  darkMode: "class",
   theme: {
-    extend: {},
+    container: {
+      center: true,
+      padding: "1rem"
+    },
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: "#16a34a", // emerald-600
+          50:  "#ecfdf5",
+          100: "#d1fae5",
+          200: "#a7f3d0",
+          300: "#6ee7b7",
+          400: "#34d399",
+          500: "#10b981",
+          600: "#16a34a",
+          700: "#15803d",
+          800: "#166534",
+          900: "#14532d"
+        }
+      },
+      fontFamily: {
+        display: [
+          "ui-sans-serif",
+          "system-ui",
+          "-apple-system",
+          "Segoe UI",
+          "Inter",
+          "Roboto",
+          "Helvetica Neue",
+          "Arial",
+          "sans-serif"
+        ],
+        mono: [
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "Monaco",
+          "Consolas",
+          "monospace"
+        ]
+      }
+    }
   },
-  plugins: [],
+  plugins: []
 };


### PR DESCRIPTION
## Summary
- configure Tailwind with dark mode, brand colors, and font families
- hook Tailwind and Autoprefixer into PostCSS
- add base styles and utility classes with Tailwind directives

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68a3f95bd2b08329a2f7399937f3a207