### PR TITLE
wire AI tips and zones

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,17 +1,10 @@
 [build]
-# Run the build inside the /web folder
-base    = "web"
-# IMPORTANT: publish is RELATIVE to base
-publish = "dist"
-# First try npm ci (uses lockfile). If missing, fall back to npm i so first deploy still works.
-command = "npm ci || npm i --no-audit --no-fund && npm run build"
+  base = "web"
+  command = "npm ci && npm run build"
+  publish = "dist"
+  functions = "netlify/functions"
 
-[build.environment]
-NODE_VERSION = "18.18.0"
-NPM_FLAGS    = "--no-audit --no-fund"
-
-# SPA routing so deep links don't 404
 [[redirects]]
-from = "/*"
-to   = "/index.html"
-status = 200
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/netlify/functions/generate-tip.ts
+++ b/netlify/functions/generate-tip.ts
@@ -1,0 +1,71 @@
+import type { Handler } from "@netlify/functions";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY! // server-side only
+);
+
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod !== "POST") {
+      return { statusCode: 405, body: "Method Not Allowed" };
+    }
+
+    const { topic = "eco-friendly living" } = JSON.parse(event.body || "{}");
+
+    // --- OpenAI call (text generation) ---
+    const r = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "system",
+            content:
+              "You write short, practical eco & wellness tips (max 60 words).",
+          },
+          {
+            role: "user",
+            content: `Give me one concise tip about: ${topic}`,
+          },
+        ],
+        temperature: 0.7,
+      }),
+    });
+
+    if (!r.ok) {
+      const text = await r.text();
+      return { statusCode: 500, body: `OpenAI error: ${text}` };
+    }
+
+    const data = await r.json();
+    const content = data.choices?.[0]?.message?.content?.trim();
+    if (!content) {
+      return { statusCode: 500, body: "No content from OpenAI." };
+    }
+
+    // --- Save in Supabase (table: tips) ---
+    const { error, data: inserted } = await supabase
+      .from("tips")
+      .insert([{ content, topic }])
+      .select()
+      .single();
+
+    if (error) {
+      return { statusCode: 500, body: `Supabase insert error: ${error.message}` };
+    }
+
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(inserted),
+    };
+  } catch (e: any) {
+    return { statusCode: 500, body: `Unexpected error: ${e?.message}` };
+  }
+};

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import AppHome from "./AppHome";
 // zones
 import Zones from "./pages/zones";
 import MusicZone from "./pages/zones/MusicZone";
+import ArcadeIndex from "./pages/zones/arcade";
 // content
 import TurianTips from "./pages/TurianTips";
 // marketplace & account
@@ -19,6 +20,7 @@ export default function App() {
         <Route path="/" element={<AppHome />} />
         <Route path="/zones" element={<Zones />} />
         <Route path="/zones/music" element={<MusicZone />} />
+        <Route path="/zones/arcade" element={<ArcadeIndex />} />
         <Route path="/marketplace" element={<Marketplace />} />
         <Route path="/account" element={<AccountHome />} />
         <Route path="/turian-tips" element={<TurianTips />} />

--- a/web/src/lib/supabaseClient.ts
+++ b/web/src/lib/supabaseClient.ts
@@ -1,11 +1,6 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    persistSession: true,
-    autoRefreshToken: true,
-  },
-});
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_ANON_KEY!
+);

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,9 +1,17 @@
+import { Link } from "react-router-dom";
+
 export default function Home() {
   return (
     <section style={{ maxWidth: 720, margin: "2rem auto", padding: "0 1rem" }}>
       <h2>Welcome 🌿</h2>
       <p>Naturverse is live — explore the zones, worlds, marketplace, and tips.</p>
+      <nav>
+        <ul>
+          <li><Link to="/zones/arcade">Arcade</Link></li>
+          <li><Link to="/zones/music">Music Zone</Link></li>
+          <li><Link to="/turian-tips">Turian Tips</Link></li>
+        </ul>
+      </nav>
     </section>
   );
 }
-

--- a/web/src/pages/zones/MusicZone.tsx
+++ b/web/src/pages/zones/MusicZone.tsx
@@ -1,38 +1,39 @@
-import { useEffect, useState } from "react";
-import { supabase } from "../../lib/supabaseClient";
+import React, { useEffect, useState } from "react";
+import { supabase } from "../../lib/supabaseClient"; // adjust if your path differs
 
-type Playlist = { id: string; title: string; description?: string; cover_url?: string; spotify_url?: string };
+type Playlist = { id: number; title: string; description?: string | null };
 
 export default function MusicZone() {
-  const [rows, setRows] = useState<Playlist[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [lists, setLists] = useState<Playlist[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
       const { data, error } = await supabase
         .from("playlists")
-        .select("id,title,description,cover_url,spotify_url")
-        .order("created_at", { ascending: false });
-      if (!error && data) setRows(data as any);
-      setLoading(false);
+        .select("id,title,description")
+        .order("id", { ascending: true });
+      if (error) setError(error.message);
+      else setLists(data ?? []);
     })();
   }, []);
 
-  if (loading) return <p>🎵 Music Zone • Loading…</p>;
-  if (!rows.length) return <p>🎵 Music Zone<br/>Add rows to <code>playlists</code> in Supabase to see them here.</p>;
-
   return (
-    <section>
+    <section style={{ padding: 16 }}>
       <h2>🎵 Music Zone</h2>
-      <ul>
-        {rows.map(p => (
-          <li key={p.id} style={{margin:"1rem 0"}}>
-            <strong>{p.title}</strong>
-            {p.description && <p>{p.description}</p>}
-            {p.spotify_url && <a href={p.spotify_url} target="_blank">Open playlist</a>}
-          </li>
-        ))}
-      </ul>
+      {error && <p style={{ color: "red" }}>{error}</p>}
+      {lists.length === 0 ? (
+        <p>Add rows to <code>playlists</code> in Supabase to see them here.</p>
+      ) : (
+        <ul>
+          {lists.map(p => (
+            <li key={p.id}>
+              <strong>{p.title}</strong>
+              {p.description ? <> — {p.description}</> : null}
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- configure Netlify build, function path, and SPA redirects
- add serverless function to generate and persist Turian Tips
- expose new Turian Tips and Music Zone pages with Supabase and routes

## Testing
- `npm test` *(fails: Missing script)*
- `cd web && npm test` *(fails: Missing script)*
- `cd web && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4658d7b008329a5aead452e32b617