### PR TITLE
codex/launch-naturversity-hub

### DIFF
--- a/netlify/functions/nv-dao.ts
+++ b/netlify/functions/nv-dao.ts
@@ -1,0 +1,38 @@
+import type { Handler } from '@netlify/functions';
+import { supa } from './nv-supabase';
+
+const DEMO_USER = 'demo-parent';
+
+export const handler: Handler = async (event) => {
+  const db = supa();
+
+  if (event.httpMethod === 'GET') {
+    const { data: props, error } = await db.from('dao_proposals').select('*').order('created_at', { ascending: false });
+    if (error) return resp(500, { error: error.message });
+    const withCounts = await Promise.all(
+      (props ?? []).map(async p => {
+        const { count: yes } = await db.from('dao_votes').select('*', { count: 'exact', head: true }).eq('proposal_id', p.id).eq('vote', true);
+        const { count: no }  = await db.from('dao_votes').select('*', { count: 'exact', head: true }).eq('proposal_id', p.id).eq('vote', false);
+        return { ...p, yes: yes ?? 0, no: no ?? 0 };
+      })
+    );
+    return resp(200, withCounts);
+  }
+
+  if (event.httpMethod === 'POST') {
+    const payload = JSON.parse(event.body || '{}');
+    const { proposal_id, vote } = payload;
+    if (!proposal_id || typeof vote !== 'boolean') return resp(400, { error: 'invalid payload' });
+    const { error } = await db.from('dao_votes').upsert({ proposal_id, user_id: DEMO_USER, vote });
+    if (error) return resp(500, { error: error.message });
+
+    const res = await (await handler({ httpMethod: 'GET' } as any) as any);
+    return res;
+  }
+
+  return resp(405, { error: 'method not allowed' });
+};
+
+function resp(statusCode: number, body: any) {
+  return { statusCode, body: JSON.stringify(body) };
+}

--- a/netlify/functions/nv-parent.ts
+++ b/netlify/functions/nv-parent.ts
@@ -1,0 +1,40 @@
+import type { Handler } from '@netlify/functions';
+import { supa } from './nv-supabase';
+
+const DEFAULT_CHILD = 'demo-child';
+
+export const handler: Handler = async (event) => {
+  const db = supa();
+
+  if (event.httpMethod === 'GET') {
+    const { data, error } = await db
+      .from('parent_controls')
+      .select('*')
+      .eq('child_id', DEFAULT_CHILD)
+      .maybeSingle();
+    if (error) return resp(500, { error: error.message });
+    if (!data) {
+      const ins = await db.from('parent_controls').insert({ child_id: DEFAULT_CHILD, content_locked: false, spending_limit: 0 }).select().single();
+      if (ins.error) return resp(500, { error: ins.error.message });
+      return resp(200, ins.data);
+    }
+    return resp(200, data);
+  }
+
+  if (event.httpMethod === 'POST') {
+    const payload = JSON.parse(event.body || '{}');
+    const { content_locked = false, spending_limit = 0 } = payload;
+    const { data, error } = await db
+      .from('parent_controls')
+      .upsert({ child_id: DEFAULT_CHILD, content_locked, spending_limit })
+      .select().single();
+    if (error) return resp(500, { error: error.message });
+    return resp(200, data);
+  }
+
+  return resp(405, { error: 'method not allowed' });
+};
+
+function resp(statusCode: number, body: any) {
+  return { statusCode, body: JSON.stringify(body) };
+}

--- a/netlify/functions/nv-progress.ts
+++ b/netlify/functions/nv-progress.ts
@@ -1,0 +1,31 @@
+import type { Handler } from '@netlify/functions';
+import { supa } from './nv-supabase';
+
+export const handler: Handler = async (event) => {
+  const db = supa();
+
+  if (event.httpMethod === 'GET') {
+    const { data, error } = await db
+      .from('student_progress')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .limit(100);
+    if (error) return resp(500, { error: error.message });
+    return resp(200, data);
+  }
+
+  if (event.httpMethod === 'POST') {
+    const payload = JSON.parse(event.body || '{}');
+    const { student_id, quiz_id, score } = payload;
+    if (!student_id || !quiz_id || typeof score !== 'number') return resp(400, { error: 'invalid payload' });
+    const { data, error } = await db.from('student_progress').insert({ student_id, quiz_id, score }).select();
+    if (error) return resp(500, { error: error.message });
+    return resp(200, data?.[0] ?? null);
+  }
+
+  return resp(405, { error: 'method not allowed' });
+};
+
+function resp(statusCode: number, body: any) {
+  return { statusCode, body: JSON.stringify(body) };
+}

--- a/netlify/functions/nv-supabase.ts
+++ b/netlify/functions/nv-supabase.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js';
+
+export function supa() {
+  const url = process.env.SUPABASE_URL!;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  return createClient(url, key, { auth: { persistSession: false } });
+}

--- a/netlify/functions/nv-wallet.ts
+++ b/netlify/functions/nv-wallet.ts
@@ -1,0 +1,29 @@
+import type { Handler } from '@netlify/functions';
+import { supa } from './nv-supabase';
+
+const DEMO_USER = 'demo-parent';
+
+export const handler: Handler = async (event) => {
+  const db = supa();
+
+  if (event.httpMethod === 'GET') {
+    const { data, error } = await db
+      .from('natur_wallets')
+      .select('*')
+      .eq('user_id', DEMO_USER)
+      .maybeSingle();
+    if (error) return resp(500, { error: error.message });
+    if (!data) {
+      const ins = await db.from('natur_wallets').insert({ user_id: DEMO_USER, balance: 120 }).select().single();
+      if (ins.error) return resp(500, { error: ins.error.message });
+      return resp(200, ins.data);
+    }
+    return resp(200, data);
+  }
+
+  return resp(405, { error: 'method not allowed' });
+};
+
+function resp(statusCode: number, body: any) {
+  return { statusCode, body: JSON.stringify(body) };
+}

--- a/supabase/migrations/2025-08-19-naturversity.sql
+++ b/supabase/migrations/2025-08-19-naturversity.sql
@@ -1,0 +1,45 @@
+-- Student quiz progress
+create table if not exists public.student_progress (
+  id uuid primary key default gen_random_uuid(),
+  student_id text not null,
+  quiz_id text not null,
+  score int not null check (score >= 0 and score <= 100),
+  created_at timestamptz not null default now()
+);
+
+-- Parent controls per child
+create table if not exists public.parent_controls (
+  id uuid primary key default gen_random_uuid(),
+  child_id text not null unique,
+  content_locked boolean not null default false,
+  spending_limit int,
+  updated_at timestamptz not null default now()
+);
+
+-- Custodial NATUR wallet (centralized balance for now)
+create table if not exists public.natur_wallets (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null unique,
+  balance numeric not null default 0
+);
+
+-- DAO proposals & votes
+create table if not exists public.dao_proposals (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  description text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.dao_votes (
+  id uuid primary key default gen_random_uuid(),
+  proposal_id uuid not null references public.dao_proposals (id) on delete cascade,
+  user_id text not null,
+  vote boolean not null,
+  unique (proposal_id, user_id)
+);
+
+-- Seed one demo proposal if none exists
+insert into public.dao_proposals (title, description)
+select 'Add Music Zone expansion', 'New instruments, loops, and collabs'
+where not exists (select 1 from public.dao_proposals);

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -11,6 +11,7 @@ export default function Nav() {
       <Link to="/stories">Stories</Link>{' '}
       <Link to="/quizzes">Quizzes</Link>{' '}
       <Link to="/observations">Observations</Link>{' '}
+      <Link to="/naturversity">Naturversity</Link>{' '}
       <Link to="/tips">Turian Tips</Link>{' '}
       <Link to="/profile">Profile</Link>
     </nav>

--- a/web/src/content/naturversity/dao-literacy.tsx
+++ b/web/src/content/naturversity/dao-literacy.tsx
@@ -1,0 +1,13 @@
+export default function DaoBasics() {
+  return (
+    <article className="prose">
+      <h2>DAO Literacy</h2>
+      <p>DAOs are clubs that decide together. Members propose ideas and vote with governance tokens.</p>
+      <ol>
+        <li>Read a proposal.</li>
+        <li>Discuss in community.</li>
+        <li>Vote yes/no.</li>
+      </ol>
+    </article>
+  );
+}

--- a/web/src/content/naturversity/web3-basics.tsx
+++ b/web/src/content/naturversity/web3-basics.tsx
@@ -1,0 +1,15 @@
+export default function Web3Basics() {
+  return (
+    <article className="prose">
+      <h2>What is Web3?</h2>
+      <p>Web3 uses blockchains to let people own digital items and vote on decisions together.</p>
+      <h3>Key ideas</h3>
+      <ul>
+        <li><strong>Wallet:</strong> your digital backpack for tokens and items.</li>
+        <li><strong>Tokens:</strong> points with utility. Here, <em>NATUR</em> powers votes and rewards.</li>
+        <li><strong>DAO:</strong> a shared group that proposes and votes.</li>
+      </ul>
+      <p>Families can use custodial wallets so adults approve actions.</p>
+    </article>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4,3 +4,19 @@ export async function api<T = any>(path: string, init?: RequestInit): Promise<T>
   return res.json() as Promise<T>;
 }
 
+export async function callFn(
+  name: string,
+  method: 'GET' | 'POST' = 'GET',
+  body?: any,
+  params?: Record<string, string | number | boolean>
+) {
+  const q = params ? '?' + new URLSearchParams(Object.entries(params).map(([k, v]) => [k, String(v)])) : '';
+  const res = await fetch(`/.netlify/functions/${name}${q}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: method === 'POST' ? JSON.stringify(body ?? {}) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  return { ok: res.ok, data: json };
+}
+

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -28,7 +28,12 @@ import CreatorLab from './pages/CreatorLab';
 import Community from './pages/Community';
 import Teachers from './pages/Teachers';
 import Partners from './pages/Partners';
-import Naturversity from './pages/Naturversity';
+import NaturversityHub from './pages/Naturversity';
+import Web3Page from './pages/Naturversity/Web3';
+import WalletsPage from './pages/Naturversity/Wallets';
+import TeachersPageNv from './pages/Naturversity/Teachers';
+import ParentsPageNv from './pages/Naturversity/Parents';
+import DaoPage from './pages/Naturversity/DAO';
 import Parents from './pages/Parents';
 import Profile from './pages/Profile';
 import { ContentProvider } from './context/ContentContext';
@@ -65,7 +70,12 @@ const router = createBrowserRouter([
       { path: 'community', element: <Community/> },
       { path: 'teachers', element: <Teachers/> },
       { path: 'partners', element: <Partners/> },
-      { path: 'naturversity', element: <Naturversity/> },
+      { path: 'naturversity', element: <NaturversityHub/> },
+      { path: 'naturversity/web3', element: <Web3Page/> },
+      { path: 'naturversity/wallets', element: <WalletsPage/> },
+      { path: 'naturversity/teachers', element: <TeachersPageNv/> },
+      { path: 'naturversity/parents', element: <ParentsPageNv/> },
+      { path: 'naturversity/dao', element: <DaoPage/> },
       { path: 'parents', element: <Parents/> },
 
       { path: 'profile', element: <Profile/> },

--- a/web/src/pages/Naturversity/DAO.tsx
+++ b/web/src/pages/Naturversity/DAO.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { callFn } from '../../lib/api';
+import type { DaoProposal } from '../../types/naturversity';
+
+export default function DaoPage() {
+  const [proposals, setProposals] = useState<(DaoProposal & { yes: number; no: number })[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const res = await callFn('nv-dao', 'GET');
+      if (res?.ok) setProposals(res.data);
+      setLoading(false);
+    })();
+  }, []);
+
+  async function vote(id: string, v: boolean) {
+    const res = await callFn('nv-dao', 'POST', { proposal_id: id, vote: v });
+    if (res?.ok) setProposals(res.data);
+  }
+
+  return (
+    <main className="page">
+      <h1>DAO Literacy</h1>
+      {loading ? <p>Loading…</p> : proposals.map(p => (
+        <div key={p.id} className="card">
+          <h3>{p.title}</h3>
+          <p>{p.description}</p>
+          <p>Votes: ✅ {p.yes} ❌ {p.no}</p>
+          <button onClick={() => vote(p.id, true)}>Vote Yes</button>
+          <button onClick={() => vote(p.id, false)} style={{marginLeft:8}}>Vote No</button>
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/web/src/pages/Naturversity/Parents.tsx
+++ b/web/src/pages/Naturversity/Parents.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { callFn } from '../../lib/api';
+import type { ParentControls } from '../../types/naturversity';
+
+export default function ParentsPage() {
+  const [controls, setControls] = useState<ParentControls | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const res = await callFn('nv-parent', 'GET');
+      if (res?.ok) setControls(res.data as ParentControls);
+    })();
+  }, []);
+
+  async function save() {
+    setSaving(true);
+    const res = await callFn('nv-parent', 'POST', controls);
+    if (res?.ok) setControls(res.data as ParentControls);
+    setSaving(false);
+  }
+
+  if (!controls) return <main className="page"><h1>Parent Controls</h1><p>Loading…</p></main>;
+
+  return (
+    <main className="page">
+      <h1>Parent Controls</h1>
+      <label>
+        <input
+          type="checkbox"
+          checked={!!controls.content_locked}
+          onChange={e => setControls({ ...controls!, content_locked: e.target.checked })}
+        />
+        Lock mature content
+      </label>
+
+      <div style={{marginTop:12}}>
+        <label>Spending limit (NATUR)</label>
+        <input
+          type="number"
+          value={controls.spending_limit ?? 0}
+          onChange={e => setControls({ ...controls!, spending_limit: Number(e.target.value || 0) })}
+        />
+      </div>
+
+      <button onClick={save} disabled={saving} style={{marginTop:12}}>
+        {saving ? 'Saving…' : 'Save'}
+      </button>
+    </main>
+  );
+}

--- a/web/src/pages/Naturversity/Teachers.tsx
+++ b/web/src/pages/Naturversity/Teachers.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { callFn } from '../../lib/api';
+import type { StudentProgress } from '../../types/naturversity';
+
+export default function TeachersPage() {
+  const [rows, setRows] = useState<StudentProgress[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      const res = await callFn('nv-progress', 'GET');
+      if (res?.ok) setRows(res.data as StudentProgress[]);
+      setLoading(false);
+    })();
+  }, []);
+
+  return (
+    <main className="page">
+      <h1>Teacher Dashboard</h1>
+      <p>Recent quiz submissions.</p>
+      {loading ? <p>Loading…</p> : (
+        <table className="table">
+          <thead>
+            <tr><th>Student</th><th>Quiz</th><th>Score</th><th>When</th></tr>
+          </thead>
+          <tbody>
+            {rows.map(r => (
+              <tr key={r.id}>
+                <td>{r.student_id}</td>
+                <td>{r.quiz_id}</td>
+                <td>{r.score}%</td>
+                <td>{new Date(r.created_at).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </main>
+  );
+}

--- a/web/src/pages/Naturversity/Wallets.tsx
+++ b/web/src/pages/Naturversity/Wallets.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { callFn } from '../../lib/api';
+
+type Wallet = { user_id: string; balance: number };
+
+export default function WalletsPage() {
+  const [data, setData] = useState<Wallet | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      const res = await callFn('nv-wallet', 'GET');
+      if (res?.ok) setData(res.data as Wallet);
+      setLoading(false);
+    })();
+  }, []);
+
+  return (
+    <main className="page">
+      <h1>Custodial Wallet</h1>
+      {loading ? <p>Loading…</p> : (
+        <>
+          <p><strong>Balance:</strong> {data?.balance ?? 0} NATUR</p>
+          <p>Status: 🔒 Parent-managed (read-only in app; changes via approvals)</p>
+        </>
+      )}
+    </main>
+  );
+}

--- a/web/src/pages/Naturversity/Web3.tsx
+++ b/web/src/pages/Naturversity/Web3.tsx
@@ -1,0 +1,10 @@
+import Web3Basics from '../../content/naturversity/web3-basics';
+
+export default function Web3Page() {
+  return (
+    <main className="page">
+      <h1>Web3 & Crypto Basics</h1>
+      <Web3Basics />
+    </main>
+  );
+}

--- a/web/src/pages/Naturversity/index.tsx
+++ b/web/src/pages/Naturversity/index.tsx
@@ -1,8 +1,25 @@
-export default function Naturversity(){
+import { Link } from 'react-router-dom';
+
+export default function NaturversityHub() {
+  const cards = [
+    { to: '/naturversity/web3', title: 'Web3 & Crypto Basics', desc: 'Simple guides for families' },
+    { to: '/naturversity/wallets', title: 'Custodial Wallet Tools', desc: 'Parent-managed NATUR balance' },
+    { to: '/naturversity/teachers', title: 'Teacher Dashboards', desc: 'Quiz results & progress' },
+    { to: '/naturversity/parents', title: 'Parent Controls', desc: 'Locks, limits, approvals' },
+    { to: '/naturversity/dao', title: 'DAO Literacy', desc: 'Proposals & voting with $NATUR' },
+  ];
   return (
-    <div>
-      <h1>Naturversity</h1>
-      <p>Coming soon.</p>
-    </div>
+    <main className="page">
+      <h1>Naturversity™</h1>
+      <p>Resources for parents, teachers, and older users.</p>
+      <div className="card-grid">
+        {cards.map(c => (
+          <Link key={c.to} to={c.to} className="card">
+            <h3>{c.title}</h3>
+            <p>{c.desc}</p>
+          </Link>
+        ))}
+      </div>
+    </main>
   );
 }

--- a/web/src/types/naturversity.ts
+++ b/web/src/types/naturversity.ts
@@ -1,0 +1,22 @@
+export type StudentProgress = {
+  id: string;
+  student_id: string;
+  quiz_id: string;
+  score: number;
+  created_at: string;
+};
+
+export type ParentControls = {
+  id: string;
+  child_id: string;
+  content_locked: boolean;
+  spending_limit: number | null;
+  updated_at: string;
+};
+
+export type DaoProposal = {
+  id: string;
+  title: string;
+  description: string | null;
+  created_at: string;
+};


### PR DESCRIPTION
## Summary
- add Naturversity hub with Web3, wallet, teacher, parent, and DAO sections
- wire Netlify functions to Supabase for progress, parent controls, wallet balance, and DAO voting
- seed Naturversity content components, types, API helper, nav link, and routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm test` in `web` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found; `npm install vite@latest` forbidden)
- `npx tsc -p web/tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'vite/client')*


------
https://chatgpt.com/codex/tasks/task_e_68a56da1d9308329ac0ccae58b21252e