### PR TITLE
Restore full site sections with zero-dep content system (no Netlify changes)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>The Naturverse</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Naturverse</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --strictPort"
+    "preview": "vite preview --strictPort --port 5173"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/web/src/lib/content.ts
+++ b/web/src/lib/content.ts
@@ -1,0 +1,69 @@
+// zero-dependency content provider
+
+export type Zone = {
+  slug: string;
+  title: string;
+  tagline: string;
+};
+
+export type Doc = {
+  id: string;
+  title: string;
+  summary: string;
+  zone?: string; // optional zone association
+  body: string;
+};
+
+export const zones: Zone[] = [
+  { slug: "music",        title: "Music",        tagline: "Create, listen, play." },
+  { slug: "wellness",     title: "Wellness",     tagline: "Mind & body." },
+  { slug: "creator-lab",  title: "Creator Lab",  tagline: "Make and learn." },
+  { slug: "community",    title: "Community",    tagline: "Clubs & groups." },
+  { slug: "teachers",     title: "Teachers",     tagline: "Classroom tools." },
+  { slug: "partners",     title: "Partners",     tagline: "Collaborations." },
+  { slug: "naturversity", title: "Naturversity", tagline: "Courses & paths." },
+  { slug: "parents",      title: "Parents",      tagline: "Guides for home." },
+];
+
+export const stories: Doc[] = [
+  { id: "sprout-journey", title: "The Sprout’s Journey",
+    summary: "A short story about growth and curiosity.",
+    zone: "naturversity",
+    body: "Once upon a time, a sprout learned **photosynthesis** by playing in the sun." },
+  { id: "sound-city", title: "Sound City",
+    summary: "Field notes from the Music Zone.",
+    zone: "music",
+    body: "Beats, loops, and friendly robots keep the rhythm going." },
+];
+
+export const quizzes: Doc[] = [
+  { id: "eco-basics", title: "Eco Basics Quiz",
+    summary: "5 quick questions on reduce-reuse-recycle.",
+    zone: "parents",
+    body: "Q1) Which bin gets paper?\nA) Blue.\n... (stub)" },
+];
+
+export const observations: Doc[] = [
+  { id: "garden-log-001", title: "Garden Log #001",
+    summary: "First sprouts observed after rainfall.",
+    zone: "wellness",
+    body: "Moist soil, ambient temp 20°C, sunlight 6h." },
+];
+
+export const tips: Doc[] = [
+  { id: "hydrate", title: "Hydrate like a pro",
+    summary: "Simple reminder system for water breaks.",
+    zone: "wellness",
+    body: "Set a 90-minute timer; drink a glass each chime." },
+];
+
+export type Game = { id: string; title: string; description: string; url: string };
+export const games: Game[] = [
+  { id: "runner", title: "Leaf Runner", description: "Endless runner with coins + hi-score.", url: "/games/runner/" },
+  { id: "puzzle", title: "Eco Puzzle", description: "Match items to the right bins.", url: "/games/puzzle/" },
+  { id: "fling",  title: "Seed Fling", description: "Slingshot seeds to grow trees.", url: "/games/fling/" },
+];
+
+// helpers
+export const byId = (arr: Doc[], id?: string) => arr.find(d => d.id === id);
+export const zoneBySlug = (slug?: string) => zones.find(z => z.slug === slug);

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,13 +1,11 @@
 import React from "react";
-import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
-import App from "./App";
-import "./styles/global.css";
+import ReactDOM from "react-dom/client";
+import { RouterProvider } from "react-router-dom";
+import router from "./router";
+import "./styles.css";
 
-createRoot(document.getElementById("root")!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <RouterProvider router={router} />
   </React.StrictMode>
 );

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { createBrowserRouter } from "react-router-dom";
+import Home from "./routes/Home";
+import Zones from "./routes/Zones";
+import Marketplace from "./routes/Marketplace";
+import Arcade from "./routes/Arcade";
+import Worlds from "./routes/Worlds";
+import Zone from "./routes/Zone";
+import Stories from "./routes/Stories";
+import Story from "./routes/Story";
+import Quizzes from "./routes/Quizzes";
+import Quiz from "./routes/Quiz";
+import Observations from "./routes/Observations";
+import Observation from "./routes/Observation";
+import Tips from "./routes/Tips";
+import Tip from "./routes/Tip";
+import Profile from "./routes/Profile";
+import NotFound from "./routes/NotFound";
+
+export default createBrowserRouter([
+  { path: "/", element: <Home /> },
+  { path: "/zones", element: <Zones /> },
+  { path: "/marketplace", element: <Marketplace /> },
+  { path: "/arcade", element: <Arcade /> },
+  { path: "/worlds", element: <Worlds /> },
+
+  // zone shortcuts
+  { path: "/zones/:slug", element: <Zone /> },
+
+  // content
+  { path: "/stories", element: <Stories /> },
+  { path: "/stories/:id", element: <Story /> },
+
+  { path: "/quizzes", element: <Quizzes /> },
+  { path: "/quizzes/:id", element: <Quiz /> },
+
+  { path: "/observations", element: <Observations /> },
+  { path: "/observations/:id", element: <Observation /> },
+
+  { path: "/tips", element: <Tips /> },
+  { path: "/tips/:id", element: <Tip /> },
+
+  { path: "/profile", element: <Profile /> },
+  { path: "*", element: <NotFound /> },
+]);

--- a/web/src/routes/Arcade.tsx
+++ b/web/src/routes/Arcade.tsx
@@ -1,0 +1,16 @@
+import { games } from "../lib/content";
+
+export default function Arcade(){
+  return (
+    <div className="container">
+      <h1>Arcade</h1>
+      <ul>
+        {games.map(g => (
+          <li key={g.id}><a href={g.url}>{g.title}</a> — <span className="meta">{g.description}</span></li>
+        ))}
+      </ul>
+      <hr/>
+      <p className="meta">High scores & leaderboard endpoints can be attached later.</p>
+    </div>
+  );
+}

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -1,0 +1,39 @@
+import { Link } from "react-router-dom";
+import { zones } from "../lib/content";
+
+export default function Home() {
+  return (
+    <div className="container">
+      <h1>Welcome 🌿</h1>
+      <p>Naturverse is live and the client router is working.</p>
+
+      <h2>Explore</h2>
+      <div className="nav">
+        <Link to="/zones">Zones</Link>
+        <Link to="/marketplace">Marketplace</Link>
+        <Link to="/arcade">Arcade</Link>
+        <Link to="/worlds">Worlds</Link>
+      </div>
+
+      <h2>Zones (shortcuts)</h2>
+      <div className="nav">
+        {zones.map(z => (
+          <Link key={z.slug} to={`/zones/${z.slug}`}>{z.title}</Link>
+        ))}
+      </div>
+
+      <h2>Content</h2>
+      <div className="nav">
+        <Link to="/stories">Stories</Link>
+        <Link to="/quizzes">Quizzes</Link>
+        <Link to="/observations">Observations</Link>
+        <Link to="/tips">Turian Tips</Link>
+      </div>
+
+      <h2>Account</h2>
+      <div className="nav">
+        <Link to="/profile">Profile & Settings</Link>
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/Marketplace.tsx
+++ b/web/src/routes/Marketplace.tsx
@@ -1,0 +1,8 @@
+export default function Marketplace(){
+  return (
+    <div className="container">
+      <h1>Marketplace</h1>
+      <p className="meta">Natur token, items, and upgrades (stubbed UI; contract wiring later).</p>
+    </div>
+  );
+}

--- a/web/src/routes/NotFound.tsx
+++ b/web/src/routes/NotFound.tsx
@@ -1,0 +1,9 @@
+import { Link } from "react-router-dom";
+export default function NotFound(){
+  return (
+    <div className="container">
+      <h1>404 — Not Found</h1>
+      <p><Link to="/">Go home</Link></p>
+    </div>
+  );
+}

--- a/web/src/routes/Observation.tsx
+++ b/web/src/routes/Observation.tsx
@@ -1,0 +1,16 @@
+import { useParams } from "react-router-dom";
+import { byId, observations } from "../lib/content";
+
+export default function Observation(){
+  const { id } = useParams();
+  const doc = byId(observations, id);
+  if(!doc) return <div className="container"><h1>Observation</h1><p className="meta">Not found.</p></div>;
+  return (
+    <div className="container">
+      <h1>{doc.title}</h1>
+      <p className="meta">{doc.summary}</p>
+      <hr/>
+      <pre>{doc.body}</pre>
+    </div>
+  );
+}

--- a/web/src/routes/Observations.tsx
+++ b/web/src/routes/Observations.tsx
@@ -1,0 +1,18 @@
+import { Link } from "react-router-dom";
+import { observations } from "../lib/content";
+
+export default function Observations(){
+  return (
+    <div className="container">
+      <h1>Observations</h1>
+      <div className="list">
+        {observations.map(o => (
+          <div className="card" key={o.id}>
+            <b><Link to={`/observations/${o.id}`}>{o.title}</Link></b>
+            <div className="meta">{o.summary}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/Profile.tsx
+++ b/web/src/routes/Profile.tsx
@@ -1,0 +1,8 @@
+export default function Profile(){
+  return (
+    <div className="container">
+      <h1>Profile & Settings</h1>
+      <p className="meta">Auth, avatars, preferences (Supabase wiring next).</p>
+    </div>
+  );
+}

--- a/web/src/routes/Quiz.tsx
+++ b/web/src/routes/Quiz.tsx
@@ -1,0 +1,16 @@
+import { useParams } from "react-router-dom";
+import { byId, quizzes } from "../lib/content";
+
+export default function Quiz(){
+  const { id } = useParams();
+  const doc = byId(quizzes, id);
+  if(!doc) return <div className="container"><h1>Quiz</h1><p className="meta">Not found.</p></div>;
+  return (
+    <div className="container">
+      <h1>{doc.title}</h1>
+      <p className="meta">{doc.summary}</p>
+      <hr/>
+      <pre>{doc.body}</pre>
+    </div>
+  );
+}

--- a/web/src/routes/Quizzes.tsx
+++ b/web/src/routes/Quizzes.tsx
@@ -1,0 +1,18 @@
+import { Link } from "react-router-dom";
+import { quizzes } from "../lib/content";
+
+export default function Quizzes(){
+  return (
+    <div className="container">
+      <h1>Quizzes</h1>
+      <div className="list">
+        {quizzes.map(q => (
+          <div className="card" key={q.id}>
+            <b><Link to={`/quizzes/${q.id}`}>{q.title}</Link></b>
+            <div className="meta">{q.summary}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/Stories.tsx
+++ b/web/src/routes/Stories.tsx
@@ -1,0 +1,19 @@
+import { Link } from "react-router-dom";
+import { stories } from "../lib/content";
+
+export default function Stories(){
+  return (
+    <div className="container">
+      <h1>Stories</h1>
+      <p className="meta">Stories library.</p>
+      <div className="list">
+        {stories.map(s => (
+          <div className="card" key={s.id}>
+            <b><Link to={`/stories/${s.id}`}>{s.title}</Link></b>
+            <div className="meta">{s.summary}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/Story.tsx
+++ b/web/src/routes/Story.tsx
@@ -1,0 +1,16 @@
+import { useParams } from "react-router-dom";
+import { byId, stories } from "../lib/content";
+
+export default function Story(){
+  const { id } = useParams();
+  const doc = byId(stories, id);
+  if(!doc) return <div className="container"><h1>Story</h1><p className="meta">Not found.</p></div>;
+  return (
+    <div className="container">
+      <h1>{doc.title}</h1>
+      <p className="meta">{doc.summary}</p>
+      <hr/>
+      <div>{doc.body}</div>
+    </div>
+  );
+}

--- a/web/src/routes/Tip.tsx
+++ b/web/src/routes/Tip.tsx
@@ -1,0 +1,16 @@
+import { useParams } from "react-router-dom";
+import { byId, tips } from "../lib/content";
+
+export default function Tip(){
+  const { id } = useParams();
+  const doc = byId(tips, id);
+  if(!doc) return <div className="container"><h1>Tip</h1><p className="meta">Not found.</p></div>;
+  return (
+    <div className="container">
+      <h1>{doc.title}</h1>
+      <p className="meta">{doc.summary}</p>
+      <hr/>
+      <div>{doc.body}</div>
+    </div>
+  );
+}

--- a/web/src/routes/Tips.tsx
+++ b/web/src/routes/Tips.tsx
@@ -1,0 +1,18 @@
+import { Link } from "react-router-dom";
+import { tips } from "../lib/content";
+
+export default function Tips(){
+  return (
+    <div className="container">
+      <h1>Turian Tips</h1>
+      <div className="list">
+        {tips.map(t => (
+          <div className="card" key={t.id}>
+            <b><Link to={`/tips/${t.id}`}>{t.title}</Link></b>
+            <div className="meta">{t.summary}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/Worlds.tsx
+++ b/web/src/routes/Worlds.tsx
@@ -1,0 +1,8 @@
+export default function Worlds(){
+  return (
+    <div className="container">
+      <h1>Worlds</h1>
+      <p className="meta">3D scenes / web worlds coming next.</p>
+    </div>
+  );
+}

--- a/web/src/routes/Zone.tsx
+++ b/web/src/routes/Zone.tsx
@@ -1,0 +1,26 @@
+import { useParams, Link } from "react-router-dom";
+import { zoneBySlug, stories, tips } from "../lib/content";
+
+export default function Zone() {
+  const { slug } = useParams();
+  const zone = zoneBySlug(slug);
+  if (!zone) return <div className="container"><h1>Zone</h1><p className="meta">Not found.</p></div>;
+
+  const zoneStories = stories.filter(s => s.zone === slug);
+  const zoneTips = tips.filter(t => t.zone === slug);
+
+  return (
+    <div className="container">
+      <h1>{zone.title}</h1>
+      <p className="meta">{zone.tagline}</p>
+      {!!zoneStories.length && (<>
+        <h2>Stories</h2>
+        <ul>{zoneStories.map(s => <li key={s.id}><Link to={`/stories/${s.id}`}>{s.title}</Link></li>)}</ul>
+      </>)}
+      {!!zoneTips.length && (<>
+        <h2>Tips</h2>
+        <ul>{zoneTips.map(t => <li key={t.id}><Link to={`/tips/${t.id}`}>{t.title}</Link></li>)}</ul>
+      </>)}
+    </div>
+  );
+}

--- a/web/src/routes/Zones.tsx
+++ b/web/src/routes/Zones.tsx
@@ -1,0 +1,18 @@
+import { Link } from "react-router-dom";
+import { zones } from "../lib/content";
+
+export default function Zones() {
+  return (
+    <div className="container">
+      <h1>Zones</h1>
+      <div className="list">
+        {zones.map(z => (
+          <div className="card" key={z.slug}>
+            <b><Link to={`/zones/${z.slug}`}>{z.title}</Link></b>
+            <div className="meta">{z.tagline}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,14 @@
+:root { --fg:#0b1220; --muted:#5b6473; --link:#1b64f1; }
+*{box-sizing:border-box}
+body{margin:0;font:16px/1.45 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif;color:var(--fg)}
+a{color:var(--link);text-decoration:none}
+a:hover{text-decoration:underline}
+.container{max-width:960px;margin:0 auto;padding:24px}
+h1{font-size:clamp(28px,4vw,40px);margin:0 0 16px}
+h2{margin:32px 0 12px}
+.list{display:grid;gap:10px}
+.card{padding:12px 14px;border:1px solid #e5e7eb;border-radius:10px}
+.meta{color:var(--muted);font-size:14px}
+hr{border:0;border-top:1px solid #eee;margin:24px 0}
+.nav{display:flex;gap:10px;flex-wrap:wrap;margin:8px 0 16px}
+.nav a{font-weight:600}


### PR DESCRIPTION
## Summary
- add client-side router wiring all site sections
- include static content provider for zones and sample docs
- update entrypoint, styles, HTML template, and preview script

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a4d5e167248329afdcb3573e07a4ef