### PR TITLE
Stabilize build & wire serverless OpenAI (no SDK)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-# Serverless key (add in Netlify > Site settings > Environment)
-OPENAI_API_KEY=
-
-# Frontend (Vite)
+# Frontend (optional – app works without them)
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
+
+# Serverless only (set in Netlify UI → Site settings → Environment):
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Node
-node_modules/
+node_modules
 
 # Local env
 .dev.vars
@@ -7,9 +7,10 @@ node_modules/
 
 # env
 .env
+.env.*
 
 # Ignore build output and stray routes
-dist/
+dist
 dist/_routes.json
 
 # keep lockfile for reliable Netlify builds

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,31 +1,27 @@
 [build]
-  command = "npm run build"
-  publish = "dist"
-  functions = "netlify/functions"
+command = "npm ci && npm run build"
+publish = "dist"
+functions = "netlify/functions"
 
+[build.environment]
+NODE_VERSION = "20"
+
+# Bundle TS functions with esbuild
 [functions]
-  node_bundler = "esbuild"
+node_bundler = "esbuild"
 
-# SPA routing
+# Single Page App routing
 [[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+from = "/*"
+to = "/index.html"
+status = 200
 
-# Basic security + allow required APIs; keep CSP minimal to avoid blocking app
+# Tight but working CSP; adjust later as you add origins
 [[headers]]
-  for = "/*"
-  [headers.values]
-    X-Frame-Options = "DENY"
-    X-Content-Type-Options = "nosniff"
-    Referrer-Policy = "strict-origin-when-cross-origin"
-    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
-    Content-Security-Policy = """
-      default-src 'self';
-      script-src 'self' 'unsafe-inline' 'unsafe-eval';
-      style-src 'self' 'unsafe-inline';
-      img-src 'self' data: https:;
-      connect-src 'self' https://*.supabase.co https://api.openai.com;
-      font-src 'self' data:;
-      frame-ancestors 'none';
-    """
+for = "/*"
+[headers.values]
+Content-Security-Policy = "default-src 'self'; connect-src 'self' https://api.openai.com https://*.supabase.co; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none'; base-uri 'self';"
+Referrer-Policy = "strict-origin-when-cross-origin"
+X-Content-Type-Options = "nosniff"
+X-Frame-Options = "DENY"
+Permissions-Policy = "geolocation=(), microphone=(), camera=()"

--- a/package.json
+++ b/package.json
@@ -1,27 +1,29 @@
 {
   "name": "naturverse-web",
-  "version": "0.1.0",
   "private": true,
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "preview": "vite preview --port 5173",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.5",
-    "@netlify/functions": "^2.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
-    "@types/node": "^20.11.30",
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react-swc": "^3.6.0",
     "typescript": "^5.5.4",
-    "vite": "^5.4.9"
+    "vite": "^5.4.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20 <21"
   }
 }

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,10 +1,10 @@
-export async function askTurian(prompt: string, system?: string) {
-  const r = await fetch("/.netlify/functions/chat", {
+export async function askTurian(prompt: string): Promise<string> {
+  const res = await fetch("/.netlify/functions/chat", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ prompt, system }),
+    body: JSON.stringify({ prompt })
   });
-  if (!r.ok) throw new Error(await r.text());
-  const data = (await r.json()) as { text: string };
-  return data.text;
+  if (!res.ok) throw new Error(`Chat failed: ${res.status}`);
+  const { text } = await res.json();
+  return text;
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,0 @@
-import { createClient } from "@supabase/supabase-js";
-
-const url  = import.meta.env.VITE_SUPABASE_URL as string | undefined;
-const anon = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
-
-export const supabase = (url && anon) ? createClient(url, anon) : null;

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,8 @@
+import { createClient } from "@supabase/supabase-js";
+
+const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const anon = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+export const supabase = url && anon
+  ? createClient(url, anon)
+  : (undefined as unknown as ReturnType<typeof createClient>);

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,1 +1,1 @@
-export { supabase } from "./lib/supabase";
+export { supabase } from "./lib/supabaseClient";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,21 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,
+    "types": ["node"],
+    "allowJs": false,
     "resolveJsonModule": true,
-    "isolatedModules": true,
     "skipLibCheck": true,
-    "types": ["node"]
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
-  "include": ["src", "netlify/functions/**/*.ts", "vite.config.*"],
+  "include": ["src", "netlify/functions", "vite.config.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,8 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import react from "@vitejs/plugin-react-swc";
 
 export default defineConfig({
   plugins: [react()],
-  base: "/",               // important for Netlify at root domain
-  build: { outDir: "dist" }, // publish = dist
-  resolve: {
-    alias: {
-      "@": resolve(__dirname, "src"),
-    },
-  },
+  server: { port: 5173 },
+  preview: { port: 5173 }
 });


### PR DESCRIPTION
## Summary
- simplify build setup with Vite React SWC, Node 20 engines, and stricter Netlify config
- add safe Supabase client and lightweight chat helper
- implement serverless OpenAI chat function without SDK

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npm run typecheck` *(fails: tsc: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a693a204a0832990b5e496a6026c14