### PR TITLE
fix: include PostCSS/Tailwind dev deps for Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,15 @@
 [build]
 base = "web"
-publish = "dist"
-command = "npm install --include=dev --no-audit --no-fund && npm run build"
+publish = "web/dist"
+# include dev deps so PostCSS/Tailwind are installed in Netlify's build image
+command = "npm install --include=dev --no-audit --no-fund && npm --prefix web run build"
 
 [functions]
 directory = "web/functions"
+node_bundler = "esbuild"
+
+[plugins]
+  package = "@netlify/plugin-functions-install-core"
 
 [[redirects]]
   from = "/*"

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   "dependencies": {},
   "devDependencies": {
     "autoprefixer": "^10.4.20",
-    "postcss": "^8.4.41",
+    "postcss": "^8.4.47",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.4.0",
     "vite": "^5.4.0"

--- a/web/postcss.config.cjs
+++ b/web/postcss.config.cjs
@@ -1,3 +1,4 @@
+/** PostCSS config used by Vite build on Netlify */
 module.exports = {
   plugins: {
     tailwindcss: {},

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   content: [
     "./index.html",
-    "./src/**/*.{ts,tsx,js,jsx}"
+    "./src/**/*.{ts,tsx,js,jsx,html}"
   ],
   darkMode: "class",
   theme: {


### PR DESCRIPTION
## Summary
- ensure Netlify includes dev dependencies and installs functions plugin
- document PostCSS config and expand Tailwind content paths

## Testing
- `npm --prefix web run build` *(fails: Cannot find package '@vitejs/plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_68a40339ebd083298a4c36c0bbb36537