### PR TITLE
Fix Netlify publish path (use dist with base = "web")

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,21 @@
-[build]
-  base = "web"
-  command = "npm install --no-audit --no-fund && npm run build"
-  publish = "web/dist"
+# Root Netlify config
 
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+[build]
+# Tell Netlify to run everything from the web/ folder
+base = "web"
+
+# IMPORTANT: publish is RELATIVE to base. Use "dist", not "web/dist".
+publish = "dist"
+
+# Your build – runs inside the base dir (web/)
+command = "npm install --legacy-peer-deps --no-audit --no-fund && npm run build"
 
 [build.environment]
-  NODE_VERSION = "18"
-  NPM_FLAGS = "--legacy-peer-deps"
+NODE_VERSION = "18"
+NPM_FLAGS = "--legacy-peer-deps"
+
+# SPA routing
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200


### PR DESCRIPTION
## Summary
- ensure Netlify publishes the `dist` directory relative to the `web` base
- install with `--legacy-peer-deps` in Netlify build command and document SPA routing

## Testing
- `npm test` (fails: Missing script: "test")
- `(cd web && npm test)` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a494d1a8048329ba8fe3a0cac422ba