### PR TITLE
Add Navatar Creator Zone (builder, preview, save to Supabase) + wire into Nav + Marketplace

### DIFF
--- a/src/components/NavatarChip.tsx
+++ b/src/components/NavatarChip.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { fetchNavatar, type NavatarRecord } from "@/lib/navatar";
+import { supabase } from "@/supabaseClient";
+
+export default function NavatarChip() {
+  const [rec, setRec] = useState<NavatarRecord | null>(null);
+
+  useEffect(() => {
+    if (!supabase) return;
+    let mounted = true;
+    (async () => {
+      const { data } = await supabase.auth.getUser();
+      const uid = data.user?.id;
+      if (!uid) return;
+      const r = await fetchNavatar(uid);
+      if (mounted) setRec(r);
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  if (!rec) return null;
+  return (
+    <a href="/navatar" aria-label="My Navatar" className="nav-chip" title="My Navatar">
+      <span dangerouslySetInnerHTML={{ __html: rec.svg }} />
+      <style>{`
+        .nav-chip span svg{ width:32px; height:32px; display:block; }
+      `}</style>
+    </a>
+  );
+}

--- a/src/components/navatar/Preview.tsx
+++ b/src/components/navatar/Preview.tsx
@@ -1,0 +1,13 @@
+type Props = { svg: string };
+
+export default function Preview({ svg }: Props) {
+  return (
+    <div className="preview">
+      <div dangerouslySetInnerHTML={{ __html: svg }} />
+      <style>{`
+        .preview { padding: 12px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; }
+        .preview svg { width: 260px; height: 260px; display:block; margin:auto; }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/navatar/TraitSelector.tsx
+++ b/src/components/navatar/TraitSelector.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import type { NavatarTraits } from "@/lib/navatar";
+
+const REALMS = ["animal", "fruit", "insect", "spirit"] as const;
+const COLORS = ["#7dd3fc","#a7f3d0","#fde68a","#fda4af","#c4b5fd","#fca5a5","#fef08a"];
+const SPECIES: Record<NavatarTraits["realm"], string[]> = {
+  animal: ["Panda","Elephant","Hedgehog","Parrot","Tiger","Kangaroo","Penguin"],
+  fruit: ["Durian","Mango","Banana","Coconut","Kiwi","Lemon","Peach"],
+  insect: ["Butterfly","Bee","Ladybug","Dragonfly","Firefly","Caterpillar"],
+  spirit: ["Forest Spirit","River Sprite","Sky Wisp","Sunbeam","Moonlight"],
+};
+
+type Props = {
+  value: NavatarTraits;
+  onChange: (t: NavatarTraits) => void;
+};
+
+export default function TraitSelector({ value, onChange }: Props) {
+  const [local, setLocal] = useState<NavatarTraits>(value);
+
+  function update<K extends keyof NavatarTraits>(k: K, v: NavatarTraits[K]) {
+    const next = { ...local, [k]: v };
+    setLocal(next);
+    onChange(next);
+  }
+
+  return (
+    <div className="stack gap-3">
+      <div>
+        <label>Realm</label>
+        <div className="row wrap gap-2">
+          {REALMS.map(r => (
+            <button
+              key={r}
+              className={`chip ${local.realm===r ? "chip--active":""}`}
+              onClick={() => update("realm", r)}
+              type="button"
+            >{r}</button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label>Species</label>
+        <select value={local.species} onChange={e => update("species", e.target.value)}>
+          {SPECIES[local.realm].map(s => <option key={s} value={s}>{s}</option>)}
+        </select>
+      </div>
+
+      <div>
+        <label>Color</label>
+        <div className="row gap-2">
+          {COLORS.map(c => (
+            <button
+              key={c}
+              aria-label={c}
+              onClick={() => update("color", c)}
+              type="button"
+              style={{ width: 28, height: 28, borderRadius: 999, background: c, border: local.color===c ? "2px solid #111" : "2px solid #fff" }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label>Eyes</label>
+        <select value={local.eyes} onChange={e => update("eyes", e.target.value as any)}>
+          <option value="happy">happy</option>
+          <option value="kind">kind</option>
+          <option value="sleepy">sleepy</option>
+          <option value="hero">hero</option>
+        </select>
+      </div>
+
+      <div>
+        <label>Accessory</label>
+        <select value={local.accessory ?? "none"} onChange={e => update("accessory", e.target.value as any)}>
+          <option value="none">none</option>
+          <option value="crown">crown</option>
+          <option value="flower">flower</option>
+          <option value="glasses">glasses</option>
+          <option value="scarf">scarf</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -1,0 +1,82 @@
+import { supabase } from "@/supabaseClient";
+
+export type NavatarTraits = {
+  realm: "animal" | "fruit" | "insect" | "spirit";
+  species: string;
+  color: string;
+  eyes: "happy" | "kind" | "sleepy" | "hero";
+  accessory?: "none" | "crown" | "flower" | "glasses" | "scarf";
+};
+
+export type NavatarRecord = {
+  id: string;
+  user_id: string;
+  svg: string;
+  traits: NavatarTraits;
+  updated_at: string;
+};
+
+export function makeNavatarSVG(traits: NavatarTraits): string {
+  // simple inline SVG avatar – deterministic from traits, CSP-safe (no eval)
+  const baseFill = traits.color || "#7dd3fc";
+  const eye = traits.eyes === "sleepy" ? "M2 2h4" : "M1 1h2 M5 1h2";
+  const accessory =
+    traits.accessory === "crown"
+      ? `<path d="M6 1l2 3 2-3 2 3 2-3v2H6z" fill="#facc15"/>`
+      : traits.accessory === "flower"
+      ? `<circle cx="6" cy="2" r="1" fill="#f472b6"/><path d="M6 3v2" stroke="#f472b6"/>`
+      : traits.accessory === "glasses"
+      ? `<circle cx="5" cy="5" r="1" stroke="#111" fill="none"/><circle cx="9" cy="5" r="1" stroke="#111" fill="none"/><path d="M6 5h2" stroke="#111"/>`
+      : traits.accessory === "scarf"
+      ? `<path d="M4 10h6v2H4z" fill="#ef4444"/>`
+      : "";
+
+  const label = `${traits.realm} • ${traits.species}`;
+  return `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" width="320" height="320">
+  <rect x="0" y="0" width="14" height="14" rx="3" fill="${baseFill}"/>
+  <circle cx="7" cy="6" r="4" fill="#fff"/>
+  <path d="${eye}" stroke="#111" stroke-width="0.5" stroke-linecap="round" transform="translate(3,5)"/>
+  ${accessory}
+  <text x="7" y="13" font-size="1.2" text-anchor="middle" fill="#0f172a" font-family="system-ui, sans-serif">${label}</text>
+</svg>`.trim();
+}
+
+export async function saveNavatar(userId: string, traits: NavatarTraits) {
+  if (!supabase) throw new Error("Supabase client not initialized");
+  const svg = makeNavatarSVG(traits);
+  const { data: existing, error: getErr } = await supabase
+    .from("user_avatars")
+    .select("id")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (getErr) throw getErr;
+
+  if (existing?.id) {
+    const { error } = await supabase
+      .from("user_avatars")
+      .update({ svg, traits })
+      .eq("id", existing.id);
+    if (error) throw error;
+    return { id: existing.id, svg, traits };
+  } else {
+    const { data, error } = await supabase
+      .from("user_avatars")
+      .insert({ user_id: userId, svg, traits })
+      .select()
+      .single();
+    if (error) throw error;
+    return data as NavatarRecord;
+  }
+}
+
+export async function fetchNavatar(userId: string): Promise<NavatarRecord | null> {
+  if (!supabase) throw new Error("Supabase client not initialized");
+  const { data, error } = await supabase
+    .from("user_avatars")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw error;
+  return (data as NavatarRecord) ?? null;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,7 @@ import ZonePartners from "./routes/zones/Partners";
 import ZoneNaturversity from "./routes/zones/Naturversity";
 import ZoneParents from "./routes/zones/Parents";
 import ZoneNaturBank from "./routes/zones/NaturBank";
+import NavatarCreator from "./routes/zones/Navatar";
 
 // Arcade
 import Arcade from "./routes/arcade/Arcade";
@@ -58,6 +59,7 @@ const router = createBrowserRouter([
       { index: true, element: <Home /> },
 
       { path: "naturbank", element: <ZoneNaturBank /> },
+      { path: "navatar", element: <NavatarCreator /> },
 
       // Worlds
       { path: "worlds", element: <Worlds /> },

--- a/src/root/Root.tsx
+++ b/src/root/Root.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet } from "react-router-dom";
+import NavatarChip from "@/components/NavatarChip";
 
 export default function Root() {
   return (
@@ -12,6 +13,7 @@ export default function Root() {
           <NavLink to="/naturbank">NaturBank</NavLink>
           <NavLink to="/arcade">Arcade</NavLink>
           <NavLink to="/marketplace">Marketplace</NavLink>
+          <NavLink to="/navatar">Navatar</NavLink>
           <NavLink to="/stories">Stories</NavLink>
           <NavLink to="/quizzes">Quizzes</NavLink>
           <NavLink to="/observations">Observations</NavLink>
@@ -19,6 +21,7 @@ export default function Root() {
           <NavLink to="/tips">Turian Tips</NavLink>
           <NavLink to="/profile">Profile</NavLink>
         </nav>
+        <NavatarChip />
       </header>
 
       <main className="content">

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -12,6 +12,15 @@ export default function Home() {
             </div>
           </a>
         </li>
+        <li className="card">
+          <a className="card-link" href="/navatar">
+            <div className="card-emoji">🧩</div>
+            <div>
+              <div className="card-title">Navatar Creator</div>
+              <div className="card-sub">Build your character for the Naturverse</div>
+            </div>
+          </a>
+        </li>
       </ul>
     </>
   );

--- a/src/routes/marketplace/Checkout.tsx
+++ b/src/routes/marketplace/Checkout.tsx
@@ -1,8 +1,21 @@
+import { useEffect, useState } from "react";
 import { useStore } from "../../store/Store";
-import { supabase } from "../../lib/supabase";
+import { fetchNavatar, type NavatarRecord } from "@/lib/navatar";
+import { supabase } from "@/supabaseClient";
 
 export default function MarketCheckout(){
   const { state, dispatch } = useStore();
+  const [navatar, setNavatar] = useState<NavatarRecord | null>(null);
+  useEffect(() => {
+    if (!supabase) return;
+    (async () => {
+      const { data } = await supabase.auth.getUser();
+      const uid = data.user?.id;
+      if (!uid) return;
+      const r = await fetchNavatar(uid);
+      setNavatar(r);
+    })();
+  }, []);
   const total = state.cart.reduce((n,i)=>n+i.qty*i.price,0);
   const pay = async () => {
     if (supabase && state.cart.length){
@@ -20,14 +33,25 @@ export default function MarketCheckout(){
       <h3>Checkout</h3>
       <p>Items: {state.cart.reduce((n,i)=>n+i.qty,0)} · Total: <strong>${total}</strong></p>
       <div className="grid2">
-        <input placeholder="Full name" />
-        <input placeholder="Email" />
-        <input placeholder="Address" />
-        <input placeholder="City" />
-        <input placeholder="Card number" />
-        <input placeholder="Expiry / CVC" />
+        <div>
+          <div className="grid2">
+            <input placeholder="Full name" />
+            <input placeholder="Email" />
+            <input placeholder="Address" />
+            <input placeholder="City" />
+            <input placeholder="Card number" />
+            <input placeholder="Expiry / CVC" />
+          </div>
+          <button onClick={pay}>Pay now</button>
+        </div>
+        {navatar && (
+          <div className="card" style={{ padding:12 }}>
+            <div style={{ fontWeight:600, marginBottom:6 }}>My Navatar</div>
+            <div dangerouslySetInnerHTML={{ __html: navatar.svg }} />
+            <small className="muted">We’ll print this on your plushie/shirt when ordering.</small>
+          </div>
+        )}
       </div>
-      <button onClick={pay}>Pay now</button>
     </>
   );
 }

--- a/src/routes/zones/Navatar.tsx
+++ b/src/routes/zones/Navatar.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useMemo, useState } from "react";
+import TraitSelector from "@/components/navatar/TraitSelector";
+import Preview from "@/components/navatar/Preview";
+import { makeNavatarSVG, saveNavatar, fetchNavatar, type NavatarTraits } from "@/lib/navatar";
+import { supabase } from "@/supabaseClient";
+
+const DEFAULT: NavatarTraits = {
+  realm: "fruit",
+  species: "Durian",
+  color: "#7dd3fc",
+  eyes: "happy",
+  accessory: "none",
+};
+
+export default function NavatarCreator() {
+  const [userId, setUserId] = useState<string | null>(null);
+  const [traits, setTraits] = useState<NavatarTraits>(DEFAULT);
+  const svg = useMemo(() => makeNavatarSVG(traits), [traits]);
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!supabase) { setLoaded(true); return; }
+    supabase.auth.getUser().then(({ data }) => {
+      const uid = data.user?.id ?? null;
+      setUserId(uid);
+      if (uid) init(uid);
+      else setLoaded(true);
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function init(uid: string) {
+    try {
+      const existing = await fetchNavatar(uid);
+      if (existing) {
+        setTraits(existing.traits);
+      }
+    } finally {
+      setLoaded(true);
+    }
+  }
+
+  async function onSave() {
+    if (!userId) {
+      alert("Please sign in to save your Navatar.");
+      return;
+    }
+    setSaving(true);
+    try {
+      await saveNavatar(userId, traits);
+      alert("Navatar saved! You can now use it across worlds and in the marketplace.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function downloadSVG() {
+    const blob = new Blob([svg], { type: "image/svg+xml;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = "navatar.svg"; a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <>
+      <h3>Create your Navatar ✨</h3>
+      <p className="muted">Pick a realm, species, colors and accessories. Save to use it in Worlds, Arcade, and the Marketplace.</p>
+
+      {!loaded ? <p>Loading…</p> : (
+        <div className="grid-2 gap-6">
+          <div className="stack gap-4">
+            <TraitSelector value={traits} onChange={setTraits}/>
+            <div className="row gap-2">
+              <button onClick={onSave} disabled={saving}>{saving ? "Saving…" : "Save Navatar"}</button>
+              <button onClick={downloadSVG} type="button">Download SVG</button>
+            </div>
+            {!userId && <div className="note">Tip: sign in to save your Navatar to your profile.</div>}
+          </div>
+          <Preview svg={svg}/>
+        </div>
+      )}
+
+      <style>{`
+        .grid-2 { display:grid; grid-template-columns: 1fr; }
+        @media(min-width: 900px){ .grid-2{ grid-template-columns: 1fr 1fr; } }
+        .stack{ display:flex; flex-direction:column; }
+        .row{ display:flex; align-items:center; }
+        .wrap{ flex-wrap: wrap; }
+        .gap-2{ gap:8px; } .gap-3{ gap:12px; } .gap-4{ gap:16px; } .gap-6{ gap:24px; }
+        .chip{ padding:6px 10px; border:1px solid #cbd5e1; border-radius:999px; background:#fff; }
+        .chip--active{ background:#111; color:#fff; border-color:#111; }
+        label{ display:block; font-weight:600; margin-bottom:6px; }
+        select{ padding:8px; border-radius:8px; border:1px solid #cbd5e1; background:#fff; }
+        button{ padding:10px 14px; border-radius:10px; border:1px solid #0f172a; background:#0f172a; color:#fff; }
+        .muted{ color:#64748b; }
+        .note{ font-size: 14px; color:#0f172a; background:#f1f5f9; padding:10px; border-radius:8px; }
+      `}</style>
+    </>
+  );
+}

--- a/src/routes/zones/Zones.tsx
+++ b/src/routes/zones/Zones.tsx
@@ -9,6 +9,7 @@ const links = [
   ["partners","Partners"],
   ["naturversity","Naturversity"],
   ["parents","Parents"],
+  ["navatar","Navatar Creator"],
 ];
 
 export default function Zones() {

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,0 +1,1 @@
+export { supabase } from "./lib/supabase";

--- a/supabase/migrations/2025-08-21_create_user_avatars.sql
+++ b/supabase/migrations/2025-08-21_create_user_avatars.sql
@@ -1,0 +1,9 @@
+create table if not exists user_avatars (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  svg text not null,
+  traits jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_user_avatars_user_id on user_avatars(user_id);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,10 @@
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "baseUrl": "./src",
-    "paths": {},
+    "paths": {
+      "@/*": ["*"],
+      "@": ["."]
+    },
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,17 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   base: "/",               // important for Netlify at root domain
   build: { outDir: "dist" }, // publish = dist
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "src"),
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- create `user_avatars` table migration for storing user-generated SVG avatars
- add Navatar builder library and zone with trait selection & preview
- show saved Navatar chip in header and on marketplace checkout, plus navigation links and route wiring

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a6115c74ec8329b2f0b02c9a178432