### PR TITLE
chore: refine tsconfig and typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.5",
@@ -17,6 +17,7 @@
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
+    "@types/node": "^20.11.30",
     "typescript": "^5.5.4",
     "vite": "^5.4.9"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,17 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "baseUrl": "./src",
-    "paths": {
-      "@/*": ["*"],
-      "@": ["."]
-    },
-    "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "types": ["node"]
   },
-  "include": ["src", "vite-env.d.ts"]
+  "include": ["src", "netlify/functions/**/*.ts", "vite.config.*"],
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- add `@types/node` dev dependency and point typecheck script at tsconfig
- replace tsconfig with stricter settings including Node types and serverless function coverage

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@netlify%2ffunctions)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a68a54dca0832982a06fc1852e228b