### PR TITLE
Passport v1 — stamps, badges, XP & NATUR (uses localStorage only)

### DIFF
--- a/src/lib/navatar/store.ts
+++ b/src/lib/navatar/store.ts
@@ -1,0 +1,24 @@
+export type Navatar = {
+  name: string;
+  species: string;
+  base: string;
+  emoji?: string;
+  photo?: string;
+};
+
+const K = "naturverse.navatar.current.v1";
+
+export function getCurrent(): Navatar | null {
+  try {
+    return JSON.parse(localStorage.getItem(K) || "null");
+  } catch {
+    return null;
+  }
+}
+
+export function setCurrent(n: Navatar | null) {
+  try {
+    if (n) localStorage.setItem(K, JSON.stringify(n));
+    else localStorage.removeItem(K);
+  } catch {}
+}

--- a/src/lib/passport/store.ts
+++ b/src/lib/passport/store.ts
@@ -1,0 +1,30 @@
+const K = {
+  stamps: "naturverse.passport.stamps.v1",
+  badges: "naturverse.passport.badges.v1",
+  xp:     "naturverse.passport.xp.v1",
+  coin:   "naturverse.passport.natur.v1",
+};
+
+const read = <T>(k: string, d: T) => { try { return JSON.parse(localStorage.getItem(k) || "null") ?? d; } catch { return d; } };
+const write = (k: string, v: unknown) => { try { localStorage.setItem(k, JSON.stringify(v)); } catch {} };
+
+export type Badge = { id: string; title: string; emoji: string; desc: string; };
+
+export function getStamps(): string[] { return read<string[]>(K.stamps, []); }
+export function toggleStamp(id: string) {
+  const s = new Set(getStamps());
+  s.has(id) ? s.delete(id) : s.add(id);
+  write(K.stamps, [...s]);
+}
+
+export function getBadges(): Badge[] { return read<Badge[]>(K.badges, []); }
+export function addBadge(b: Badge) {
+  const list = getBadges();
+  if (!list.find(x => x.id === b.id)) { list.unshift(b); write(K.badges, list.slice(0, 50)); }
+}
+
+export function getXP(): number { return read<number>(K.xp, 0); }
+export function addXP(n: number) { write(K.xp, Math.max(0, getXP() + n)); }
+
+export function getNatur(): number { return read<number>(K.coin, 0); }
+export function addNatur(n: number) { write(K.coin, Math.max(0, getNatur() + n)); }

--- a/src/pages/Passport.tsx
+++ b/src/pages/Passport.tsx
@@ -1,0 +1,92 @@
+import React, { useMemo, useState } from "react";
+import { getCurrent } from "../lib/navatar/store";
+import type { Badge } from "../lib/passport/store";
+import { getStamps, toggleStamp, getBadges, addBadge, getXP, addXP, getNatur, addNatur } from "../lib/passport/store";
+
+const KINGDOMS = [
+  "Thailandia","Brazilandia","Indilandia","Amerilandia",
+  "Australandia","Chilandia","Japonica","Africania",
+  "Europalia","Britannula","Kiwilandia","Madagascaria",
+  "Greenlandia","Antarcticland"
+];
+
+export default function PassportPage() {
+  const nav = getCurrent();
+  const [stamps, setStamps] = useState<string[]>(getStamps());
+  const [badges, setBadges] = useState<Badge[]>(getBadges());
+  const [xp, setXp] = useState(getXP());
+  const [natur, setNatur] = useState(getNatur());
+
+  const stampCount = stamps.length;
+  const level = useMemo(() => 1 + Math.floor(xp / 100), [xp]);
+
+  const onToggle = (k: string) => { toggleStamp(k); setStamps(getStamps()); };
+  const demoBadge = () => {
+    addBadge({ id: "first-tour", title: "First Tour", emoji: "🗺️", desc: "Visited your first kingdom." });
+    setBadges(getBadges());
+  };
+  const earnXP = (n: number) => { addXP(n); setXp(getXP()); };
+  const earnNatur = (n: number) => { addNatur(n); setNatur(getNatur()); };
+
+  return (
+    <div>
+      <h1>Passport</h1>
+      <p>Badges, stamps, XP, and NATUR coin.</p>
+
+      {/* Identity / Navatar */}
+      <div className="passport-id">
+        <div className="avatar">
+          {nav?.photo ? <img src={nav.photo} alt="" /> : <span className="emoji">{nav?.emoji || "🪪"}</span>}
+        </div>
+        <div className="id-text">
+          <div className="name">{nav?.name || "Explorer"}</div>
+          <div className="muted">{nav ? `${nav.base} · ${nav.species}` : "Create a Navatar to personalize."}</div>
+        </div>
+        <div className="stats">
+          <div className="stat"><div className="k">Level</div><div className="v">{level}</div></div>
+          <div className="stat"><div className="k">XP</div><div className="v">{xp}</div></div>
+          <div className="stat"><div className="k">NATUR</div><div className="v">{natur}</div></div>
+        </div>
+      </div>
+
+      <div className="row gap">
+        <button className="btn tiny" onClick={() => earnXP(10)}>+10 XP</button>
+        <button className="btn tiny" onClick={() => earnNatur(5)}>+5 NATUR</button>
+        <button className="btn tiny outline" onClick={demoBadge}>Award Demo Badge</button>
+      </div>
+
+      {/* Stamps */}
+      <h2 className="mt">Stamps</h2>
+      <p className="muted">Tap a kingdom to toggle a stamp. ({stampCount}/14)</p>
+      <div className="stamps-grid">
+        {KINGDOMS.map(k => {
+          const on = stamps.includes(k);
+          return (
+            <button key={k} className={"stamp" + (on ? " on" : "")} onClick={() => onToggle(k)} aria-pressed={on}>
+              <span className="dot">{on ? "✅" : "⬜️"}</span>
+              <span>{k}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Badges */}
+      <h2 className="mt">Badges</h2>
+      {badges.length === 0 ? (
+        <p className="muted">No badges yet. Complete quests to earn some!</p>
+      ) : (
+        <div className="badges">
+          {badges.map(b => (
+            <div className="badge" key={b.id} title={b.desc}>
+              <div className="emoji">{b.emoji}</div>
+              <div className="title">{b.title}</div>
+              <div className="desc">{b.desc}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <p className="meta">Coming soon: travel logs, per-kingdom progress, leaderboard, wallet-linked NATUR ledger, and verifiable stamp NFTs.</p>
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -28,7 +28,7 @@ import BankToken from "./pages/naturbank/Token";
 import BankNFTs from "./pages/naturbank/NFTs";
 import BankLearn from "./pages/naturbank/Learn";
 import Navatar from "./routes/navatar";
-import Passport from "./routes/passport";
+import Passport from "./pages/Passport";
 import Turian from "./routes/turian";
 import Profile from "./routes/profile";
 import AppShell from "./shell/AppShell";

--- a/src/routes/passport/index.tsx
+++ b/src/routes/passport/index.tsx
@@ -1,9 +1,0 @@
-export default function Passport() {
-  return (
-    <section>
-      <h2 className="text-2xl font-bold">Passport</h2>
-      <p className="text-gray-600">Badges, stamps, XP, and NATUR coin.</p>
-      <p className="mt-3"><strong>Stamps:</strong> Thailandia · Chilandia · Indilandia</p>
-    </section>
-  );
-}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,5 @@
 @import "./styles/bank.css";
+@import "./styles/passport.css";
 :root { --ink:#0b2545; --muted:#6b7280; --card:#f6f7fb; --ring:#dbe2ef; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}

--- a/src/styles/passport.css
+++ b/src/styles/passport.css
@@ -1,0 +1,22 @@
+.passport-id{ display:flex; align-items:center; gap:14px; padding:12px; border:1px solid #e5e7eb; border-radius:14px; background:#fff; margin:10px 0 2px; }
+.passport-id .avatar{ width:72px; height:72px; border-radius:12px; overflow:hidden; border:1px solid #e5e7eb; display:flex; align-items:center; justify-content:center; background:#f8fafc; }
+.passport-id .avatar img{ width:100%; height:100%; object-fit:cover; }
+.passport-id .avatar .emoji{ font-size:42px; }
+.passport-id .id-text .name{ font-weight:800; font-size:18px; }
+.passport-id .id-text .muted{ color:#6b7280; }
+.passport-id .stats{ margin-left:auto; display:flex; gap:18px; }
+.stat .k{ color:#6b7280; font-size:12px; }
+.stat .v{ font-weight:800; font-size:18px; }
+
+.stamps-grid{ display:grid; grid-template-columns:repeat(auto-fill,minmax(160px,1fr)); gap:8px; margin:8px 0 14px; }
+.stamp{ display:flex; gap:8px; align-items:center; padding:10px; border:1px solid #e5e7eb; border-radius:12px; background:#fff; text-align:left; }
+.stamp.on{ border-color:#22c55e; background:#22c55e11; }
+.stamp .dot{ width:22px; text-align:center; }
+
+.badges{ display:grid; grid-template-columns:repeat(auto-fill,minmax(180px,1fr)); gap:10px; }
+.badge{ border:1px solid #e5e7eb; border-radius:12px; background:#fff; padding:10px; }
+.badge .emoji{ font-size:28px; }
+.badge .title{ font-weight:800; }
+.badge .desc{ color:#6b7280; font-size:13px; }
+
+.mt{ margin-top:18px; }


### PR DESCRIPTION
## Summary
- add localStorage-based passport store for stamps, badges, XP, and NATUR
- implement Passport page showing navatar info with stamp toggles and badge/XPNatur demos
- style Passport UI and wire up router and styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7145fc4b48329b3c8c73ee3908cbe