### PR TITLE
Add 6 worlds with assets + seed Stories/Quizzes/Wellness/Music

### DIFF
--- a/src/components/worlds/WorldCard.tsx
+++ b/src/components/worlds/WorldCard.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+import type { World } from '../../types/worlds';
+
+export default function WorldCard({ w }: { w: World }) {
+  const disabled = w.status !== 'available';
+  return (
+    <Link
+      to={disabled ? '#' : `/worlds/${w.slug}`}
+      aria-disabled={disabled}
+      className={`block rounded-lg border p-4 ${disabled ? 'opacity-60 pointer-events-none' : 'hover:shadow'}`}
+    >
+      <div className="text-lg font-semibold">{w.name}</div>
+      <div className="text-sm opacity-80">{w.subtitle}</div>
+      <div className="mt-2 text-xl">{w.emojis.join(' ')}</div>
+    </Link>
+  );
+}
+

--- a/src/content/music/index.json
+++ b/src/content/music/index.json
@@ -1,0 +1,4 @@
+[
+  { "id": "jungle-loop-1", "title": "Jungle Loop", "bpm": 92, "world": "brazilandia" },
+  { "id": "bamboo-bells", "title": "Bamboo Bells", "bpm": 80, "world": "chilandia" }
+]

--- a/src/content/quizzes/index.json
+++ b/src/content/quizzes/index.json
@@ -1,0 +1,4 @@
+[
+  { "id": "thai-animals-1", "world": "thailandia", "question": "Which animal is Thailandia’s gentle giant?", "choices": ["Elephant","Tiger","Penguin"], "answer": 0 },
+  { "id": "brazil-fruit-1", "world": "brazilandia", "question": "Which fruit is common in Brazilandia?", "choices": ["Banana","Kiwi","Apple"], "answer": 0 }
+]

--- a/src/content/stories/index.json
+++ b/src/content/stories/index.json
@@ -1,0 +1,4 @@
+[
+  { "id": "thailandia-welcome", "title": "Welcome to Thailandia", "world": "thailandia", "summary": "Meet Turian and friends among coconuts & elephants." },
+  { "id": "brazilandia-rainforest", "title": "Rainforest Rhythm", "world": "brazilandia", "summary": "Parrots and drums teach the beat of the forest." }
+]

--- a/src/content/wellness/index.json
+++ b/src/content/wellness/index.json
@@ -1,0 +1,4 @@
+[
+  { "id": "breathe-outdoors", "title": "Breathe with the Trees", "duration": "3 min", "world": "amerilandia" },
+  { "id": "sun-salute", "title": "Sun Salute", "duration": "2 min", "world": "indilandia" }
+]

--- a/src/content/worlds/worlds.data.ts
+++ b/src/content/worlds/worlds.data.ts
@@ -1,0 +1,167 @@
+import type { World } from '../../types/worlds';
+
+// Asset helper: if a file is missing in /attached_assets, the UI
+// will still render using emojis.
+const a = (p: string) => `/attached_assets/${p}`;
+
+export const worldsData: World[] = [
+  {
+    slug: 'thailandia',
+    name: 'Thailandia',
+    subtitle: 'Coconuts & Elephants',
+    emojis: ['🐘','🥥'],
+    status: 'available',
+    map: a('thailandia/map.png'),
+    banner: a('Backgrounds/thailandia-banner.jpg'),
+    main: {
+      id: 'turian',
+      name: 'Turian',
+      role: 'main',
+      emoji: '🥭',
+      image: a('named images/Turian.png')
+    },
+    cast: [
+      { id: 'inkie', name: 'Inkie', role: 'support', emoji: '🖌️', image: a('thailandia/inkie.png'), zone: 'creator' },
+      { id: 'dr-p', name: 'Dr. P', role: 'guide', emoji: '🧠', image: a('thailandia/dr-p.png'), zone: 'wellness' },
+    ]
+  },
+  {
+    slug: 'chilandia',
+    name: 'Chinlandia',
+    subtitle: 'Bamboo & Pandas',
+    emojis: ['🐼','🎋'],
+    status: 'available',
+    map: a('Chilandiaassets/map.png'),
+    banner: a('Backgrounds/chilandia-banner.jpg'),
+    main: { id: 'bao', name: 'Bao', role: 'main', emoji: '🐼', image: a('Chilandiaassets/bao.png') },
+    cast: [
+      { id: 'li', name: 'Li', role: 'guide', emoji: '🎼', image: a('Chilandiaassets/li.png'), zone: 'music' },
+    ]
+  },
+  {
+    slug: 'indilandia',
+    name: 'Indilandia',
+    subtitle: 'Mangoes & Tigers',
+    emojis: ['🐅','🥭'],
+    status: 'available',
+    map: a('Indilandiaassets/map.png'),
+    banner: a('Backgrounds/indilandia-banner.jpg'),
+    main: { id: 'mango-mike', name: 'Mango Mike', role: 'main', emoji: '🥭', image: a('Indilandiaassets/mango-mike.png') },
+    cast: [
+      { id: 'jay-sing', name: 'Jay-Sing', role: 'support', emoji: '🎤', image: a('Indilandiaassets/jay-sing.png'), zone: 'music' },
+    ]
+  },
+  {
+    slug: 'brazilandia',
+    name: 'Brazilandia',
+    subtitle: 'Bananas & Parrots',
+    emojis: ['🦜','🍌'],
+    status: 'available',
+    map: a('Brazilandiaassets/map.png'),
+    banner: a('Backgrounds/brazilandia-banner.jpg'),
+    main: { id: 'frankie', name: 'Frankie Frogs', role: 'main', emoji: '🐸', image: a('Brazilandiaassets/frankie.png') },
+    cast: [
+      { id: 'jen-suex', name: 'Jen-Suex', role: 'guide', emoji: '🪘', image: a('Brazilandiaassets/jen-suex.png'), zone: 'music' },
+    ]
+  },
+  {
+    slug: 'amerilandia',
+    name: 'Amerilandia',
+    subtitle: 'Apples & Eagles',
+    emojis: ['🦅','🍎'],
+    status: 'available',
+    map: a('Amerilandiaassets/map.png'),
+    banner: a('Backgrounds/amerilandia-banner.jpg'),
+    main: { id: 'nikki', name: 'Nikki MT', role: 'main', emoji: '🗽', image: a('Amerilandiaassets/nikki-mt.png') },
+    cast: [
+      { id: 'lao-cow', name: 'Lao Cow', role: 'support', emoji: '🐮', image: a('Amerilandiaassets/lao-cow.png'), zone: 'community' },
+    ]
+  },
+  {
+    slug: 'australandia',
+    name: 'Australandia',
+    subtitle: 'Peaches & Kangaroos',
+    emojis: ['🦘','🍑'],
+    status: 'available',
+    map: a('Australandiaassets/map.png'),
+    banner: a('Backgrounds/australandia-banner.jpg'),
+    main: { id: 'coconut-cruze', name: 'Coconut Cruze', role: 'main', emoji: '🥥', image: a('Australandiaassets/coconut-cruze.png') },
+    cast: [
+      { id: 'non-bua', name: 'Non-Bua', role: 'guide', emoji: '🌿', image: a('Australandiaassets/non-bua.png'), zone: 'wellness' },
+    ]
+  },
+  // Coming soon worlds
+  {
+    slug: 'japanthia',
+    name: 'Japanthia',
+    subtitle: 'Cherry Blossoms',
+    emojis: ['🌸','🗾'],
+    status: 'coming-soon',
+    main: { id: 'japanthia-main', name: 'TBD', role: 'main' },
+    cast: []
+  },
+  {
+    slug: 'afrilandia',
+    name: 'Afrilandia',
+    subtitle: 'Mangoes & Lions',
+    emojis: ['🦁','🥭'],
+    status: 'coming-soon',
+    main: { id: 'afrilandia-main', name: 'TBD', role: 'main' },
+    cast: []
+  },
+  {
+    slug: 'eurolandia',
+    name: 'Eurolandia',
+    subtitle: 'Sunflowers & Hedgehogs',
+    emojis: ['🌻','🦔'],
+    status: 'coming-soon',
+    main: { id: 'eurolandia-main', name: 'TBD', role: 'main' },
+    cast: []
+  },
+  {
+    slug: 'britlandia',
+    name: 'Britlandia',
+    subtitle: 'Roses & Hedgehogs',
+    emojis: ['🌹','🦔'],
+    status: 'coming-soon',
+    main: { id: 'britlandia-main', name: 'TBD', role: 'main' },
+    cast: []
+  },
+  {
+    slug: 'kiwilandia',
+    name: 'Kiwilandia',
+    subtitle: 'Kiwis & Sheep',
+    emojis: ['🥝','🐑'],
+    status: 'coming-soon',
+    main: { id: 'kiwilandia-main', name: 'TBD', role: 'main' },
+    cast: []
+  },
+  {
+    slug: 'madagalandia',
+    name: 'Madagalandia',
+    subtitle: 'Lemons & Lemurs',
+    emojis: ['🍋','🦝'],
+    status: 'coming-soon',
+    main: { id: 'madagalandia-main', name: 'TBD', role: 'main' },
+    cast: []
+  },
+  {
+    slug: 'greenlandia',
+    name: 'Greenlandia',
+    subtitle: 'Ice & Polar Bears',
+    emojis: ['❄️','🐻‍❄️'],
+    status: 'coming-soon',
+    main: { id: 'greenlandia-main', name: 'TBD', role: 'main' },
+    cast: []
+  },
+  {
+    slug: 'antarctilandia',
+    name: 'Antarctilandia',
+    subtitle: 'Ice Crystals & Penguins',
+    emojis: ['💎','🐧'],
+    status: 'coming-soon',
+    main: { id: 'antarctilandia-main', name: 'TBD', role: 'main' },
+    cast: []
+  }
+];
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,11 +8,14 @@ import './index.css'
 const router = createBrowserRouter([
   { path: '/', element: <AppHome />, errorElement: <ErrorBoundary /> },
   { path: '/worlds', lazy: () => import('./pages/Worlds') },
+  { path: '/worlds/:slug', lazy: () => import('./pages/world-detail') },
   { path: '/zones', lazy: () => import('./pages/zones') },
   { path: '/arcade', lazy: () => import('./pages/arcade') },
   { path: '/marketplace', lazy: () => import('./pages/marketplace') },
   { path: '/stories', lazy: () => import('./pages/Stories') },
   { path: '/quizzes', lazy: () => import('./pages/Quizzes') },
+  { path: '/music', lazy: () => import('./pages/Music') },
+  { path: '/wellness', lazy: () => import('./pages/Wellness') },
   { path: '/observations', lazy: () => import('./pages/Observations') },
   { path: '/tips', lazy: () => import('./pages/TurianTips') },
   { path: '/profile', lazy: () => import('./pages/Profile') }

--- a/src/pages/Music/index.tsx
+++ b/src/pages/Music/index.tsx
@@ -1,14 +1,18 @@
-import CommonCard from '../../components/CommonCard';
-import { useMusic } from '../../hooks/useContent';
-
-export default function Music(){
-  const songs = useMusic();
+import tracks from '../../content/music/index.json';
+export default function Music() {
   return (
-    <div>
+    <div className="container mx-auto p-4">
       <h1>Music</h1>
-      {songs.map(s => (
-        <CommonCard key={s.slug} title={s.title}/>
-      ))}
+      <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+        {tracks.map(t => (
+          <li key={t.id} className="border rounded p-3">
+            <div className="font-medium">{t.title}</div>
+            <div className="text-sm opacity-70">BPM: {t.bpm}</div>
+            <div className="text-xs mt-1">World: {t.world}</div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
+

--- a/src/pages/Quizzes/index.tsx
+++ b/src/pages/Quizzes/index.tsx
@@ -1,17 +1,20 @@
-import CommonCard from '../../components/CommonCard';
-import { useQuizzes } from '../../hooks/useContent';
-import { Link } from 'react-router-dom';
-
-export default function Quizzes(){
-  const quizzes = useQuizzes();
+import items from '../../content/quizzes/index.json';
+export default function Quizzes() {
   return (
-    <div>
+    <div className="container mx-auto p-4">
       <h1>Quizzes</h1>
-      {quizzes.map(q=> (
-        <CommonCard key={q.slug} title={q.title}>
-          <Link to={`/quizzes/${q.slug}`}>Take Quiz</Link>
-        </CommonCard>
-      ))}
+      <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+        {items.map(q => (
+          <li key={q.id} className="border rounded p-3">
+            <div className="font-medium">{q.question}</div>
+            <ol className="list-decimal ml-5 mt-2">
+              {q.choices.map((c, i) => <li key={i}>{c}</li>)}
+            </ol>
+            <div className="text-xs mt-2 opacity-70">World: {q.world}</div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
+

--- a/src/pages/Stories/index.tsx
+++ b/src/pages/Stories/index.tsx
@@ -1,19 +1,18 @@
-import CommonCard from '../../components/CommonCard';
-import FavButton from '../../components/FavButton';
-import { useStories } from '../../hooks/useContent';
-import { Link } from 'react-router-dom';
-
-export default function Stories(){
-  const stories = useStories();
+import data from '../../content/stories/index.json';
+export default function Stories() {
   return (
-    <div>
+    <div className="container mx-auto p-4">
       <h1>Stories</h1>
-      {stories.map(s=> (
-        <CommonCard key={s.slug} title={s.title}>
-          <Link to={`/stories/${s.slug}`}>Read</Link>
-          <FavButton type="content" id={s.slug}/>
-        </CommonCard>
-      ))}
+      <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+        {data.map(s => (
+          <li key={s.id} className="border rounded p-3">
+            <div className="font-medium">{s.title}</div>
+            <div className="opacity-70 text-sm">{s.summary}</div>
+            <div className="text-xs mt-1">World: {s.world}</div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
+

--- a/src/pages/Wellness/index.tsx
+++ b/src/pages/Wellness/index.tsx
@@ -1,16 +1,18 @@
-import CommonCard from '../../components/CommonCard';
-import { useWellness } from '../../hooks/useContent';
-
-export default function Wellness(){
-  const tips = useWellness();
+import flows from '../../content/wellness/index.json';
+export default function Wellness() {
   return (
-    <div>
+    <div className="container mx-auto p-4">
       <h1>Wellness</h1>
-      {tips.map(t => (
-        <CommonCard key={t.slug} title={t.title}>
-          {t.body}
-        </CommonCard>
-      ))}
+      <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+        {flows.map(f => (
+          <li key={f.id} className="border rounded p-3">
+            <div className="font-medium">{f.title}</div>
+            <div className="text-sm opacity-70">Duration: {f.duration}</div>
+            <div className="text-xs mt-1">World: {f.world}</div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
+

--- a/src/pages/Worlds/index.tsx
+++ b/src/pages/Worlds/index.tsx
@@ -1,170 +1,26 @@
-import React from 'react';
-import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import worldsData from '../../content/worlds';
-import type { World } from '../../types/world';
-import WorldCard from '../../components/WorldCard';
+import { worldsData } from '../../content/worlds/worlds.data';
+import WorldCard from '../../components/worlds/WorldCard';
 
 export default function Worlds() {
-  const [params, setParams] = useSearchParams();
-  const selected = params.get('world');
-  const world = useMemo<World | undefined>(
-    () => worldsData.find(w => w.slug === selected ?? ''),
-    [selected]
-  );
-
-  const available = worldsData.filter(w => w.status === 'available');
-  const locked = worldsData.filter(w => w.status === 'coming_soon');
-
+  const avail = worldsData.filter(w => w.status === 'available');
+  const soon = worldsData.filter(w => w.status === 'coming-soon');
   return (
-    <main style={{ padding: 16, maxWidth: 1100, margin: '0 auto' }}>
-      <header style={{ marginBottom: 16 }}>
-        <h1 style={{ margin: 0 }}>Worlds</h1>
-        <p style={{ margin: '6px 0 0', opacity: 0.8 }}>
-          Explore the 14 kingdoms of the Naturverse™. Tap a card to preview details.
-        </p>
-      </header>
-
-      <section style={{ marginTop: 16 }}>
-        <h2 style={{ fontSize: 18, marginBottom: 8 }}>Available</h2>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
-            gap: 12
-          }}
-        >
-          {available.map(w => (
-            <WorldCard key={w.slug} world={w} />
-          ))}
-        </div>
-      </section>
-
-      <section style={{ marginTop: 28 }}>
-        <h2 style={{ fontSize: 18, marginBottom: 8 }}>Coming Soon</h2>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
-            gap: 12
-          }}
-        >
-          {locked.map(w => (
-            <WorldCard key={w.slug} world={w} />
-          ))}
-        </div>
-      </section>
-
-      {world && (
-        <article
-          aria-live="polite"
-          style={{
-            marginTop: 32,
-            padding: 16,
-            border: '1px solid rgba(0,0,0,0.08)',
-            borderRadius: 12,
-            background:
-              'url(/assets/placeholders/world-bg.svg) center/cover no-repeat, #fff'
-          }}
-        >
-          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
-            <h2 style={{ margin: 0 }}>
-              {world.name} <span style={{ opacity: 0.8, fontSize: 16 }}>{world.emoji ?? ''}</span>
-            </h2>
-            <button
-              onClick={() => setParams({})}
-              style={{
-                border: '1px solid rgba(0,0,0,0.12)',
-                background: '#fff',
-                borderRadius: 8,
-                padding: '6px 10px',
-                cursor: 'pointer'
-              }}
-            >
-              Close
-            </button>
+    <div className="container mx-auto p-4">
+      <h1>Worlds</h1>
+      <p className="opacity-80">Explore the 14 kingdoms of the Naturverse™.</p>
+      <h2 className="mt-6 mb-2 text-xl">Available</h2>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {avail.map(w => <WorldCard key={w.slug} w={w} />)}
+      </div>
+      {soon.length > 0 && (
+        <>
+          <h2 className="mt-8 mb-2 text-xl">Coming Soon</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {soon.map(w => <WorldCard key={w.slug} w={w} />)}
           </div>
-
-          <p style={{ marginTop: 8, opacity: 0.9 }}>{world.tagline}</p>
-
-          <div
-            style={{
-              marginTop: 10,
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
-              gap: 12,
-              alignItems: 'start'
-            }}
-          >
-            <div
-              style={{
-                borderRadius: 12,
-                overflow: 'hidden',
-                minHeight: 160,
-                background: 'rgba(255,255,255,0.7)',
-                border: '1px solid rgba(0,0,0,0.06)'
-              }}
-            >
-              {world.image ? (
-                <img
-                  src={world.image}
-                  alt={`${world.name} cover`}
-                  style={{ width: '100%', display: 'block' }}
-                  onError={(e) => {
-                    (e.currentTarget as HTMLImageElement).style.display = 'none';
-                  }}
-                />
-              ) : (
-                <div
-                  style={{
-                    display: 'grid',
-                    placeItems: 'center',
-                    height: 160,
-                    background: 'url(/assets/placeholders/world-bg.svg) center/cover no-repeat'
-                  }}
-                >
-                  <span style={{ fontSize: 14, opacity: 0.7 }}>Cover placeholder</span>
-                </div>
-              )}
-            </div>
-
-            <div>
-              <h3 style={{ margin: '0 0 6px' }}>About</h3>
-              <ul style={{ margin: 0, paddingLeft: 16 }}>
-                <li>
-                  <strong>Region:</strong> {world.region}
-                </li>
-                <li>
-                  <strong>Fruit:</strong> {world.fruit}
-                </li>
-                <li>
-                  <strong>Animal:</strong> {world.animal}
-                </li>
-                <li>
-                  <strong>Status:</strong>{' '}
-                  {world.status === 'available' ? 'Available to explore' : 'Coming soon'}
-                </li>
-              </ul>
-
-              <div style={{ marginTop: 10, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                <a href="/Stories" style={btnStyle}>Stories</a>
-                <a href="/Quizzes" style={btnStyle}>Quizzes</a>
-                <a href="/Observations" style={btnStyle}>Observations</a>
-                <a href="/Marketplace" style={btnStyle}>Marketplace</a>
-              </div>
-            </div>
-          </div>
-        </article>
+        </>
       )}
-    </main>
+    </div>
   );
 }
-
-const btnStyle: React.CSSProperties = {
-  display: 'inline-block',
-  border: '1px solid rgba(0,0,0,0.15)',
-  borderRadius: 10,
-  padding: '8px 12px',
-  textDecoration: 'none'
-};
 

--- a/src/pages/world-detail.tsx
+++ b/src/pages/world-detail.tsx
@@ -1,0 +1,43 @@
+import { useParams } from 'react-router-dom';
+import { worldsData } from '../content/worlds/worlds.data';
+
+export default function WorldDetail() {
+  const { slug } = useParams();
+  const world = worldsData.find(w => w.slug === slug);
+  if (!world) return <div className="p-4">World not found.</div>;
+  return (
+    <div className="container mx-auto p-4">
+      <h1>{world.name}</h1>
+      <p className="opacity-80">{world.subtitle} • {world.emojis.join(' ')}</p>
+      {world.banner && <img src={world.banner} alt="" className="mt-4 rounded-lg w-full max-h-72 object-cover" />}
+      <h3 className="mt-6 text-lg">Main Character</h3>
+      <div className="flex items-center gap-3 mt-2">
+        {world.main.image && <img src={world.main.image} alt={world.main.name} className="h-14 w-14 rounded-full object-cover" />}
+        <div><div className="font-medium">{world.main.name}</div><div className="opacity-70">{world.main.emoji ?? ''}</div></div>
+      </div>
+      {world.cast.length > 0 && (
+        <>
+          <h3 className="mt-6 text-lg">Supporting Cast</h3>
+          <ul className="mt-2 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {world.cast.map(c => (
+              <li key={c.id} className="flex items-center gap-3 border rounded p-3">
+                {c.image && <img src={c.image} alt={c.name} className="h-12 w-12 rounded-full object-cover" />}
+                <div>
+                  <div className="font-medium">{c.name} {c.emoji ?? ''}</div>
+                  {c.zone && <div className="text-xs opacity-70">Zone: {c.zone}</div>}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {world.map && (
+        <>
+          <h3 className="mt-6 text-lg">Map</h3>
+          <img src={world.map} alt={`${world.name} map`} className="mt-2 rounded-lg w-full" />
+        </>
+      )}
+    </div>
+  );
+}
+

--- a/src/types/worlds.ts
+++ b/src/types/worlds.ts
@@ -1,0 +1,23 @@
+export type ZoneKey = 'music' | 'wellness' | 'creator' | 'community' | 'teachers' | 'partners' | 'naturversity' | 'parents';
+
+export interface Character {
+  id: string;
+  name: string;
+  role: 'main' | 'guide' | 'support';
+  emoji?: string;
+  image?: string; // path in /attached_assets
+  zone?: ZoneKey;
+}
+
+export interface World {
+  slug: string;
+  name: string;
+  subtitle: string;           // “Coconuts & Elephants”
+  emojis: string[];           // quick icons
+  status: 'available' | 'coming-soon';
+  map?: string;               // map asset path
+  banner?: string;            // background/banner
+  main: Character;            // main character (e.g., Turian)
+  cast: Character[];          // supporting cast
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
+    "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
## Summary
- add strong typing and data for worlds plus available/coming-soon entries
- show worlds with cards, detail views and new routes
- seed starter JSON content for stories, quizzes, wellness and music with simple page renderers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type... / missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bbfd3b6c83299d7d8bc16a6c3d65