### PR TITLE
Add Community Zone: polls (voting) + volunteer boards (client-only)

### DIFF
--- a/src/lib/community/store.ts
+++ b/src/lib/community/store.ts
@@ -1,0 +1,63 @@
+import { BoardPost, Poll } from './types';
+
+const PK = 'naturverse.community.polls.v1';
+const BK = 'naturverse.community.board.v1';
+const VK = 'naturverse.community.voted.v1'; // pollId -> choiceId
+
+const read = <T>(k: string, d: T) => {
+  try {
+    return JSON.parse(localStorage.getItem(k) || 'null') ?? d;
+  } catch {
+    return d;
+  }
+};
+const write = (k: string, v: unknown) => {
+  try {
+    localStorage.setItem(k, JSON.stringify(v));
+  } catch {}
+};
+
+export function uid() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+/* Polls */
+export function loadPolls(): Poll[] {
+  return read<Poll[]>(PK, []);
+}
+export function savePolls(list: Poll[]) {
+  write(PK, list);
+}
+export function submitVote(pollId: string, choiceId: string) {
+  const voted = read<Record<string, string>>(VK, {});
+  if (voted[pollId]) return false; // already voted
+  const polls = loadPolls();
+  const p = polls.find((p) => p.id === pollId);
+  if (!p) return false;
+  const c = p.choices.find((c) => c.id === choiceId);
+  if (!c) return false;
+  c.votes += 1;
+  voted[pollId] = choiceId;
+  savePolls(polls);
+  write(VK, voted);
+  return true;
+}
+export function hasVoted(pollId: string) {
+  const voted = read<Record<string, string>>(VK, {});
+  return !!voted[pollId];
+}
+
+/* Board */
+export function loadBoard(): BoardPost[] {
+  return read<BoardPost[]>(BK, []);
+}
+export function saveBoard(list: BoardPost[]) {
+  write(BK, list);
+}
+export function rsvp(postId: string) {
+  const list = loadBoard();
+  const p = list.find((x) => x.id === postId);
+  if (!p) return;
+  p.rsvps += 1;
+  saveBoard(list);
+}

--- a/src/lib/community/types.ts
+++ b/src/lib/community/types.ts
@@ -1,0 +1,18 @@
+export type Choice = { id: string; label: string; votes: number };
+export type Poll = {
+  id: string;
+  title: string;
+  notes?: string;
+  choices: Choice[];
+  createdAt: string; // ISO
+};
+
+export type BoardPost = {
+  id: string;
+  title: string;
+  date?: string; // ISO
+  location?: string;
+  details?: string;
+  rsvps: number;
+  createdAt: string; // ISO
+};

--- a/src/pages/zones/Community.tsx
+++ b/src/pages/zones/Community.tsx
@@ -1,0 +1,292 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import '../../styles/zone-widgets.css';
+import { BoardPost, Poll } from '../../lib/community/types';
+import {
+  hasVoted,
+  loadBoard,
+  loadPolls,
+  rsvp,
+  saveBoard,
+  savePolls,
+  submitVote,
+  uid,
+} from '../../lib/community/store';
+
+export default function Community() {
+  const [tab, setTab] = useState<'polls' | 'board' | 'coming'>('polls');
+  const [polls, setPolls] = useState<Poll[]>([]);
+  const [board, setBoard] = useState<BoardPost[]>([]);
+
+  useEffect(() => {
+    const p = loadPolls();
+    if (p.length === 0) {
+      const seed: Poll[] = [
+        {
+          id: uid(),
+          title: 'Vote for the next land to unlock',
+          notes: 'Choose one of the proposed regions for 2025 content.',
+          createdAt: new Date().toISOString(),
+          choices: [
+            { id: uid(), label: 'Coralia — reefs & sea caves', votes: 0 },
+            { id: uid(), label: 'Highvale — mountains & raptors', votes: 0 },
+            { id: uid(), label: 'Bloomwood — flowers & pollinators', votes: 0 },
+          ],
+        },
+        {
+          id: uid(),
+          title: 'Pick a new Navatar companion',
+          createdAt: new Date().toISOString(),
+          choices: [
+            { id: uid(), label: 'Red Panda', votes: 0 },
+            { id: uid(), label: 'Sea Turtle', votes: 0 },
+            { id: uid(), label: 'Snowy Owl', votes: 0 },
+          ],
+        },
+      ];
+      savePolls(seed);
+      setPolls(seed);
+    } else setPolls(p);
+
+    const b = loadBoard();
+    if (b.length === 0) {
+      const seedB: BoardPost[] = [
+        {
+          id: uid(),
+          title: 'Beach cleanup — Pacifica (Sat)',
+          date: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString(),
+          location: 'Pacifica • Shell Bay',
+          details: 'Bags & gloves provided. Family friendly.',
+          rsvps: 3,
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: uid(),
+          title: 'Tree planting — Africani Park',
+          date: new Date(Date.now() + 1000 * 60 * 60 * 24 * 14).toISOString(),
+          location: 'Africani • Lion’s Gate',
+          details: 'Help plant 50 native saplings.',
+          rsvps: 5,
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      saveBoard(seedB);
+      setBoard(seedB);
+    } else setBoard(b);
+  }, []);
+
+  const totalVotes = (p: Poll) => p.choices.reduce((s, c) => s + c.votes, 0);
+  const sortedBoard = useMemo(
+    () => [...board].sort((a, b) => (a.date || a.createdAt).localeCompare(b.date || b.createdAt)),
+    [board],
+  );
+
+  /* Create poll */
+  const [newPollTitle, setNewPollTitle] = useState('');
+  const [newOptions, setNewOptions] = useState<string>('Option A\nOption B');
+  const addPoll = () => {
+    const opts = newOptions
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (!newPollTitle.trim() || opts.length < 2) return;
+    const poll: Poll = {
+      id: uid(),
+      title: newPollTitle.trim(),
+      createdAt: new Date().toISOString(),
+      choices: opts.map((o) => ({ id: uid(), label: o, votes: 0 })),
+    };
+    const list = [poll, ...polls];
+    savePolls(list);
+    setPolls(list);
+    setNewPollTitle('');
+    setNewOptions('Option A\nOption B');
+  };
+
+  /* Create board post */
+  const [post, setPost] = useState<BoardPost>({
+    id: '',
+    title: '',
+    date: '',
+    location: '',
+    details: '',
+    rsvps: 0,
+    createdAt: '',
+  } as BoardPost);
+
+  const addPost = () => {
+    if (!post.title.trim()) return;
+    const item: BoardPost = {
+      ...post,
+      id: uid(),
+      title: post.title.trim(),
+      createdAt: new Date().toISOString(),
+      rsvps: 0,
+    };
+    const list = [item, ...board];
+    saveBoard(list);
+    setBoard(list);
+    setPost({ id: '', title: '', date: '', location: '', details: '', rsvps: 0, createdAt: '' } as BoardPost);
+  };
+
+  return (
+    <div>
+      <h1>🗳️🌍 Community</h1>
+      <p>Vote for new lands & characters, and join local volunteer events.</p>
+
+      <div className="tabs" role="tablist" aria-label="Community">
+        <button className="tab" aria-selected={tab === 'polls'} onClick={() => setTab('polls')}>
+          Polls
+        </button>
+        <button className="tab" aria-selected={tab === 'board'} onClick={() => setTab('board')}>
+          Volunteer Board
+        </button>
+        <button className="tab" aria-selected={tab === 'coming'} onClick={() => setTab('coming')}>
+          Coming Soon
+        </button>
+      </div>
+
+      {tab === 'polls' && (
+        <section className="polls">
+          <div className="panel">
+            <h2>Create a Poll</h2>
+            <input
+              className="input"
+              placeholder="Poll title"
+              value={newPollTitle}
+              onChange={(e) => setNewPollTitle(e.target.value)}
+            />
+            <textarea
+              className="textarea"
+              rows={4}
+              value={newOptions}
+              onChange={(e) => setNewOptions(e.target.value)}
+              placeholder={'One option per line'}
+            />
+            <button className="btn" onClick={addPoll}>
+              Add Poll
+            </button>
+            <p className="meta">Client-only; votes are stored in your browser.</p>
+          </div>
+
+          <div className="poll-list">
+            {polls.map((p) => {
+              const total = totalVotes(p) || 1;
+              const voted = hasVoted(p.id);
+              return (
+                <div key={p.id} className="poll-card">
+                  <div className="poll-title">{p.title}</div>
+                  {p.notes && <div className="poll-notes">{p.notes}</div>}
+
+                  <div className="poll-options">
+                    {p.choices.map((c) => {
+                      const pct = Math.round((c.votes / total) * 100);
+                      return (
+                        <button
+                          key={c.id}
+                          className={'poll-option' + (voted ? ' voted' : '')}
+                          onClick={() => {
+                            if (voted) return;
+                            const ok = submitVote(p.id, c.id);
+                            if (ok) setPolls(loadPolls());
+                          }}
+                          aria-label={`Vote ${c.label}`}
+                          disabled={voted}
+                        >
+                          <span>{c.label}</span>
+                          <span className="pct">{pct}%</span>
+                          <span className="bar">
+                            <i style={{ width: `${pct}%` }} />
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  <div className="poll-foot">
+                    <span className="meta">Total votes: {totalVotes(p)}</span>
+                    {voted && <span className="tag">Thanks for voting!</span>}
+                  </div>
+                </div>
+              );
+            })}
+            {polls.length === 0 && <p className="meta">No polls yet.</p>}
+          </div>
+        </section>
+      )}
+
+      {tab === 'board' && (
+        <section className="board">
+          <div className="panel">
+            <h2>Post a Volunteer Event</h2>
+            <input
+              className="input"
+              placeholder="Title (e.g., Park cleanup)"
+              value={post.title}
+              onChange={(e) => setPost({ ...post, title: e.target.value })}
+            />
+            <div className="row">
+              <input
+                className="input"
+                type="date"
+                value={post.date?.slice(0, 10) || ''}
+                onChange={(e) => setPost({ ...post, date: e.target.value })}
+              />
+              <input
+                className="input"
+                placeholder="Location"
+                value={post.location || ''}
+                onChange={(e) => setPost({ ...post, location: e.target.value })}
+              />
+            </div>
+            <textarea
+              className="textarea"
+              rows={3}
+              placeholder="Details"
+              value={post.details || ''}
+              onChange={(e) => setPost({ ...post, details: e.target.value })}
+            />
+            <button className="btn" onClick={addPost}>
+              Add Event
+            </button>
+            <p className="meta">Client-only; RSVPs are local for now.</p>
+          </div>
+
+          <div className="board-list">
+            {sortedBoard.map((x) => (
+              <div key={x.id} className="board-card">
+                <div className="board-title">{x.title}</div>
+                <div className="meta">
+                  {x.date && <>📅 {new Date(x.date).toLocaleDateString()} · </>}
+                  {x.location && <>📍 {x.location}</>}
+                </div>
+                {x.details && <p className="board-details">{x.details}</p>}
+                <div className="actions">
+                  <button
+                    className="btn outline"
+                    onClick={() => {
+                      rsvp(x.id);
+                      setBoard(loadBoard());
+                    }}
+                  >
+                    RSVP • {x.rsvps}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {tab === 'coming' && (
+        <section>
+          <h2>Coming Soon</h2>
+          <ul>
+            <li>Verified community profiles & chapters per kingdom.</li>
+            <li>Cause matching, donations, and brand partners via Naturversity.</li>
+            <li>On-chain votes with NATUR coin.</li>
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -12,6 +12,7 @@ import CreatorLabZone from "./routes/zones/creator-lab";
 import Stories from "./pages/zones/Stories";
 import Quizzes from "./pages/zones/Quizzes";
 import Observations from "./pages/zones/Observations";
+import Community from "./pages/zones/Community";
 import Marketplace from "./routes/marketplace";
 import Catalog from "./routes/marketplace/catalog";
 import Wishlist from "./routes/marketplace/wishlist";
@@ -44,6 +45,7 @@ export const router = createBrowserRouter([
       { path: "zones/stories", element: <Stories /> },
       { path: "zones/quizzes", element: <Quizzes /> },
       { path: "zones/observations", element: <Observations /> },
+      { path: "zones/community", element: <Community /> },
       { path: "marketplace", element: <Marketplace /> },
       { path: "marketplace/catalog", element: <Catalog /> },
       { path: "marketplace/wishlist", element: <Wishlist /> },

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -39,6 +39,12 @@ const ZONES = [
     title: 'Observations',
     sub: 'Upload nature pics; tag, learn, earn.',
   },
+  {
+    to: '/zones/community',
+    emoji: '🗳️',
+    title: 'Community',
+    sub: 'Voting, events, & volunteering.',
+  },
 ];
 
 export default function Zones() {

--- a/src/styles/zone-widgets.css
+++ b/src/styles/zone-widgets.css
@@ -175,3 +175,25 @@
 .obs-panel{ position:sticky; top:12px; align-self:start; border:1px solid #e5e7eb; border-radius:12px; background:#fff; padding:12px; }
 .obs-full{ width:100%; border-radius:10px; margin-bottom:8px; }
 @media (max-width: 980px){ .flex-split{ grid-template-columns:1fr; } .obs-panel{ position:static; } }
+
+/* Community */
+.panel{ border:1px solid #e5e7eb; background:#fff; border-radius:12px; padding:12px; margin:12px 0; }
+.row{ display:flex; gap:8px; }
+@media (max-width: 720px){ .row{ flex-direction:column; } }
+
+.poll-list{ display:grid; gap:12px; }
+.poll-card{ border:1px solid #e5e7eb; background:#fff; border-radius:12px; padding:12px; }
+.poll-title{ font-weight:800; margin-bottom:6px; }
+.poll-notes{ color:#4b5563; margin-bottom:8px; }
+.poll-options{ display:grid; gap:8px; }
+.poll-option{ border:1px solid #e5e7eb; background:#f9fafb; border-radius:10px; padding:8px; display:grid; grid-template-columns:1fr auto; gap:8px; text-align:left; }
+.poll-option .pct{ font-variant-numeric: tabular-nums; opacity:.8; }
+.poll-option .bar{ grid-column:1 / -1; height:8px; background:#eef2ff; border-radius:999px; overflow:hidden; }
+.poll-option .bar i{ display:block; height:100%; background:#6366f1; }
+.poll-option.voted{ cursor:default; opacity:.9; }
+.poll-foot{ display:flex; gap:8px; align-items:center; margin-top:6px; justify-content:space-between; }
+
+.board-list{ display:grid; gap:12px; }
+.board-card{ border:1px solid #e5e7eb; background:#fff; border-radius:12px; padding:12px; }
+.board-title{ font-weight:800; }
+.board-details{ margin:6px 0; }


### PR DESCRIPTION
## Summary
- add client-only Community zone with polls and volunteer board
- persist votes, polls and RSVP data in browser localStorage
- wire Community zone into router, zone list, and styles

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68a703acb6248329ae4c71776e3e4178