### PR TITLE
Marketplace — wishlist, cart, checkout (Natur tokens), orders

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,5 +12,5 @@
   status = 200
 
 [functions]
-directory = "netlify/functions"
-node_bundler = "esbuild"
+  directory = "netlify/functions"
+  node_bundler = "esbuild"

--- a/netlify/functions/orders.ts
+++ b/netlify/functions/orders.ts
@@ -1,0 +1,44 @@
+import type { Handler } from "@netlify/functions";
+import { createClient } from "@supabase/supabase-js";
+const db = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+export const handler: Handler = async (e) => {
+  try {
+    if (e.httpMethod === "GET") {
+      const device = (e.queryStringParameters?.device||"").toString();
+      if (!device) return bad("device required");
+      const { data, error } = await db.from("orders").select("*").eq("device_id", device).order("created_at",{ascending:false});
+      if (error) throw error;
+      return ok(data);
+    }
+
+    if (e.httpMethod === "POST") {
+      const { device_id, items, address, total_tokens } = JSON.parse(e.body || "{}");
+      if (!device_id || !Array.isArray(items) || typeof total_tokens !== "number") return bad("invalid payload");
+
+      const bal = await db.from("token_balances").select("*").eq("device_id", device_id).maybeSingle();
+      const balance = bal.data?.balance ?? 1000;
+      if (balance < total_tokens) return bad("insufficient balance");
+      await db.from("token_balances").upsert({ device_id, balance: balance - total_tokens }, { onConflict:"device_id" });
+
+      const o = await db.from("orders").insert({
+        device_id, total_tokens,
+        name: address?.name, email: address?.email, phone: address?.phone,
+        address1: address?.address1, address2: address?.address2,
+        city: address?.city, region: address?.region, postal: address?.postal, country: address?.country
+      }).select().single();
+      if (o.error) throw o.error;
+
+      if (items.length) {
+        await db.from("order_items").insert(items.map((it:any)=>({
+          order_id: o.data!.id, product_id: it.product_id, title: it.title, qty: it.qty, price_tokens: it.price_tokens
+        })));
+      }
+      return ok({ order_id: o.data!.id });
+    }
+
+    return bad("method");
+  } catch (e:any) { return { statusCode: 500, body: e.message || "error" }; }
+};
+const ok = (b:any)=>({ statusCode:200, headers:{ "Content-Type":"application/json" }, body: JSON.stringify(b) });
+const bad = (m:string)=>({ statusCode:400, body: m });

--- a/netlify/functions/tokens.ts
+++ b/netlify/functions/tokens.ts
@@ -1,0 +1,34 @@
+import type { Handler } from "@netlify/functions";
+import { createClient } from "@supabase/supabase-js";
+const db = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+export const handler: Handler = async (e) => {
+  const device = (e.queryStringParameters?.device || JSON.parse(e.body||"{}").device_id || "").toString();
+  if (!device) return bad("device required");
+
+  if (e.httpMethod === "GET") {
+    const bal = await ensure(device);
+    return ok(bal);
+  }
+  if (e.httpMethod === "POST") {
+    const { delta } = JSON.parse(e.body || "{}");
+    if (typeof delta !== "number") return bad("delta number required");
+    const bal = await ensure(device);
+    const next = bal.balance + delta;
+    if (next < 0) return bad("insufficient balance");
+    const { data, error } = await db.from("token_balances").update({ balance: next }).eq("device_id", device).select().single();
+    if (error) return fail(error);
+    return ok({ device_id: device, balance: data.balance });
+  }
+  return bad("method");
+};
+
+async function ensure(device_id: string) {
+  const got = await db.from("token_balances").select("*").eq("device_id", device_id).maybeSingle();
+  if (got.data) return { device_id, balance: got.data.balance };
+  const ins = await db.from("token_balances").insert({ device_id }).select().single();
+  return { device_id, balance: ins.data?.balance ?? 1000 };
+}
+const ok = (b:any)=>({ statusCode:200, headers:{ "Content-Type":"application/json" }, body: JSON.stringify(b) });
+const bad = (m:string)=>({ statusCode:400, body: m });
+const fail = (e:any)=>({ statusCode:500, body: e.message||"error" });

--- a/netlify/functions/wishlist.ts
+++ b/netlify/functions/wishlist.ts
@@ -1,0 +1,29 @@
+import type { Handler } from "@netlify/functions";
+import { createClient } from "@supabase/supabase-js";
+const db = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+export const handler: Handler = async (e) => {
+  try {
+    if (e.httpMethod === "GET") {
+      const device = (e.queryStringParameters?.device||"").toString();
+      if (!device) return bad("device required");
+      const { data, error } = await db.from("wishlists").select("product_id").eq("device_id", device);
+      if (error) throw error;
+      return ok(data);
+    }
+    if (e.httpMethod === "POST") {
+      const { device_id, product_id } = JSON.parse(e.body || "{}");
+      if (!device_id || !product_id) return bad("device_id & product_id required");
+      const existing = await db.from("wishlists").select("id").eq("device_id", device_id).eq("product_id", product_id).maybeSingle();
+      if (existing.data) {
+        await db.from("wishlists").delete().eq("id", existing.data.id);
+        return ok({ status: "removed" });
+      }
+      await db.from("wishlists").insert({ device_id, product_id });
+      return ok({ status: "added" });
+    }
+    return bad("method");
+  } catch (e:any) { return { statusCode: 500, body: e.message || "error" }; }
+};
+const ok = (b:any)=>({ statusCode:200, headers:{ "Content-Type":"application/json" }, body: JSON.stringify(b) });
+const bad = (m:string)=>({ statusCode:400, body: m });

--- a/supabase/marketplace.sql
+++ b/supabase/marketplace.sql
@@ -1,0 +1,31 @@
+create table if not exists token_balances (
+  id uuid primary key default gen_random_uuid(),
+  device_id text unique not null,
+  balance integer not null default 1000,
+  updated_at timestamptz default now()
+);
+
+create table if not exists wishlists (
+  id uuid primary key default gen_random_uuid(),
+  device_id text not null,
+  product_id text not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists orders (
+  id uuid primary key default gen_random_uuid(),
+  device_id text not null,
+  total_tokens integer not null,
+  name text, email text, phone text,
+  address1 text, address2 text, city text, region text, postal text, country text,
+  created_at timestamptz default now()
+);
+
+create table if not exists order_items (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid references orders(id) on delete cascade,
+  product_id text not null,
+  title text,
+  qty integer not null,
+  price_tokens integer not null
+);

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview --strictPort --port 5173"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.47.6",
+    "@supabase/supabase-js": "^2.45.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2"

--- a/web/public/content/products.json
+++ b/web/public/content/products.json
@@ -1,0 +1,5 @@
+[
+  { "id": "seed-1", "title": "Natur Tee", "priceTokens": 120, "image": "/attached_assets/Frankie Frogs_1754677400700.png", "desc": "Soft organic cotton tee." },
+  { "id": "seed-2", "title": "Butterfly Sticker", "priceTokens": 15,  "image": "/attached_assets/Blu Butterfly_1754677394021.png",    "desc": "Glossy sticker pack." },
+  { "id": "seed-3", "title": "Rainforest Poster", "priceTokens": 80,  "image": "/attached_assets/2kay_1754677394018.png",               "desc": "A2 matte print." }
+]

--- a/web/src/components/AddressForm.tsx
+++ b/web/src/components/AddressForm.tsx
@@ -1,0 +1,21 @@
+import { useState } from "react";
+import type { Address } from "../types/commerce";
+
+export default function AddressForm({ onSubmit }: { onSubmit: (a: Address)=>void }) {
+  const [a, setA] = useState<Address>({name:"",email:"",address1:"",city:"",postal:"",country:""});
+  const up = (k: keyof Address) => (e:any)=> setA(s=>({...s,[k]:e.target.value}));
+  return (
+    <form onSubmit={(e)=>{ e.preventDefault(); onSubmit(a); }} style={{ display:"grid", gap:8, maxWidth:420 }}>
+      <input placeholder="Name" value={a.name} onChange={up("name")} required />
+      <input placeholder="Email" value={a.email} onChange={up("email")} required />
+      <input placeholder="Phone" value={a.phone||""} onChange={up("phone")} />
+      <input placeholder="Address line 1" value={a.address1} onChange={up("address1")} required />
+      <input placeholder="Address line 2" value={a.address2||""} onChange={up("address2")} />
+      <input placeholder="City" value={a.city} onChange={up("city")} required />
+      <input placeholder="Region/State" value={a.region||""} onChange={up("region")} />
+      <input placeholder="Postal code" value={a.postal} onChange={up("postal")} required />
+      <input placeholder="Country" value={a.country} onChange={up("country")} required />
+      <button type="submit">Continue</button>
+    </form>
+  );
+}

--- a/web/src/components/ProductCard.tsx
+++ b/web/src/components/ProductCard.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import type { Product } from "../types/commerce";
+import { addToCart } from "../lib/cart";
+import { getDeviceId } from "../lib/device";
+
+export default function ProductCard({ p }: { p: Product }) {
+  const dev = getDeviceId();
+  const [hearted, setHearted] = useState(false);
+
+  async function refreshHeart() {
+    const r = await fetch(`/.netlify/functions/wishlist?device=${dev}`);
+    const data: { product_id: string }[] = await r.json();
+    setHearted(data.some(d => d.product_id === p.id));
+  }
+  useEffect(() => { refreshHeart(); }, []);
+
+  async function toggleHeart(e: React.MouseEvent) {
+    e.preventDefault();
+    await fetch(`/.netlify/functions/wishlist`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ device_id: dev, product_id: p.id })
+    });
+    refreshHeart();
+  }
+
+  function add(e: React.MouseEvent) {
+    e.preventDefault();
+    addToCart({ product_id: p.id, title: p.title, price_tokens: p.priceTokens, qty: 1, image: p.image });
+  }
+
+  return (
+    <div style={{ border:"1px solid #eee", borderRadius:8, padding:12 }}>
+      {p.image && <img src={p.image} alt={p.title} style={{ width:"100%", height:160, objectFit:"cover", borderRadius:6 }} />}
+      <h4 style={{ margin:"8px 0" }}>{p.title}</h4>
+      <p style={{ minHeight:36 }}>{p.desc}</p>
+      <div style={{ display:"flex", alignItems:"center", gap:8, justifyContent:"space-between" }}>
+        <strong>{p.priceTokens} NATUR</strong>
+        <div style={{ display:"flex", gap:8 }}>
+          <button onClick={add}>Add to cart</button>
+          <button aria-label="wishlist" onClick={toggleHeart}>{hearted ? "💙" : "🤍"}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/TokenBalance.tsx
+++ b/web/src/components/TokenBalance.tsx
@@ -1,0 +1,10 @@
+import { useEffect, useState } from "react";
+import { getDeviceId } from "../lib/device";
+export default function TokenBalance() {
+  const [bal, setBal] = useState<number | null>(null);
+  useEffect(() => {
+    const dev = getDeviceId();
+    fetch(`/.netlify/functions/tokens?device=${dev}`).then(r=>r.json()).then(d=>setBal(d.balance));
+  }, []);
+  return <span>Balance: <strong>{bal ?? "…"}</strong> NATUR</span>;
+}

--- a/web/src/lib/cart.ts
+++ b/web/src/lib/cart.ts
@@ -1,0 +1,13 @@
+import type { CartItem } from "../types/commerce";
+const K = "natur-cart-v1";
+export const readCart = (): CartItem[] => JSON.parse(localStorage.getItem(K) || "[]");
+export const writeCart = (items: CartItem[]) => localStorage.setItem(K, JSON.stringify(items));
+export function addToCart(item: CartItem) {
+  const cart = readCart();
+  const i = cart.findIndex(c => c.product_id === item.product_id);
+  if (i >= 0) cart[i].qty += item.qty; else cart.push(item);
+  writeCart(cart); return cart;
+}
+export const removeFromCart = (id: string) => writeCart(readCart().filter(c => c.product_id !== id));
+export const clearCart = () => writeCart([]);
+export const cartTotal = (cart: CartItem[]) => cart.reduce((s,c)=> s + c.price_tokens*c.qty, 0);

--- a/web/src/lib/device.ts
+++ b/web/src/lib/device.ts
@@ -1,0 +1,6 @@
+export function getDeviceId(): string {
+  const k = "natur-device-id";
+  let id = localStorage.getItem(k);
+  if (!id) { id = crypto.randomUUID(); localStorage.setItem(k, id); }
+  return id;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,6 +9,12 @@ import Quizzes from './pages/Quizzes';
 import Observations from './pages/Observations';
 import Tips from './pages/tips';
 import Marketplace from './pages/Marketplace';
+import ProductDetail from './pages/Marketplace/ProductDetail';
+import CartPage from './pages/Marketplace/cart';
+import Shipping from './pages/Marketplace/checkout';
+import Review from './pages/Marketplace/checkout/Review';
+import Pay from './pages/Marketplace/checkout/Pay';
+import OrderSuccess from './pages/Marketplace/OrderSuccess';
 import Worlds from './pages/Worlds';
 import Zones from './pages/Zones';
 import Arcade from './pages/Arcade';
@@ -34,6 +40,12 @@ const router = createBrowserRouter([
       { path: 'observations', element: <Observations/> },
       { path: 'tips', element: <Tips/> },
       { path: 'marketplace', element: <Marketplace/> },
+      { path: 'marketplace/productdetail', element: <ProductDetail/> },
+      { path: 'marketplace/cart', element: <CartPage/> },
+      { path: 'marketplace/checkout', element: <Shipping/> },
+      { path: 'marketplace/checkout/Review', element: <Review/> },
+      { path: 'marketplace/checkout/Pay', element: <Pay/> },
+      { path: 'marketplace/OrderSuccess', element: <OrderSuccess/> },
 
       { path: 'zones', element: <Zones/> },
       { path: 'worlds', element: <Worlds/> },

--- a/web/src/pages/Marketplace/OrderSuccess.tsx
+++ b/web/src/pages/Marketplace/OrderSuccess.tsx
@@ -1,0 +1,4 @@
+export default function OrderSuccess() {
+  const id = new URLSearchParams(location.search).get("order");
+  return (<section><h1>Order placed 🎉</h1><p>Order ID: {id}</p></section>);
+}

--- a/web/src/pages/Marketplace/ProductDetail.tsx
+++ b/web/src/pages/Marketplace/ProductDetail.tsx
@@ -1,0 +1,11 @@
+import { useEffect, useMemo, useState } from "react";
+import type { Product } from "../../types/commerce";
+import ProductCard from "../../components/ProductCard";
+
+export default function ProductDetail() {
+  const id = useMemo(()=> new URLSearchParams(location.search).get("id") || "", []);
+  const [p, setP] = useState<Product | undefined>();
+  useEffect(() => { fetch("/content/products.json").then(r=>r.json()).then((all:Product[])=> setP(all.find(x=>x.id===id))); }, [id]);
+  if (!p) return <p>Loading…</p>;
+  return (<section><h1>{p.title}</h1><ProductCard p={p} /><p style={{marginTop:12}}>{p.desc}</p></section>);
+}

--- a/web/src/pages/Marketplace/cart.tsx
+++ b/web/src/pages/Marketplace/cart.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import { readCart, removeFromCart, clearCart, cartTotal } from "../../lib/cart";
+import { Link } from "react-router-dom";
+
+export default function CartPage() {
+  const [cart, setCart] = useState(readCart());
+  useEffect(()=>{ setCart(readCart()); },[]);
+  const remove = (id:string)=>{ removeFromCart(id); setCart(readCart()); };
+  const total = cartTotal(cart);
+  return (
+    <section>
+      <h1>Cart</h1>
+      {cart.length===0 ? <p>Your cart is empty.</p> :
+        <>
+          <ul>{cart.map(c=> <li key={c.product_id}>{c.title} × {c.qty} — {c.price_tokens*c.qty} NATUR <button onClick={()=>remove(c.product_id)}>Remove</button></li>)}</ul>
+          <p><strong>Total: {total} NATUR</strong></p>
+          <p><Link to="/marketplace/checkout">Proceed to Checkout</Link> · <button onClick={()=>{ clearCart(); setCart([]); }}>Clear</button></p>
+        </>
+      }
+    </section>
+  );
+}

--- a/web/src/pages/Marketplace/checkout/Pay.tsx
+++ b/web/src/pages/Marketplace/checkout/Pay.tsx
@@ -1,0 +1,25 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { readCart, clearCart, cartTotal } from "../../../lib/cart";
+import { getDeviceId } from "../../../lib/device";
+
+export default function Pay() {
+  const nav = useNavigate();
+  const { state } = useLocation() as any;
+  const addr = state?.addr;
+  const cart = readCart();
+  const total = cartTotal(cart);
+  const dev = getDeviceId();
+
+  async function place() {
+    const r = await fetch("/.netlify/functions/orders", {
+      method: "POST", headers: { "Content-Type":"application/json" },
+      body: JSON.stringify({ device_id: dev, items: cart, address: addr, total_tokens: total })
+    });
+    if (!r.ok) { alert(await r.text()); return; }
+    const { order_id } = await r.json();
+    clearCart();
+    nav("/marketplace/OrderSuccess?order="+encodeURIComponent(order_id));
+  }
+
+  return (<section><h1>Checkout — Pay</h1><p>Total: <strong>{total} NATUR</strong></p><button onClick={place}>Confirm & Deduct Tokens</button></section>);
+}

--- a/web/src/pages/Marketplace/checkout/Review.tsx
+++ b/web/src/pages/Marketplace/checkout/Review.tsx
@@ -1,0 +1,18 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { readCart, cartTotal } from "../../../lib/cart";
+
+export default function Review() {
+  const nav = useNavigate();
+  const { state } = useLocation() as any;
+  const addr = state?.addr;
+  const cart = readCart();
+  return (
+    <section>
+      <h1>Checkout — Review</h1>
+      <pre>{JSON.stringify(addr, null, 2)}</pre>
+      <ul>{cart.map(c=> <li key={c.product_id}>{c.title} × {c.qty} — {c.price_tokens*c.qty} NATUR</li>)}</ul>
+      <p><strong>Total: {cartTotal(cart)} NATUR</strong></p>
+      <button onClick={()=>nav("/marketplace/checkout/Pay", { state:{ addr } })}>Pay with NATUR</button>
+    </section>
+  );
+}

--- a/web/src/pages/Marketplace/checkout/index.tsx
+++ b/web/src/pages/Marketplace/checkout/index.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+import type { Address } from "../../../types/commerce";
+import AddressForm from "../../../components/AddressForm";
+import { useNavigate } from "react-router-dom";
+
+export default function Shipping() {
+  const nav = useNavigate();
+  const [addr, setAddr] = useState<Address | null>(null);
+  return (
+    <section>
+      <h1>Checkout — Shipping</h1>
+      {addr ? (
+        <>
+          <pre>{JSON.stringify(addr, null, 2)}</pre>
+          <button onClick={()=>nav("/marketplace/checkout/Review", { state:{ addr } })}>Continue to Review</button>
+        </>
+      ) : <AddressForm onSubmit={setAddr} />}
+    </section>
+  );
+}

--- a/web/src/pages/Marketplace/index.tsx
+++ b/web/src/pages/Marketplace/index.tsx
@@ -1,35 +1,23 @@
-import { products } from '../../data/marketplace'
-import { useEffect, useState } from 'react'
-type Cart = Record<string, number>
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import type { Product } from "../../types/commerce";
+import TokenBalance from "../../components/TokenBalance";
+import ProductCard from "../../components/ProductCard";
 
-export default function Marketplace(){
-  const [cart,setCart] = useState<Cart>({})
-  useEffect(()=>{ setCart(JSON.parse(localStorage.getItem('nv_cart')||'{}'))},[])
-  useEffect(()=>{ localStorage.setItem('nv_cart', JSON.stringify(cart))},[cart])
-
-  const add = (id:string)=> setCart(c=>({...c,[id]:(c[id]||0)+1}))
-  const total = products.reduce((sum,p)=> sum + (cart[p.id]||0)*p.price, 0)
-
+export default function Marketplace() {
+  const [products, setProducts] = useState<Product[]>([]);
+  useEffect(() => { fetch("/content/products.json").then(r=>r.json()).then(setProducts); }, []);
   return (
     <section>
       <h1>Marketplace</h1>
-      <div style={{display:'grid', gridTemplateColumns:'repeat(auto-fill,minmax(200px,1fr))', gap:16}}>
-        {products.map(p=>(
-          <div key={p.id} style={{border:'1px solid #ddd', padding:12, borderRadius:8}}>
-            <h3>{p.name}</h3>
-            <p>{p.blurb}</p>
-            <p><strong>${p.price.toFixed(2)}</strong></p>
-            <button onClick={()=>add(p.id)}>Add to cart</button>
-          </div>
+      <p><TokenBalance /> · <Link to="/marketplace/cart">Cart</Link></p>
+      <div style={{ display:"grid", gridTemplateColumns:"repeat(auto-fill,minmax(220px,1fr))", gap:12 }}>
+        {products.map(p => (
+          <Link key={p.id} to={`/marketplace/productdetail?id=${encodeURIComponent(p.id)}`} style={{ textDecoration:"none", color:"inherit" }}>
+            <ProductCard p={p} />
+          </Link>
         ))}
       </div>
-      <h2 style={{marginTop:20}}>Cart</h2>
-      <ul>
-        {Object.entries(cart).map(([id,qty])=>{
-          const p = products.find(x=>x.id===id)!; return <li key={id}>{p.name} × {qty}</li>
-        })}
-      </ul>
-      <p><strong>Total: ${total.toFixed(2)}</strong></p>
     </section>
-  )
+  );
 }

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -1,6 +1,0 @@
-export default function Profile(){
-  return (<>
-    <h2>Profile & Settings</h2>
-    <p>Sign‑in, preferences, and wallet hooks can be wired here later.</p>
-  </>);
-}

--- a/web/src/pages/Profile/index.tsx
+++ b/web/src/pages/Profile/index.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+import { getDeviceId } from "../../lib/device";
+
+export default function Profile() {
+  const dev = getDeviceId();
+  const [orders, setOrders] = useState<any[]>([]);
+  useEffect(()=>{ fetch(`/.netlify/functions/orders?device=${dev}`).then(r=>r.json()).then(setOrders); },[]);
+  return (
+    <section>
+      <h1>Profile & Settings</h1>
+      <h3>Orders</h3>
+      {orders.length===0 ? <p>No orders yet.</p> :
+        <ul>{orders.map(o=> <li key={o.id}>{new Date(o.created_at).toLocaleString()} — {o.total_tokens} NATUR</li>)}</ul>}
+    </section>
+  );
+}

--- a/web/src/types/commerce.ts
+++ b/web/src/types/commerce.ts
@@ -1,0 +1,6 @@
+export type Product = { id: string; title: string; priceTokens: number; image?: string; desc?: string };
+export type CartItem = { product_id: string; title: string; price_tokens: number; qty: number; image?: string };
+export type Address = {
+  name: string; email: string; phone?: string;
+  address1: string; address2?: string; city: string; region?: string; postal: string; country: string
+};


### PR DESCRIPTION
## Summary
- configure Netlify functions and add SQL schema for marketplace tables
- add commerce types, local cart helpers, and token balance/wishlist handling
- implement marketplace pages with cart, checkout, and order history

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a551f533008329af2b65e6ed2db764