### PR TITLE
chore: add env vars for netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,11 @@
 [build.environment]
   NODE_VERSION = "18"
   NPM_FLAGS = "--legacy-peer-deps"
+  VITE_SUPABASE_URL = "${VITE_SUPABASE_URL}"
+  VITE_SUPABASE_ANON_KEY = "${VITE_SUPABASE_ANON_KEY}"
+  SUPABASE_URL = "${SUPABASE_URL}"
+  SUPABASE_SERVICE_ROLE_KEY = "${SUPABASE_SERVICE_ROLE_KEY}"
+  OPENAI_API_KEY = "${OPENAI_API_KEY}"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Summary
- expand Netlify build config with Supabase and OpenAI env variables

## Testing
- `npm test` *(fails: Missing script)*
- `(cd web && npm test)` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a4732bbe408329bba5c0e77275c364