### PR TITLE
fix: run Netlify build from web directory

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,13 @@
 [build]
-command = "npm install --no-audit --no-fund && npm run build"
-publish = "dist"
-base = "web"
+  base = "web"
+  command = "npm ci --legacy-peer-deps --no-audit --no-fund && npm run build"
+  publish = "dist"
 
 [[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
+  from = "/*"
+  to = "/index.html"
+  status = 200
 
 [functions]
-node_bundler = "esbuild"
-included_files = ["db/*.sql","web/src/content/*.json"]
+  node_bundler = "esbuild"
+  included_files = ["db/*.sql","web/src/content/*.json"]

--- a/web/package.json
+++ b/web/package.json
@@ -1,14 +1,22 @@
 {
   "name": "naturverse-web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "vite preview --port 4173",
     "db:push": "echo 'Run seed via Netlify function or Supabase SQL editor'"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.4",
     "gray-matter": "^4.0.3",
     "marked": "^12.0.2"
+  },
+  "devDependencies": {
+    "vite": "^5.4.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- ensure Netlify builds `web` using npm ci and publishes the SPA
- add vite, plugin-react, and typescript dev deps with correct preview port

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm test --prefix web` *(fails: Missing script "test")*
- `npm run build --prefix web` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a56ef14784832981dd918928f06520