### PR TITLE
Wire router + navbar for Naturverse pages

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,18 +1,88 @@
-import { Link, Outlet } from 'react-router-dom'
+import { lazy, Suspense } from "react";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import Nav from "./components/Nav";
 
-export default function App() {
+// Lazy imports (only what we’ve seen in your repo tree)
+const Home = lazy(() => import("./pages/Home"));
+const Health = lazy(() => import("./pages/Health"));
+const Login = lazy(() => import("./pages/Login"));
+const Profile = lazy(() => import("./pages/Profile"));
+const Settings = lazy(() => import("./pages/settings"));
+const About = lazy(() => import("./pages/about"));
+const Contact = lazy(() => import("./pages/contact"));
+const FAQ = lazy(() => import("./pages/faq"));
+const Privacy = lazy(() => import("./pages/privacy"));
+const Terms = lazy(() => import("./pages/terms"));
+
+const Worlds = lazy(() => import("./pages/Worlds"));
+const WorldHub = lazy(() => import("./pages/world-hub"));
+const MapHub = lazy(() => import("./pages/MapHub"));
+const Observations = lazy(() => import("./pages/Observations"));
+const ObservationsDemo = lazy(() => import("./pages/ObservationsDemo"));
+const Quizzes = lazy(() => import("./pages/Quizzes"));
+const Stories = lazy(() => import("./pages/Stories"));
+const StoryStudio = lazy(() => import("./pages/story-studio"));
+
+const DesertWorld = lazy(() => import("./pages/DesertWorld"));
+const OceanWorld = lazy(() => import("./pages/OceanWorld"));
+const Rainforest = lazy(() => import("./pages/Rainforest"));
+const RainforestWorld = lazy(() => import("./pages/RainforestWorld"));
+
+const Marketplace = lazy(() => import("./pages/marketplace"));
+const Naturversity = lazy(() => import("./pages/naturversity"));
+const Zones = lazy(() => import("./pages/zones"));
+const NotFound = lazy(() => import("./pages/NotFound"));
+
+function App() {
   return (
-    <div style={{ maxWidth: 960, margin: '40px auto', padding: '0 16px' }}>
-      <header style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
-        <h1 style={{ margin: 0, fontSize: 24 }}>The Naturverse</h1>
-        <nav style={{ display: 'flex', gap: 12 }}>
-          <Link to="/">Home</Link>
-          <Link to="/health">Health</Link>
-        </nav>
-      </header>
-      <main style={{ marginTop: 24 }}>
-        <Outlet />
+    <BrowserRouter>
+      <Nav />
+      <main style={{ maxWidth: 960, margin: "0 auto", padding: "1.5rem" }}>
+        <Suspense fallback={<p>Loading…</p>}>
+          <Routes>
+            {/* core */}
+            <Route path="/" element={<Home />} />
+            <Route path="/health" element={<Health />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/profile" element={<Profile />} />
+            <Route path="/settings" element={<Settings />} />
+
+            {/* info */}
+            <Route path="/about" element={<About />} />
+            <Route path="/contact" element={<Contact />} />
+            <Route path="/faq" element={<FAQ />} />
+            <Route path="/privacy" element={<Privacy />} />
+            <Route path="/terms" element={<Terms />} />
+
+            {/* experiences */}
+            <Route path="/worlds" element={<Worlds />} />
+            <Route path="/world-hub" element={<WorldHub />} />
+            <Route path="/map" element={<MapHub />} />
+            <Route path="/observations" element={<Observations />} />
+            <Route path="/observations/demo" element={<ObservationsDemo />} />
+            <Route path="/quizzes" element={<Quizzes />} />
+            <Route path="/stories" element={<Stories />} />
+            <Route path="/story-studio" element={<StoryStudio />} />
+
+            {/* biomes */}
+            <Route path="/desert" element={<DesertWorld />} />
+            <Route path="/ocean" element={<OceanWorld />} />
+            <Route path="/rainforest" element={<Rainforest />} />
+            <Route path="/rainforest/world" element={<RainforestWorld />} />
+
+            {/* sections */}
+            <Route path="/marketplace" element={<Marketplace />} />
+            <Route path="/naturversity" element={<Naturversity />} />
+            <Route path="/zones" element={<Zones />} />
+
+            {/* compatibility + 404 */}
+            <Route path="/home" element={<Navigate to="/" replace />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
       </main>
-    </div>
-  )
+    </BrowserRouter>
+  );
 }
+
+export default App;

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -1,0 +1,24 @@
+import { NavLink } from "react-router-dom";
+
+const linkStyle: React.CSSProperties = {
+  marginRight: "1rem",
+  textDecoration: "none",
+};
+
+export default function Nav() {
+  return (
+    <header style={{ borderBottom: "1px solid #eee" }}>
+      <div style={{ maxWidth: 960, margin: "0 auto", padding: "1rem 1.5rem" }}>
+        <h1 style={{ margin: 0 }}>The Naturverse</h1>
+        <nav style={{ marginTop: ".5rem" }}>
+          <NavLink to="/" style={linkStyle}>Home</NavLink>
+          <NavLink to="/health" style={linkStyle}>Health</NavLink>
+          <NavLink to="/worlds" style={linkStyle}>Worlds</NavLink>
+          <NavLink to="/marketplace" style={linkStyle}>Marketplace</NavLink>
+          <NavLink to="/naturversity" style={linkStyle}>Naturversity</NavLink>
+          <NavLink to="/zones" style={linkStyle}>Zones</NavLink>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,55 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import App from "./App";
 import "./index.css";
-
-function Layout({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mx-auto max-w-3xl p-6">
-      <header className="mb-8">
-        <h1 className="text-3xl font-bold">The Naturverse</h1>
-        <nav className="mt-2 flex gap-4 text-blue-700">
-          <a href="/">Home</a>
-          <a href="/health">Health</a>
-        </nav>
-      </header>
-      {children}
-    </div>
-  );
-}
-
-function Home() {
-  return (
-    <Layout>
-      <h2 className="text-2xl font-semibold mb-2">Welcome 🌿</h2>
-      <p className="prose">Naturverse is live and the client router is working.</p>
-    </Layout>
-  );
-}
-
-function Health() {
-  const [status, setStatus] = React.useState<string>("checking…");
-  React.useEffect(() => {
-    fetch("/.netlify/functions/health")
-      .then(r => r.json())
-      .then(d => setStatus(d.ok ? "ok ✅" : "not ok"))
-      .catch(() => setStatus("not ok"));
-  }, []);
-  return (
-    <Layout>
-      <h2 className="text-2xl font-semibold mb-2">Health</h2>
-      <p className="prose">API status: {status}</p>
-    </Layout>
-  );
-}
-
-const router = createBrowserRouter([
-  { path: "/", element: <Home /> },
-  { path: "/health", element: <Health /> },
-]);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <App />
   </React.StrictMode>
 );

--- a/web/src/pages/Health.tsx
+++ b/web/src/pages/Health.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export default function Health() {
+  const [status, setStatus] = useState<string>("checking…");
+
+  useEffect(() => {
+    fetch("/.netlify/functions/health")
+      .then((r) => r.json())
+      .then((d) => setStatus(d.ok ? "ok ✅" : "not ok"))
+      .catch(() => setStatus("not ok"));
+  }, []);
+
+  return (
+    <main className="page">
+      <h1>Health</h1>
+      <p>API status: {status}</p>
+    </main>
+  );
+}

--- a/web/src/pages/naturversity/index.tsx
+++ b/web/src/pages/naturversity/index.tsx
@@ -1,0 +1,8 @@
+export default function Naturversity() {
+  return (
+    <main className="page">
+      <h1>Naturversity</h1>
+      <p>Learning hub coming soon.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate React Router with lazy-loaded pages and SPA navigation
- add top navbar with links to core sections
- create placeholder Naturversity and Health pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "@/lib/supabaseClient" from "src/pages/Login.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_68a421d58230832994140fa0832c7ba4