### PR TITLE
feat: add basic client router and health function

### DIFF
--- a/web/functions/health.js
+++ b/web/functions/health.js
@@ -1,5 +1,0 @@
-exports.handler = async () => ({
-  statusCode: 200,
-  headers: { "content-type": "application/json" },
-  body: JSON.stringify({ ok: true })
-});

--- a/web/functions/health.ts
+++ b/web/functions/health.ts
@@ -1,0 +1,9 @@
+import type { Handler } from "@netlify/functions";
+
+export const handler: Handler = async () => {
+  return {
+    statusCode: 200,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ok: true, ts: Date.now() })
+  };
+};

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,6 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+/* typography plugin adds .prose used above */
 
 /* Light/Dark design tokens */
 :root {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,11 +1,55 @@
-import React from 'react'
-import { createRoot } from 'react-dom/client'
-import { RouterProvider } from 'react-router-dom'
-import router from './router'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import "./index.css";
 
-createRoot(document.getElementById('root')!).render(
+function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold">The Naturverse</h1>
+        <nav className="mt-2 flex gap-4 text-blue-700">
+          <a href="/">Home</a>
+          <a href="/health">Health</a>
+        </nav>
+      </header>
+      {children}
+    </div>
+  );
+}
+
+function Home() {
+  return (
+    <Layout>
+      <h2 className="text-2xl font-semibold mb-2">Welcome 🌿</h2>
+      <p className="prose">Naturverse is live and the client router is working.</p>
+    </Layout>
+  );
+}
+
+function Health() {
+  const [status, setStatus] = React.useState<string>("checking…");
+  React.useEffect(() => {
+    fetch("/.netlify/functions/health")
+      .then(r => r.json())
+      .then(d => setStatus(d.ok ? "ok ✅" : "not ok"))
+      .catch(() => setStatus("not ok"));
+  }, []);
+  return (
+    <Layout>
+      <h2 className="text-2xl font-semibold mb-2">Health</h2>
+      <p className="prose">API status: {status}</p>
+    </Layout>
+  );
+}
+
+const router = createBrowserRouter([
+  { path: "/", element: <Home /> },
+  { path: "/health", element: <Health /> },
+]);
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <RouterProvider router={router} />
   </React.StrictMode>
-)
+);


### PR DESCRIPTION
## Summary
- replace placeholder entry with client-side router demo
- convert health function to TypeScript and include timestamp
- document typography plugin usage in Tailwind index.css

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a41d0b967c83298b2b31e99650f4f5