### PR TITLE
Seed Zones content and wire list/detail views

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,8 @@
     "db:push": "echo 'Run seed via Netlify function or Supabase SQL editor'"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.45.4"
+    "@supabase/supabase-js": "^2.45.4",
+    "gray-matter": "^4.0.3",
+    "marked": "^12.0.2"
   }
 }

--- a/web/src/content/community/club-starter-pack.md
+++ b/web/src/content/community/club-starter-pack.md
@@ -1,0 +1,9 @@
+---
+title: Nature Club Starter Pack
+summary: Kick off weekly meetups with mini-missions.
+zone: community
+order: 1
+---
+- 10-minute clean-up
+- 1 photo of something tiny
+- 1 sketch of a leaf

--- a/web/src/content/creator-lab/remix-birdsong.md
+++ b/web/src/content/creator-lab/remix-birdsong.md
@@ -1,0 +1,8 @@
+---
+title: Remix Birdsong
+summary: Cut, loop, and share a birdsong beat.
+zone: creator-lab
+tags: [audio, remix]
+order: 1
+---
+Record 10 seconds of birdsong. Trim to a 1-bar loop. Layer hand-claps. Share!

--- a/web/src/content/music/instruments-from-parks.json
+++ b/web/src/content/music/instruments-from-parks.json
@@ -1,0 +1,15 @@
+{
+  "title": "Instruments from Parks",
+  "summary": "Make simple instruments with safe park finds.",
+  "zone": "music",
+  "slug": "instruments-from-parks",
+  "order": 2,
+  "tags": ["diy","maker"],
+  "data": {
+    "items": [
+      {"name":"Seed Pod Maracas","steps":3},
+      {"name":"Stick Guiro","steps":2},
+      {"name":"Bottle Drum","steps":2}
+    ]
+  }
+}

--- a/web/src/content/music/introducing-nature-beats.md
+++ b/web/src/content/music/introducing-nature-beats.md
@@ -1,0 +1,14 @@
+---
+title: Nature Beats
+summary: Loopable rhythms made from rain, wind, and wildlife.
+zone: music
+tags: [loops, beginner]
+order: 1
+cover: /src/attached_assets/Jay-Sing_1754677394023.png
+---
+## Try a Loop
+- Rain Tap (90bpm)
+- Leaf Shaker (100bpm)
+- River Kick (92bpm)
+
+> Tip: Start with **Rain Tap** and count to 4 while clapping. Layer Leaf Shaker next!

--- a/web/src/content/naturversity/skill-paths-overview.md
+++ b/web/src/content/naturversity/skill-paths-overview.md
@@ -1,0 +1,7 @@
+---
+title: Skill Paths Overview
+summary: Micro-badges for Music, Wellness, and Maker skills.
+zone: naturversity
+order: 1
+---
+Earn badges by completing 3 tasks per path. Share evidence with a short video.

--- a/web/src/content/parents/safety-outside.md
+++ b/web/src/content/parents/safety-outside.md
@@ -1,0 +1,9 @@
+---
+title: Safety Outside
+summary: Simple rules for safe adventures.
+zone: parents
+order: 1
+---
+- Buddy system  
+- Check weather  
+- Water & sun protection  

--- a/web/src/content/partners/how-to-collab.md
+++ b/web/src/content/partners/how-to-collab.md
@@ -1,0 +1,7 @@
+---
+title: How to Collaborate
+summary: Co-create events, challenges, or content.
+zone: partners
+order: 1
+---
+Email partners@thenaturverse.com with your idea and timeline.

--- a/web/src/content/teachers/outdoor-math-guide.md
+++ b/web/src/content/teachers/outdoor-math-guide.md
@@ -1,0 +1,10 @@
+---
+title: Outdoor Math Guide (K-2)
+summary: Counting, shapes, and patterns outside.
+zone: teachers
+tags: [lesson-plan]
+order: 1
+---
+- Count 20 leaves by tens  
+- Find 5 circles, 5 triangles  
+- Build a repeating pattern with stones  

--- a/web/src/content/wellness/breath-like-a-tree.md
+++ b/web/src/content/wellness/breath-like-a-tree.md
@@ -1,0 +1,10 @@
+---
+title: Breathe Like a Tree
+summary: Calm breathing using “roots down, branches up.”
+zone: wellness
+order: 1
+cover: /src/attached_assets/Frankie Frogs_1754677400700.png
+---
+1. Feet on the ground (roots).  
+2. Inhale slowly, lift arms (branches).  
+3. Exhale gently, arms float down.  

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -19,6 +19,8 @@ import Pay from './pages/Marketplace/checkout/Pay';
 import OrderSuccess from './pages/Marketplace/OrderSuccess';
 import Worlds from './pages/Worlds';
 import Zones from './pages/Zones';
+import ZoneList from './pages/ZoneList';
+import ZoneDoc from './pages/ZoneDoc';
 import Arcade from './pages/Arcade';
 import Music from './pages/Music';
 import Wellness from './pages/Wellness';
@@ -53,6 +55,8 @@ const router = createBrowserRouter([
       { path: 'marketplace/OrderSuccess', element: <OrderSuccess/> },
 
       { path: 'zones', element: <Zones/> },
+      { path: 'zones/:zone', element: <ZoneList/> },
+      { path: 'zones/:zone/:slug', element: <ZoneDoc/> },
       { path: 'worlds', element: <Worlds/> },
       { path: 'arcade', element: <Arcade/> },
       { path: 'music', element: <Music/> },

--- a/web/src/pages/ZoneDoc.tsx
+++ b/web/src/pages/ZoneDoc.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { getDoc } from "../lib/content";
+import type { Doc } from "../types/content";
+
+export default function ZoneDoc(){
+  const { zone = "", slug = "" } = useParams();
+  const [doc,setDoc] = useState<Doc>();
+  useEffect(()=>{ getDoc(zone as any, slug).then(setDoc); },[zone,slug]);
+
+  if(!doc) return <main className="container"><p>Loading…</p></main>;
+  return (
+    <main className="container">
+      <p><Link to={`/zones/${zone}`}>← Back to {zone}</Link></p>
+      <h1>{doc.title}</h1>
+      {doc.cover && <img src={doc.cover} alt="" style={{maxWidth:"320px"}} />}
+      {doc.body && <div dangerouslySetInnerHTML={{__html: doc.body}} />}
+      {doc.data && (
+        <pre style={{background:"#f6f6f6", padding:"1rem", borderRadius:8}}>
+          {JSON.stringify(doc.data, null, 2)}
+        </pre>
+      )}
+    </main>
+  );
+}

--- a/web/src/pages/ZoneList.tsx
+++ b/web/src/pages/ZoneList.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { getZoneDocs } from "../lib/content";
+import type { Doc } from "../types/content";
+
+export default function ZoneList(){
+  const { zone = "" } = useParams();
+  const [docs,setDocs] = useState<Doc[]>([]);
+  useEffect(()=>{ getZoneDocs(zone as any).then(setDocs); },[zone]);
+  return (
+    <main className="container">
+      <h1>{zoneToTitle(zone)}</h1>
+      <ul>
+        {docs.map(d=>(
+          <li key={d.slug}>
+            <Link to={`/zones/${zone}/${d.slug}`}><strong>{d.title}</strong></Link>
+            {d.summary ? <> — {d.summary}</> : null}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+function zoneToTitle(z?: string){ return (z??"").split("-").map(s=>s[0]?.toUpperCase()+s.slice(1)).join(" "); }

--- a/web/src/pages/Zones.tsx
+++ b/web/src/pages/Zones.tsx
@@ -1,17 +1,26 @@
-import { zones } from '../data/zones'
-import { Link } from 'react-router-dom'
+import { Link } from "react-router-dom";
+const zones = [
+  { id:"music", name:"Music", blurb:"Songs, loops, nature rhythms." },
+  { id:"wellness", name:"Wellness", blurb:"Mind & body outdoors." },
+  { id:"creator-lab", name:"Creator Lab", blurb:"Make, remix, publish." },
+  { id:"community", name:"Community", blurb:"Clubs, events, shout-outs." },
+  { id:"teachers", name:"Teachers", blurb:"Classroom packs & guides." },
+  { id:"partners", name:"Partners", blurb:"Collabs & initiatives." },
+  { id:"naturversity", name:"Naturversity", blurb:"Skill paths & badges." },
+  { id:"parents", name:"Parents", blurb:"Resources & safety." }
+] as const;
 
 export default function Zones(){
   return (
-    <section>
+    <main className="container">
       <h1>Zones</h1>
       <ul>
         {zones.map(z=>(
-          <li key={z.path}>
-            <Link to={z.path}>{z.title}</Link> — {z.blurb}
+          <li key={z.id}>
+            <Link to={`/zones/${z.id}`}><strong>{z.name}</strong></Link> — {z.blurb}
           </li>
         ))}
       </ul>
-    </section>
-  )
+    </main>
+  );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7,3 +7,5 @@ p { line-height: 1.5; }
 ul { padding-left: 1.2rem; }
 nav a { margin-right: .75rem; }
 button { cursor: pointer; }
+.container { max-width: 920px; margin: 0 auto; padding: 1.25rem; }
+.container img { display:block; margin:1rem 0; border-radius: 12px; }

--- a/web/src/types/content.ts
+++ b/web/src/types/content.ts
@@ -1,0 +1,18 @@
+export type ZoneId =
+  | "music" | "wellness" | "creator-lab" | "community"
+  | "teachers" | "partners" | "naturversity" | "parents";
+
+export interface DocMeta {
+  title: string;
+  summary?: string;
+  zone: ZoneId;
+  slug: string;         // filesystem slug
+  tags?: string[];
+  cover?: string;       // path in /src/attached_assets or remote
+  order?: number;
+}
+
+export interface Doc<T = unknown> extends DocMeta {
+  body?: string;        // markdown html
+  data?: T;             // optional JSON payload (quizzes, links, etc.)
+}


### PR DESCRIPTION
## Summary
- add typed content loader for zone docs and support markdown/json payloads
- seed starter docs across all zones
- render doc lists and details with new routes

## Testing
- `npm i gray-matter marked` *(fails: 403 Forbidden - GET https://registry.npmjs.org/gray-matter)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a56845f204832987f97a4ed2dd9313