### PR TITLE
hotfix(web): restore app mount + router, add error boundary (fix blank page)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <!-- Vite will rewrite this to the built bundle -->
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "react-router-dom": "6.26.2"
   },
   "devDependencies": {
     "@types/react": "18.3.5",

--- a/web/src/ErrorBoundary.tsx
+++ b/web/src/ErrorBoundary.tsx
@@ -1,0 +1,18 @@
+import { Component, ReactNode } from "react";
+
+export default class ErrorBoundary extends Component<{children: ReactNode},{error?: Error}> {
+  state: { error?: Error } = {};
+  static getDerivedStateFromError(error: Error) { return { error }; }
+  componentDidCatch(error: Error) { console.error("App crashed:", error); }
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: 24, fontFamily: "system-ui" }}>
+          <h1>Something went wrong.</h1>
+          <p>{this.state.error.message}</p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,5 +1,17 @@
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./AppHome";
+import { RouterProvider } from "react-router-dom";
+import router from "./router";              // must export a Router
+import ErrorBoundary from "./ErrorBoundary";
+import "./styles.css";
 
-const container = document.getElementById("root")!;
-createRoot(container).render(<App />);
+const root = document.getElementById("root");
+if (!root) throw new Error("Missing #root element in index.html");
+
+createRoot(root).render(
+  <StrictMode>
+    <ErrorBoundary>
+      <RouterProvider router={router} />
+    </ErrorBoundary>
+  </StrictMode>
+);

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,0 +1,13 @@
+import { createBrowserRouter } from "react-router-dom";
+import AppHome from "./AppHome";
+import ErrorBoundary from "./ErrorBoundary";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <AppHome />,
+    errorElement: <div style={{ padding: 24 }}>Route not found.</div>
+  }
+]);
+
+export default router;

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -6,11 +6,9 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "jsx": "react-jsx",
-    "allowJs": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "noEmit": true,
-    "types": []
+    "resolveJsonModule": true,
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,13 +1,8 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// IMPORTANT: no build.rollupOptions.external here.
-// Vite will bundle react/jsx-runtime from React automatically.
-
 export default defineConfig({
   plugins: [react()],
-  server: { port: 5173 },
-  build: {
-    sourcemap: false
-  }
+  base: "/",                 // important for Netlify SPA
+  build: { sourcemap: false }
 });


### PR DESCRIPTION
## Summary
- restore Vite index.html scaffold and root mount
- add ErrorBoundary and RouterProvider in main entry
- provide a minimal router for the home route
- simplify Vite and TS configs and include react-router-dom dependency

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "react-router-dom" — dependency install blocked)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a57a1c87b48329b4b0740ed7aa8679