### PR TITLE
chore: configure Netlify build for web app

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,17 @@
-# netlify.toml
 [build]
-  # The app lives in /web; Netlify should run commands from there.
-  base    = "web"
-  command = "npm ci && npm run build"
-  publish = "web/dist"
+# Run the build inside the /web folder
+base    = "web"
+# IMPORTANT: publish is RELATIVE to base
+publish = "dist"
+# First try npm ci (uses lockfile). If missing, fall back to npm i so first deploy still works.
+command = "npm ci || npm i --no-audit --no-fund && npm run build"
 
-# Single Page App redirect so deep links hit index.html
+[build.environment]
+NODE_VERSION = "18.18.0"
+NPM_FLAGS    = "--no-audit --no-fund"
+
+# SPA routing so deep links don't 404
 [[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+from = "/*"
+to   = "/index.html"
+status = 200


### PR DESCRIPTION
## Summary
- set Netlify build base to `web` and publish to `dist`
- add build environment variables and fallback install logic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix web run build`

------
https://chatgpt.com/codex/tasks/task_e_68a461e939988329be590d83c802744c