### PR TITLE
Fix Netlify double web/ path (publish should be dist)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base    = "web"
-  publish = "web/dist"
+  publish = "dist"                    # <-- was web/dist causing web/web/dist
   command = "npm install --legacy-peer-deps --no-audit --no-fund && npm run build"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- fix Netlify publish directory to `dist` so deployment uses `web/dist`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4acd0f46c8329bec9774bd5aaa98b