### PR TITLE
Fix JSX runtime resolution for Vite

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,11 +12,15 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.45.4",
     "gray-matter": "^4.0.3",
-    "marked": "^12.0.2"
+    "marked": "^12.0.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "vite": "^5.4.0",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vite": "^5.4.0"
   }
 }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
+    "jsx": "react-jsx",
     "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
     "skipLibCheck": true,
-    "jsx": "react-jsx",
-    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary
- add React runtime and type dependencies
- enable React JSX runtime and strict options in TS config

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npm run build` *(fails: Rollup failed to resolve import "react/jsx-runtime" from src/main.tsx)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a57482bacc8329b0526148d97f9eb2