### PR TITLE
Add Supabase auth, OpenAI proxy, and arcade leaderboard

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,4 @@
 
 [functions]
 directory = "netlify/functions"
+node_bundler = "esbuild"

--- a/netlify/functions/chat.ts
+++ b/netlify/functions/chat.ts
@@ -1,0 +1,29 @@
+// @ts-ignore - Netlify provides types at build
+import type { Handler } from "@netlify/functions";
+import OpenAI from "openai";
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+export const handler: Handler = async (event) => {
+  try {
+    if (!process.env.OPENAI_API_KEY) return resp(500, "OPENAI_API_KEY missing");
+    const body = event.body ? JSON.parse(event.body) : {};
+    const msgs = body?.messages ?? [{ role: "user", content: "Hello" }];
+
+    const completion = await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: msgs,
+      temperature: 0.7,
+    });
+
+    const reply = completion.choices?.[0]?.message?.content ?? "";
+    return resp(200, { reply });
+  } catch (e: any) {
+    return resp(500, e.message ?? "error");
+  }
+};
+
+function resp(statusCode: number, body: any) {
+  return { statusCode, headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) };
+}
+

--- a/netlify/functions/scores.ts
+++ b/netlify/functions/scores.ts
@@ -1,0 +1,45 @@
+// @ts-ignore
+import type { Handler } from "@netlify/functions";
+import { createClient } from "@supabase/supabase-js";
+
+const url = process.env.SUPABASE_URL!;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY!; // server-only
+const supabase = createClient(url, key);
+
+export const handler: Handler = async (event) => {
+  try {
+    const method = event.httpMethod;
+    const game = (event.queryStringParameters?.game ?? "game1").toString();
+
+    if (method === "GET") {
+      const { data, error } = await supabase
+        .from("scores")
+        .select("*")
+        .eq("game", game)
+        .order("points", { ascending: false })
+        .limit(25);
+      if (error) throw error;
+      return ok(data);
+    }
+
+    if (method === "POST") {
+      const { name, points } = JSON.parse(event.body || "{}");
+      if (!name || typeof points !== "number") return bad("name & points required");
+      const { data, error } = await supabase
+        .from("scores")
+        .insert([{ game, name, points }])
+        .select()
+        .single();
+      if (error) throw error;
+      return ok(data);
+    }
+
+    return bad("Unsupported method");
+  } catch (e: any) {
+    return { statusCode: 500, body: e.message ?? "error" };
+  }
+};
+
+const ok = (b: any) => ({ statusCode: 200, headers: { "Content-Type": "application/json" }, body: JSON.stringify(b) });
+const bad = (m: string) => ({ statusCode: 400, body: m });
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "ethers": "^6.13.0"
+    "ethers": "^6.13.0",
+    "@supabase/supabase-js": "^2.45.4",
+    "openai": "^4.56.0"
   }
 }

--- a/web/src/components/ChatBox.tsx
+++ b/web/src/components/ChatBox.tsx
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import type { ChatReq, ChatRes } from "../types";
+import { api } from "../lib/api";
+
+export default function ChatBox() {
+  const [input, setInput] = useState("");
+  const [log, setLog] = useState<{ role: "user"|"assistant"; content: string }[]>([]);
+
+  async function send() {
+    if (!input.trim()) return;
+    const next = [...log, { role: "user", content: input }];
+    setLog(next);
+    setInput("");
+    const req: ChatReq = { messages: [{ role: "system", content: "You are a friendly Naturverse guide." }, ...next] as any };
+    const res = await api<ChatRes>("/.netlify/functions/chat", { method: "POST", body: JSON.stringify(req) });
+    setLog((l) => [...l, { role: "assistant", content: res.reply }]);
+  }
+
+  return (
+    <div style={{ border: "1px solid #ddd", padding: 12, borderRadius: 8 }}>
+      <div style={{ minHeight: 80, marginBottom: 8 }}>
+        {log.map((m, i) => <p key={i}><strong>{m.role}:</strong> {m.content}</p>)}
+      </div>
+      <input value={input} onChange={(e)=>setInput(e.target.value)} placeholder="Ask Natur…" />
+      <button onClick={send}>Send</button>
+    </div>
+  );
+}
+

--- a/web/src/components/Leaderboard.tsx
+++ b/web/src/components/Leaderboard.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import type { Score } from "../types";
+import { api } from "../lib/api";
+
+export default function Leaderboard({ game = "game1" }: { game?: string }) {
+  const [scores, setScores] = useState<Score[]>([]);
+  const [name, setName] = useState("");
+  const [points, setPoints] = useState<number>(0);
+
+  async function load() {
+    const data = await api<Score[]>(`/.netlify/functions/scores?game=${encodeURIComponent(game)}`);
+    setScores(data);
+  }
+  useEffect(()=>{ load(); }, [game]);
+
+  async function submit() {
+    await api(`/.netlify/functions/scores?game=${encodeURIComponent(game)}`, {
+      method: "POST",
+      body: JSON.stringify({ name: name || "Player", points }),
+    });
+    setPoints(0);
+    load();
+  }
+
+  return (
+    <div>
+      <h3>Leaderboard</h3>
+      <ol>{scores.map(s => <li key={s.id}>{s.name} — {s.points}</li>)}</ol>
+      <div style={{ display: "flex", gap: 8 }}>
+        <input placeholder="Name" value={name} onChange={(e)=>setName(e.target.value)} />
+        <input type="number" placeholder="Points" value={points} onChange={(e)=>setPoints(parseInt(e.target.value||"0"))} />
+        <button onClick={submit}>Submit</button>
+      </div>
+    </div>
+  );
+}
+

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,6 @@
+export async function api<T = any>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, { headers: { "Content-Type": "application/json" }, ...init });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json() as Promise<T>;
+}
+

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -1,19 +1,10 @@
-// Minimal, browser-safe Supabase client
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from "@supabase/supabase-js";
 
-const url = import.meta.env.VITE_SUPABASE_URL;
-const anon = import.meta.env.VITE_SUPABASE_ANON_KEY;
+// NEVER put service_role in the browser.
+const url = import.meta.env.VITE_SUPABASE_URL!;
+const anon = import.meta.env.VITE_SUPABASE_ANON_KEY!;
 
-if (!url || !anon) {
-  // Fail fast during build/preview if env vars are missing
-  // (Won't break Netlify if envs are set there)
-  console.warn('[Supabase] VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY is missing.');
-}
-
-export const supabase = createClient(url ?? '', anon ?? '', {
-  auth: {
-    persistSession: true,
-    autoRefreshToken: true,
-    detectSessionInUrl: true,
-  },
+export const supabase = createClient(url, anon, {
+  auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true },
 });
+

--- a/web/src/pages/Arcade/Game1.tsx
+++ b/web/src/pages/Arcade/Game1.tsx
@@ -1,0 +1,13 @@
+import Leaderboard from "../../components/Leaderboard";
+
+export default function Game1() {
+  // Your game logic stays; this just shows/uses the shared leaderboard API
+  return (
+    <section>
+      <h1>Game 1</h1>
+      <p>Play and post your score.</p>
+      <Leaderboard game="game1" />
+    </section>
+  );
+}
+

--- a/web/src/pages/Arcade/index.tsx
+++ b/web/src/pages/Arcade/index.tsx
@@ -1,32 +1,13 @@
-import { games } from '../../data/games'
-import { useEffect, useState } from 'react'
-
-type Scores = Record<string, number>
+import { Link } from "react-router-dom";
+import Leaderboard from "../../components/Leaderboard";
 
 export default function Arcade() {
-  const [scores, setScores] = useState<Scores>({})
-  useEffect(() => {
-    const raw = localStorage.getItem('nv_scores') || '{}'
-    setScores(JSON.parse(raw))
-  }, [])
-  const bump = (id:string) => {
-    const next = { ...scores, [id]: (scores[id]||0)+Math.ceil(Math.random()*5) }
-    setScores(next); localStorage.setItem('nv_scores', JSON.stringify(next))
-  }
   return (
     <section>
       <h1>Arcade</h1>
-      <ul>
-        {games.map(g => (
-          <li key={g.id} style={{margin:'12px 0'}}>
-            <strong>{g.title}</strong> — {g.description}
-            <div style={{display:'flex', gap:8, marginTop:6}}>
-              <button onClick={()=>bump(g.id)}>Play (demo)</button>
-              <span>High score: {scores[g.id] || 0}</span>
-            </div>
-          </li>
-        ))}
-      </ul>
+      <p><Link to="/arcade/game1">Game 1</Link> · <Link to="/arcade/game2">Game 2</Link> · <Link to="/arcade/game3">Game 3</Link></p>
+      <Leaderboard game="game1" />
     </section>
-  )
+  );
 }
+

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,0 +1,4 @@
+export type Score = { id: string; game: string; name: string; points: number; created_at: string };
+export type ChatReq = { messages: { role: "system"|"user"|"assistant"; content: string }[] };
+export type ChatRes = { reply: string };
+


### PR DESCRIPTION
## Summary
- add secure Netlify functions for OpenAI chat and Supabase-backed scores
- introduce Supabase client, API helper, ChatBox, and Leaderboard components with arcade wiring
- configure Netlify functions bundler and project dependencies

## Testing
- `npm test` (fails: Missing script: "test")
- `npm --prefix web test` (fails: Missing script: "test")
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68a54aa978d88329915ff8b6827afc92