### PR TITLE
Creator Lab: local character card builder, gallery & sticker sheet (client-only)

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+export type CardData = {
+  id: string;
+  name: string;
+  realm: string;
+  species: string;
+  emoji: string;
+  color: string;
+  power: string;
+  motto: string;
+  avatarDataUrl?: string; // optional base64 image
+};
+
+export const CharacterCard: React.FC<{ data: CardData }> = ({ data }) => {
+  const {
+    name, realm, species, emoji, color, power, motto, avatarDataUrl,
+  } = data;
+
+  return (
+    <div
+      className="nv-card"
+      style={{
+        border: `2px solid ${color || "#e5e7eb"}`,
+        boxShadow: "0 6px 20px rgba(0,0,0,.08)",
+      }}
+    >
+      <div className="nv-card__header" style={{ background: color || "#f3f4f6" }}>
+        <div className="nv-card__emoji" aria-hidden>{emoji || "🌱"}</div>
+        <div className="nv-card__title">
+          <div className="nv-card__name">{name || "Navatar"}</div>
+          <div className="nv-card__sub">{species || "Species"} · {realm || "Realm"}</div>
+        </div>
+      </div>
+
+      <div className="nv-card__body">
+        <div className="nv-card__avatar">
+          {avatarDataUrl ? (
+            <img src={avatarDataUrl} alt={`${name} avatar`} />
+          ) : (
+            <div className="nv-card__avatar--placeholder">Add image</div>
+          )}
+        </div>
+        <dl className="nv-card__facts">
+          <div>
+            <dt>Power</dt><dd>{power || "—"}</dd>
+          </div>
+          <div>
+            <dt>Motto</dt><dd>{motto || "—"}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="nv-card__footer">Naturverse • Character Card</div>
+    </div>
+  );
+};
+

--- a/src/routes/zones/creator-lab/index.tsx
+++ b/src/routes/zones/creator-lab/index.tsx
@@ -1,12 +1,178 @@
-export default function CreatorLabZone() {
+import React, { useMemo, useState } from "react";
+import { CharacterCard, CardData } from "../../../components/CharacterCard";
+import "../../../styles/zone-widgets.css";
+
+const STORAGE_KEY = "naturverse.creatorLab.cards";
+
+const blank: CardData = {
+  id: "",
+  name: "",
+  realm: "",
+  species: "",
+  emoji: "🎴",
+  color: "#c7f9cc",
+  power: "",
+  motto: "",
+  avatarDataUrl: undefined,
+};
+
+function uid() {
+  return Math.random().toString(36).slice(2, 9);
+}
+
+function loadCards(): CardData[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as CardData[]) : [];
+  } catch {
+    return [];
+  }
+}
+function saveCards(list: CardData[]) {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(list)); } catch {}
+}
+
+export default function CreatorLab() {
+  const [cards, setCards] = useState<CardData[]>(loadCards());
+  const [tab, setTab] = useState<"build"|"gallery"|"stickers"|"coming">("build");
+  const [form, setForm] = useState<CardData>({ ...blank, id: uid() });
+
+  const formValid = useMemo(
+    () => form.name.trim().length > 0,
+    [form.name]
+  );
+
+  const onFile = (f?: File) => {
+    if (!f) return setForm(p => ({ ...p, avatarDataUrl: undefined }));
+    const reader = new FileReader();
+    reader.onload = () =>
+      setForm(p => ({ ...p, avatarDataUrl: String(reader.result || "") }));
+    reader.readAsDataURL(f);
+  };
+
+  const addCard = () => {
+    if (!formValid) return;
+    const next = [{ ...form }, ...cards];
+    setCards(next);
+    saveCards(next);
+    setForm({ ...blank, id: uid() });
+  };
+
+  const removeCard = (id: string) => {
+    const next = cards.filter(c => c.id !== id);
+    setCards(next);
+    saveCards(next);
+  };
+
   return (
-    <section className="space-y-4">
-      <h2 className="text-2xl font-bold">🎨🤖 Creator Lab</h2>
-      <p className="text-gray-600">AI art & character cards.</p>
-      <div className="rounded-lg border p-4 opacity-60">
-        <div className="font-semibold">Coming Soon</div>
-        <p className="text-sm text-gray-600">Tools arrive here later.</p>
+    <div>
+      <h1>🎨🤖 Creator Lab</h1>
+      <p>AI art &amp; character cards (client-only tools for now).</p>
+
+      <div className="tabs" role="tablist" aria-label="Creator Lab">
+        <button className="tab" aria-selected={tab==="build"} onClick={()=>setTab("build")}>Card Builder</button>
+        <button className="tab" aria-selected={tab==="gallery"} onClick={()=>setTab("gallery")}>My Gallery <span className="badge">{cards.length}</span></button>
+        <button className="tab" aria-selected={tab==="stickers"} onClick={()=>setTab("stickers")}>Sticker Sheet</button>
+        <button className="tab" aria-selected={tab==="coming"} onClick={()=>setTab("coming")}>Coming Soon</button>
       </div>
-    </section>
+
+      {tab === "build" && (
+        <div className="clab-grid">
+          {/* Builder form */}
+          <section>
+            <h2>Build a card</h2>
+            <div className="form-row">
+              <input className="input" placeholder="Name" value={form.name}
+                     onChange={e=>setForm({...form, name:e.target.value})}/>
+              <input className="input" placeholder="Realm (e.g., Amazonia)"
+                     value={form.realm} onChange={e=>setForm({...form, realm:e.target.value})}/>
+            </div>
+            <div className="form-row">
+              <input className="input" placeholder="Species (e.g., Macaw)"
+                     value={form.species} onChange={e=>setForm({...form, species:e.target.value})}/>
+            </div>
+            <div className="form-row">
+              <input className="input small" placeholder="Emoji" value={form.emoji}
+                     onChange={e=>setForm({...form, emoji:e.target.value})} />
+              <input className="input small" type="color" value={form.color}
+                     onChange={e=>setForm({...form, color:e.target.value})}/>
+              <label className="input small" style={{display:"inline-flex", alignItems:"center", gap:8}}>
+                <span>Avatar</span>
+                <input type="file" accept="image/*" onChange={e=>onFile(e.target.files?.[0])}/>
+              </label>
+            </div>
+            <div className="form-row">
+              <input className="input" placeholder="Power (e.g., River Songcraft)"
+                     value={form.power} onChange={e=>setForm({...form, power:e.target.value})}/>
+            </div>
+            <div className="form-row">
+              <input className="input" placeholder="Motto (short quote)"
+                     value={form.motto} onChange={e=>setForm({...form, motto:e.target.value})}/>
+            </div>
+
+            <div className="actions">
+              <button className="btn" onClick={addCard} disabled={!formValid} title={formValid ? "Save to gallery" : "Enter a name first"}>
+                Save to Gallery
+              </button>
+              <button className="btn outline" onClick={()=>setForm({ ...blank, id: uid() })}>Reset</button>
+            </div>
+
+            <p className="meta">Cards are stored in your browser (localStorage) and never leave your device.</p>
+          </section>
+
+          {/* Live preview */}
+          <section>
+            <h2>Preview</h2>
+            <CharacterCard data={form}/>
+          </section>
+        </div>
+      )}
+
+      {tab === "gallery" && (
+        <section>
+          <h2>My Gallery</h2>
+          {cards.length === 0 && <p>No cards yet. Build one in the tab above.</p>}
+          <div className="list-grid">
+            {cards.map(c=>(
+              <div className="card-mini" key={c.id}>
+                <CharacterCard data={c}/>
+                <div className="actions" style={{marginTop:10}}>
+                  <button className="btn outline" onClick={()=>navigator.clipboard.writeText(JSON.stringify(c,null,2))}>Copy JSON</button>
+                  <button className="btn outline" onClick={()=>removeCard(c.id)}>Delete</button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {tab === "stickers" && (
+        <section>
+          <h2>Sticker Sheet</h2>
+          <p className="meta">Print this page to get a simple sticker sheet of your cards.</p>
+          <div className="list-grid">
+            {cards.map(c=>(
+              <div key={c.id} className="card-mini" style={{textAlign:"center"}}>
+                <div style={{fontSize:32, marginBottom:6}}>{c.emoji || "🌱"}</div>
+                <div style={{fontWeight:700}}>{c.name}</div>
+                <div className="meta">{c.species} • {c.realm}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {tab === "coming" && (
+        <section>
+          <h2>Coming Soon</h2>
+          <ul>
+            <li>AI art generator for avatars.</li>
+            <li>Prompt presets per world.</li>
+            <li>Share cards to Passport & earn stamps.</li>
+          </ul>
+        </section>
+      )}
+    </div>
   );
 }
+

--- a/src/styles/zone-widgets.css
+++ b/src/styles/zone-widgets.css
@@ -83,3 +83,42 @@
   min-width:64px; text-align:center; padding:6px 10px; border-radius:9999px;
   border:1px solid #d1d5db; background:#f9fafb;
 }
+
+/* Creator Lab */
+.nv-card {
+  border-radius: 14px;
+  background:#fff;
+  overflow:hidden;
+  max-width: 560px;
+}
+.nv-card__header{
+  display:flex; gap:12px; align-items:center; padding:14px;
+  color:#111827;
+}
+.nv-card__emoji{ font-size:28px; }
+.nv-card__name{ font-weight:700; font-size:20px; line-height:1.1; }
+.nv-card__sub{ color:#4b5563; font-size:14px; }
+.nv-card__body{ display:grid; grid-template-columns:140px 1fr; gap:16px; padding:16px; }
+.nv-card__avatar{ width:140px; height:140px; border-radius:12px; overflow:hidden; border:1px solid #e5e7eb; background:#f9fafb; display:flex; align-items:center; justify-content:center; }
+.nv-card__avatar img{ width:100%; height:100%; object-fit:cover; }
+.nv-card__avatar--placeholder{ color:#9ca3af; font-size:12px; }
+.nv-card__facts dt{ font-size:12px; text-transform:uppercase; color:#6b7280; letter-spacing:.04em; }
+.nv-card__facts dd{ margin:2px 0 10px; font-size:15px; }
+.nv-card__footer{ padding:10px 14px; border-top:1px dashed #e5e7eb; color:#6b7280; font-size:12px; }
+
+.clab-grid{ display:grid; gap:20px; }
+@media(min-width: 960px){ .clab-grid{ grid-template-columns: 1fr 1fr; } }
+
+.form-row{ display:flex; gap:10px; flex-wrap:wrap; }
+.input, .select, .textarea{
+  width:100%; padding:10px 12px; border:1px solid #e5e7eb; border-radius:10px; background:#fff;
+}
+.small{ max-width:200px; }
+.actions{ display:flex; gap:10px; flex-wrap:wrap; margin-top:8px; }
+.btn{ padding:8px 12px; border:1px solid #111827; border-radius:9999px; background:#111827; color:#fff; cursor:pointer; }
+.btn.outline{ background:#fff; color:#111827; }
+.badge{ padding:4px 10px; border-radius:9999px; background:#f3f4f6; font-size:12px; }
+.list-grid{ display:grid; gap:16px; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.card-mini{ border:1px solid #e5e7eb; border-radius:12px; padding:12px; background:#fff; }
+.meta{ color:#6b7280; font-size:12px; }
+


### PR DESCRIPTION
## Summary
- add CharacterCard component for rendering customizable navatar cards
- implement Creator Lab page with localStorage-backed builder, gallery, and sticker sheet
- style Creator Lab widgets and cards

## Testing
- `npm test` *(fails: Missing script)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6f4ac7d0483298f5e8a34f2b3ac34