### PR TITLE
Add Supabase client dependency and wire src/lib/supabase.ts (no config changes)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview --strictPort --port 5173"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.47.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2"

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -1,9 +1,19 @@
+// Minimal, browser-safe Supabase client
 import { createClient } from '@supabase/supabase-js';
 
-// Uses client-safe envs. Do not expose service role here.
-const url = import.meta.env.VITE_SUPABASE_URL as string;
-const anon = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const url = import.meta.env.VITE_SUPABASE_URL;
+const anon = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(url, anon, {
-  auth: { persistSession: true, autoRefreshToken: true }
+if (!url || !anon) {
+  // Fail fast during build/preview if env vars are missing
+  // (Won't break Netlify if envs are set there)
+  console.warn('[Supabase] VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY is missing.');
+}
+
+export const supabase = createClient(url ?? '', anon ?? '', {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+  },
 });


### PR DESCRIPTION
## Summary
- add `@supabase/supabase-js` to web app dependencies
- provide browser-safe Supabase client with env var checks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5468aa8c0832980fd51c54e2d3146