### PR TITLE
Fix build (jsx-runtime), lock toolchain, correct Netlify publish, and mount router

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 command = "npm install --no-audit --no-fund && npm run build"
-publish = "web/dist"
+publish = "dist"
 base = "web"
 
 # SPA redirect (keep)

--- a/web/package.json
+++ b/web/package.json
@@ -6,18 +6,21 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 4173"
+    "preview": "vite preview --port 5173"
   },
   "dependencies": {
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router-dom": "6.22.3"
+    "react-router-dom": "6.26.2"
   },
   "devDependencies": {
-    "@types/react": "18.3.3",
+    "@types/react": "18.3.5",
     "@types/react-dom": "18.3.0",
-    "@vitejs/plugin-react": "4.2.1",
-    "typescript": "5.4.5",
+    "@vitejs/plugin-react": "4.3.1",
+    "typescript": "5.5.4",
     "vite": "5.4.9"
+  },
+  "engines": {
+    "node": ">=18.18 <=22"
   }
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,14 +1,12 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
-import { RouterProvider } from "react-router-dom";
-import router from "./router";
-import "./styles/index.css";
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { RouterProvider } from 'react-router-dom'
+import { router } from './router'
+import './styles/index.css'
 
-const rootEl = document.getElementById("root");
-if (rootEl) {
-  createRoot(rootEl).render(
-    <StrictMode>
-      <RouterProvider router={router} />
-    </StrictMode>
-  );
-}
+const el = document.getElementById('root')!
+createRoot(el).render(
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>
+)

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -18,7 +18,7 @@ const withSuspense = (el: JSX.Element) => (
   <React.Suspense fallback={<div />}>{el}</React.Suspense>
 );
 
-const router = createBrowserRouter([
+export const router = createBrowserRouter([
   { path: "/", element: <AppHome />, errorElement: <ErrorBoundary /> },
   { path: "/worlds", element: withSuspense(<Worlds />) },
   { path: "/zones", element: withSuspense(<Zones />) },
@@ -31,5 +31,3 @@ const router = createBrowserRouter([
   { path: "/profile", element: withSuspense(<Profile />) },
   { path: "*", element: withSuspense(<NotFound />) },
 ]);
-
-export default router;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,12 +1,8 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 
+// Clean config: no runtime aliasing. Vite + React 18 resolve jsx-runtime automatically.
 export default defineConfig({
   plugins: [react()],
-  resolve: {
-    alias: {
-      "react/jsx-runtime": "react/jsx-runtime.js"
-    }
-  }
-});
+})
 


### PR DESCRIPTION
## Summary
- point Netlify publish directory to built dist for correct deployment
- lock React and tooling versions and specify supported Node versions
- simplify Vite config and mount router under `React.StrictMode`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58801ec1c832988560417ea806cf0