### PR TITLE
Wire up sections, add Layout, richer pages (Zones/Marketplace/Arcade)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import AppHome from "./AppHome";
-import Layout from "./components/ui/Layout";
 
-// Folder-index pages
+// Sections with folder indexes
 import Zones from "./pages/zones";
 import Marketplace from "./pages/marketplace";
 import Arcade from "./pages/arcade";
@@ -32,39 +31,63 @@ import Profile from "./pages/Profile";
 import Login from "./pages/Login";
 import NotFound from "./pages/NotFound";
 
+// very light layout so every page isn’t a blank stub
+function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <header style={{ padding: "16px 20px", borderBottom: "1px solid #eee" }}>
+        <nav style={{ display: "flex", gap: 14, flexWrap: "wrap" }}>
+          <strong style={{ marginRight: 10 }}>The Naturverse</strong>
+          <Link to="/">Home</Link>
+          <Link to="/zones">Zones</Link>
+          <Link to="/marketplace">Marketplace</Link>
+          <Link to="/arcade">Arcade</Link>
+          <Link to="/worlds">Worlds</Link>
+          <Link to="/profile">Profile</Link>
+          <Link to="/settings">Settings</Link>
+        </nav>
+      </header>
+      <main style={{ padding: "24px 20px", maxWidth: 1100, margin: "0 auto" }}>
+        {children}
+      </main>
+      <footer style={{ padding: "24px 20px", borderTop: "1px solid #eee", marginTop: 40 }}>
+        © {new Date().getFullYear()} Naturverse
+      </footer>
+    </div>
+  );
+}
+
 export default function App() {
   return (
     <BrowserRouter>
-      <Layout>
-        <Routes>
-          <Route path="/" element={<AppHome />} />
-          <Route path="/home" element={<Home />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/contact" element={<Contact />} />
-          <Route path="/faq" element={<FAQ />} />
-          <Route path="/privacy" element={<Privacy />} />
-          <Route path="/terms" element={<Terms />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/stories" element={<Stories />} />
-          <Route path="/story-studio" element={<StoryStudio />} />
-          <Route path="/quizzes" element={<Quizzes />} />
-          <Route path="/observations" element={<Observations />} />
-          <Route path="/observations-demo" element={<ObservationsDemo />} />
-          <Route path="/map" element={<MapHub />} />
-          <Route path="/profile" element={<Profile />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/worlds" element={<Worlds />} />
-          <Route path="/world-hub" element={<WorldHub />} />
-          <Route path="/oceanworld" element={<OceanWorld />} />
-          <Route path="/desertworld" element={<DesertWorld />} />
-          <Route path="/naturversity" element={<Naturversity />} />
-          <Route path="/rainforest" element={<Rainforest />} />
-          <Route path="/zones" element={<Zones />} />
-          <Route path="/marketplace" element={<Marketplace />} />
-          <Route path="/arcade" element={<Arcade />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </Layout>
+      <Routes>
+        <Route path="/" element={<Layout><AppHome /></Layout>} />
+        <Route path="/home" element={<Layout><Home /></Layout>} />
+        <Route path="/about" element={<Layout><About /></Layout>} />
+        <Route path="/contact" element={<Layout><Contact /></Layout>} />
+        <Route path="/faq" element={<Layout><FAQ /></Layout>} />
+        <Route path="/privacy" element={<Layout><Privacy /></Layout>} />
+        <Route path="/terms" element={<Layout><Terms /></Layout>} />
+        <Route path="/settings" element={<Layout><Settings /></Layout>} />
+        <Route path="/stories" element={<Layout><Stories /></Layout>} />
+        <Route path="/story-studio" element={<Layout><StoryStudio /></Layout>} />
+        <Route path="/quizzes" element={<Layout><Quizzes /></Layout>} />
+        <Route path="/observations" element={<Layout><Observations /></Layout>} />
+        <Route path="/observations-demo" element={<Layout><ObservationsDemo /></Layout>} />
+        <Route path="/map" element={<Layout><MapHub /></Layout>} />
+        <Route path="/profile" element={<Layout><Profile /></Layout>} />
+        <Route path="/login" element={<Layout><Login /></Layout>} />
+        <Route path="/worlds" element={<Layout><Worlds /></Layout>} />
+        <Route path="/world-hub" element={<Layout><WorldHub /></Layout>} />
+        <Route path="/oceanworld" element={<Layout><OceanWorld /></Layout>} />
+        <Route path="/desertworld" element={<Layout><DesertWorld /></Layout>} />
+        <Route path="/naturversity" element={<Layout><Naturversity /></Layout>} />
+        <Route path="/rainforest" element={<Layout><Rainforest /></Layout>} />
+        <Route path="/zones" element={<Layout><Zones /></Layout>} />
+        <Route path="/marketplace" element={<Layout><Marketplace /></Layout>} />
+        <Route path="/arcade" element={<Layout><Arcade /></Layout>} />
+        <Route path="*" element={<Layout><NotFound /></Layout>} />
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,9 +1,30 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
 export default function Home() {
   return (
     <section>
-      <h2 className="text-2xl font-semibold mb-2">Welcome 🌿</h2>
-      <p className="text-gray-700">
-        Pick a section from the navigation above or the Explore list on the home page.
+      <h1 style={{ margin: "0 0 8px" }}>Welcome 🌿</h1>
+      <p style={{ marginBottom: 24 }}>
+        Naturverse is live. Jump in below:
+      </p>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(220px,1fr))", gap: 14 }}>
+        <Link to="/zones">🌎 Zones</Link>
+        <Link to="/marketplace">🛒 Marketplace</Link>
+        <Link to="/arcade">🎮 Arcade</Link>
+        <Link to="/naturversity">🎓 Naturversity</Link>
+        <Link to="/rainforest">🌧️ Rainforest</Link>
+        <Link to="/oceanworld">🌊 Ocean World</Link>
+        <Link to="/desertworld">🏜️ Desert World</Link>
+        <Link to="/world-hub">🧭 World Hub</Link>
+      </div>
+
+      <hr style={{ margin: "24px 0" }} />
+      <h2 style={{ marginBottom: 10 }}>Turian Tips</h2>
+      <p>
+        Quick wellness + nature nuggets will appear here. (Full “Turian Tips” component
+        can slot in later; this is a safe placeholder.)
       </p>
     </section>
   );

--- a/web/src/pages/arcade/BrainChallenge.tsx
+++ b/web/src/pages/arcade/BrainChallenge.tsx
@@ -1,0 +1,68 @@
+import React, { useMemo, useState } from "react";
+
+const ALL = ["🐸","🦋","🦎","🍃","🌿","🌸","🪲","🐚"];
+function shuffled<T>(arr: T[]) { return [...arr].sort(() => Math.random() - 0.5); }
+
+type Card = { id: number; emoji: string; flipped: boolean; matched: boolean };
+
+export default function BrainChallenge() {
+  const [cards, setCards] = useState<Card[]>(() => {
+    const base = shuffled(ALL).slice(0, 6);
+    const deck = shuffled([...base, ...base]).map((e, i) => ({ id: i, emoji: e, flipped: false, matched: false }));
+    return deck;
+  });
+  const [openIds, setOpenIds] = useState<number[]>([]);
+  const matchedCount = useMemo(() => cards.filter(c => c.matched).length, [cards]);
+
+  function flip(id: number) {
+    if (openIds.length === 2 || cards[id].flipped || cards[id].matched) return;
+    const next = cards.map(c => (c.id === id ? { ...c, flipped: true } : c));
+    const newOpen = [...openIds, id];
+    setCards(next); setOpenIds(newOpen);
+
+    if (newOpen.length === 2) {
+      const [a, b] = newOpen.map(i => next[i]);
+      setTimeout(() => {
+        if (a.emoji === b.emoji) {
+          setCards(cur => cur.map(c => (c.id === a.id || c.id === b.id) ? { ...c, matched: true } : c));
+        } else {
+          setCards(cur => cur.map(c => (c.id === a.id || c.id === b.id) ? { ...c, flipped: false } : c));
+        }
+        setOpenIds([]);
+      }, 550);
+    }
+  }
+
+  function reset() {
+    const base = shuffled(ALL).slice(0, 6);
+    const deck = shuffled([...base, ...base]).map((e, i) => ({ id: i, emoji: e, flipped: false, matched: false }));
+    setCards(deck); setOpenIds([]);
+  }
+
+  return (
+    <section>
+      <h1>🧠 Brain Challenge</h1>
+      <p>Flip two matching nature icons. Clear the board to win!</p>
+      <div style={{ display:"grid", gridTemplateColumns:"repeat(4,70px)", gap: 12, marginTop: 16 }}>
+        {cards.map(c => (
+          <button
+            key={c.id}
+            onClick={() => flip(c.id)}
+            style={{
+              width: 70, height: 70, fontSize: 28, borderRadius: 8,
+              background: c.matched ? "#e7ffe7" : c.flipped ? "#fff" : "#e9eef6",
+              border: "1px solid #d0d7de"
+            }}
+          >
+            {(c.flipped || c.matched) ? c.emoji : "❔"}
+          </button>
+        ))}
+      </div>
+      <div style={{ marginTop: 14 }}>
+        <strong>Matched:</strong> {matchedCount}/{cards.length}
+        <button onClick={reset} style={{ marginLeft: 10 }}>Reset</button>
+      </div>
+    </section>
+  );
+}
+

--- a/web/src/pages/arcade/index.tsx
+++ b/web/src/pages/arcade/index.tsx
@@ -4,10 +4,11 @@ import { Link } from "react-router-dom";
 export default function Arcade() {
   return (
     <section>
-      <h2 className="text-2xl font-semibold mb-2">🎮 Arcade</h2>
-      <p className="mb-4">Interactive Naturverse games.</p>
-      <ul className="list-disc ml-5">
-        <li><Link to="/quizzes" className="text-blue-600 hover:underline">Brain Challenge</Link> (coming soon)</li>
+      <h1>🎮 Arcade</h1>
+      <p>Interactive Naturverse games.</p>
+
+      <ul style={{ marginTop: 16 }}>
+        <li><Link to="/arcade/brain-challenge">🧠 Brain Challenge</Link></li>
       </ul>
     </section>
   );

--- a/web/src/pages/marketplace/index.tsx
+++ b/web/src/pages/marketplace/index.tsx
@@ -1,9 +1,29 @@
 import React from "react";
+
+type Item = { id: string; name: string; price: string; note?: string };
+
+const ITEMS: Item[] = [
+  { id: "seed-pack", name: "Rainforest Seed Pack", price: "$9.99" },
+  { id: "eco-bottle", name: "Eco Water Bottle", price: "$14.00" },
+  { id: "field-guide", name: "Pocket Field Guide", price: "$7.50" },
+  { id: "poster", name: "Ocean Creatures Poster", price: "$12.00" },
+];
+
 export default function Marketplace() {
   return (
     <section>
-      <h2 className="text-2xl font-semibold mb-2">🛒 Marketplace</h2>
+      <h1>🛒 Marketplace</h1>
       <p>Discover and trade Naturverse items.</p>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(220px,1fr))", gap: 16, marginTop: 16 }}>
+        {ITEMS.map(i => (
+          <div key={i.id} style={{ border: "1px solid #eee", borderRadius: 8, padding: 16 }}>
+            <div style={{ fontWeight: 600, marginBottom: 6 }}>{i.name}</div>
+            <div>{i.price}</div>
+            <button style={{ marginTop: 10 }}>Add to cart</button>
+          </div>
+        ))}
+      </div>
     </section>
   );
 }

--- a/web/src/pages/rainforest/index.tsx
+++ b/web/src/pages/rainforest/index.tsx
@@ -2,8 +2,8 @@ import React from "react";
 export default function Rainforest() {
   return (
     <section>
-      <h2 className="text-2xl font-semibold mb-2">🌧️ Rainforest</h2>
-      <p>Welcome to the rainforest zone.</p>
+      <h1>🌧️ Rainforest</h1>
+      <p>Welcome to the rainforest zone. Trails, species cards, and quests will live here.</p>
     </section>
   );
 }

--- a/web/src/pages/zones/index.tsx
+++ b/web/src/pages/zones/index.tsx
@@ -1,9 +1,27 @@
 import React from "react";
+import { Link } from "react-router-dom";
+
+const ZONES = [
+  { slug: "rainforest", title: "Rainforest", emoji: "🌧️", blurb: "Lush canopies and biodiversity." },
+  { slug: "oceanworld", title: "Ocean World", emoji: "🌊", blurb: "Deep blue wonders." },
+  { slug: "desertworld", title: "Desert World", emoji: "🏜️", blurb: "Dunes, stars, survival." },
+];
+
 export default function Zones() {
   return (
     <section>
-      <h2 className="text-2xl font-semibold mb-2">🗺️ Zones</h2>
+      <h1>🌍 Zones</h1>
       <p>Browse biomes and worlds.</p>
+
+      <ul style={{ listStyle: "none", padding: 0, marginTop: 16, display: "grid", gap: 14 }}>
+        {ZONES.map(z => (
+          <li key={z.slug} style={{ border: "1px solid #eee", borderRadius: 8, padding: 16 }}>
+            <h3 style={{ marginTop: 0 }}>{z.emoji} {z.title}</h3>
+            <p style={{ marginBottom: 10 }}>{z.blurb}</p>
+            <Link to={`/${z.slug}`}>Enter {z.title}</Link>
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add lightweight layout with navigation and footer
- expand Home page with quick links and placeholder section
- scaffold Zones, Marketplace, Arcade sections and new Brain Challenge game

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a44193a4dc8329ba473628bec0e856