### PR TITLE
fix: ensure vite & tailwind deps and correct Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,20 +1,15 @@
 [build]
   base = "web"
-  command = "npm install --include=dev --no-audit --no-fund && npm run build"
-  publish = "dist"
+  publish = "web/dist"
+  command = "npm --prefix web install --include=dev --no-audit --no-fund && npm --prefix web run build"
 
 [functions]
-  directory = "functions"
+  directory = "web/functions"
   node_bundler = "esbuild"
-
-[[plugins]]
-  package = "@netlify/plugin-functions-install-core"
+  included_files = ["web/functions/**"]
 
 [[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200
 
-[build.environment]
-  NODE_VERSION = "20"
-  NPM_FLAGS = "--no-audit --no-fund"

--- a/web/package.json
+++ b/web/package.json
@@ -1,19 +1,22 @@
 {
   "name": "naturverse-web",
-  "private": true,
   "version": "0.0.0",
-  "type": "module",
+  "private": true,
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview --port 5173"
   },
+  "type": "module",
   "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",
-    "autoprefixer": "^10.4.19",
-    "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.10"
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.10",
+    "vite": "^5.4.9"
   }
 }


### PR DESCRIPTION
## Summary
- fix Netlify build to install dev dependencies inside `web` and build into `web/dist`
- add vite, tailwind, and React dependencies for the web app and expose preview on port 5173

## Testing
- `npm --prefix web install --include=dev --no-audit --no-fund` *(fails: 403 Forbidden)*
- `npm --prefix web test` *(fails: Missing script: "test")*
- `npm --prefix web run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a40b323a5883298defa4d6bc63ebee