### PR TITLE
feat: add supabase integration and marketplace updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
-# Supabase
-VITE_SUPABASE_URL=https://your-project.supabase.co
-VITE_SUPABASE_ANON_KEY=your-anon-key
-SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# Supabase (project settings → API)
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE=        # server only (Netlify functions)
+VITE_SUPABASE_URL=            # optional client anon if you want realtime reads only
+VITE_SUPABASE_ANON_KEY=
 
-# OpenAI
-OPENAI_API_KEY=your-openai-api-key
+# OpenAI (Netlify functions only)
+OPENAI_API_KEY=
+
+# Optional web3 (read-only RPC for Natur token preview)
+VITE_ALCHEMY_RPC_URL=
+VITE_NATUR_TOKEN_ADDRESS=0x0000000000000000000000000000000000000000

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,46 +1,27 @@
--- users are anonymous for now; device_id identifies a browser
-create table if not exists profiles (
-  id uuid primary key default gen_random_uuid(),
-  device_id text unique,
-  created_at timestamp default now()
-);
-
-create table if not exists user_tokens (
-  id bigint generated always as identity primary key,
-  device_id text not null,
-  balance int not null default 0,
-  updated_at timestamp default now()
-);
-
-create table if not exists content (
-  id uuid primary key default gen_random_uuid(),
-  type text not null,            -- story | quiz | observation | tip | music | wellness | world ...
+create table if not exists nv_zones (
+  id text primary key,               -- slug
   title text not null,
-  slug text unique,
-  body text,
-  meta jsonb default '{}'::jsonb,
-  created_at timestamp default now()
+  blurb text not null
 );
 
-create table if not exists quizzes (
+create table if not exists nv_products (
+  id text primary key,
+  name text not null,
+  price numeric not null,
+  emoji text,
+  desc text
+);
+
+create table if not exists nv_stories (
+  id text primary key,
+  title text not null,
+  body text not null
+);
+
+create table if not exists nv_orders (
   id uuid primary key default gen_random_uuid(),
-  content_id uuid references content(id) on delete cascade,
-  questions jsonb not null
-);
-
-create table if not exists progress (
-  id bigint generated always as identity primary key,
-  device_id text not null,
-  content_id uuid references content(id) on delete cascade,
-  score int default 0,
-  completed_at timestamp
-);
-
-create table if not exists wishlists (
-  id bigint generated always as identity primary key,
-  device_id text not null,
-  thing_type text not null,      -- product | content
-  thing_id text not null,        -- sku or content.slug
-  created_at timestamp default now(),
-  unique(device_id, thing_type, thing_id)
+  email text,
+  total numeric not null,
+  items jsonb not null,
+  created_at timestamptz default now()
 );

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,19 +1,18 @@
 [build]
   command = "npm run build"
-  publish = "dist"
+  publish  = "dist"
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/*"
+  to   = "/index.html"
+  status = 200
 
 [[headers]]
   for = "/*"
   [headers.values]
-  X-Frame-Options = "DENY"
+  Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https: http:; frame-ancestors 'none'; base-uri 'self';"
   X-Content-Type-Options = "nosniff"
+  X-Frame-Options = "DENY"
   Referrer-Policy = "strict-origin-when-cross-origin"
-  Permissions-Policy = "geolocation=(), microphone=(), camera=()"
   Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
-  Content-Security-Policy = "default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https: blob:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https: blob:; font-src 'self' https: data:; connect-src 'self' https://*.supabase.co https://api.openai.com https://*.netlify.app https://*.netlify.com https://*.netlify.dev https://*.openai.com https://*.cloudflare.com https://*.googleapis.com wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
-
-# SPA fallback
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200

--- a/netlify/functions/ai-chat.ts
+++ b/netlify/functions/ai-chat.ts
@@ -1,36 +1,24 @@
-import type { Handler } from '@netlify/functions';
-
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY as string;
+import type { Handler } from "@netlify/functions";
 
 export const handler: Handler = async (event) => {
-  try {
-    if (!OPENAI_API_KEY) {
-      return { statusCode: 500, body: JSON.stringify({ error: 'Missing OPENAI_API_KEY' }) };
-    }
-    const { messages = [] } = event.body ? JSON.parse(event.body) : {};
+  if (event.httpMethod !== "POST") return { statusCode: 405, body: "Method Not Allowed" };
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return { statusCode: 200, body: JSON.stringify({ content: "AI temporarily offline." }) };
 
-    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${OPENAI_API_KEY}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o-mini',
-        messages,
-        temperature: 0.7
-      })
-    });
-
-    if (!resp.ok) {
-      const text = await resp.text();
-      return { statusCode: resp.status, body: JSON.stringify({ error: text }) };
-    }
-
-    const json = await resp.json();
-    const reply = json.choices?.[0]?.message?.content ?? '';
-    return { statusCode: 200, body: JSON.stringify({ reply }) };
-  } catch (err: any) {
-    return { statusCode: 500, body: JSON.stringify({ error: String(err) }) };
-  }
+  const { prompt } = JSON.parse(event.body || "{}");
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [
+        { role: "system", content: "You are Naturverse Tutor. Be concise, kid-friendly, and curious." },
+        { role: "user", content: prompt || "Say hi!" }
+      ],
+      temperature: 0.7
+    })
+  });
+  const json = await res.json();
+  const content = json?.choices?.[0]?.message?.content ?? "…";
+  return { statusCode: 200, body: JSON.stringify({ content }) };
 };

--- a/netlify/functions/seed.ts
+++ b/netlify/functions/seed.ts
@@ -1,0 +1,47 @@
+import type { Handler } from "@netlify/functions";
+
+const CONTENT = {
+  zones: [
+    { slug:"music", title:"Music", blurb:"Playlists, rhythm games, and instruments." },
+    { slug:"wellness", title:"Wellness", blurb:"Breathing, stretching, and mindfulness quests." },
+    { slug:"creator-lab", title:"Creator Lab", blurb:"Make stories, art, code, and music." },
+    { slug:"community", title:"Community", blurb:"Clubs, challenges, and events." },
+    { slug:"teachers", title:"Teachers", blurb:"Class packs and resources." },
+    { slug:"partners", title:"Partners", blurb:"Collaborations and programs." },
+    { slug:"naturversity", title:"Naturversity", blurb:"Courses and learning paths." },
+    { slug:"parents", title:"Parents", blurb:"Dashboard and safety controls." },
+  ],
+  products: [
+    { id:"kit-1", name:"Explorer Kit", price:29, emoji:"🧭", desc:"Nature journal, stickers, and field tasks." },
+    { id:"cards-1", name:"Creature Cards", price:19, emoji:"🦊", desc:"Collectible animal facts deck." },
+    { id:"tee-1", name:"Leaf Tee", price:24, emoji:"👕", desc:"Soft tee with Naturverse leaf." }
+  ],
+  stories: [
+    { id:"st-1", title:"Panda and the Bamboo Flute", body:"..." },
+    { id:"st-2", title:"Mangoes for the Tiger", body:"..." }
+  ]
+};
+
+export const handler: Handler = async () => {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE;
+  if (!(url && key)) return { statusCode: 200, body: JSON.stringify({ seeded:false, reason:"No Supabase service key." }) };
+
+  const upsert = async (table: string, rows: any[]) => {
+    const res = await fetch(`${url}/rest/v1/${table}`, {
+      method: "POST",
+      headers: {
+        "apikey": key, "Authorization": `Bearer ${key}`,
+        "Content-Type":"application/json", "Prefer":"resolution=merge-duplicates"
+      },
+      body: JSON.stringify(rows)
+    });
+    if (!res.ok) throw new Error(`${table}: ${res.status} ${await res.text()}`);
+  };
+
+  await upsert("nv_zones", CONTENT.zones.map(z=>({ id:z.slug, ...z })));
+  await upsert("nv_products", CONTENT.products);
+  await upsert("nv_stories", CONTENT.stories);
+
+  return { statusCode: 200, body: JSON.stringify({ seeded:true }) };
+};

--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -14,8 +14,8 @@ export default function ChatBox() {
     const req: ChatReq = {
       messages: [{ role: "system", content: "You are a friendly Naturverse guide." }, ...next] as any,
     };
-    const res = await api<ChatRes>("/.netlify/functions/chat", { method: "POST", body: JSON.stringify(req) });
-    setLog((l) => [...l, { role: "assistant", content: res.reply }]);
+    const res = await api("chat", req);
+    setLog((l) => [...l, { role: "assistant", content: (res as ChatRes).reply }]);
   }
 
   return (

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -8,16 +8,13 @@ export default function Leaderboard({ game = "game1" }: { game?: string }) {
   const [points, setPoints] = useState<number>(0);
 
   async function load() {
-    const data = await api<Score[]>(`/.netlify/functions/scores?game=${encodeURIComponent(game)}`);
-    setScores(data);
+    const data = await api(`scores?game=${encodeURIComponent(game)}`);
+    setScores(data as Score[]);
   }
   useEffect(()=>{ load(); }, [game]);
 
   async function submit() {
-    await api(`/.netlify/functions/scores?game=${encodeURIComponent(game)}`, {
-      method: "POST",
-      body: JSON.stringify({ name: name || "Player", points }),
-    });
+    await api(`scores?game=${encodeURIComponent(game)}`, { name: name || "Player", points });
     setPoints(0);
     load();
   }

--- a/src/components/NaturToken.tsx
+++ b/src/components/NaturToken.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+export default function NaturToken(){
+  const [balance, setBalance] = useState<number | null>(null);
+  useEffect(()=>{
+    const rpc = import.meta.env.VITE_ALCHEMY_RPC_URL;
+    const token = import.meta.env.VITE_NATUR_TOKEN_ADDRESS;
+    const addr = "0x000000000000000000000000000000000000dEaD"; // demo address
+    async function fetchBalance(){
+      try {
+        if (!(rpc && token)) return setBalance(0);
+        const data = {
+          jsonrpc:"2.0", id:1, method:"alchemy_getTokenBalances",
+          params:[addr, [token]]
+        };
+        const res = await fetch(rpc, { method:"POST", headers:{ "Content-Type":"application/json" }, body: JSON.stringify(data) });
+        const json = await res.json();
+        const raw = json?.result?.tokenBalances?.[0]?.tokenBalance || "0x0";
+        setBalance(parseInt(raw, 16) / 1e18);
+      } catch { setBalance(0); }
+    }
+    fetchBalance();
+  },[]);
+  return <div className="muted">Natur Token: <strong>{balance ?? "…"}</strong></div>;
+}

--- a/src/context/ContentContext.tsx
+++ b/src/context/ContentContext.tsx
@@ -10,6 +10,7 @@ const C = createContext<Ctx | null>(null);
 export const useContentCtx = () => useContext(C)!;
 
 async function fromSupabase(type: string): Promise<Item[]> {
+  if (!supabase) throw new Error('no supabase');
   const { data, error } = await supabase.from('content').select('*').eq('type', type).order('created_at',{ascending:false});
   if (error) throw error;
   return (data || []).map((d:any)=>({ slug:d.slug, title:d.title, body:d.body, type:d.type, meta:d.meta }));

--- a/src/data/local.ts
+++ b/src/data/local.ts
@@ -1,0 +1,16 @@
+export const LOCAL_ZONES = [
+  { slug:"music", title:"Music", blurb:"Playlists, rhythm games, and instruments." },
+  { slug:"wellness", title:"Wellness", blurb:"Breathing, stretching, and mindfulness quests." },
+  { slug:"creator-lab", title:"Creator Lab", blurb:"Make stories, art, code, and music." },
+  { slug:"community", title:"Community", blurb:"Clubs, challenges, and events." },
+  { slug:"teachers", title:"Teachers", blurb:"Class packs and resources." },
+  { slug:"partners", title:"Partners", blurb:"Collaborations and programs." },
+  { slug:"naturversity", title:"Naturversity", blurb:"Courses and learning paths." },
+  { slug:"parents", title:"Parents", blurb:"Dashboard and safety controls." },
+];
+
+export const LOCAL_PRODUCTS = [
+  { id:"kit-1", name:"Explorer Kit", price:29, emoji:"🧭", desc:"Nature journal, stickers, and field tasks." },
+  { id:"cards-1", name:"Creature Cards", price:19, emoji:"🦊", desc:"Collectible animal facts deck." },
+  { id:"tee-1", name:"Leaf Tee", price:24, emoji:"👕", desc:"Soft tee with Naturverse leaf." }
+];

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,22 +1,10 @@
-export async function api<T = any>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(path, { headers: { "Content-Type": "application/json" }, ...init });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json() as Promise<T>;
-}
-
-export async function callFn(
-  name: string,
-  method: 'GET' | 'POST' = 'GET',
-  body?: any,
-  params?: Record<string, string | number | boolean>
-) {
-  const q = params ? '?' + new URLSearchParams(Object.entries(params).map(([k, v]) => [k, String(v)])) : '';
-  const res = await fetch(`/.netlify/functions/${name}${q}`, {
-    method,
-    headers: { 'Content-Type': 'application/json' },
-    body: method === 'POST' ? JSON.stringify(body ?? {}) : undefined,
+export async function api(path: string, body?: any, init?: RequestInit){
+  const res = await fetch(`/.netlify/functions/${path}`, {
+    method: body ? "POST" : "GET",
+    headers: { "Content-Type": "application/json", ...(init?.headers||{}) },
+    body: body ? JSON.stringify(body) : undefined,
+    ...init
   });
-  const json = await res.json().catch(() => ({}));
-  return { ok: res.ok, data: json };
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
 }
-

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient } from "@supabase/supabase-js";
 
-const url = import.meta.env.VITE_SUPABASE_URL as string
-const anon = import.meta.env.VITE_SUPABASE_ANON_KEY as string
+const url  = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const anon = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
-export const supabase = createClient(url, anon, {
-  auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true }
-})
+export const supabase = (url && anon) ? createClient(url, anon) : null;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -35,6 +35,8 @@ import Stories from "./routes/Stories";
 import Quizzes from "./routes/Quizzes";
 import Observations from "./routes/Observations";
 import Naturversity from "./routes/Naturversity";
+import NaturTutor from "./routes/naturversity/Tutor";
+import NaturCourses from "./routes/naturversity/Courses";
 import Tips from "./routes/Tips";
 
 // Profile
@@ -102,6 +104,8 @@ const router = createBrowserRouter([
       { path: "quizzes", element: <Quizzes /> },
       { path: "observations", element: <Observations /> },
       { path: "naturversity", element: <Naturversity /> },
+      { path: "naturversity/courses", element: <NaturCourses /> },
+      { path: "naturversity/tutor", element: <NaturTutor /> },
       { path: "tips", element: <Tips /> },
 
       // Profile

--- a/src/routes/Observations.tsx
+++ b/src/routes/Observations.tsx
@@ -1,9 +1,13 @@
-export default function Observations() {
+export default function Observations(){
   return (
     <>
       <h2>Observations</h2>
-      <p>Nature observations coming soon.</p>
+      <p className="muted">Log your nature finds here.</p>
+      <div className="grid2">
+        <input placeholder="What did you see?" />
+        <input placeholder="Where?" />
+        <button>Save</button>
+      </div>
     </>
   );
 }
-

--- a/src/routes/Quizzes.tsx
+++ b/src/routes/Quizzes.tsx
@@ -1,9 +1,11 @@
-export default function Quizzes() {
+export default function Quizzes(){
   return (
     <>
       <h2>Quizzes</h2>
-      <p>Quiz hub coming soon.</p>
+      <ul className="list">
+        <li className="row"><div className="grow">Rainforest Basics</div><button>Start</button></li>
+        <li className="row"><div className="grow">Ocean Zones</div><button>Start</button></li>
+      </ul>
     </>
   );
 }
-

--- a/src/routes/Stories.tsx
+++ b/src/routes/Stories.tsx
@@ -1,9 +1,11 @@
-export default function Stories() {
+export default function Stories(){
   return (
     <>
       <h2>Stories</h2>
-      <p>Story list coming soon.</p>
+      <ul className="list">
+        <li className="row"><div className="grow">Panda and the Bamboo Flute</div><button>Read</button></li>
+        <li className="row"><div className="grow">Mangoes for the Tiger</div><button>Read</button></li>
+      </ul>
     </>
   );
 }
-

--- a/src/routes/marketplace/Catalog.tsx
+++ b/src/routes/marketplace/Catalog.tsx
@@ -1,13 +1,28 @@
 import { Link } from "react-router-dom";
-import { PRODUCTS } from "./data";
+import { LOCAL_PRODUCTS } from "../../data/local";
+import { supabase } from "../../lib/supabase";
+import { useEffect, useState } from "react";
+
+type P = { id:string; name:string; price:number; emoji?:string; desc?:string };
 
 export default function MarketCatalog(){
+  const [items,setItems]=useState<P[]|null>(null);
+
+  useEffect(()=>{
+    (async ()=>{
+      if (!supabase) return setItems(LOCAL_PRODUCTS);
+      const { data, error } = await supabase.from("nv_products").select("*").order("name");
+      setItems(error? LOCAL_PRODUCTS : (data as P[]));
+    })();
+  },[]);
+
+  const list = items ?? LOCAL_PRODUCTS;
   return (
     <ul className="cards">
-      {PRODUCTS.map(p=>(
+      {list.map(p=>(
         <li key={p.id} className="card">
           <Link to={`/marketplace/product/${p.id}`} className="card-link">
-            <div className="card-emoji">{p.emoji}</div>
+            <div className="card-emoji">{p.emoji || "🛒"}</div>
             <div>
               <div className="card-title">{p.name}</div>
               <div className="card-sub">${p.price} · {p.desc}</div>

--- a/src/routes/marketplace/Checkout.tsx
+++ b/src/routes/marketplace/Checkout.tsx
@@ -1,9 +1,20 @@
 import { useStore } from "../../store/Store";
+import { supabase } from "../../lib/supabase";
 
 export default function MarketCheckout(){
   const { state, dispatch } = useStore();
   const total = state.cart.reduce((n,i)=>n+i.qty*i.price,0);
-  const pay = () => { alert("Order placed!"); dispatch({type:"clear"}); };
+  const pay = async () => {
+    if (supabase && state.cart.length){
+      await supabase.from("nv_orders").insert({
+        email: "demo@example.com",
+        total,
+        items: state.cart
+      });
+    }
+    alert("Order placed!");
+    dispatch({type:"clear"});
+  };
   return (
     <>
       <h3>Checkout</h3>

--- a/src/routes/marketplace/Marketplace.tsx
+++ b/src/routes/marketplace/Marketplace.tsx
@@ -1,5 +1,6 @@
 import { Link, Outlet, useLocation } from "react-router-dom";
 import { useStore } from "../../store/Store";
+import NaturToken from "../../components/NaturToken";
 
 export default function Marketplace(){
   const { state } = useStore();
@@ -14,6 +15,7 @@ export default function Marketplace(){
         <Link className="pill" to="/marketplace/cart">Cart ({count})</Link>
         <Link className="pill" to="/marketplace/checkout">Checkout</Link>
       </div>
+      <NaturToken />
       {index ? <Outlet /> : <Outlet />}
     </>
   );

--- a/src/routes/marketplace/Product.tsx
+++ b/src/routes/marketplace/Product.tsx
@@ -1,16 +1,34 @@
 import { useParams, Link } from "react-router-dom";
-import { PRODUCTS } from "./data";
 import { useStore } from "../../store/Store";
+import { LOCAL_PRODUCTS } from "../../data/local";
+import { useEffect, useState } from "react";
+import { supabase } from "../../lib/supabase";
+
+type P = { id:string; name:string; price:number; emoji?:string; desc?:string };
 
 export default function MarketProduct(){
   const { id } = useParams();
-  const item = PRODUCTS.find(p=>p.id===id);
   const { dispatch } = useStore();
+  const [item,setItem]=useState<P | null>(null);
+
+  useEffect(()=>{
+    (async()=>{
+      if (!id) return;
+      if (!supabase){
+        setItem(LOCAL_PRODUCTS.find(p=>p.id===id) || null);
+      } else {
+        const { data, error } = await supabase.from("nv_products").select("*").eq("id", id).single();
+        if (error) setItem(LOCAL_PRODUCTS.find(p=>p.id===id) || null);
+        else setItem(data as P);
+      }
+    })();
+  },[id]);
+
   if (!item) return <p>Product not found.</p>;
   return (
     <>
       <p><Link to="/marketplace">← Back to catalog</Link></p>
-      <h3>{item.emoji} {item.name}</h3>
+      <h3>{item.emoji || "🛒"} {item.name}</h3>
       <p className="muted">{item.desc}</p>
       <p><strong>${item.price}</strong></p>
       <button onClick={()=>dispatch({type:"add", item})}>Add to cart</button>

--- a/src/routes/marketplace/data.ts
+++ b/src/routes/marketplace/data.ts
@@ -1,5 +1,0 @@
-export const PRODUCTS = [
-  { id: "kit-1", name: "Explorer Kit", price: 29, emoji: "🧭", desc: "Nature journal, stickers, and field tasks." },
-  { id: "cards-1", name: "Creature Cards", price: 19, emoji: "🦊", desc: "Collectible animal facts deck." },
-  { id: "tee-1", name: "Leaf Tee", price: 24, emoji: "👕", desc: "Soft tee with Naturverse leaf." },
-];

--- a/src/routes/naturversity/Courses.tsx
+++ b/src/routes/naturversity/Courses.tsx
@@ -1,0 +1,12 @@
+export default function NaturCourses(){
+  return (
+    <>
+      <h3>Courses</h3>
+      <ul className="cards">
+        <li className="card"><div className="card-emoji">🐼</div><div><div className="card-title">Bamboo Biomes</div><div className="card-sub">Habitats, herbivores, and ecosystems.</div></div></li>
+        <li className="card"><div className="card-emoji">🌊</div><div><div className="card-title">Oceans & Currents</div><div className="card-sub">Salinity, waves, coral and kelp.</div></div></li>
+        <li className="card"><div className="card-emoji">🪴</div><div><div className="card-title">Plant Power</div><div className="card-sub">Photosynthesis, roots, and seeds.</div></div></li>
+      </ul>
+    </>
+  );
+}

--- a/src/routes/naturversity/Tutor.tsx
+++ b/src/routes/naturversity/Tutor.tsx
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import { api } from "../../lib/api";
+
+export default function NaturTutor(){
+  const [q, setQ] = useState("");
+  const [a, setA] = useState<string | null>(null);
+  const ask = async () => {
+    setA("…");
+    try {
+      const res = await api("ai-chat", { prompt: q });
+      setA(res.content);
+    } catch (e:any) { setA("Tutor is resting right now."); }
+  };
+  return (
+    <>
+      <h3>Naturversity Tutor</h3>
+      <div className="grid2">
+        <input placeholder="Ask a nature question…" value={q} onChange={e=>setQ(e.target.value)} />
+        <button onClick={ask}>Ask</button>
+      </div>
+      {a && <p style={{marginTop:12}}>{a}</p>}
+    </>
+  );
+}

--- a/src/routes/zones/Community.tsx
+++ b/src/routes/zones/Community.tsx
@@ -1,1 +1,13 @@
-export default function ZoneCommunity(){ return (<><h3>Community</h3><p>Challenges, events, and clubs.</p></>); }
+export default function ZoneCommunity(){
+  return (
+    <>
+      <h3>Community</h3>
+      <p className="muted">Clubs and monthly challenges.</p>
+      <ul className="list">
+        <li className="row"><div className="grow">🌎 Eco-Club</div><button>Join</button></li>
+        <li className="row"><div className="grow">📸 Wild Photo Challenge</div><button>Join</button></li>
+        <li className="row"><div className="grow">🧪 Science Saturday</div><button>Join</button></li>
+      </ul>
+    </>
+  );
+}

--- a/src/routes/zones/CreatorLab.tsx
+++ b/src/routes/zones/CreatorLab.tsx
@@ -1,1 +1,14 @@
-export default function ZoneCreator(){ return (<><h3>Creator Lab</h3><p>Make stories, art, code, and music.</p></>); }
+import { Link } from "react-router-dom";
+export default function ZoneCreator(){
+  return (
+    <>
+      <h3>Creator Lab</h3>
+      <p>Make stories, art, code, and music.</p>
+      <ul className="cards">
+        <li className="card"><div className="card-emoji">📖</div><div><div className="card-title">Story Forge</div><div className="card-sub">Prompts and scenes to write.</div></div></li>
+        <li className="card"><div className="card-emoji">🎨</div><div><div className="card-title">Sketch Pad</div><div className="card-sub">Draw with layers and stickers.</div></div></li>
+        <li className="card"><Link className="card-link" to="/naturversity/tutor"><div className="card-emoji">🧠</div><div><div className="card-title">Idea Helper</div><div className="card-sub">Ask AI Tutor for ideas.</div></div></Link></li>
+      </ul>
+    </>
+  );
+}

--- a/src/routes/zones/Music.tsx
+++ b/src/routes/zones/Music.tsx
@@ -1,1 +1,13 @@
-export default function ZoneMusic(){ return (<><h3>Music</h3><p>Playlists, rhythm games, and instruments.</p></>); }
+export default function ZoneMusic(){
+  return (
+    <>
+      <h3>Music</h3>
+      <p className="muted">Listen, play, and compose.</p>
+      <ul className="cards">
+        <li className="card"><div className="card-emoji">🥁</div><div><div className="card-title">Beat Blocks</div><div className="card-sub">Tap patterns to complete rhythms.</div></div></li>
+        <li className="card"><div className="card-emoji">🎼</div><div><div className="card-title">Scale Climber</div><div className="card-sub">Learn major/minor scales interactively.</div></div></li>
+        <li className="card"><div className="card-emoji">🎹</div><div><div className="card-title">Piano Playground</div><div className="card-sub">On-screen keys and simple songs.</div></div></li>
+      </ul>
+    </>
+  );
+}

--- a/src/routes/zones/Naturversity.tsx
+++ b/src/routes/zones/Naturversity.tsx
@@ -1,1 +1,13 @@
-export default function ZoneNaturversity(){ return (<><h3>Naturversity</h3><p>Courses and learning paths.</p></>); }
+import { Link } from "react-router-dom";
+export default function ZoneNaturversity(){
+  return (
+    <>
+      <h3>Naturversity</h3>
+      <p className="muted">Pick a course or ask the Tutor.</p>
+      <div className="pillbar">
+        <Link className="pill" to="/naturversity/courses">Courses</Link>
+        <Link className="pill" to="/naturversity/tutor">Tutor</Link>
+      </div>
+    </>
+  );
+}

--- a/src/routes/zones/Parents.tsx
+++ b/src/routes/zones/Parents.tsx
@@ -1,1 +1,12 @@
-export default function ZoneParents(){ return (<><h3>Parents</h3><p>Parent dashboard and safety settings.</p></>); }
+export default function ZoneParents(){
+  return (
+    <>
+      <h3>Parents</h3>
+      <ul className="list">
+        <li className="row"><div className="grow">🔐 Safety & Privacy</div><button>Open</button></li>
+        <li className="row"><div className="grow">⏱️ Time Limits</div><button>Open</button></li>
+        <li className="row"><div className="grow">📬 Contact & Support</div><button>Open</button></li>
+      </ul>
+    </>
+  );
+}

--- a/src/routes/zones/Partners.tsx
+++ b/src/routes/zones/Partners.tsx
@@ -1,1 +1,12 @@
-export default function ZonePartners(){ return (<><h3>Partners</h3><p>Programs and collaborations.</p></>); }
+export default function ZonePartners(){
+  return (
+    <>
+      <h3>Partners</h3>
+      <p className="muted">Programs with museums, parks, and labs.</p>
+      <ul className="list">
+        <li className="row"><div className="grow">🏛️ City Museum — Creature Cards Exhibit</div><button>Learn more</button></li>
+        <li className="row"><div className="grow">🌲 State Park — Junior Ranger Days</div><button>Learn more</button></li>
+      </ul>
+    </>
+  );
+}

--- a/src/routes/zones/Teachers.tsx
+++ b/src/routes/zones/Teachers.tsx
@@ -1,1 +1,11 @@
-export default function ZoneTeachers(){ return (<><h3>Teachers</h3><p>Class packs, guides, and resources.</p></>); }
+export default function ZoneTeachers(){
+  return (
+    <>
+      <h3>Teachers</h3>
+      <ul className="cards">
+        <li className="card"><div className="card-emoji">📦</div><div><div className="card-title">Class Packs</div><div className="card-sub">Projects and printable guides.</div></div></li>
+        <li className="card"><div className="card-emoji">🧭</div><div><div className="card-title">Field Tasks</div><div className="card-sub">Outdoor observation templates.</div></div></li>
+      </ul>
+    </>
+  );
+}

--- a/src/routes/zones/Wellness.tsx
+++ b/src/routes/zones/Wellness.tsx
@@ -1,1 +1,12 @@
-export default function ZoneWellness(){ return (<><h3>Wellness</h3><p>Breathing, stretching, and mindfulness.</p></>); }
+export default function ZoneWellness(){
+  return (
+    <>
+      <h3>Wellness</h3>
+      <ul className="cards">
+        <li className="card"><div className="card-emoji">🌬️</div><div><div className="card-title">4-7-8 Breathing</div><div className="card-sub">Guided breaths for calm focus.</div></div></li>
+        <li className="card"><div className="card-emoji">🧘‍♀️</div><div><div className="card-title">Stretch Flow</div><div className="card-sub">5 minute movement break.</div></div></li>
+        <li className="card"><div className="card-emoji">🌿</div><div><div className="card-title">Nature Scan</div><div className="card-sub">Mindfulness with sounds & sights.</div></div></li>
+      </ul>
+    </>
+  );
+}

--- a/src/store/Store.tsx
+++ b/src/store/Store.tsx
@@ -25,8 +25,15 @@ function reducer(state: State, action: Action): State {
 }
 
 export function StoreProvider({children}:{children: React.ReactNode}){
-  const [state, dispatch] = useReducer(reducer, { cart: [] });
+  const [state, dispatch] = useReducer(reducer, undefined, () => {
+    try { return JSON.parse(localStorage.getItem("nv-store") || "") as State; }
+    catch { return { cart: [] }; }
+  });
   const value = useMemo(()=>({state, dispatch}),[state]);
+  // persist
+  if (typeof window !== "undefined") {
+    window.requestIdleCallback?.(()=>localStorage.setItem("nv-store", JSON.stringify(state)));
+  }
   return <Store.Provider value={value}>{children}</Store.Provider>;
 }
 export function useStore(){


### PR DESCRIPTION
## Summary
- configure Netlify build and environment samples for Supabase, OpenAI, and optional web3
- add Supabase client with fallbacks, Netlify seed/ai-chat functions, and new Naturversity tutor & courses routes
- enhance marketplace with Supabase-backed catalog/checkout, persistent cart, and Natur token balance widget

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a607db2df883299d42c9e284cd4708