### PR TITLE
Connect Supabase client and OpenAI via Netlify function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,6 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+[functions]
+directory = "netlify/functions"

--- a/netlify/functions/ai-chat.ts
+++ b/netlify/functions/ai-chat.ts
@@ -1,0 +1,36 @@
+import type { Handler } from '@netlify/functions';
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY as string;
+
+export const handler: Handler = async (event) => {
+  try {
+    if (!OPENAI_API_KEY) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Missing OPENAI_API_KEY' }) };
+    }
+    const { messages = [] } = event.body ? JSON.parse(event.body) : {};
+
+    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${OPENAI_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages,
+        temperature: 0.7
+      })
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      return { statusCode: resp.status, body: JSON.stringify({ error: text }) };
+    }
+
+    const json = await resp.json();
+    const reply = json.choices?.[0]?.message?.content ?? '';
+    return { statusCode: 200, body: JSON.stringify({ reply }) };
+  } catch (err: any) {
+    return { statusCode: 500, body: JSON.stringify({ error: String(err) }) };
+  }
+};

--- a/web/src/lib/openai.ts
+++ b/web/src/lib/openai.ts
@@ -1,0 +1,12 @@
+export type ChatMessage = { role: 'user' | 'assistant' | 'system'; content: string };
+
+export async function askAI(prompt: string) {
+  const res = await fetch('/.netlify/functions/ai-chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messages: [{ role: 'user', content: prompt }] })
+  });
+  if (!res.ok) throw new Error(`AI error ${res.status}`);
+  const data = await res.json();
+  return data.reply as string;
+}

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Uses client-safe envs. Do not expose service role here.
+const url = import.meta.env.VITE_SUPABASE_URL as string;
+const anon = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(url, anon, {
+  auth: { persistSession: true, autoRefreshToken: true }
+});

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,7 @@ import Root from './layouts/Root';
 import Home from './pages/Home';
 import SectionList from './pages/SectionList';
 import SectionDetail from './pages/SectionDetail';
+import TurianTips from './pages/tips';
 /** Marketplace pages */
 import MarketplaceHome from './pages/Marketplace';
 import ProductDetail from './pages/Marketplace/ProductDetail';
@@ -41,7 +42,7 @@ const router = createBrowserRouter([
       { path: 'observations', element: <SectionList/> },
       { path: 'observations/:slug', element: <SectionDetail/> },
 
-      { path: 'tips', element: <SectionList/> },
+      { path: 'tips', element: <TurianTips/> },
       { path: 'tips/:slug', element: <SectionDetail/> },
 
       {

--- a/web/src/pages/tips/index.tsx
+++ b/web/src/pages/tips/index.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../../lib/supabase';
+import { askAI } from '../../lib/openai';
+
+type Tip = { id: string; text: string; created_at: string };
+
+export default function TurianTips() {
+  const [tips, setTips] = useState<Tip[]>([]);
+  const [newTip, setNewTip] = useState('');
+  const [ai, setAi] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const { data, error } = await supabase
+        .from('tips')
+        .select('*')
+        .order('created_at', { ascending: false })
+        .limit(10);
+      if (!error && data) setTips(data as Tip[]);
+    })();
+  }, []);
+
+  async function addTip() {
+    if (!newTip.trim()) return;
+    const { data, error } = await supabase.from('tips').insert({ text: newTip }).select().single();
+    if (!error && data) setTips((t) => [data as Tip, ...t]);
+    setNewTip('');
+  }
+
+  async function ask() {
+    setAi('Thinking…');
+    try {
+      const reply = await askAI('Give a short nature-themed tip for kids.');
+      setAi(reply);
+    } catch (e: any) {
+      setAi(`AI error: ${e.message}`);
+    }
+  }
+
+  return (
+    <section>
+      <h1>Turian Tips</h1>
+
+      <h2>Supabase tips</h2>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <input value={newTip} onChange={e => setNewTip(e.target.value)} placeholder="Add a tip…" />
+        <button onClick={addTip}>Save</button>
+      </div>
+      <ul>
+        {tips.map(t => <li key={t.id}>{t.text}</li>)}
+      </ul>
+
+      <h2>Ask OpenAI</h2>
+      <button onClick={ask}>Generate a tip</button>
+      {ai && <p style={{ marginTop: 8 }}>{ai}</p>}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add Supabase browser client configured via VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY
- add Netlify function `ai-chat` that calls OpenAI using server-side OPENAI_API_KEY
- add demo `/tips` page with Supabase CRUD and AI tip generation
- update router and Netlify config to recognize new function directory

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix web test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a542af66c083299931e62ee5f37e44