### PR TITLE
Add two safe mini-games to Zones → Arcade (client-only)

### DIFF
--- a/src/routes/zones/arcade/index.tsx
+++ b/src/routes/zones/arcade/index.tsx
@@ -1,18 +1,180 @@
-export default function ArcadeZone() {
+import { useEffect, useRef, useState } from "react";
+import "../../../styles/zone-widgets.css";
+
+export default function Arcade() {
   return (
-    <section className="space-y-4">
-      <h2 className="text-2xl font-bold">🕹️ Arcade</h2>
-      <p className="text-gray-600">Mini-games, leaderboards & tournaments.</p>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="rounded-lg border p-4">
-          <div className="font-semibold">Featured</div>
-          <p className="text-sm text-gray-600">Starter activity for Arcade.</p>
-        </div>
-        <div className="rounded-lg border p-4 opacity-60">
-          <div className="font-semibold">Coming Soon</div>
-          <p className="text-sm text-gray-600">More tools will appear here.</p>
-        </div>
+    <main className="container">
+      <div className="breadcrumb">Home / Zones / Arcade</div>
+      <h2 className="section-title">Arcade</h2>
+      <p className="section-lead">Mini-games, leaderboards &amp; tournaments.</p>
+
+      <div className="zone-wrap">
+        <section className="zone-card">
+          <div className="zone-title">⚡ Reaction Timer</div>
+          <div className="zone-sub">Wait for green, then tap as fast as you can. Best of 5.</div>
+          <ReactionTimer />
+        </section>
+
+        <section className="zone-card">
+          <div className="zone-title">🎯 Bubble Popper</div>
+          <div className="zone-sub">Pop as many bubbles as possible in 20 seconds.</div>
+          <BubblePopper />
+        </section>
       </div>
-    </section>
+    </main>
   );
+}
+
+/* ---------- Reaction Timer ---------- */
+function ReactionTimer() {
+  type Phase = "idle" | "wait" | "go" | "tooSoon" | "done";
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [results, setResults] = useState<number[]>([]);
+  const startAt = useRef<number>(0);
+  const timer = useRef<number | null>(null);
+
+  const startRound = () => {
+    setPhase("wait");
+    const delay = 800 + Math.random() * 1800;
+    timer.current = window.setTimeout(() => {
+      startAt.current = performance.now();
+      setPhase("go");
+    }, delay);
+  };
+
+  const stop = () => {
+    if (phase === "wait") {
+      if (timer.current) window.clearTimeout(timer.current);
+      setPhase("tooSoon");
+      return;
+    }
+    if (phase === "go") {
+      const ms = Math.round(performance.now() - startAt.current);
+      const next = [...results, ms];
+      setResults(next);
+      if (next.length >= 5) setPhase("done");
+      else startRound();
+    }
+  };
+
+  const reset = () => {
+    if (timer.current) window.clearTimeout(timer.current);
+    setResults([]);
+    setPhase("idle");
+  };
+
+  const avg = results.length
+    ? Math.round(results.reduce((a, b) => a + b, 0) / results.length)
+    : null;
+
+  return (
+    <div className="widget">
+      {phase === "idle" && (
+        <>
+          <p>Tap to begin a round.</p>
+          <button onClick={startRound}>Start</button>
+        </>
+      )}
+
+      {phase === "wait" && (
+        <div className="rt-stage rt-wait" onClick={stop}>
+          <b>Wait for green…</b>
+        </div>
+      )}
+      {phase === "go" && (
+        <div className="rt-stage rt-go" onClick={stop}>
+          <b>Tap!</b>
+        </div>
+      )}
+      {phase === "tooSoon" && (
+        <>
+          <div className="rt-stage rt-too"><b>Too soon!</b></div>
+          <button onClick={startRound}>Try again</button>
+        </>
+      )}
+      {phase === "done" && (
+        <>
+          <p><b>Results:</b> {results.join(" ms, ")} ms</p>
+          <p><b>Average:</b> {avg} ms</p>
+          <button onClick={reset}>Reset</button>
+        </>
+      )}
+      {results.length > 0 && phase !== "done" && (
+        <p style={{ marginTop: 8 }}>
+          Round {results.length + 1} of 5 • Last: {results[results.length - 1]} ms
+        </p>
+      )}
+    </div>
+  );
+}
+
+/* ---------- Bubble Popper ---------- */
+function BubblePopper() {
+  const [running, setRunning] = useState(false);
+  const [hits, setHits] = useState(0);
+  const [timeLeft, setTimeLeft] = useState(20);
+  const stageRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!running) return;
+    const t = setInterval(() => setTimeLeft(tl => (tl > 0 ? tl - 1 : 0)), 1000);
+    return () => clearInterval(t);
+  }, [running]);
+
+  useEffect(() => {
+    if (running && timeLeft === 0) setRunning(false);
+  }, [running, timeLeft]);
+
+  const spawnBubble = () => {
+    const stage = stageRef.current;
+    if (!stage) return;
+    const b = document.createElement("div");
+    b.className = "bubble";
+    b.textContent = "•";
+    const rect = stage.getBoundingClientRect();
+    const x = Math.random() * (rect.width - 34);
+    const y = Math.random() * (rect.height - 34);
+    b.style.left = `${x}px`;
+    b.style.top = `${y}px`;
+    const kill = () => {
+      setHits(h => h + 1);
+      b.remove();
+    };
+    b.addEventListener("click", kill, { once: true });
+    stage.appendChild(b);
+    window.setTimeout(() => b.remove(), 1200);
+  };
+
+  useInterval(() => {
+    if (running) spawnBubble();
+  }, 450);
+
+  const start = () => {
+    setHits(0);
+    setTimeLeft(20);
+    setRunning(true);
+  };
+
+  return (
+    <div className="widget">
+      <div className="popper-stage" ref={stageRef} aria-label="Bubble popper playfield" />
+      <div className="stats">
+        <div>⏱️ Time: {timeLeft}s</div>
+        <div>🎯 Hits: {hits}</div>
+      </div>
+      <div style={{ marginTop: 10 }}>
+        <button onClick={start} disabled={running}>{running ? "Playing…" : "Start (20s)"}</button>
+      </div>
+    </div>
+  );
+}
+
+/* small interval hook */
+function useInterval(fn: () => void, ms: number) {
+  const saved = useRef(fn);
+  useEffect(() => { saved.current = fn; }, [fn]);
+  useEffect(() => {
+    const id = window.setInterval(() => saved.current(), ms);
+    return () => window.clearInterval(id);
+  }, [ms]);
 }

--- a/src/styles/zone-widgets.css
+++ b/src/styles/zone-widgets.css
@@ -1,0 +1,28 @@
+.zone-wrap { display: grid; gap: 20px; }
+.zone-card {
+  background:#fff; border:1px solid #e5e7eb; border-radius:14px; padding:16px 18px;
+  box-shadow:0 1px 2px rgba(0,0,0,.04);
+}
+.zone-title { font-weight:800; font-size:18px; margin-bottom:8px; }
+.zone-sub { color:#6b7280; margin-bottom:12px; }
+
+.widget {
+  border:1px dashed #e5e7eb; border-radius:12px; padding:14px; background:#fafafa;
+}
+.widget button {
+  border:1px solid #d1d5db; border-radius:10px; padding:10px 14px; background:#fff; cursor:pointer;
+}
+.widget button:hover { background:#f9fafb; }
+
+.rt-stage { height:160px; display:grid; place-items:center; border-radius:10px; color:#111827; }
+.rt-wait { background:#fde68a; }
+.rt-go { background:#bbf7d0; }
+.rt-too { background:#fecaca; }
+
+.popper-stage { position:relative; height:220px; background:#f3f4f6; border-radius:10px; overflow:hidden; }
+.bubble {
+  position:absolute; width:34px; height:34px; border-radius:50%;
+  background:#60a5fa; display:grid; place-items:center; color:#fff; font-weight:700;
+  box-shadow:0 2px 6px rgba(59,130,246,.35);
+}
+.stats { display:flex; gap:12px; color:#374151; font-size:14px; margin-top:8px; }


### PR DESCRIPTION
## Summary
- implement Reaction Timer mini-game
- add Bubble Popper aim trainer
- style arcade widgets with standalone CSS

## Testing
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68a6e9e2cd1c8329aca605e476449444