### PR TITLE
feat: add shared layout and navigation

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,22 @@
+import { Outlet, Link } from "react-router-dom";
+import Nav from "./Nav";
+
+export default function Layout() {
+  return (
+    <div style={{ maxWidth: 980, margin: "2rem auto", padding: "0 1rem" }}>
+      <header style={{ marginBottom: "1.25rem" }}>
+        <Link to="/" style={{ color: "inherit", textDecoration: "none" }}>
+          <h1 style={{ fontSize: "2.25rem", margin: 0 }}>
+            Welcome <span role="img" aria-label="leaf">🌿</span>
+          </h1>
+        </Link>
+        <Nav />
+      </header>
+      <Outlet />
+      <footer style={{ opacity: 0.6, marginTop: "3rem", fontSize: ".9rem" }}>
+        © {new Date().getFullYear()} Naturverse
+      </footer>
+    </div>
+  );
+}
+

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,19 +1,27 @@
-import { Link } from 'react-router-dom';
+import { NavLink } from "react-router-dom";
+
+const link = ({ isActive }: { isActive: boolean }) =>
+  ({
+    display: "inline-block",
+    marginRight: "1rem",
+    textDecoration: isActive ? "underline" : "none",
+  }) as React.CSSProperties;
 
 export default function Nav() {
   return (
-    <nav style={{padding:'0.5rem 0', fontWeight:600}}>
-      <Link to="/">Home</Link>{' '}
-      <Link to="/worlds">Worlds</Link>{' '}
-      <Link to="/zones">Zones</Link>{' '}
-      <Link to="/arcade">Arcade</Link>{' '}
-      <Link to="/marketplace">Marketplace</Link>{' '}
-      <Link to="/stories">Stories</Link>{' '}
-      <Link to="/quizzes">Quizzes</Link>{' '}
-      <Link to="/observations">Observations</Link>{' '}
-      <Link to="/naturversity">Naturversity</Link>{' '}
-      <Link to="/tips">Turian Tips</Link>{' '}
-      <Link to="/profile">Profile</Link>
+    <nav style={{ marginTop: "0.75rem" }}>
+      <NavLink to="/" style={link}>Home</NavLink>
+      <NavLink to="/worlds" style={link}>Worlds</NavLink>
+      <NavLink to="/zones" style={link}>Zones</NavLink>
+      <NavLink to="/arcade" style={link}>Arcade</NavLink>
+      <NavLink to="/marketplace" style={link}>Marketplace</NavLink>
+      <NavLink to="/stories" style={link}>Stories</NavLink>
+      <NavLink to="/quizzes" style={link}>Quizzes</NavLink>
+      <NavLink to="/observations" style={link}>Observations</NavLink>
+      <NavLink to="/naturversity" style={link}>Naturversity</NavLink>
+      <NavLink to="/turian" style={link}>Turian Tips</NavLink>
+      <NavLink to="/profile" style={link}>Profile</NavLink>
     </nav>
   );
 }
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,10 @@
+:root { color-scheme: light dark; font-synthesis-weight: none; }
+html, body, #root { height: 100%; }
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  line-height: 1.5;
+}
+a { color: #1e66f5; }
+h1, h2 { font-weight: 800; letter-spacing: -0.02em; }
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
 );
+

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,22 +1,18 @@
 import { createBrowserRouter } from "react-router-dom";
+import Layout from "./components/Layout";
 
-/**
- * Minimal route components (safe placeholders so the UI renders even
- * if dedicated pages are still under construction).
- * Replace these with your real pages as they land.
- */
 const Page = (title: string, body?: string) => () =>
   (
-    <main style={{ maxWidth: 860, margin: "2rem auto", padding: "0 1rem" }}>
-      <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>{title}</h1>
+    <section>
+      <h2 style={{ fontSize: "1.75rem", margin: "0 0 .5rem" }}>{title}</h2>
       {body ? <p style={{ opacity: 0.8 }}>{body}</p> : null}
-    </main>
+    </section>
   );
 
-const Home = Page("Welcome 🌿", "Choose a section from the navigation.");
+const Home = Page("Explore", "Choose a section from the navigation above.");
 const Worlds = Page("Worlds");
 const Zones = Page("Zones");
-const Arcade = Page("Arcade");
+const Arcade = Page("Arcade", "Mini-games arriving soon.");
 const Marketplace = Page("Marketplace");
 const Stories = Page("Stories");
 const Quizzes = Page("Quizzes");
@@ -26,27 +22,27 @@ const TurianTips = Page("Turian Tips");
 const Profile = Page("Profile & Settings");
 const NotFound = Page("Not Found", "That page doesn't exist (yet).");
 
-/**
- * Route table.
- * Export both the routes (named) and the created router (default).
- */
 export const routes = [
   {
     path: "/",
-    element: <Home />,
+    element: <Layout />,
+    children: [
+      { index: true, element: <Home /> },
+      { path: "worlds", element: <Worlds /> },
+      { path: "zones", element: <Zones /> },
+      { path: "arcade", element: <Arcade /> },
+      { path: "marketplace", element: <Marketplace /> },
+      { path: "stories", element: <Stories /> },
+      { path: "quizzes", element: <Quizzes /> },
+      { path: "observations", element: <Observations /> },
+      { path: "naturversity", element: <Naturversity /> },
+      { path: "turian", element: <TurianTips /> },
+      { path: "profile", element: <Profile /> },
+      { path: "*", element: <NotFound /> },
+    ],
   },
-  { path: "/worlds", element: <Worlds /> },
-  { path: "/zones", element: <Zones /> },
-  { path: "/arcade", element: <Arcade /> },
-  { path: "/marketplace", element: <Marketplace /> },
-  { path: "/stories", element: <Stories /> },
-  { path: "/quizzes", element: <Quizzes /> },
-  { path: "/observations", element: <Observations /> },
-  { path: "/naturversity", element: <Naturversity /> },
-  { path: "/turian", element: <TurianTips /> },
-  { path: "/profile", element: <Profile /> },
-  { path: "*", element: <NotFound /> },
 ];
 
-export const router = createBrowserRouter(routes);
+const router = createBrowserRouter(routes);
 export default router;
+


### PR DESCRIPTION
## Summary
- add shared Layout with header, navigation, and footer
- restore Nav links for all site sections
- nest routes under shared layout and include base styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: Cannot find module '@netlify/functions')

------
https://chatgpt.com/codex/tasks/task_e_68a6b0b62d788329ac563d33f00f8899