### PR TITLE
chore: add lightweight OpenAI chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Backend (Functions)
+# Serverless key (add in Netlify > Site settings > Environment)
 OPENAI_API_KEY=
 
 # Frontend (Vite)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,12 @@
 [build]
-  command = "npm install --no-audit --no-fund && npm run build"
+  command = "npm run build"
   publish = "dist"
+  functions = "netlify/functions"
 
 [functions]
-  directory = "netlify/functions"
   node_bundler = "esbuild"
-  external_node_modules = ["openai"]
 
-# SPA fallback
+# SPA routing
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.45.5",
         "@netlify/functions": "^2.6.0",
-        "openai": "^4.57.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.28.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.45.5",
     "@netlify/functions": "^2.6.0",
-    "openai": "^4.57.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.28.0"

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,0 +1,10 @@
+export async function askTurian(prompt: string, system?: string) {
+  const r = await fetch("/.netlify/functions/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt, system }),
+  });
+  if (!r.ok) throw new Error(await r.text());
+  const data = (await r.json()) as { text: string };
+  return data.text;
+}


### PR DESCRIPTION
## Summary
- add Netlify function and client helper for Turian chat using OpenAI Responses API via fetch
- remove openai dependency and simplify Netlify build settings

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68a686ac81508329804bc9ae2d977c60