### PR TITLE
Autowire all existing pages, keep Netlify stable, and restore base styles

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
-  base = "web"          # repo root has /web; build from there
-  publish = "dist"      # Vite outputs to /web/dist
+  base = "web"
+  publish = "dist"
   command = "npm install --legacy-peer-deps --no-audit --no-fund && npm run build"
 
 [build.environment]

--- a/web/package.json
+++ b/web/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --strictPort",
-    "check": "echo ok"
+    "preview": "vite preview --strictPort"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,62 +1,25 @@
-import { Link, Route, Routes } from "react-router-dom";
+import { Route, Routes, Link } from "react-router-dom";
 import Home from "./pages/Home";
-import Zones from "./pages/Zones";
-import Marketplace from "./pages/Marketplace";
-import Arcade from "./pages/Arcade";
-import Worlds from "./pages/Worlds";
-
-import Music from "./pages/zones/Music";
-import Wellness from "./pages/zones/Wellness";
-import CreatorLab from "./pages/zones/CreatorLab";
-import Community from "./pages/zones/Community";
-import Teachers from "./pages/zones/Teachers";
-import Partners from "./pages/zones/Partners";
-import Naturversity from "./pages/zones/Naturversity";
-import Parents from "./pages/zones/Parents";
-
-import Stories from "./pages/content/Stories";
-import Quizzes from "./pages/content/Quizzes";
-import Observations from "./pages/content/Observations";
-import Tips from "./pages/content/Tips";
-import Account from "./pages/Account";
+import { getAutoRoutes } from "./router/autoRoutes";
 
 export default function App() {
+  const auto = getAutoRoutes();
+
   return (
-    <>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/zones" element={<Zones />} />
-        <Route path="/marketplace" element={<Marketplace />} />
-        <Route path="/arcade" element={<Arcade />} />
-        <Route path="/worlds" element={<Worlds />} />
+    <Routes>
+      <Route path="/" element={<Home />} />
 
-        <Route path="/zones/music" element={<Music />} />
-        <Route path="/zones/wellness" element={<Wellness />} />
-        <Route path="/zones/creator-lab" element={<CreatorLab />} />
-        <Route path="/zones/community" element={<Community />} />
-        <Route path="/zones/teachers" element={<Teachers />} />
-        <Route path="/zones/partners" element={<Partners />} />
-        <Route path="/zones/naturversity" element={<Naturversity />} />
-        <Route path="/zones/parents" element={<Parents />} />
+      {/* Every file in src/pages/** becomes a route automatically */}
+      {auto.map(r => (
+        <Route key={r.path} path={r.path} element={r.element} />
+      ))}
 
-        <Route path="/content/stories" element={<Stories />} />
-        <Route path="/content/quizzes" element={<Quizzes />} />
-        <Route path="/content/observations" element={<Observations />} />
-        <Route path="/tips" element={<Tips />} />
-        <Route path="/account" element={<Account />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </>
-  );
-}
-
-function NotFound() {
-  return (
-    <div style={{ padding: 24 }}>
-      <h1>404 — Not Found</h1>
-      <p>
-        <Link to="/">Go home</Link>
-      </p>
-    </div>
+      <Route path="*" element={
+        <div style={{ padding: 24 }}>
+          <h1>404 — Not Found</h1>
+          <p><Link to="/">Go home</Link></p>
+        </div>
+      } />
+    </Routes>
   );
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
+import "./styles/global.css";
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -2,42 +2,40 @@ import { Link } from "react-router-dom";
 
 export default function Home() {
   return (
-    <main style={{ padding: 24, lineHeight: 1.6 }}>
+    <main>
       <h1>Welcome 🌿</h1>
       <p>Naturverse is live and the client router is working.</p>
 
       <h2>Explore</h2>
-      <Nav to="/zones">Zones</Nav>
-      <Nav to="/marketplace">Marketplace</Nav>
-      <Nav to="/arcade">Arcade</Nav>
-      <Nav to="/worlds">Worlds</Nav>
+      <p>
+        <Link to="/zones">Zones</Link> •{" "}
+        <Link to="/marketplace">Marketplace</Link> •{" "}
+        <Link to="/arcade">Arcade</Link> •{" "}
+        <Link to="/worlds">Worlds</Link>
+      </p>
 
       <h2>Zones (shortcuts)</h2>
-      <Nav to="/zones/music">Music</Nav>
-      <Nav to="/zones/wellness">Wellness</Nav>
-      <Nav to="/zones/creator-lab">Creator Lab</Nav>
-      <Nav to="/zones/community">Community</Nav>
-      <Nav to="/zones/teachers">Teachers</Nav>
-      <Nav to="/zones/partners">Partners</Nav>
-      <Nav to="/zones/naturversity">Naturversity</Nav>
-      <Nav to="/zones/parents">Parents</Nav>
+      <p>
+        <Link to="/zones/music">Music</Link> •{" "}
+        <Link to="/zones/wellness">Wellness</Link> •{" "}
+        <Link to="/zones/creator-lab">Creator Lab</Link> •{" "}
+        <Link to="/zones/community">Community</Link> •{" "}
+        <Link to="/zones/teachers">Teachers</Link> •{" "}
+        <Link to="/zones/partners">Partners</Link> •{" "}
+        <Link to="/zones/naturversity">Naturversity</Link> •{" "}
+        <Link to="/zones/parents">Parents</Link>
+      </p>
 
       <h2>Content</h2>
-      <Nav to="/content/stories">Stories</Nav>
-      <Nav to="/content/quizzes">Quizzes</Nav>
-      <Nav to="/content/observations">Observations</Nav>
-      <Nav to="/tips">Turian Tips</Nav>
+      <p>
+        <Link to="/content/stories">Stories</Link> •{" "}
+        <Link to="/content/quizzes">Quizzes</Link> •{" "}
+        <Link to="/content/observations">Observations</Link> •{" "}
+        <Link to="/tips">Turian Tips</Link>
+      </p>
 
       <h2>Account</h2>
-      <Nav to="/account">Profile & Settings</Nav>
+      <p><Link to="/account">Profile & Settings</Link></p>
     </main>
-  );
-}
-
-function Nav({ to, children }: { to: string; children: React.ReactNode }) {
-  return (
-    <div>
-      <Link to={to}>{children}</Link>
-    </div>
   );
 }

--- a/web/src/router/autoRoutes.tsx
+++ b/web/src/router/autoRoutes.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { RouteObject } from "react-router-dom";
+
+/**
+ * Eagerly import every page component under src/pages/**.tsx
+ * A page must have a default export React component.
+ */
+const modules = import.meta.glob("../pages/**/*.tsx", { eager: true });
+
+function toPath(file: string) {
+  // ../pages/Arcade/index.tsx -> /arcade
+  // ../pages/content/Stories.tsx -> /content/stories
+  let p = file.replace("../pages", "").replace(/\.tsx$/i, "");
+  p = p.replace(/\/index$/i, "/");              // index routes
+  p = p.replace(/\\/g, "/");
+  // lower-case segments, keep dashes in filenames
+  p = p.split("/").map((seg) => seg ? seg.toLowerCase() : seg).join("/");
+  if (!p.startsWith("/")) p = "/" + p;
+  if (p !== "/" && p.endsWith("/")) p = p.slice(0, -1);
+  return p || "/";
+}
+
+export function getAutoRoutes(): RouteObject[] {
+  const routes: RouteObject[] = [];
+
+  Object.entries(modules).forEach(([file, mod]) => {
+    // Skip non-components or utility files if any
+    const m = mod as any;
+    const Component = m?.default;
+    if (!Component || typeof Component !== "function") return;
+
+    const path = toPath(file);
+    // We'll mount Home ("/") explicitly in App; skip here to avoid duplicates
+    if (path === "/") return;
+
+    routes.push({
+      path,
+      element: React.createElement(Component)
+    });
+  });
+
+  // Sort deeper paths after shallow ones to avoid conflicts
+  routes.sort((a, b) => (a.path!.split("/").length - b.path!.split("/").length));
+  return routes;
+}

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -1,0 +1,8 @@
+html,body,#root { height: 100%; }
+body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.6; }
+main { padding: 24px; max-width: 960px; }
+h1 { font-size: 1.8rem; margin: 0 0 0.5rem; }
+h2 { font-size: 1.3rem; margin: 1.5rem 0 0.5rem; }
+a { color: #0b57d0; text-decoration: none; }
+a:hover { text-decoration: underline; }
+ul { padding-left: 1.25rem; }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,5 +3,5 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
-  build: { outDir: "dist" },
+  build: { outDir: "dist" }
 });


### PR DESCRIPTION
## Summary
- Autoload all existing page components and wire them into the router with a 404 fallback
- Restore a basic global stylesheet and load it in the app entry
- Keep Netlify configuration stable with Node 18 and SPA redirect

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4c781db3c83299da583d46e364f74