### PR TITLE
feat: add worlds content and detail view

### DIFF
--- a/web/public/assets/placeholders/lock.svg
+++ b/web/public/assets/placeholders/lock.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="#111" stroke-width="1.5">
+  <rect x="3" y="11" width="18" height="10" rx="2" />
+  <path d="M7 11V8a5 5 0 0 1 10 0v3" />
+</svg>

--- a/web/public/assets/placeholders/world-bg.svg
+++ b/web/public/assets/placeholders/world-bg.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#e8fff3"/>
+      <stop offset="1" stop-color="#bdf0d3"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#g)"/>
+  <g fill="#ffffff" opacity="0.35">
+    <circle cx="240" cy="180" r="80"/>
+    <circle cx="520" cy="260" r="60"/>
+    <circle cx="980" cy="200" r="90"/>
+    <circle cx="1300" cy="320" r="70"/>
+  </g>
+</svg>

--- a/web/src/assets/placeholders/lock.svg
+++ b/web/src/assets/placeholders/lock.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="#111" stroke-width="1.5">
+  <rect x="3" y="11" width="18" height="10" rx="2" />
+  <path d="M7 11V8a5 5 0 0 1 10 0v3" />
+</svg>

--- a/web/src/assets/placeholders/world-bg.svg
+++ b/web/src/assets/placeholders/world-bg.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#e8fff3"/>
+      <stop offset="1" stop-color="#bdf0d3"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#g)"/>
+  <g fill="#ffffff" opacity="0.35">
+    <circle cx="240" cy="180" r="80"/>
+    <circle cx="520" cy="260" r="60"/>
+    <circle cx="980" cy="200" r="90"/>
+    <circle cx="1300" cy="320" r="70"/>
+  </g>
+</svg>

--- a/web/src/components/WorldCard.tsx
+++ b/web/src/components/WorldCard.tsx
@@ -1,0 +1,47 @@
+import { useSearchParams } from 'react-router-dom';
+import type { World } from '../types/world';
+
+function gradientFor(slug: string): string {
+  const colors = [
+    ['#dbffea', '#8ee3b5'],
+    ['#fff3d6', '#ffc48a'],
+    ['#e8e7ff', '#c0baff'],
+    ['#e6fbff', '#b9f1ff'],
+    ['#ffe6ef', '#ffc2d9'],
+    ['#f2ffe0', '#c8f57a'],
+  ];
+  const i = Math.abs([...slug].reduce((a, c) => a + c.charCodeAt(0), 0)) % colors.length;
+  const [a, b] = colors[i];
+  return `linear-gradient(135deg, ${a} 0%, ${b} 100%)`;
+}
+
+export default function WorldCard({ world }: { world: World }) {
+  const [, setParams] = useSearchParams();
+  const locked = world.status === 'coming_soon';
+  const handleOpen = () => setParams({ world: world.slug });
+  return (
+    <button
+      onClick={handleOpen}
+      aria-label={world.name}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        textAlign: 'left',
+        borderRadius: 12,
+        padding: 12,
+        background: gradientFor(world.slug),
+        border: '1px solid rgba(0,0,0,0.07)',
+        cursor: 'pointer'
+      }}
+    >
+      <div style={{ fontWeight: 700 }}>{world.name}</div>
+      <div style={{ opacity: 0.8, fontSize: 12 }}>{world.tagline}</div>
+      <div style={{ fontSize: 18 }}>{world.emoji ?? ''}</div>
+      {locked && (
+        <div style={{ marginTop: 6, fontSize: 12, fontWeight: 600 }}>🔒 Coming soon</div>
+      )}
+    </button>
+  );
+}
+

--- a/web/src/content/worlds.ts
+++ b/web/src/content/worlds.ts
@@ -1,0 +1,153 @@
+import type { World } from '../types/world';
+
+export const worlds: World[] = [
+  {
+    slug: 'thailandia',
+    name: 'Thailandia',
+    tagline: 'Coconuts & Elephants',
+    fruit: 'Coconut',
+    animal: 'Elephant',
+    region: 'Southeast Asia',
+    status: 'available',
+    emoji: '🐘🥥',
+    image: '/assets/worlds/thailandia/cover.png'
+  },
+  {
+    slug: 'chinlandia',
+    name: 'Chinlandia',
+    tagline: 'Bamboo & Pandas',
+    fruit: 'Bamboo Shoots',
+    animal: 'Panda',
+    region: 'China',
+    status: 'available',
+    emoji: '🐼🎋',
+    image: '/assets/worlds/chinlandia/cover.png'
+  },
+  {
+    slug: 'japanthia',
+    name: 'Japanthia',
+    tagline: 'Cherry Blossoms',
+    fruit: 'Sakura Cherry',
+    animal: 'Crane',
+    region: 'Japan',
+    status: 'coming_soon',
+    emoji: '🌸🗾'
+  },
+  {
+    slug: 'indilandia',
+    name: 'Indilandia',
+    tagline: 'Mangoes & Tigers',
+    fruit: 'Mango',
+    animal: 'Tiger',
+    region: 'India',
+    status: 'available',
+    emoji: '🐅🥭',
+    image: '/assets/worlds/indilandia/cover.png'
+  },
+  {
+    slug: 'brazilandia',
+    name: 'Brazilandia',
+    tagline: 'Bananas & Parrots',
+    fruit: 'Banana',
+    animal: 'Parrot',
+    region: 'Brazil',
+    status: 'available',
+    emoji: '🦜🍌',
+    image: '/assets/worlds/brazilandia/cover.png'
+  },
+  {
+    slug: 'afrilandia',
+    name: 'Afrilandia',
+    tagline: 'Mangoes & Lions',
+    fruit: 'Mango',
+    animal: 'Lion',
+    region: 'Africa',
+    status: 'coming_soon',
+    emoji: '🦁🥭'
+  },
+  {
+    slug: 'eurolandia',
+    name: 'Eurolandia',
+    tagline: 'Sunflowers & Hedgehogs',
+    fruit: 'Sunflower Seeds',
+    animal: 'Hedgehog',
+    region: 'Europe',
+    status: 'coming_soon',
+    emoji: '🌻🦔'
+  },
+  {
+    slug: 'britlandia',
+    name: 'Britlandia',
+    tagline: 'Roses & Hedgehogs',
+    fruit: 'Rose Hip',
+    animal: 'Hedgehog',
+    region: 'United Kingdom',
+    status: 'coming_soon',
+    emoji: '🌹🦔'
+  },
+  {
+    slug: 'amerilandia',
+    name: 'Amerilandia',
+    tagline: 'Apples & Eagles',
+    fruit: 'Apple',
+    animal: 'Eagle',
+    region: 'North America',
+    status: 'available',
+    emoji: '🦅🍎',
+    image: '/assets/worlds/amerilandia/cover.png'
+  },
+  {
+    slug: 'australandia',
+    name: 'Australandia',
+    tagline: 'Peaches & Kangaroos',
+    fruit: 'Peach',
+    animal: 'Kangaroo',
+    region: 'Australia',
+    status: 'available',
+    emoji: '🦘🍑',
+    image: '/assets/worlds/australandia/cover.png'
+  },
+  {
+    slug: 'kiwilandia',
+    name: 'Kiwilandia',
+    tagline: 'Kiwis & Sheep',
+    fruit: 'Kiwi',
+    animal: 'Sheep',
+    region: 'New Zealand',
+    status: 'coming_soon',
+    emoji: '🥝🐑'
+  },
+  {
+    slug: 'madagalandia',
+    name: 'Madagalandia',
+    tagline: 'Lemons & Lemurs',
+    fruit: 'Lemon',
+    animal: 'Lemur',
+    region: 'Madagascar',
+    status: 'coming_soon',
+    emoji: '🍋🦝'
+  },
+  {
+    slug: 'greenlandia',
+    name: 'Greenlandia',
+    tagline: 'Ice & Polar Bears',
+    fruit: 'Cloudberry',
+    animal: 'Polar Bear',
+    region: 'Greenland',
+    status: 'coming_soon',
+    emoji: '❄️🐻‍❄️'
+  },
+  {
+    slug: 'antarctilandia',
+    name: 'Antarctilandia',
+    tagline: 'Ice Crystals & Penguins',
+    fruit: 'Snowberry',
+    animal: 'Penguin',
+    region: 'Antarctica',
+    status: 'coming_soon',
+    emoji: '💎🐧'
+  }
+];
+
+export default worlds;
+

--- a/web/src/pages/Worlds/index.tsx
+++ b/web/src/pages/Worlds/index.tsx
@@ -1,14 +1,170 @@
-import CommonCard from '../../components/CommonCard';
-import { useWorlds } from '../../hooks/useContent';
+import React from 'react';
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import worldsData from '../../content/worlds';
+import type { World } from '../../types/world';
+import WorldCard from '../../components/WorldCard';
 
-export default function Worlds(){
-  const worlds = useWorlds();
+export default function Worlds() {
+  const [params, setParams] = useSearchParams();
+  const selected = params.get('world');
+  const world = useMemo<World | undefined>(
+    () => worldsData.find(w => w.slug === selected ?? ''),
+    [selected]
+  );
+
+  const available = worldsData.filter(w => w.status === 'available');
+  const locked = worldsData.filter(w => w.status === 'coming_soon');
+
   return (
-    <div>
-      <h1>Worlds</h1>
-      {worlds.map(w => (
-        <CommonCard key={w.slug} title={w.title}/>
-      ))}
-    </div>
+    <main style={{ padding: 16, maxWidth: 1100, margin: '0 auto' }}>
+      <header style={{ marginBottom: 16 }}>
+        <h1 style={{ margin: 0 }}>Worlds</h1>
+        <p style={{ margin: '6px 0 0', opacity: 0.8 }}>
+          Explore the 14 kingdoms of the Naturverse™. Tap a card to preview details.
+        </p>
+      </header>
+
+      <section style={{ marginTop: 16 }}>
+        <h2 style={{ fontSize: 18, marginBottom: 8 }}>Available</h2>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+            gap: 12
+          }}
+        >
+          {available.map(w => (
+            <WorldCard key={w.slug} world={w} />
+          ))}
+        </div>
+      </section>
+
+      <section style={{ marginTop: 28 }}>
+        <h2 style={{ fontSize: 18, marginBottom: 8 }}>Coming Soon</h2>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+            gap: 12
+          }}
+        >
+          {locked.map(w => (
+            <WorldCard key={w.slug} world={w} />
+          ))}
+        </div>
+      </section>
+
+      {world && (
+        <article
+          aria-live="polite"
+          style={{
+            marginTop: 32,
+            padding: 16,
+            border: '1px solid rgba(0,0,0,0.08)',
+            borderRadius: 12,
+            background:
+              'url(/assets/placeholders/world-bg.svg) center/cover no-repeat, #fff'
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+            <h2 style={{ margin: 0 }}>
+              {world.name} <span style={{ opacity: 0.8, fontSize: 16 }}>{world.emoji ?? ''}</span>
+            </h2>
+            <button
+              onClick={() => setParams({})}
+              style={{
+                border: '1px solid rgba(0,0,0,0.12)',
+                background: '#fff',
+                borderRadius: 8,
+                padding: '6px 10px',
+                cursor: 'pointer'
+              }}
+            >
+              Close
+            </button>
+          </div>
+
+          <p style={{ marginTop: 8, opacity: 0.9 }}>{world.tagline}</p>
+
+          <div
+            style={{
+              marginTop: 10,
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+              gap: 12,
+              alignItems: 'start'
+            }}
+          >
+            <div
+              style={{
+                borderRadius: 12,
+                overflow: 'hidden',
+                minHeight: 160,
+                background: 'rgba(255,255,255,0.7)',
+                border: '1px solid rgba(0,0,0,0.06)'
+              }}
+            >
+              {world.image ? (
+                <img
+                  src={world.image}
+                  alt={`${world.name} cover`}
+                  style={{ width: '100%', display: 'block' }}
+                  onError={(e) => {
+                    (e.currentTarget as HTMLImageElement).style.display = 'none';
+                  }}
+                />
+              ) : (
+                <div
+                  style={{
+                    display: 'grid',
+                    placeItems: 'center',
+                    height: 160,
+                    background: 'url(/assets/placeholders/world-bg.svg) center/cover no-repeat'
+                  }}
+                >
+                  <span style={{ fontSize: 14, opacity: 0.7 }}>Cover placeholder</span>
+                </div>
+              )}
+            </div>
+
+            <div>
+              <h3 style={{ margin: '0 0 6px' }}>About</h3>
+              <ul style={{ margin: 0, paddingLeft: 16 }}>
+                <li>
+                  <strong>Region:</strong> {world.region}
+                </li>
+                <li>
+                  <strong>Fruit:</strong> {world.fruit}
+                </li>
+                <li>
+                  <strong>Animal:</strong> {world.animal}
+                </li>
+                <li>
+                  <strong>Status:</strong>{' '}
+                  {world.status === 'available' ? 'Available to explore' : 'Coming soon'}
+                </li>
+              </ul>
+
+              <div style={{ marginTop: 10, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                <a href="/Stories" style={btnStyle}>Stories</a>
+                <a href="/Quizzes" style={btnStyle}>Quizzes</a>
+                <a href="/Observations" style={btnStyle}>Observations</a>
+                <a href="/Marketplace" style={btnStyle}>Marketplace</a>
+              </div>
+            </div>
+          </div>
+        </article>
+      )}
+    </main>
   );
 }
+
+const btnStyle: React.CSSProperties = {
+  display: 'inline-block',
+  border: '1px solid rgba(0,0,0,0.15)',
+  borderRadius: 10,
+  padding: '8px 12px',
+  textDecoration: 'none'
+};
+

--- a/web/src/types/world.ts
+++ b/web/src/types/world.ts
@@ -1,0 +1,14 @@
+export type WorldStatus = 'available' | 'coming_soon';
+
+export interface World {
+  slug: string;
+  name: string;
+  tagline: string;
+  fruit: string;
+  animal: string;
+  region: string;
+  status: WorldStatus;
+  emoji?: string;
+  image?: string; // optional cover if provided (e.g., /assets/worlds/<slug>/cover.png)
+}
+


### PR DESCRIPTION
## Summary
- add typed world model and content for 14 kingdoms
- show worlds page with card grid and query-param detail view
- add placeholder world images and card component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)
- `npm install --no-save vite react react-dom react-router-dom @types/react @types/react-dom @types/react-router-dom` (fails: 403 Forbidden - @types/react)


------
https://chatgpt.com/codex/tasks/task_e_68a5643333688329820fb86a5d09842d