### PR TITLE
Add zones, arcade games, marketplace, and profile routes

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,50 +1,126 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import {
-  createBrowserRouter,
-  RouterProvider,
-} from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import Root from "./root/Root";
 import Home from "./routes/Home";
 import Worlds from "./routes/Worlds";
 import WorldDetail from "./routes/WorldDetail";
-import Zones from "./routes/Zones";
-import Arcade from "./routes/Arcade";
-import Marketplace from "./routes/Marketplace";
+
+// Zones
+import Zones from "./routes/zones/Zones";
+import ZoneMusic from "./routes/zones/Music";
+import ZoneWellness from "./routes/zones/Wellness";
+import ZoneCreator from "./routes/zones/CreatorLab";
+import ZoneCommunity from "./routes/zones/Community";
+import ZoneTeachers from "./routes/zones/Teachers";
+import ZonePartners from "./routes/zones/Partners";
+import ZoneNaturversity from "./routes/zones/Naturversity";
+import ZoneParents from "./routes/zones/Parents";
+
+// Arcade
+import Arcade from "./routes/arcade/Arcade";
+import GameSnake from "./routes/arcade/games/Snake";
+import GameMemory from "./routes/arcade/games/Memory";
+import GameTyping from "./routes/arcade/games/Typing";
+
+// Marketplace
+import Marketplace from "./routes/marketplace/Marketplace";
+import MarketCatalog from "./routes/marketplace/Catalog";
+import MarketProduct from "./routes/marketplace/Product";
+import MarketCart from "./routes/marketplace/Cart";
+import MarketCheckout from "./routes/marketplace/Checkout";
+
+// Other top-level
 import Stories from "./routes/Stories";
 import Quizzes from "./routes/Quizzes";
 import Observations from "./routes/Observations";
 import Naturversity from "./routes/Naturversity";
 import Tips from "./routes/Tips";
-import Profile from "./routes/Profile";
+
+// Profile
+import Profile from "./routes/profile/Profile";
+import ProfileSettings from "./routes/profile/Settings";
+import ProfileOrders from "./routes/profile/Orders";
+import NotFound from "./routes/NotFound";
+
 import "./styles.css";
+import { StoreProvider } from "./store/Store";
 
 const router = createBrowserRouter([
   {
     path: "/",
     element: <Root />,
+    errorElement: <NotFound />,
     children: [
       { index: true, element: <Home /> },
 
+      // Worlds
       { path: "worlds", element: <Worlds /> },
       { path: "worlds/:slug", element: <WorldDetail /> },
 
-      { path: "zones", element: <Zones /> },
-      { path: "arcade", element: <Arcade /> },
-      { path: "marketplace", element: <Marketplace /> },
+      // Zones (shortcuts)
+      {
+        path: "zones",
+        element: <Zones />,
+        children: [
+          { path: "music", element: <ZoneMusic /> },
+          { path: "wellness", element: <ZoneWellness /> },
+          { path: "creator-lab", element: <ZoneCreator /> },
+          { path: "community", element: <ZoneCommunity /> },
+          { path: "teachers", element: <ZoneTeachers /> },
+          { path: "partners", element: <ZonePartners /> },
+          { path: "naturversity", element: <ZoneNaturversity /> },
+          { path: "parents", element: <ZoneParents /> },
+        ],
+      },
+
+      // Arcade
+      {
+        path: "arcade",
+        element: <Arcade />,
+        children: [
+          { path: "snake", element: <GameSnake /> },
+          { path: "memory", element: <GameMemory /> },
+          { path: "typing", element: <GameTyping /> },
+        ],
+      },
+
+      // Marketplace
+      {
+        path: "marketplace",
+        element: <Marketplace />,
+        children: [
+          { index: true, element: <MarketCatalog /> },
+          { path: "product/:id", element: <MarketProduct /> },
+          { path: "cart", element: <MarketCart /> },
+          { path: "checkout", element: <MarketCheckout /> },
+        ],
+      },
+
+      // Content
       { path: "stories", element: <Stories /> },
       { path: "quizzes", element: <Quizzes /> },
       { path: "observations", element: <Observations /> },
       { path: "naturversity", element: <Naturversity /> },
       { path: "tips", element: <Tips /> },
-      { path: "profile", element: <Profile /> },
+
+      // Profile
+      {
+        path: "profile",
+        element: <Profile />,
+        children: [
+          { path: "settings", element: <ProfileSettings /> },
+          { path: "orders", element: <ProfileOrders /> },
+        ],
+      },
     ],
   },
 ]);
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <StoreProvider>
+      <RouterProvider router={router} />
+    </StoreProvider>
   </React.StrictMode>
 );
-

--- a/src/routes/Arcade.tsx
+++ b/src/routes/Arcade.tsx
@@ -1,9 +1,0 @@
-export default function Arcade() {
-  return (
-    <>
-      <h2>Arcade</h2>
-      <p>Mini-games arriving soon.</p>
-    </>
-  );
-}
-

--- a/src/routes/Marketplace.tsx
+++ b/src/routes/Marketplace.tsx
@@ -1,9 +1,0 @@
-export default function Marketplace() {
-  return (
-    <>
-      <h2>Marketplace</h2>
-      <p>Coming soon.</p>
-    </>
-  );
-}
-

--- a/src/routes/NotFound.tsx
+++ b/src/routes/NotFound.tsx
@@ -1,0 +1,11 @@
+import { Link, useRouteError } from "react-router-dom";
+export default function NotFound() {
+  const err = useRouteError() as any;
+  return (
+    <>
+      <h2>Not Found</h2>
+      <p>{err?.status || 404} — {err?.statusText || "This page does not exist."}</p>
+      <p><Link to="/">Go home</Link></p>
+    </>
+  );
+}

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -1,9 +1,0 @@
-export default function Profile() {
-  return (
-    <>
-      <h2>Profile &amp; Settings</h2>
-      <p>Sign-in and settings coming soon.</p>
-    </>
-  );
-}
-

--- a/src/routes/Zones.tsx
+++ b/src/routes/Zones.tsx
@@ -1,9 +1,0 @@
-export default function Zones() {
-  return (
-    <>
-      <h2>Zones</h2>
-      <p>Shortcuts: Music • Wellness • Creator Lab • Community • Teachers • Partners • Naturversity • Parents</p>
-    </>
-  );
-}
-

--- a/src/routes/arcade/Arcade.tsx
+++ b/src/routes/arcade/Arcade.tsx
@@ -1,0 +1,17 @@
+import { Link, Outlet, useLocation } from "react-router-dom";
+
+export default function Arcade() {
+  const { pathname } = useLocation();
+  const isIndex = pathname.endsWith("/arcade") || pathname === "/arcade";
+  return (
+    <>
+      <h2>Arcade</h2>
+      <div className="cards">
+        <li className="card"><Link className="card-link" to="snake"><div className="card-emoji">🐍</div><div><div className="card-title">Snake</div><div className="card-sub">Collect fruit, avoid walls.</div></div></Link></li>
+        <li className="card"><Link className="card-link" to="memory"><div className="card-emoji">🧠</div><div><div className="card-title">Memory</div><div className="card-sub">Flip and match cards.</div></div></Link></li>
+        <li className="card"><Link className="card-link" to="typing"><div className="card-emoji">⌨️</div><div><div className="card-title">Typing</div><div className="card-sub">Speed & accuracy.</div></div></Link></li>
+      </div>
+      {!isIndex && <Outlet />}
+    </>
+  );
+}

--- a/src/routes/arcade/games/Memory.tsx
+++ b/src/routes/arcade/games/Memory.tsx
@@ -1,0 +1,38 @@
+import { useMemo, useState } from "react";
+const EMOJI = ["🐶","🐱","🦊","🐼","🐸","🐵","🐯","🦁"];
+
+export default function GameMemory(){
+  const deck = useMemo(()=>shuffle([...EMOJI, ...EMOJI]).map((v,i)=>({id:i, v})),[]);
+  const [open,setOpen]=useState<number[]>([]);
+  const [matched,setMatched]=useState<number[]>([]);
+  const [moves,setMoves]=useState(0);
+
+  const click=(i:number)=>{
+    if (open.includes(i) || matched.includes(i)) return;
+    const next=[...open,i];
+    setOpen(next);
+    if (next.length===2){
+      setMoves(m=>m+1);
+      const [a,b]=next;
+      if (deck[a].v===deck[b].v){ setMatched(m=>[...m,a,b]); setOpen([]); }
+      else setTimeout(()=>setOpen([]),700);
+    }
+  };
+
+  return (
+    <div>
+      <h3>Memory — Moves: {moves}</h3>
+      <div className="grid">
+        {deck.map((card,i)=>{
+          const show=open.includes(i)||matched.includes(i);
+          return (
+            <button key={card.id} className={"tile"+(show?" show":"")} onClick={()=>click(i)}>
+              {show?card.v:"❓"}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+function shuffle<T>(a:T[]){ for(let i=a.length-1;i>0;i--){const j=Math.floor(Math.random()*(i+1)); [a[i],a[j]]= [a[j],a[i]];} return a; }

--- a/src/routes/arcade/games/Snake.tsx
+++ b/src/routes/arcade/games/Snake.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from "react";
+
+export default function GameSnake() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    const c = canvasRef.current!;
+    const ctx = c.getContext("2d")!;
+    const size = 16, cols = 20, rows = 20;
+    c.width = cols * size; c.height = rows * size;
+
+    let snake = [{x:10,y:10}];
+    let apple = {x:15,y:15};
+    let vx = 1, vy = 0, speed = 120, dead = false;
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowUp"    && vy === 0) { vx=0; vy=-1; }
+      if (e.key === "ArrowDown"  && vy === 0) { vx=0; vy= 1; }
+      if (e.key === "ArrowLeft"  && vx === 0) { vx=-1; vy=0; }
+      if (e.key === "ArrowRight" && vx === 0) { vx= 1; vy=0; }
+    };
+    window.addEventListener("keydown", onKey);
+
+    const tick = () => {
+      if (dead) return;
+      const head = {x: snake[0].x + vx, y: snake[0].y + vy};
+      if (head.x<0||head.y<0||head.x>=cols||head.y>=rows||snake.some(p=>p.x===head.x&&p.y===head.y)){ dead=true; return; }
+      snake.unshift(head);
+      if (head.x===apple.x && head.y===apple.y) {
+        setScore(s=>s+1);
+        apple = {x: Math.floor(Math.random()*cols), y: Math.floor(Math.random()*rows)};
+      } else snake.pop();
+
+      ctx.fillStyle="#0b1220"; ctx.fillRect(0,0,c.width,c.height);
+      ctx.fillStyle="#86efac"; snake.forEach(p=>ctx.fillRect(p.x*size, p.y*size, size-1, size-1));
+      ctx.fillStyle="#fca5a5"; ctx.fillRect(apple.x*size, apple.y*size, size-1, size-1);
+    };
+
+    const id = setInterval(tick, speed);
+    return () => { clearInterval(id); window.removeEventListener("keydown", onKey); };
+  }, []);
+
+  return (
+    <div className="game">
+      <h3>Snake — Score: {score}</h3>
+      <canvas ref={canvasRef} style={{border:"1px solid #e2e8f0", borderRadius:8}} />
+    </div>
+  );
+}

--- a/src/routes/arcade/games/Typing.tsx
+++ b/src/routes/arcade/games/Typing.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useMemo, useState } from "react";
+const WORDS = "nature leaf river mountain ocean forest panda eagle mango coconut bamboo".split(" ");
+
+export default function GameTyping(){
+  const target = useMemo(()=>WORDS.sort(()=>Math.random()-0.5).slice(0,5),[]);
+  const [i,setI]=useState(0);
+  const [input,setInput]=useState("");
+  const [start]=useState(Date.now());
+  const done = i>=target.length;
+
+  useEffect(()=>{ if (input.trim()===target[i]){ setI(v=>v+1); setInput(""); }},[input,i,target]);
+
+  return (
+    <div>
+      <h3>Typing</h3>
+      {done ? <p>Finished in {Math.round((Date.now()-start)/1000)}s</p> : (
+        <>
+          <p>Type the word:</p>
+          <p style={{fontSize:24, fontWeight:800}}>{target[i]}</p>
+          <input value={input} onChange={e=>setInput(e.target.value)} placeholder="type here" />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/routes/marketplace/Cart.tsx
+++ b/src/routes/marketplace/Cart.tsx
@@ -1,0 +1,28 @@
+import { Link } from "react-router-dom";
+import { useStore } from "../../store/Store";
+
+export default function MarketCart(){
+  const { state, dispatch } = useStore();
+  const total = state.cart.reduce((n,i)=>n+i.qty*i.price,0);
+  if (!state.cart.length) return (<p>Cart is empty. <Link to="/marketplace">Browse items</Link></p>);
+  return (
+    <>
+      <ul className="list">
+        {state.cart.map(i=>(
+          <li key={i.id} className="row">
+            <div className="grow">{i.name}</div>
+            <input
+              type="number" min={1} value={i.qty}
+              onChange={e=>dispatch({type:"qty", id:i.id, qty:Number(e.target.value)})}
+              style={{width:64}}
+            />
+            <div style={{width:80, textAlign:"right"}}>${i.price*i.qty}</div>
+            <button onClick={()=>dispatch({type:"remove", id:i.id})}>✕</button>
+          </li>
+        ))}
+      </ul>
+      <p style={{textAlign:"right"}}><strong>Total: ${total}</strong></p>
+      <p style={{textAlign:"right"}}><Link to="/marketplace/checkout" className="pill">Proceed to checkout →</Link></p>
+    </>
+  );
+}

--- a/src/routes/marketplace/Catalog.tsx
+++ b/src/routes/marketplace/Catalog.tsx
@@ -1,0 +1,20 @@
+import { Link } from "react-router-dom";
+import { PRODUCTS } from "./data";
+
+export default function MarketCatalog(){
+  return (
+    <ul className="cards">
+      {PRODUCTS.map(p=>(
+        <li key={p.id} className="card">
+          <Link to={`/marketplace/product/${p.id}`} className="card-link">
+            <div className="card-emoji">{p.emoji}</div>
+            <div>
+              <div className="card-title">{p.name}</div>
+              <div className="card-sub">${p.price} · {p.desc}</div>
+            </div>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/routes/marketplace/Checkout.tsx
+++ b/src/routes/marketplace/Checkout.tsx
@@ -1,0 +1,22 @@
+import { useStore } from "../../store/Store";
+
+export default function MarketCheckout(){
+  const { state, dispatch } = useStore();
+  const total = state.cart.reduce((n,i)=>n+i.qty*i.price,0);
+  const pay = () => { alert("Order placed!"); dispatch({type:"clear"}); };
+  return (
+    <>
+      <h3>Checkout</h3>
+      <p>Items: {state.cart.reduce((n,i)=>n+i.qty,0)} · Total: <strong>${total}</strong></p>
+      <div className="grid2">
+        <input placeholder="Full name" />
+        <input placeholder="Email" />
+        <input placeholder="Address" />
+        <input placeholder="City" />
+        <input placeholder="Card number" />
+        <input placeholder="Expiry / CVC" />
+      </div>
+      <button onClick={pay}>Pay now</button>
+    </>
+  );
+}

--- a/src/routes/marketplace/Marketplace.tsx
+++ b/src/routes/marketplace/Marketplace.tsx
@@ -1,0 +1,20 @@
+import { Link, Outlet, useLocation } from "react-router-dom";
+import { useStore } from "../../store/Store";
+
+export default function Marketplace(){
+  const { state } = useStore();
+  const count = state.cart.reduce((n,i)=>n+i.qty,0);
+  const { pathname } = useLocation();
+  const index = pathname.endsWith("/marketplace") || pathname === "/marketplace";
+  return (
+    <>
+      <h2>Marketplace</h2>
+      <div className="pillbar">
+        <Link className="pill" to="/marketplace">Catalog</Link>
+        <Link className="pill" to="/marketplace/cart">Cart ({count})</Link>
+        <Link className="pill" to="/marketplace/checkout">Checkout</Link>
+      </div>
+      {index ? <Outlet /> : <Outlet />}
+    </>
+  );
+}

--- a/src/routes/marketplace/Product.tsx
+++ b/src/routes/marketplace/Product.tsx
@@ -1,0 +1,19 @@
+import { useParams, Link } from "react-router-dom";
+import { PRODUCTS } from "./data";
+import { useStore } from "../../store/Store";
+
+export default function MarketProduct(){
+  const { id } = useParams();
+  const item = PRODUCTS.find(p=>p.id===id);
+  const { dispatch } = useStore();
+  if (!item) return <p>Product not found.</p>;
+  return (
+    <>
+      <p><Link to="/marketplace">← Back to catalog</Link></p>
+      <h3>{item.emoji} {item.name}</h3>
+      <p className="muted">{item.desc}</p>
+      <p><strong>${item.price}</strong></p>
+      <button onClick={()=>dispatch({type:"add", item})}>Add to cart</button>
+    </>
+  );
+}

--- a/src/routes/marketplace/data.ts
+++ b/src/routes/marketplace/data.ts
@@ -1,0 +1,5 @@
+export const PRODUCTS = [
+  { id: "kit-1", name: "Explorer Kit", price: 29, emoji: "🧭", desc: "Nature journal, stickers, and field tasks." },
+  { id: "cards-1", name: "Creature Cards", price: 19, emoji: "🦊", desc: "Collectible animal facts deck." },
+  { id: "tee-1", name: "Leaf Tee", price: 24, emoji: "👕", desc: "Soft tee with Naturverse leaf." },
+];

--- a/src/routes/profile/Orders.tsx
+++ b/src/routes/profile/Orders.tsx
@@ -1,0 +1,8 @@
+export default function ProfileOrders(){
+  return (
+    <>
+      <h3>Orders</h3>
+      <p className="muted">Your recent marketplace orders will appear here.</p>
+    </>
+  );
+}

--- a/src/routes/profile/Profile.tsx
+++ b/src/routes/profile/Profile.tsx
@@ -1,0 +1,15 @@
+import { Link, Outlet, useLocation } from "react-router-dom";
+export default function Profile(){
+  const { pathname } = useLocation();
+  const index = pathname.endsWith("/profile") || pathname === "/profile";
+  return (
+    <>
+      <h2>Profile & Settings</h2>
+      <div className="pillbar">
+        <Link className="pill" to="/profile/settings">Settings</Link>
+        <Link className="pill" to="/profile/orders">Orders</Link>
+      </div>
+      {index ? <p className="muted">Manage your account.</p> : <Outlet />}
+    </>
+  );
+}

--- a/src/routes/profile/Settings.tsx
+++ b/src/routes/profile/Settings.tsx
@@ -1,0 +1,13 @@
+export default function ProfileSettings(){
+  return (
+    <>
+      <h3>Settings</h3>
+      <div className="grid2">
+        <input placeholder="Display name" />
+        <input placeholder="Email" />
+        <select><option>Light</option><option>Dark</option></select>
+        <button>Save</button>
+      </div>
+    </>
+  );
+}

--- a/src/routes/zones/Community.tsx
+++ b/src/routes/zones/Community.tsx
@@ -1,0 +1,1 @@
+export default function ZoneCommunity(){ return (<><h3>Community</h3><p>Challenges, events, and clubs.</p></>); }

--- a/src/routes/zones/CreatorLab.tsx
+++ b/src/routes/zones/CreatorLab.tsx
@@ -1,0 +1,1 @@
+export default function ZoneCreator(){ return (<><h3>Creator Lab</h3><p>Make stories, art, code, and music.</p></>); }

--- a/src/routes/zones/Music.tsx
+++ b/src/routes/zones/Music.tsx
@@ -1,0 +1,1 @@
+export default function ZoneMusic(){ return (<><h3>Music</h3><p>Playlists, rhythm games, and instruments.</p></>); }

--- a/src/routes/zones/Naturversity.tsx
+++ b/src/routes/zones/Naturversity.tsx
@@ -1,0 +1,1 @@
+export default function ZoneNaturversity(){ return (<><h3>Naturversity</h3><p>Courses and learning paths.</p></>); }

--- a/src/routes/zones/Parents.tsx
+++ b/src/routes/zones/Parents.tsx
@@ -1,0 +1,1 @@
+export default function ZoneParents(){ return (<><h3>Parents</h3><p>Parent dashboard and safety settings.</p></>); }

--- a/src/routes/zones/Partners.tsx
+++ b/src/routes/zones/Partners.tsx
@@ -1,0 +1,1 @@
+export default function ZonePartners(){ return (<><h3>Partners</h3><p>Programs and collaborations.</p></>); }

--- a/src/routes/zones/Teachers.tsx
+++ b/src/routes/zones/Teachers.tsx
@@ -1,0 +1,1 @@
+export default function ZoneTeachers(){ return (<><h3>Teachers</h3><p>Class packs, guides, and resources.</p></>); }

--- a/src/routes/zones/Wellness.tsx
+++ b/src/routes/zones/Wellness.tsx
@@ -1,0 +1,1 @@
+export default function ZoneWellness(){ return (<><h3>Wellness</h3><p>Breathing, stretching, and mindfulness.</p></>); }

--- a/src/routes/zones/Zones.tsx
+++ b/src/routes/zones/Zones.tsx
@@ -1,0 +1,28 @@
+import { Link, Outlet, useLocation } from "react-router-dom";
+
+const links = [
+  ["music","Music"],
+  ["wellness","Wellness"],
+  ["creator-lab","Creator Lab"],
+  ["community","Community"],
+  ["teachers","Teachers"],
+  ["partners","Partners"],
+  ["naturversity","Naturversity"],
+  ["parents","Parents"],
+];
+
+export default function Zones() {
+  const { pathname } = useLocation();
+  const isIndex = pathname.endsWith("/zones") || pathname === "/zones";
+  return (
+    <>
+      <h2>Zones</h2>
+      <div className="pillbar">
+        {links.map(([slug, label]) => (
+          <Link key={slug} className="pill" to={`/zones/${slug}`}>{label}</Link>
+        ))}
+      </div>
+      {isIndex ? <p className="muted">Choose a zone above.</p> : <Outlet />}
+    </>
+  );
+}

--- a/src/store/Store.tsx
+++ b/src/store/Store.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useMemo, useReducer } from "react";
+
+type Item = { id: string; name: string; price: number; qty: number };
+type State = { cart: Item[] };
+type Action =
+  | { type: "add"; item: Omit<Item,"qty"> }
+  | { type: "remove"; id: string }
+  | { type: "qty"; id: string; qty: number }
+  | { type: "clear" };
+
+const Store = createContext<{state: State; dispatch: React.Dispatch<Action>} | null>(null);
+
+function reducer(state: State, action: Action): State {
+  switch(action.type){
+    case "add": {
+      const found = state.cart.find(i=>i.id===action.item.id);
+      if (found) return { cart: state.cart.map(i=>i.id===found.id? {...i, qty:i.qty+1}:i) };
+      return { cart: [...state.cart, {...action.item, qty:1}] };
+    }
+    case "remove": return { cart: state.cart.filter(i=>i.id!==action.id) };
+    case "qty": return { cart: state.cart.map(i=>i.id===action.id? {...i, qty: action.qty }: i) };
+    case "clear": return { cart: [] };
+    default: return state;
+  }
+}
+
+export function StoreProvider({children}:{children: React.ReactNode}){
+  const [state, dispatch] = useReducer(reducer, { cart: [] });
+  const value = useMemo(()=>({state, dispatch}),[state]);
+  return <Store.Provider value={value}>{children}</Store.Provider>;
+}
+export function useStore(){
+  const ctx = useContext(Store);
+  if (!ctx) throw new Error("Store missing");
+  return ctx;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -30,3 +30,19 @@ p { color: var(--muted); margin: 0 0 18px; }
 .card-sub { color: var(--muted); }
 .site-footer { border-top: 1px solid var(--border); padding: 32px 16px; text-align: center; color: var(--muted); }
 
+.pillbar { display:flex; gap:10px; flex-wrap:wrap; margin: 10px 0 18px; }
+.pill { border:1px solid var(--border); background:var(--card); padding:8px 12px; border-radius:999px; text-decoration:none; color:var(--fg); }
+.pill:hover { outline:3px solid var(--ring); }
+
+.list { list-style:none; padding:0; margin:0; display:grid; gap:10px; }
+.row { display:flex; align-items:center; gap:10px; border:1px solid var(--border); background:var(--card); padding:10px 12px; border-radius:10px; }
+.row .grow { flex:1; }
+.grid { display:grid; grid-template-columns: repeat(4, minmax(64px,1fr)); gap:10px; max-width:420px; }
+.tile { height:64px; border:1px solid var(--border); border-radius:10px; background:var(--card); font-size:24px; }
+.tile.show { background:#eef6ff; }
+.grid2 { display:grid; grid-template-columns: repeat(2, minmax(160px,1fr)); gap:12px; max-width:640px; }
+input, select, button { padding:10px 12px; border-radius:8px; border:1px solid var(--border); }
+button { background: var(--brand); color: #fff; border-color: transparent; cursor: pointer; }
+button:hover { filter: brightness(0.95); }
+.muted { color: var(--muted); }
+.game { margin-top: 10px; }


### PR DESCRIPTION
## Summary
- Add nested zones, arcade games, marketplace flow, profile pages, and shared store to wire full navigation.
- Implement mini-games (Snake, Memory, Typing), cart and checkout, and profile settings/orders.
- Expand CSS for pills, grids, lists, and game styling.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5ffeb4dcc8329b66378a3507ca909