### PR TITLE
chore: unregister old service workers and update CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,24 +8,30 @@
   to = "/index.html"
   status = 200
 
-# Security headers (CSP tuned for Vite/React in production)
+# Security headers
 [[headers]]
-  for = "/*"
+for = "/*"
   [headers.values]
-  X-Content-Type-Options = "nosniff"
-  Referrer-Policy = "strict-origin-when-cross-origin"
-  Permissions-Policy = "camera=(), geolocation=(), microphone=()"
-
-  # IMPORTANT: allow the built bundle to execute.
-  # No inline scripts required; keep eval off unless we discover a lib needs it.
+  # Single-page app routes still handled elsewhere; this is just security headers.
   Content-Security-Policy = """
     default-src 'self';
-    script-src 'self' 'wasm-unsafe-eval';
-    style-src 'self' 'unsafe-inline';
-    img-src 'self' data: blob: https:;
-    font-src 'self' data:;
-    connect-src 'self' https://*.supabase.co https://*.supabase.in ws: wss: https://api.openai.com;
     base-uri 'self';
-    frame-ancestors 'none';
+    object-src 'none';
+    script-src 'self';
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' data: https:;
+    font-src 'self' data:;
+    connect-src 'self' https://*.supabase.co https://*.supabase.in;
+    frame-ancestors 'self';
     form-action 'self';
   """
+  Referrer-Policy = "strict-origin-when-cross-origin"
+  X-Content-Type-Options = "nosniff"
+  X-Frame-Options = "SAMEORIGIN"
+  Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+
+[[headers]]
+for = "/*"
+  [headers.values]
+  Cache-Control = "no-store"
+  Clear-Site-Data = "\"cache\", \"storage\""

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,17 @@
+// Hard-kill any previously registered service workers (from older builds)
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker
+    .getRegistrations()
+    .then((regs) => {
+      for (const r of regs) r.unregister();
+    })
+    .catch(() => {});
+  // Also stop the active controller so reload pulls fresh assets
+  if (navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage({ type: "SKIP_WAITING" });
+  }
+}
+
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";


### PR DESCRIPTION
## Summary
- ensure app boots cleanly by unregistering any lingering service workers
- configure Netlify CSP for Vite build and temporarily disable client caching

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a5d61100648329a2a9295bafc0e634