### PR TITLE
feat(web): wire full client routing with shared Layout, restore link-rich home, and add folder index pages for Zones/Marketplace/Arcade/Naturversity/Rainforest

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,15 +1,16 @@
 import React from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import AppHome from "./AppHome";
+import Layout from "./components/ui/Layout";
 
-// Sections with folder indexes (stubs added below if missing)
+// Folder-index pages
 import Zones from "./pages/zones";
 import Marketplace from "./pages/marketplace";
 import Arcade from "./pages/arcade";
 import Naturversity from "./pages/naturversity";
 import Rainforest from "./pages/rainforest";
 
-// Single-file pages that already exist
+// Single-file pages
 import Worlds from "./pages/Worlds";
 import WorldHub from "./pages/world-hub";
 import OceanWorld from "./pages/OceanWorld";
@@ -34,34 +35,37 @@ import NotFound from "./pages/NotFound";
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<AppHome />} />
-        <Route path="/home" element={<Home />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/contact" element={<Contact />} />
-        <Route path="/faq" element={<FAQ />} />
-        <Route path="/privacy" element={<Privacy />} />
-        <Route path="/terms" element={<Terms />} />
-        <Route path="/settings" element={<Settings />} />
-        <Route path="/stories" element={<Stories />} />
-        <Route path="/story-studio" element={<StoryStudio />} />
-        <Route path="/quizzes" element={<Quizzes />} />
-        <Route path="/observations" element={<Observations />} />
-        <Route path="/observations-demo" element={<ObservationsDemo />} />
-        <Route path="/map" element={<MapHub />} />
-        <Route path="/profile" element={<Profile />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/worlds" element={<Worlds />} />
-        <Route path="/world-hub" element={<WorldHub />} />
-        <Route path="/oceanworld" element={<OceanWorld />} />
-        <Route path="/desertworld" element={<DesertWorld />} />
-        <Route path="/naturversity" element={<Naturversity />} />
-        <Route path="/rainforest" element={<Rainforest />} />
-        <Route path="/zones" element={<Zones />} />
-        <Route path="/marketplace" element={<Marketplace />} />
-        <Route path="/arcade" element={<Arcade />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      <Layout>
+        <Routes>
+          <Route path="/" element={<AppHome />} />
+          <Route path="/home" element={<Home />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/contact" element={<Contact />} />
+          <Route path="/faq" element={<FAQ />} />
+          <Route path="/privacy" element={<Privacy />} />
+          <Route path="/terms" element={<Terms />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/stories" element={<Stories />} />
+          <Route path="/story-studio" element={<StoryStudio />} />
+          <Route path="/quizzes" element={<Quizzes />} />
+          <Route path="/observations" element={<Observations />} />
+          <Route path="/observations-demo" element={<ObservationsDemo />} />
+          <Route path="/map" element={<MapHub />} />
+          <Route path="/profile" element={<Profile />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/worlds" element={<Worlds />} />
+          <Route path="/world-hub" element={<WorldHub />} />
+          <Route path="/oceanworld" element={<OceanWorld />} />
+          <Route path="/desertworld" element={<DesertWorld />} />
+          <Route path="/naturversity" element={<Naturversity />} />
+          <Route path="/rainforest" element={<Rainforest />} />
+          <Route path="/zones" element={<Zones />} />
+          <Route path="/marketplace" element={<Marketplace />} />
+          <Route path="/arcade" element={<Arcade />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Layout>
     </BrowserRouter>
   );
 }
+

--- a/web/src/AppHome.tsx
+++ b/web/src/AppHome.tsx
@@ -1,30 +1,56 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-const linkStyle: React.CSSProperties = { display: "block", padding: "6px 0" };
+const Item = ({ to, label }: { to: string; label: string }) => (
+  <li className="my-1">
+    <Link className="text-blue-600 hover:underline" to={to}>
+      {label}
+    </Link>
+  </li>
+);
 
 export default function AppHome() {
   return (
-    <div style={{ padding: "2rem", maxWidth: 720 }}>
-      <h1>The Naturverse</h1>
-      <p>Welcome 🌿 Naturverse is live and the client router is working.</p>
-      <h3>Explore</h3>
-      <nav>
-        <Link to="/zones" style={linkStyle}>Zones</Link>
-        <Link to="/marketplace" style={linkStyle}>Marketplace</Link>
-        <Link to="/arcade" style={linkStyle}>Arcade</Link>
-        <Link to="/naturversity" style={linkStyle}>Naturversity</Link>
-        <Link to="/rainforest" style={linkStyle}>Rainforest</Link>
-        <Link to="/oceanworld" style={linkStyle}>Ocean World</Link>
-        <Link to="/desertworld" style={linkStyle}>Desert World</Link>
-        <Link to="/world-hub" style={linkStyle}>World Hub</Link>
-        <Link to="/stories" style={linkStyle}>Stories</Link>
-        <Link to="/quizzes" style={linkStyle}>Quizzes</Link>
-        <Link to="/observations" style={linkStyle}>Observations</Link>
-        <Link to="/map" style={linkStyle}>Map Hub</Link>
-        <Link to="/profile" style={linkStyle}>Profile</Link>
-        <Link to="/settings" style={linkStyle}>Settings</Link>
-      </nav>
-    </div>
+    <section>
+      <h1 className="text-3xl font-bold mb-2">The Naturverse</h1>
+      <p className="mb-6">Welcome 🌿 Naturverse is live and the client router is working.</p>
+
+      <h2 className="text-xl font-semibold mt-6 mb-2">Explore</h2>
+      <ul>
+        <Item to="/zones" label="Zones" />
+        <Item to="/marketplace" label="Marketplace" />
+        <Item to="/arcade" label="Arcade" />
+        <Item to="/naturversity" label="Naturversity" />
+        <Item to="/rainforest" label="Rainforest" />
+        <Item to="/worlds" label="Worlds" />
+        <Item to="/world-hub" label="World Hub" />
+        <Item to="/oceanworld" label="Ocean World" />
+        <Item to="/desertworld" label="Desert World" />
+      </ul>
+
+      <h2 className="text-xl font-semibold mt-6 mb-2">Content</h2>
+      <ul>
+        <Item to="/stories" label="Stories" />
+        <Item to="/quizzes" label="Quizzes" />
+        <Item to="/observations" label="Observations" />
+        <Item to="/observations-demo" label="Observations Demo" />
+      </ul>
+
+      <h2 className="text-xl font-semibold mt-6 mb-2">Account</h2>
+      <ul>
+        <Item to="/profile" label="Profile" />
+        <Item to="/settings" label="Settings" />
+      </ul>
+
+      <h2 className="text-xl font-semibold mt-6 mb-2">Help</h2>
+      <ul>
+        <Item to="/map" label="Map Hub" />
+        <Item to="/faq" label="FAQ" />
+        <Item to="/contact" label="Contact" />
+        <Item to="/privacy" label="Privacy" />
+        <Item to="/terms" label="Terms" />
+      </ul>
+    </section>
   );
 }
+

--- a/web/src/components/ui/Layout.tsx
+++ b/web/src/components/ui/Layout.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import Navbar from "../Navbar";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="container mx-auto max-w-5xl px-4 py-8 flex-1">
+        {children}
+      </main>
+      <footer className="border-t py-6 text-sm text-center text-gray-500">
+        © {new Date().getFullYear()} The Naturverse
+      </footer>
+    </div>
+  );
+}
+

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -7,6 +7,7 @@
 :root {
   --bg: 255 255 255;   /* white */
   --fg: 17 24 39;      /* slate-900 */
+  --nv-max: 72rem;
 }
 .dark {
   --bg: 17 24 39;      /* slate-900 */
@@ -19,3 +20,5 @@ body { @apply antialiased; background-color: rgb(var(--bg)); color: rgb(var(--fg
 /* Handy primitives */
 .card { @apply rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900; }
 .btn { @apply inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-brand text-white hover:opacity-90 transition; }
+
+.container { max-width: var(--nv-max); }

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,8 +1,11 @@
 export default function Home() {
   return (
     <section>
-      <h2>Welcome 🌿</h2>
-      <p>Naturverse is live and the client router is working.</p>
+      <h2 className="text-2xl font-semibold mb-2">Welcome 🌿</h2>
+      <p className="text-gray-700">
+        Pick a section from the navigation above or the Explore list on the home page.
+      </p>
     </section>
-  )
+  );
 }
+

--- a/web/src/pages/arcade/index.tsx
+++ b/web/src/pages/arcade/index.tsx
@@ -1,4 +1,15 @@
 import React from "react";
+import { Link } from "react-router-dom";
+
 export default function Arcade() {
-  return <div style={{ padding: "2rem" }}><h2>🎮 Arcade</h2><p>Interactive Naturverse games.</p></div>;
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-2">🎮 Arcade</h2>
+      <p className="mb-4">Interactive Naturverse games.</p>
+      <ul className="list-disc ml-5">
+        <li><Link to="/quizzes" className="text-blue-600 hover:underline">Brain Challenge</Link> (coming soon)</li>
+      </ul>
+    </section>
+  );
 }
+

--- a/web/src/pages/marketplace/index.tsx
+++ b/web/src/pages/marketplace/index.tsx
@@ -1,4 +1,10 @@
 import React from "react";
 export default function Marketplace() {
-  return <div style={{ padding: "2rem" }}><h2>🛒 Marketplace</h2><p>Discover and trade Naturverse items.</p></div>;
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-2">🛒 Marketplace</h2>
+      <p>Discover and trade Naturverse items.</p>
+    </section>
+  );
 }
+

--- a/web/src/pages/naturversity/index.tsx
+++ b/web/src/pages/naturversity/index.tsx
@@ -1,4 +1,10 @@
 import React from "react";
 export default function Naturversity() {
-  return <div style={{ padding: "2rem" }}><h2>🎓 Naturversity</h2><p>Learn, courses, and knowledge.</p></div>;
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-2">📚 Naturversity</h2>
+      <p>Learn with lessons, stories, and quizzes.</p>
+    </section>
+  );
 }
+

--- a/web/src/pages/rainforest/index.tsx
+++ b/web/src/pages/rainforest/index.tsx
@@ -1,4 +1,10 @@
 import React from "react";
 export default function Rainforest() {
-  return <div style={{ padding: "2rem" }}><h2>🌧️ Rainforest</h2><p>Welcome to the rainforest zone.</p></div>;
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-2">🌧️ Rainforest</h2>
+      <p>Welcome to the rainforest zone.</p>
+    </section>
+  );
 }
+

--- a/web/src/pages/zones/index.tsx
+++ b/web/src/pages/zones/index.tsx
@@ -1,4 +1,10 @@
 import React from "react";
 export default function Zones() {
-  return <div style={{ padding: "2rem" }}><h2>🗺️ Zones</h2><p>Browse biomes and worlds.</p></div>;
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-2">🗺️ Zones</h2>
+      <p>Browse biomes and worlds.</p>
+    </section>
+  );
 }
+


### PR DESCRIPTION
## Summary
- Add shared `Layout` component with navbar, containerized main region, and footer
- Wrap routes in new Layout and wire up folder index pages
- Restore link-rich home page and enrich basic `Home` content
- Provide simple index pages for Zones, Marketplace, Arcade, Naturversity, and Rainforest
- Introduce `--nv-max` container variable in CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a430f91b388329be8e9d8efa3fc2a5