### PR TITLE
Add passport system, NFT minting, and AI guide

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import NaturbankHub from "./routes/naturbank";
 import Wallets from "./routes/naturbank/wallets";
 import NaturToken from "./routes/naturbank/natur-token";
 import LearnCrypto from "./routes/naturbank/learn";
+import NFTsPage from "./routes/naturbank/nfts";
 import NaturversityHub from "./routes/naturversity";
 import Teachers from "./routes/naturversity/teachers";
 import Partners from "./routes/naturversity/partners";
@@ -26,6 +27,8 @@ import Catalog from "./routes/marketplace/catalog";
 import Wishlist from "./routes/marketplace/wishlist";
 import Checkout from "./routes/marketplace/checkout";
 import NavatarPage from "./routes/navatar";
+import PassportPage from "./routes/passport";
+import TurianGuide from "./routes/turian";
 // If you already have a profile page, keep your existing import:
 import Profile from "./routes/profile/Profile"; // or "./routes/profile" if that’s your file
 
@@ -43,6 +46,7 @@ export default function App() {
         <Route path="/naturbank/wallets" element={<Wallets />} />
         <Route path="/naturbank/natur-token" element={<NaturToken />} />
         <Route path="/naturbank/learn" element={<LearnCrypto />} />
+        <Route path="/naturbank/nfts" element={<NFTsPage />} />
 
         <Route path="/naturversity" element={<NaturversityHub />} />
         <Route path="/naturversity/teachers" element={<Teachers />} />
@@ -64,6 +68,8 @@ export default function App() {
         <Route path="/marketplace/checkout" element={<Checkout />} />
 
         <Route path="/navatar" element={<NavatarPage />} />
+        <Route path="/passport" element={<PassportPage />} />
+        <Route path="/turian" element={<TurianGuide />} />
         <Route path="/profile" element={<Profile />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,7 +7,7 @@ const activeStyle: React.CSSProperties = { background: "#eef2ff", color: "#3730a
 export default function Header() {
   return (
     <header style={{ borderBottom: "1px solid #e5e7eb", background: "#fff" }}>
-      <div style={{ maxWidth: 1200, margin: "0 auto", padding: "12px 16px", display: "flex", alignItems: "center", gap: 16 }}>
+      <div style={{ maxWidth: 1200, margin: "0 auto", padding: "12px 16px", display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
         <Link to="/" style={{ ...linkStyle, fontWeight: 700 }}>Naturverse</Link>
         <nav style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
           <NavLink to="/worlds" style={({ isActive }) => ({ ...linkStyle, ...(isActive ? activeStyle : {}) })}>Worlds</NavLink>
@@ -16,6 +16,8 @@ export default function Header() {
           <NavLink to="/naturversity" style={({ isActive }) => ({ ...linkStyle, ...(isActive ? activeStyle : {}) })}>Naturversity</NavLink>
           <NavLink to="/naturbank" style={({ isActive }) => ({ ...linkStyle, ...(isActive ? activeStyle : {}) })}>Naturbank</NavLink>
           <NavLink to="/navatar" style={({ isActive }) => ({ ...linkStyle, ...(isActive ? activeStyle : {}) })}>Navatar</NavLink>
+          <NavLink to="/passport" style={({ isActive }) => ({ ...linkStyle, ...(isActive ? activeStyle : {}) })}>Passport</NavLink>
+          <NavLink to="/turian" style={({ isActive }) => ({ ...linkStyle, ...(isActive ? activeStyle : {}) })}>Turian</NavLink>
           <NavLink to="/profile" style={({ isActive }) => ({ ...linkStyle, ...(isActive ? activeStyle : {}) })}>Profile</NavLink>
         </nav>
       </div>

--- a/src/lib/passport.ts
+++ b/src/lib/passport.ts
@@ -1,0 +1,67 @@
+export type Stamp = { world: string; date: string };
+export type Badge = { id: string; label: string; earnedAt: string };
+export type Passport = {
+  holder?: { name?: string; navatarType?: string; traits?: string[]; imageUrl?: string };
+  xp: number;
+  coins: number;
+  stamps: Stamp[];
+  badges: Badge[];
+  nfts: { id: string; name: string; imageUrl?: string; fromNavatar?: boolean }[];
+};
+
+const KEY = "naturverse_passport";
+
+export function loadPassport(): Passport {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (raw) return JSON.parse(raw) as Passport;
+  } catch {}
+  return { xp: 0, coins: 0, stamps: [], badges: [], nfts: [] };
+}
+
+export function savePassport(p: Passport) {
+  localStorage.setItem(KEY, JSON.stringify(p));
+}
+
+export function addStamp(world: string) {
+  const p = loadPassport();
+  if (!p.stamps.some(s => s.world === world)) {
+    p.stamps.push({ world, date: new Date().toISOString() });
+    p.xp += 25;
+    savePassport(p);
+  }
+  return p;
+}
+
+export function addBadge(id: string, label: string) {
+  const p = loadPassport();
+  if (!p.badges.some(b => b.id === id)) {
+    p.badges.push({ id, label, earnedAt: new Date().toISOString() });
+    p.xp += 50;
+    savePassport(p);
+  }
+  return p;
+}
+
+export function addCoins(amount: number) {
+  const p = loadPassport();
+  p.coins += amount;
+  savePassport(p);
+  return p;
+}
+
+export function mintLocalNFT(name: string, imageUrl?: string, fromNavatar?: boolean) {
+  const p = loadPassport();
+  const id = `nft_${Date.now()}`;
+  p.nfts.push({ id, name, imageUrl, fromNavatar });
+  p.xp += 10;
+  savePassport(p);
+  return { id, passport: p };
+}
+
+export function updateHolder(holder: Passport["holder"]) {
+  const p = loadPassport();
+  p.holder = { ...(p.holder || {}), ...holder };
+  savePassport(p);
+  return p;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import "./styles/global.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,6 +10,8 @@ export default function Home() {
     { to: "/naturversity", title: "Naturversity", emoji: "🎓", description: "Teachers, partners, and courses." },
     { to: "/naturbank", title: "Naturbank", emoji: "🪙", description: "Wallets, NATUR token, and crypto basics." },
     { to: "/navatar", title: "Navatar", emoji: "🧩", description: "Create your character." },
+    { to: "/passport", title: "Passport", emoji: "🛂", description: "Track stamps, badges, XP & coins." },
+    { to: "/turian", title: "Turian", emoji: "🦔", description: "AI guide for tips & quests." },
     { to: "/profile", title: "Profile", emoji: "👤", description: "Your account and saved navatar." },
   ];
 

--- a/src/routes/naturbank/index.tsx
+++ b/src/routes/naturbank/index.tsx
@@ -7,11 +7,12 @@ export default function NaturbankHub() {
   return (
     <>
       <Breadcrumbs items={[{ to: "/", label: "Home" }, { label: "Naturbank" }]} />
-      <SectionHero title="Naturbank" subtitle="Wallets, NATUR token, and crypto basics." emoji="🪙" />
+      <SectionHero title="Naturbank" subtitle="Wallets, NATUR token, NFTs, and crypto basics." emoji="🪙" />
       <HubGrid
         items={[
           { to: "/naturbank/wallets", title: "Wallets", emoji: "👛", description: "Connect & custodial basics." },
           { to: "/naturbank/natur-token", title: "NATUR Token", emoji: "🌿", description: "Balances & testnets." },
+          { to: "/naturbank/nfts", title: "NFTs", emoji: "🧾", description: "Mint & collect." },
           { to: "/naturbank/learn", title: "Learn Crypto", emoji: "📘", description: "Beginner-friendly guides." },
         ]}
       />

--- a/src/routes/naturbank/nfts.tsx
+++ b/src/routes/naturbank/nfts.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+import Breadcrumbs from "../../components/common/Breadcrumbs";
+import SectionHero from "../../components/common/SectionHero";
+import { loadPassport, mintLocalNFT } from "../../lib/passport";
+
+export default function NFTsPage() {
+  const [name, setName] = useState("My Navatar NFT");
+  const [imageUrl, setImageUrl] = useState("");
+  const [owned, setOwned] = useState(loadPassport().nfts);
+
+  function onMint() {
+    const { passport } = mintLocalNFT(name.trim() || "Navatar NFT", imageUrl || undefined, true);
+    setOwned(passport.nfts.slice().reverse());
+  }
+
+  return (
+    <>
+      <Breadcrumbs items={[{ to: "/", label: "Home" }, { to: "/naturbank", label: "Naturbank" }, { label: "NFTs" }]} />
+      <SectionHero title="NFTs" subtitle="Mint & collect." emoji="🧾" />
+      <div style={{ maxWidth: 1000, margin: "0 auto", padding: "0 16px 48px" }}>
+        <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16, marginBottom: 24, background: "#fff" }}>
+          <h3 style={{ marginTop: 0 }}>Mint a Placeholder NFT</h3>
+          <div style={{ display: "grid", gap: 8, maxWidth: 520 }}>
+            <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" />
+            <input value={imageUrl} onChange={e => setImageUrl(e.target.value)} placeholder="Image URL (optional)" />
+            <button onClick={onMint} style={{ padding: "8px 12px" }}>Mint (local)</button>
+          </div>
+          <p style={{ marginTop: 8, fontSize: 12, opacity: 0.7 }}>
+            This stores a mock NFT in your browser for now. Later we’ll hook real chains.
+          </p>
+        </div>
+
+        <h3>Your NFTs</h3>
+        <div style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}>
+          {owned.length === 0 ? <p>No NFTs yet.</p> : owned.map(n => (
+            <div key={n.id} style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 12, background: "#fff" }}>
+              {n.imageUrl ? <img src={n.imageUrl} alt={n.name} style={{ width: "100%", borderRadius: 8, objectFit: "cover", height: 140 }} /> : null}
+              <div style={{ fontWeight: 600, marginTop: 8 }}>{n.name}</div>
+              <div style={{ fontSize: 12, opacity: 0.7 }}>{n.id}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/routes/navatar.tsx
+++ b/src/routes/navatar.tsx
@@ -1,14 +1,97 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import Breadcrumbs from "../components/common/Breadcrumbs";
 import SectionHero from "../components/common/SectionHero";
+import { mintLocalNFT, updateHolder, loadPassport } from "../lib/passport";
+
+const TYPES = ["fruit", "animal", "insect", "spirit"] as const;
+const TRAIT_BANK = ["brave", "curious", "clever", "kind", "swift", "gentle", "loud", "quiet", "sparkly", "sneaky"];
 
 export default function NavatarPage() {
+  const initial = loadPassport().holder;
+  const [navType, setNavType] = useState<string>(initial?.navatarType || "fruit");
+  const [name, setName] = useState(initial?.name || "");
+  const [traits, setTraits] = useState<string[]>(initial?.traits || []);
+  const [imageUrl, setImageUrl] = useState(initial?.imageUrl || "");
+  const [story, setStory] = useState("");
+
+  const traitOptions = useMemo(() => TRAIT_BANK, []);
+
+  function toggleTrait(t: string) {
+    setTraits(s => s.includes(t) ? s.filter(x => x !== t) : [...s, t]);
+  }
+
+  function saveProfile() {
+    updateHolder({ name, navatarType: navType, traits, imageUrl });
+    alert("Navatar saved to Passport.");
+  }
+
+  function genStory() {
+    const t = (traits[0] || "brave");
+    const s = `Born under the starlight, ${name || "your Navatar"} is a ${t} ${navType} who roams the realms helping friends, collecting stamps, and earning NATUR.`;
+    setStory(s);
+  }
+
+  function mintCard() {
+    const title = name ? `${name} — ${navType} card` : `Navatar — ${navType} card`;
+    mintLocalNFT(title, imageUrl || undefined, true);
+    alert("Minted local Navatar card to your NFTs.");
+  }
+
   return (
     <>
       <Breadcrumbs items={[{ to: "/", label: "Home" }, { label: "Navatar" }]} />
-      <SectionHero title="Navatar Creator" subtitle="Build your character." emoji="🧩" />
-      <div style={{ maxWidth: 900, margin: "0 auto", padding: "0 16px 48px" }}>
-        <p>Stub page.</p>
+      <SectionHero title="Navatar Creator" subtitle="Design your character, story, and card." emoji="🧩" />
+      <div style={{ maxWidth: 1100, margin: "0 auto", padding: "0 16px 48px", display: "grid", gap: 16 }}>
+        <div style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(280px,1fr))" }}>
+          <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16, background: "#fff" }}>
+            <h3 style={{ marginTop: 0 }}>1) Basics</h3>
+            <label>Name</label>
+            <input value={name} onChange={e => setName(e.target.value)} placeholder="Turian, Mango Mike, ..." />
+            <label style={{ marginTop: 8, display: "block" }}>Type</label>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              {TYPES.map(t => (
+                <button
+                  key={t}
+                  onClick={() => setNavType(t)}
+                  style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #e5e7eb", background: navType === t ? "#eef2ff" : "#fff" }}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+            <label style={{ marginTop: 8, display: "block" }}>Avatar Image URL (optional)</label>
+            <input value={imageUrl} onChange={e => setImageUrl(e.target.value)} placeholder="https://..." />
+            <button style={{ marginTop: 12 }} onClick={saveProfile}>Save to Passport</button>
+          </div>
+
+          <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16, background: "#fff" }}>
+            <h3 style={{ marginTop: 0 }}>2) Traits</h3>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              {traitOptions.map(t => (
+                <button
+                  key={t}
+                  onClick={() => toggleTrait(t)}
+                  style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #e5e7eb", background: traits.includes(t) ? "#dcfce7" : "#fff" }}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16, background: "#fff" }}>
+            <h3 style={{ marginTop: 0 }}>3) Backstory (AI stub)</h3>
+            <p style={{ fontSize: 12, opacity: 0.8 }}>Click generate to draft a backstory. (Placeholder; connect to OpenAI later.)</p>
+            <button onClick={genStory}>Generate Backstory</button>
+            <textarea value={story} onChange={e => setStory(e.target.value)} rows={6} style={{ width: "100%", marginTop: 8 }} />
+          </div>
+
+          <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16, background: "#fff" }}>
+            <h3 style={{ marginTop: 0 }}>4) Character Card / NFT</h3>
+            <button onClick={mintCard}>Mint Navatar Card (local)</button>
+            <p style={{ fontSize: 12, opacity: 0.8, marginTop: 8 }}>View in Naturbank → NFTs.</p>
+          </div>
+        </div>
       </div>
     </>
   );

--- a/src/routes/passport.tsx
+++ b/src/routes/passport.tsx
@@ -1,0 +1,117 @@
+import React, { useMemo, useState } from "react";
+import Breadcrumbs from "../components/common/Breadcrumbs";
+import SectionHero from "../components/common/SectionHero";
+import { addBadge, addCoins, addStamp, loadPassport, updateHolder } from "../lib/passport";
+
+export default function PassportPage() {
+  const [p, setP] = useState(loadPassport());
+  const stats = useMemo(() => ({
+    worlds: p.stamps.length, badges: p.badges.length, xp: p.xp, coins: p.coins
+  }), [p]);
+
+  return (
+    <>
+      <Breadcrumbs items={[{ to: "/", label: "Home" }, { label: "Passport" }]} />
+      <SectionHero title="Passport" subtitle="Your stamps, badges, XP & coins." emoji="🛂" />
+      <div style={{ maxWidth: 1100, margin: "0 auto", padding: "0 16px 48px", display: "grid", gap: 16 }}>
+        <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(200px,1fr))" }}>
+          <StatCard label="Worlds Visited" value={String(stats.worlds)} />
+          <StatCard label="Badges" value={String(stats.badges)} />
+          <StatCard label="XP" value={String(stats.xp)} />
+          <StatCard label="NATUR Coins" value={String(stats.coins)} />
+        </div>
+
+        <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16, background: "#fff" }}>
+          <h3 style={{ marginTop: 0 }}>Holder</h3>
+          <div style={{ display: "grid", gap: 8, maxWidth: 520 }}>
+            <input
+              defaultValue={p.holder?.name || ""}
+              placeholder="Adventurer name"
+              onBlur={e => { setP(updateHolder({ name: e.target.value })); }}
+            />
+            <input
+              defaultValue={p.holder?.navatarType || ""}
+              placeholder="Navatar type (fruit/animal/insect/spirit)"
+              onBlur={e => { setP(updateHolder({ navatarType: e.target.value })); }}
+            />
+            <input
+              defaultValue={(p.holder?.traits || []).join(", ")}
+              placeholder="Traits (comma separated)"
+              onBlur={e => { setP(updateHolder({ traits: e.target.value.split(",").map(s => s.trim()).filter(Boolean) })); }}
+            />
+          </div>
+        </div>
+
+        <div style={{ display: "grid", gap: 16, gridTemplateColumns: "repeat(auto-fit, minmax(280px,1fr))" }}>
+          <Panel title="Stamps">
+            {p.stamps.length === 0 ? <p>No stamps yet.</p> : (
+              <ul>
+                {p.stamps.map(s => <li key={s.world}>{s.world} — {new Date(s.date).toLocaleString()}</li>)}
+              </ul>
+            )}
+            <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+              <input id="stamp-world" placeholder="Add world slug e.g. thailandia" />
+              <button onClick={() => {
+                const input = document.getElementById("stamp-world") as HTMLInputElement;
+                if (!input.value.trim()) return;
+                setP(addStamp(input.value.trim()));
+                input.value = "";
+              }}>Add Stamp</button>
+            </div>
+          </Panel>
+
+          <Panel title="Badges">
+            {p.badges.length === 0 ? <p>No badges yet.</p> : (
+              <ul>
+                {p.badges.map(b => <li key={b.id}>{b.label} — {new Date(b.earnedAt).toLocaleString()}</li>)}
+              </ul>
+            )}
+            <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+              <input id="badge-id" placeholder="badge id" />
+              <input id="badge-label" placeholder="label" />
+              <button onClick={() => {
+                const id = (document.getElementById("badge-id") as HTMLInputElement).value.trim();
+                const label = (document.getElementById("badge-label") as HTMLInputElement).value.trim();
+                if (!id || !label) return;
+                setP(addBadge(id, label));
+                (document.getElementById("badge-id") as HTMLInputElement).value = "";
+                (document.getElementById("badge-label") as HTMLInputElement).value = "";
+              }}>Add Badge</button>
+            </div>
+          </Panel>
+
+          <Panel title="Coins">
+            <p>Balance: <b>{p.coins}</b> NATUR</p>
+            <div style={{ display: "flex", gap: 8 }}>
+              <input id="coin-amt" placeholder="amount" type="number" />
+              <button onClick={() => {
+                const amt = Number((document.getElementById("coin-amt") as HTMLInputElement).value);
+                if (!Number.isFinite(amt)) return;
+                setP(addCoins(amt));
+                (document.getElementById("coin-amt") as HTMLInputElement).value = "";
+              }}>Add Coins</button>
+            </div>
+          </Panel>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16, background: "#fff" }}>
+      <div style={{ opacity: 0.7, fontSize: 12 }}>{label}</div>
+      <div style={{ fontSize: 28, fontWeight: 700 }}>{value}</div>
+    </div>
+  );
+}
+
+function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16, background: "#fff" }}>
+      <h3 style={{ marginTop: 0 }}>{title}</h3>
+      {children}
+    </div>
+  );
+}

--- a/src/routes/turian.tsx
+++ b/src/routes/turian.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import Breadcrumbs from "../components/common/Breadcrumbs";
+import SectionHero from "../components/common/SectionHero";
+
+type Msg = { role: "user" | "guide"; text: string };
+
+export default function TurianGuide() {
+  const [log, setLog] = useState<Msg[]>([
+    { role: "guide", text: "Sawasdee! I’m Turian the Durian. Where shall we journey today?" }
+  ]);
+  const [text, setText] = useState("");
+
+  function send() {
+    if (!text.trim()) return;
+    const next: Msg[] = [...log, { role: "user", text }];
+    // placeholder reply
+    next.push({ role: "guide", text: "Yum! Great idea. I’ll add that to your quest log. 🍃" });
+    setLog(next);
+    setText("");
+  }
+
+  return (
+    <>
+      <Breadcrumbs items={[{ to: "/", label: "Home" }, { label: "Turian" }]} />
+      <SectionHero title="Turian the AI Guide" subtitle="Ask for tips, quests, and help." emoji="🦔" />
+      <div style={{ maxWidth: 900, margin: "0 auto", padding: "0 16px 48px" }}>
+        <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 12, background: "#fff", height: 420, overflowY: "auto" }}>
+          {log.map((m, i) => (
+            <div key={i} style={{ margin: "8px 0", textAlign: m.role === "user" ? "right" : "left" }}>
+              <div style={{
+                display: "inline-block",
+                background: m.role === "user" ? "#dbeafe" : "#dcfce7",
+                padding: "8px 10px",
+                borderRadius: 10,
+                maxWidth: "70%"
+              }}>
+                {m.text}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+          <input value={text} onChange={e => setText(e.target.value)} style={{ flex: 1 }} placeholder="Ask Turian..." />
+          <button onClick={send}>Send</button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/routes/worlds/[slug]/index.tsx
+++ b/src/routes/worlds/[slug]/index.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import Breadcrumbs from "../../../components/common/Breadcrumbs";
 import SectionHero from "../../../components/common/SectionHero";
 import { WORLDS } from "../../../data/worlds";
+import { addStamp, addBadge, addCoins } from "../../../lib/passport";
 
 export default function WorldDetail() {
   const { slug } = useParams();
@@ -27,6 +28,11 @@ export default function WorldDetail() {
       />
       <div style={{ maxWidth: 1200, margin: "0 auto", padding: "0 16px 48px" }}>
         <p>{world.blurb}</p>
+        <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+          <button onClick={() => addStamp(world.slug)}>Get Stamp</button>
+          <button onClick={() => addBadge(`badge_${world.slug}`, `${world.name} Explorer`)}>Earn Badge</button>
+          <button onClick={() => addCoins(5)}>+5 NATUR Coins</button>
+        </div>
       </div>
     </>
   );

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,6 @@
+* { box-sizing: border-box; }
+body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #f8fafc; color: #111827; }
+input, button, textarea { border: 1px solid #e5e7eb; border-radius: 8px; padding: 8px 10px; }
+button { cursor: pointer; background: #fff; }
+button:hover { background: #f3f4f6; }
+label { font-size: 12px; opacity: .8; }


### PR DESCRIPTION
## Summary
- Implement local passport with stamps, badges, coins, and NFTs persisted in browser
- Upgrade Navatar creator, add NFT minting page, Passport dashboard, and Turian AI guide
- Wire new routes, header links, home hub entries, world reward buttons, and global styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a624cd9b088329abbcfd881c2277b3