### PR TITLE
Restore hub card layout (no features added)

### DIFF
--- a/src/components/HubCard.tsx
+++ b/src/components/HubCard.tsx
@@ -1,21 +1,22 @@
-import { Link } from "react-router-dom";
+import { Link } from 'react-router-dom';
 
 type HubCardProps = {
   to: string;
+  emoji: string;
   title: string;
-  desc: string;
-  emoji?: string;
-  className?: string;
+  sub?: string;
 };
 
-export function HubCard({ to, title, desc, emoji, className = "" }: HubCardProps) {
+export default function HubCard({ to, emoji, title, sub }: HubCardProps) {
   return (
-    <Link to={to} className={"block rounded-xl border p-4 hover:bg-gray-50 " + className}>
-      <div className="text-lg font-semibold">
-        {emoji ? <span className="mr-2">{emoji}</span> : null}
-        {title}
+    <Link to={to} className="hub-card" aria-label={`${title}${sub ? ` – ${sub}` : ''}`}>
+      <div className="hub-title">
+        <span className="hub-emoji" aria-hidden>
+          {emoji}
+        </span>
+        <span>{title}</span>
       </div>
-      <div className="text-sm text-gray-600 mt-1">{desc}</div>
+      {sub ? <div className="hub-sub">{sub}</div> : null}
     </Link>
   );
 }

--- a/src/components/HubGrid.tsx
+++ b/src/components/HubGrid.tsx
@@ -1,7 +1,5 @@
-import { ReactNode } from "react";
+import { ReactNode } from 'react';
 
-export function HubGrid({ children }: { children: ReactNode }) {
-  return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">{children}</div>
-  );
+export default function HubGrid({ children }: { children: ReactNode }) {
+  return <div className="hub-grid">{children}</div>;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,12 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import { RouterProvider } from "react-router-dom";
-import { router } from "./router";
-import "./styles.css";
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import { router } from './router';
+import './styles.css';
+import './styles/hub.css';
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <RouterProvider router={router} />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,24 +1,48 @@
-import { HubCard } from "../components/HubCard";
-import { HubGrid } from "../components/HubGrid";
+import HubCard from '../components/HubCard';
+import HubGrid from '../components/HubGrid';
 
 export default function Home() {
   return (
-    <div className="space-y-6">
-      <header>
-        <h1 className="text-3xl font-bold">✨ Welcome to the Naturverse™</h1>
-        <p className="text-gray-600 mt-1">Pick a hub to begin your adventure.</p>
-      </header>
+    <main className="container">
+      <h1 className="h1">✨ Welcome to the Naturverse™</h1>
+      <p className="lead">Pick a hub to begin your adventure.</p>
+
       <HubGrid>
-        <HubCard to="/worlds"       title="Worlds"       desc="Travel the 14 magical kingdoms." emoji="📚" />
-        <HubCard to="/zones"        title="Zones"        desc="Arcade, Music, Wellness, Creator Lab, Stories, Quizzes." emoji="🎮🎵🧘" />
-        <HubCard to="/marketplace"  title="Marketplace"  desc="Wishlists, catalog, checkout." emoji="🛍️" />
-        <HubCard to="/naturversity" title="Naturversity" desc="Teachers, partners, courses." emoji="🎓" />
-        <HubCard to="/naturbank"    title="Naturbank"    desc="Wallets, NATUR token, and crypto basics." emoji="🪙" />
-        <HubCard to="/navatar"      title="Navatar"      desc="Create your character." emoji="🧩" />
-        <HubCard to="/passport"     title="Passport"     desc="Track stamps, badges, XP & coins." emoji="📘" />
-        <HubCard to="/turian"       title="Turian"       desc="AI guide for tips & quests." emoji="🦉" />
-        <HubCard to="/profile"      title="Profile"      desc="Your account & saved navatar." emoji="🧑‍🚀" />
+        <HubCard to="/worlds" emoji="📚" title="Worlds" sub="Travel the 14 magical kingdoms." />
+        <HubCard
+          to="/zones"
+          emoji="🎮🎵🧘"
+          title="Zones"
+          sub="Arcade, Music, Wellness, Creator Lab, Stories, Quizzes."
+        />
+        <HubCard
+          to="/marketplace"
+          emoji="🛍️"
+          title="Marketplace"
+          sub="Wishlists, catalog, checkout."
+        />
+        <HubCard
+          to="/naturversity"
+          emoji="🎓"
+          title="Naturversity"
+          sub="Teachers, partners, and courses."
+        />
+        <HubCard
+          to="/naturbank"
+          emoji="🪙"
+          title="Naturbank"
+          sub="Wallets, NATUR token, and crypto basics."
+        />
+        <HubCard to="/navatar" emoji="❎" title="Navatar" sub="Create your character." />
+        <HubCard
+          to="/passport"
+          emoji="🪪"
+          title="Passport"
+          sub="Track stamps, badges, XP & coins."
+        />
+        <HubCard to="/turian" emoji="🦉" title="Turian" sub="AI guide for tips & quests." />
+        <HubCard to="/profile" emoji="👤" title="Profile" sub="Your account & saved navatar." />
       </HubGrid>
-    </div>
+    </main>
   );
 }

--- a/src/routes/marketplace/index.tsx
+++ b/src/routes/marketplace/index.tsx
@@ -1,5 +1,5 @@
-import { HubCard } from "../../components/HubCard";
-import { HubGrid } from "../../components/HubGrid";
+import HubCard from '../../components/HubCard';
+import HubGrid from '../../components/HubGrid';
 
 export default function Marketplace() {
   return (
@@ -7,9 +7,9 @@ export default function Marketplace() {
       <h2 className="text-2xl font-bold">🛍️ Marketplace</h2>
       <p className="text-gray-600">Shop creations and merch.</p>
       <HubGrid>
-        <HubCard to="/marketplace/catalog"  title="Catalog"  desc="Browse items." emoji="📦" />
-        <HubCard to="/marketplace/wishlist" title="Wishlist" desc="Your favorites." emoji="❤️" />
-        <HubCard to="/marketplace/checkout" title="Checkout" desc="Pay & ship." emoji="💳" />
+        <HubCard to="/marketplace/catalog" title="Catalog" sub="Browse items." emoji="📦" />
+        <HubCard to="/marketplace/wishlist" title="Wishlist" sub="Your favorites." emoji="❤️" />
+        <HubCard to="/marketplace/checkout" title="Checkout" sub="Pay & ship." emoji="💳" />
       </HubGrid>
     </section>
   );

--- a/src/routes/naturbank/index.tsx
+++ b/src/routes/naturbank/index.tsx
@@ -1,15 +1,35 @@
-import { HubCard } from "../../components/HubCard";
-import { HubGrid } from "../../components/HubGrid";
+import HubCard from '../../components/HubCard';
+import HubGrid from '../../components/HubGrid';
 
 export default function Naturbank() {
   return (
     <section className="space-y-6">
       <h2 className="text-2xl font-bold">Naturbank</h2>
       <HubGrid>
-        <HubCard to="/naturbank/wallet" title="Wallet" desc="Create custodial wallet & view address." emoji="🪙" />
-        <HubCard to="/naturbank/token"  title="NATUR Token" desc="Earnings, redemptions, and ledger." emoji="🪙" />
-        <HubCard to="/naturbank/nfts"   title="NFTs" desc="Mint navatar cards & collectibles." emoji="🖼️" />
-        <HubCard to="/naturbank/learn"  title="Learn" desc="Crypto basics & safety guides." emoji="📘" />
+        <HubCard
+          to="/naturbank/wallet"
+          title="Wallet"
+          sub="Create custodial wallet & view address."
+          emoji="🪙"
+        />
+        <HubCard
+          to="/naturbank/token"
+          title="NATUR Token"
+          sub="Earnings, redemptions, and ledger."
+          emoji="🪙"
+        />
+        <HubCard
+          to="/naturbank/nfts"
+          title="NFTs"
+          sub="Mint navatar cards & collectibles."
+          emoji="🖼️"
+        />
+        <HubCard
+          to="/naturbank/learn"
+          title="Learn"
+          sub="Crypto basics & safety guides."
+          emoji="📘"
+        />
       </HubGrid>
       <p className="text-sm text-gray-500 mt-2">Demo address (placeholder) shown in Wallet.</p>
     </section>

--- a/src/routes/worlds/World.tsx
+++ b/src/routes/worlds/World.tsx
@@ -1,20 +1,27 @@
-import { useParams } from "react-router-dom";
-import { worlds } from "../../lib/routes";
-import { HubCard } from "../../components/HubCard";
-import { HubGrid } from "../../components/HubGrid";
+import { useParams } from 'react-router-dom';
+import { worlds } from '../../lib/routes';
+import HubCard from '../../components/HubCard';
+import HubGrid from '../../components/HubGrid';
 
 export default function World() {
   const { slug } = useParams();
-  const w = worlds.find(x => x.slug === slug);
+  const w = worlds.find((x) => x.slug === slug);
   if (!w) return <p className="text-gray-600">World not found.</p>;
   return (
     <section className="space-y-4">
-      <h2 className="text-2xl font-bold">{w.emoji} {w.title}</h2>
+      <h2 className="text-2xl font-bold">
+        {w.emoji} {w.title}
+      </h2>
       <p className="text-gray-600">{w.blurb}</p>
       <HubGrid>
-        <HubCard to="#" title="Story Path" desc={`Begin an AI-guided story in ${w.title}.`} />
-        <HubCard to="#" title="Quests" desc="Complete missions to earn stamps & XP." />
-        <HubCard to="#" title="Gallery" desc="Facts, animals, plants, foods." />
+        <HubCard
+          to="#"
+          emoji="📖"
+          title="Story Path"
+          sub={`Begin an AI-guided story in ${w.title}.`}
+        />
+        <HubCard to="#" emoji="🎯" title="Quests" sub="Complete missions to earn stamps & XP." />
+        <HubCard to="#" emoji="🖼️" title="Gallery" sub="Facts, animals, plants, foods." />
       </HubGrid>
     </section>
   );

--- a/src/routes/worlds/index.tsx
+++ b/src/routes/worlds/index.tsx
@@ -1,18 +1,40 @@
-import { HubCard } from "../../components/HubCard";
-import { HubGrid } from "../../components/HubGrid";
-import { worlds } from "../../lib/routes";
+import HubCard from '../../components/HubCard';
+import HubGrid from '../../components/HubGrid';
+
+const WORLDS = [
+  { to: '/worlds/thailandia', emoji: '🐘🌸', title: 'Thailandia', sub: 'Coconuts & Elephants' },
+  { to: '/worlds/brazilandia', emoji: '🍌🦜', title: 'Brazilandia', sub: 'Bananas & Parrots' },
+  { to: '/worlds/indilandia', emoji: '🥭🐯', title: 'Indilandia', sub: 'Mangoes & Tigers' },
+  { to: '/worlds/amerilandia', emoji: '🍎🦅', title: 'Amerilandia', sub: 'Apples & Eagles' },
+  { to: '/worlds/australandia', emoji: '🍑🦘', title: 'Australandia', sub: 'Peaches & Kangaroos' },
+  { to: '/worlds/chilandia', emoji: '🎋🐼', title: 'Chilandia', sub: 'Bamboo (shoots) & Pandas' },
+  { to: '/worlds/japonica', emoji: '🌸🦊', title: 'Japonica', sub: 'Cherry Blossoms & Foxes' },
+  { to: '/worlds/africania', emoji: '🦁🌞', title: 'Africania', sub: 'Mangoes & Lions' },
+  { to: '/worlds/europalia', emoji: '🌻🦔', title: 'Europalia', sub: 'Sunflowers & Hedgehogs' },
+  { to: '/worlds/britannula', emoji: '🌹🦔', title: 'Britannula', sub: 'Roses & Hedgehogs' },
+  { to: '/worlds/kiwilandia', emoji: '🥝🐑', title: 'Kiwilandia', sub: 'Kiwis & Sheep' },
+  { to: '/worlds/madagascaria', emoji: '🍋🦥', title: 'Madagascaria', sub: 'Lemons & Lemurs' },
+  { to: '/worlds/greenlandia', emoji: '🧊🐻‍❄️', title: 'Greenlandia', sub: 'Ice & Polar Bears' },
+  {
+    to: '/worlds/antarcticland',
+    emoji: '❄️🐧',
+    title: 'Antarcticland',
+    sub: 'Ice Crystals & Penguins',
+  },
+];
 
 export default function Worlds() {
   return (
-    <section className="space-y-6">
-      <h2 className="text-2xl font-bold">Worlds</h2>
-      <p className="text-gray-600">Explore the 14 kingdoms.</p>
+    <main className="container">
+      <div className="breadcrumb">Home / Worlds</div>
+      <h2 className="section-title">Worlds</h2>
+      <p className="section-lead">Explore the 14 kingdoms.</p>
+
       <HubGrid>
-        {worlds.map(w => (
-          <HubCard key={w.slug} to={`/worlds/${w.slug}`} title={w.title} desc={w.blurb} emoji={w.emoji} />
+        {WORLDS.map((w) => (
+          <HubCard key={w.title} to={w.to} emoji={w.emoji} title={w.title} sub={w.sub} />
         ))}
       </HubGrid>
-      <p className="text-xs text-gray-500 mt-4">Tip: Click any world to view.</p>
-    </section>
+    </main>
   );
 }

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -1,16 +1,58 @@
-import { HubCard } from "../../components/HubCard";
-import { HubGrid } from "../../components/HubGrid";
-import { zones } from "../../lib/routes";
+import HubCard from '../../components/HubCard';
+import HubGrid from '../../components/HubGrid';
+
+const ZONES = [
+  {
+    to: '/zones/arcade',
+    emoji: '📍🕹️',
+    title: 'Arcade',
+    sub: 'Mini-games, leaderboards & tournaments.',
+  },
+  { to: '/zones/music', emoji: '🎤🎵', title: 'Music', sub: 'Karaoke, AI beats & song maker.' },
+  {
+    to: '/zones/wellness',
+    emoji: '🧘',
+    title: 'Wellness',
+    sub: 'Yoga, breathing, stretches, mindful quests.',
+  },
+  {
+    to: '/zones/creator-lab',
+    emoji: '🎨🤖',
+    title: 'Creator Lab',
+    sub: 'AI art & character cards.',
+  },
+  {
+    to: '/zones/stories',
+    emoji: '📚✨',
+    title: 'Stories',
+    sub: 'AI story paths set in all 14 kingdoms.',
+  },
+  {
+    to: '/zones/quizzes',
+    emoji: '🎯🧠',
+    title: 'Quizzes',
+    sub: 'Solo & party quiz play with scoring.',
+  },
+  {
+    to: '/zones/observations',
+    emoji: '📷🌿',
+    title: 'Observations',
+    sub: 'Upload nature pics; tag, learn, earn.',
+  },
+];
 
 export default function Zones() {
   return (
-    <section className="space-y-6">
-      <h2 className="text-2xl font-bold">Zones</h2>
+    <main className="container">
+      <div className="breadcrumb">Home / Zones</div>
+      <h2 className="section-title">Zones</h2>
+      <p className="section-lead">Pick a zone to start an activity.</p>
+
       <HubGrid>
-        {zones.map(z => (
-          <HubCard key={z.slug} to={`/zones/${z.slug}`} title={z.title} desc={z.blurb} emoji={z.emoji} />
+        {ZONES.map((z) => (
+          <HubCard key={z.title} to={z.to} emoji={z.emoji} title={z.title} sub={z.sub} />
         ))}
       </HubGrid>
-    </section>
+    </main>
   );
 }

--- a/src/styles/hub.css
+++ b/src/styles/hub.css
@@ -1,0 +1,113 @@
+:root {
+  --bg: #f7f7fb;
+  --card: #ffffff;
+  --ink: #0f172a;
+  --muted: #6b7280;
+  --ring: 0 0 0 3px rgba(59, 130, 246, 0.25);
+  --radius: 14px;
+  --border: #e5e7eb;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  background: var(--bg);
+  color: var(--ink);
+}
+
+.container {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 24px 16px;
+}
+
+.h1 {
+  font-size: clamp(28px, 3.6vw, 40px);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  font-weight: 800;
+  margin: 8px 0 6px;
+}
+
+.lead {
+  color: var(--muted);
+  margin-bottom: 24px;
+}
+
+.hub-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+a.hub-card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  transition:
+    transform 0.08s ease,
+    box-shadow 0.08s ease,
+    border-color 0.08s ease;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+a.hub-card:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  border-color: #d1d5db;
+}
+
+.hub-title {
+  font-weight: 700;
+  font-size: 18px;
+  display: inline-flex;
+  gap: 10px;
+  align-items: baseline;
+}
+
+.hub-emoji {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.hub-sub {
+  margin-top: 6px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.breadcrumb {
+  font-size: 14px;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+
+.section-title {
+  font-weight: 800;
+  font-size: 30px;
+  margin: 6px 0 12px;
+}
+.section-lead {
+  color: var(--muted);
+  margin-bottom: 18px;
+}
+
+/* Reset underlines in lists rendered previously as raw anchors */
+a {
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+
+/* Small screens spacing */
+@media (max-width: 480px) {
+  .container {
+    padding: 20px 14px;
+  }
+}


### PR DESCRIPTION
## Summary
- add hub.css and tiny HubCard/HubGrid components for tile layout
- convert Home, Worlds and Zones to card grids
- import new styles in main entry

## Testing
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68a6e5c76b0c83299c031d7dcab860c1