### PR TITLE
fix: simplify markdown handling

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
-  base = ""
+  base = "web"
   publish = "dist"
-  command = "npm install --no-audit --no-fund && npm run build"
+  command = "npm install --no-fund --no-audit && npm run build"
 
 [[redirects]]
   from = "/*"

--- a/package.json
+++ b/package.json
@@ -13,14 +13,12 @@
   "dependencies": {
     "@supabase/supabase-js": "2.45.5",
     "gray-matter": "4.0.3",
-    "marked": "12.0.2",
     "openai": "4.56.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.26.2"
   },
   "devDependencies": {
-    "@types/gray-matter": "4.0.5",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "@vitejs/plugin-react": "4.3.1",

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,11 +1,8 @@
-import matter from "gray-matter";
-import { marked } from "marked";
+import { parseFrontmatter } from "./markdown";
 import type { Doc, DocMeta, ZoneId } from "../types/content";
 
 const ctxMd = import.meta.glob("../content/**/*.md", { as: "raw" });
 const ctxJson = import.meta.glob("../content/**/*.json", { as: "raw" });
-
-function toHtml(md: string){ return marked.parse(md); }
 function base(meta: any, slug: string): DocMeta {
   return {
     title: meta.title ?? slug,
@@ -25,9 +22,9 @@ export async function getZoneDocs(zone: ZoneId): Promise<Doc[]> {
 
   for (const [path, load] of mdEntries){
     const raw = await (load as any)();
-    const { data, content } = matter(raw as string);
+    const { meta, text } = await parseFrontmatter(raw as string);
     const slug = path.split("/").pop()!.replace(/\.md$/, "");
-    docs.push({ ...base(data, slug), body: toHtml(content) });
+    docs.push({ ...base(meta, slug), text });
   }
   for (const [path, load] of jsonEntries){
     const raw = await (load as any)();

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,10 @@
+export type MD<T = Record<string, unknown>> = {
+  meta: T;
+  text: string; // plain content, not HTML (yet)
+};
+
+export async function parseFrontmatter<T = Record<string, unknown>>(raw: string): Promise<MD<T>> {
+  const gm = (await import('gray-matter')).default;
+  const { data, content } = gm(raw);
+  return { meta: data as T, text: content };
+}

--- a/src/pages/ZoneDoc.tsx
+++ b/src/pages/ZoneDoc.tsx
@@ -14,7 +14,7 @@ export default function ZoneDoc(){
       <p><Link to={`/zones/${zone}`}>← Back to {zone}</Link></p>
       <h1>{doc.title}</h1>
       {doc.cover && <img src={doc.cover} alt="" style={{maxWidth:"320px"}} />}
-      {doc.body && <div dangerouslySetInnerHTML={{__html: doc.body}} />}
+      {doc.text && <div style={{whiteSpace:"pre-wrap"}}>{doc.text}</div>}
       {doc.data !== undefined && (
         <pre style={{background:"#f6f6f6", padding:"1rem", borderRadius:8}}>
           {JSON.stringify(doc.data, null, 2)}

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -13,6 +13,6 @@ export interface DocMeta {
 }
 
 export interface Doc<T = unknown> extends DocMeta {
-  body?: string;        // markdown html
+  text?: string;        // markdown text
   data?: T;             // optional JSON payload (quizzes, links, etc.)
 }

--- a/src/types/shims.d.ts
+++ b/src/types/shims.d.ts
@@ -15,16 +15,3 @@ declare module "*.jpeg";
 declare module "*.webp";
 declare module "*.gif";
 declare module "*.mp3";
-
-declare module "gray-matter" {
-  export default function matter(source: string): {
-    content: string;
-    data: Record<string, unknown>;
-  };
-}
-
-declare module "marked" {
-  export const marked: {
-    parse: (src: string) => string;
-  };
-}


### PR DESCRIPTION
## Summary
- drop unused `@types/gray-matter` and remove `marked`
- point Netlify build at `web` and keep output in `dist`
- add minimal frontmatter parser that returns plain text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a5c7f715cc83298d301fb3356aa9c6