### PR TITLE
Restore router-based app layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import Root from './layouts/Root';
+
 export default function App() {
-  return <h1>Naturverse is live 🚀</h1>;
+  return <Root />;
 }

--- a/src/layouts/Root.tsx
+++ b/src/layouts/Root.tsx
@@ -1,20 +1,19 @@
-import { Outlet, Link } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import Nav from '../components/Nav';
 
 export default function Root() {
   return (
-    <div style={{maxWidth:900, margin:'0 auto', padding:'1rem'}}>
+    <div style={{ maxWidth: 900, margin: '0 auto', padding: '1rem' }}>
       <header>
         <h1>Welcome 🌿</h1>
-        <p>Naturverse is live and the client router is working.</p>
-        <Nav/>
+        <Nav />
       </header>
 
       <main>
-        <Outlet/>
+        <Outlet />
       </main>
 
-      <footer style={{marginTop:'4rem', opacity:.7}}>
+      <footer style={{ marginTop: '4rem', opacity: 0.7 }}>
         © {new Date().getFullYear()} Naturverse
       </footer>
     </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,7 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import App from "./App";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import { router } from './router';
 
-const root = document.getElementById("root")!;
-ReactDOM.createRoot(root).render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/*" element={<App />} />
-      </Routes>
-    </BrowserRouter>
-  </React.StrictMode>
-);
+const rootEl = document.getElementById('root')!;
+createRoot(rootEl).render(<RouterProvider router={router} />);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,22 +1,30 @@
-import { createBrowserRouter } from "react-router-dom";
-import AppHome from "./AppHome";
-import Worlds from "./pages/Worlds";
-import Zones from "./pages/zones";
-import Marketplace from "./pages/marketplace";
-import Stories from "./pages/Stories";
-import Quizzes from "./pages/Quizzes";
-import Observations from "./pages/Observations";
-import Profile from "./pages/Profile";
-import ErrorBoundary from "./ErrorBoundary";
+import { createBrowserRouter, Navigate } from 'react-router-dom';
+import App from './App';
+import ErrorBoundary from './ErrorBoundary';
+import Home from './pages/Home';
+import Worlds from './pages/Worlds';
+import Zones from './pages/zones';
+import Marketplace from './pages/marketplace';
+import Stories from './pages/Stories';
+import Quizzes from './pages/Quizzes';
+import Observations from './pages/Observations';
+import Profile from './pages/Profile';
 
 export const router = createBrowserRouter([
-  { path: "/", element: <AppHome />, errorElement: <ErrorBoundary /> },
-  { path: "/worlds", element: <Worlds /> },
-  { path: "/zones", element: <Zones /> },
-  { path: "/marketplace", element: <Marketplace /> },
-  { path: "/stories", element: <Stories /> },
-  { path: "/quizzes", element: <Quizzes /> },
-  { path: "/observations", element: <Observations /> },
-  { path: "/profile", element: <Profile /> },
+  {
+    path: '/',
+    element: <App />,
+    errorElement: <ErrorBoundary />,
+    children: [
+      { index: true, element: <Home /> },
+      { path: 'worlds', element: <Worlds /> },
+      { path: 'zones', element: <Zones /> },
+      { path: 'marketplace', element: <Marketplace /> },
+      { path: 'stories', element: <Stories /> },
+      { path: 'quizzes', element: <Quizzes /> },
+      { path: 'observations', element: <Observations /> },
+      { path: 'profile', element: <Profile /> },
+      { path: '*', element: <Navigate to="/" /> },
+    ],
+  },
 ]);
-


### PR DESCRIPTION
## Summary
- replace placeholder entrypoint with RouterProvider
- reintroduce router configuration and layout with navigation
- hook up home and content pages under the new router

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5e90a15b8832999add621a2457b0f