### PR TITLE
feat(web): enable tailwind typography

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.10",
+    "@tailwindcss/typography": "^0.5.15",
     "vite": "^5.4.9"
   }
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -16,6 +16,5 @@ html, body, #root { height: 100%; }
 body { @apply antialiased; background-color: rgb(var(--bg)); color: rgb(var(--fg)); }
 
 /* Handy primitives */
-.container-prose { @apply prose max-w-none dark:prose-invert; }
 .card { @apply rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900; }
 .btn { @apply inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-brand text-white hover:opacity-90 transition; }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   content: [
     "./index.html",
-    "./src/**/*.{ts,tsx,js,jsx,html}"
+    "./src/**/*.{js,ts,jsx,tsx,md,mdx}"
   ],
   darkMode: "class",
   theme: {
@@ -49,5 +49,7 @@ module.exports = {
       }
     }
   },
-  plugins: []
+  plugins: [
+    require('@tailwindcss/typography')
+  ]
 };


### PR DESCRIPTION
## Summary
- add @tailwindcss/typography as a dev dependency
- enable typography plugin in Tailwind config and scan markdown files
- remove custom prose container from global styles

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2ftypography)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module '@tailwindcss/typography')*

------
https://chatgpt.com/codex/tasks/task_e_68a414d00c7c8329be1f81cd43e14ada