### PR TITLE
fix netlify pathing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,12 @@
+# Netlify build for the Vite app in /web
+
 [build]
-# run everything from the repo root, but target the web/ folder explicitly
-command = "npm --prefix web install --no-audit --no-fund && npm --prefix web run build"
+# IMPORTANT: run from repo root so --prefix web points to /web (not /web/web)
+base = "."
+command = "npm --prefix web install --include=dev --no-audit --no-fund && npm --prefix web run build"
 publish = "web/dist"
 functions = "web/functions"
 
 [build.environment]
-# lock Node to a recent LTS that Vite supports
 NODE_VERSION = "20"
+


### PR DESCRIPTION
## Summary
- ensure Netlify build runs from repo root with correct prefix and dev dependency install

## Testing
- `npm --prefix web test` *(fails: Missing script "test")*
- `npm --prefix web run build` *(fails: Rollup failed to resolve import "react-router-dom")*

------
https://chatgpt.com/codex/tasks/task_e_68a40f811a188329b74490ff89b1dc53