### PR TITLE
Add Cultural Zone: beliefs, holidays, ceremonies (non-interactive v1)

### DIFF
--- a/src/data/culture.ts
+++ b/src/data/culture.ts
@@ -1,0 +1,121 @@
+export type CultureItem = {
+  id: string;
+  emoji: string;
+  title: string; // Kingdom name
+  blurb: string; // Short one-liner
+  beliefs: string[]; // Core beliefs / notes
+  holidays: { name: string; when: string; about: string }[];
+  ceremonies: string[]; // Rituals / practices
+};
+
+export const cultureData: CultureItem[] = [
+  {
+    id: "thailandia",
+    emoji: "🌺🛕",
+    title: "Thailandia",
+    blurb: "Coconuts & Elephants",
+    beliefs: [
+      "Kindness, merit, and harmony with nature.",
+      "Respect for water, forests, and elephants as guardian spirits."
+    ],
+    holidays: [
+      { name: "Songkran (Water Festival)", when: "Mid-April", about: "New year blessing with water splashing, gratitude, and renewal." },
+      { name: "Loy Krathong", when: "Full moon of the 12th lunar month", about: "Lanterns & floating baskets thanking rivers and letting go of worries." }
+    ],
+    ceremonies: [
+      "Dawn offerings to temples.",
+      "Water blessings before long journeys or new quests."
+    ]
+  },
+  {
+    id: "amerilandia",
+    emoji: "🎆🦅",
+    title: "Amerilandia",
+    blurb: "Apples & Eagles",
+    beliefs: [
+      "Freedom, community service, and fair play.",
+      "Stewardship of parks, trails, and wild places."
+    ],
+    holidays: [
+      { name: "Independence Festival", when: "Early July", about: "Parades, fireworks, and community clean-ups." },
+      { name: "Harvest Day", when: "Late November", about: "Gratitude feasts and food drives for neighbors." }
+    ],
+    ceremonies: [
+      "Trail pledges before expeditions.",
+      "Community flag & firelight gatherings."
+    ]
+  },
+  {
+    id: "chilandia",
+    emoji: "🧧🐉",
+    title: "Chilandia",
+    blurb: "Bamboo & Pandas",
+    beliefs: [
+      "Balance, family, and scholarly curiosity.",
+      "Bamboo as a symbol of resilience."
+    ],
+    holidays: [
+      { name: "Lunar New Year", when: "Late Jan / Feb", about: "Reunion dinners, red envelopes, lion & dragon dances." },
+      { name: "Mid-Autumn Festival", when: "Sep / Oct", about: "Mooncakes, lantern walks, stories of the moon." }
+    ],
+    ceremonies: [
+      "Tea sharing to begin peace talks and quests.",
+      "Lantern messages for wishes and thanks."
+    ]
+  },
+  {
+    id: "japonica",
+    emoji: "🎋🦊",
+    title: "Japonica",
+    blurb: "Cherry Blossoms & Foxes",
+    beliefs: [
+      "Seasonal mindfulness and craftsmanship.",
+      "Shrine paths honoring guardians of forest and sea."
+    ],
+    holidays: [
+      { name: "Hanami Blossoms", when: "Spring", about: "Picnics under blossoms; reflection on impermanence." },
+      { name: "New Year First Sunrise", when: "Jan 1", about: "Hatsumode shrine visits; first wishes and goals." }
+    ],
+    ceremonies: [
+      "Forest bell & clap at shrines before adventures.",
+      "Paper charms for safe travel."
+    ]
+  },
+  {
+    id: "europalia",
+    emoji: "🌻🦔",
+    title: "Europalia",
+    blurb: "Sunflowers & Hedgehogs",
+    beliefs: [
+      "Village festivals, guilds, and artistry.",
+      "Stone circles and garden lore."
+    ],
+    holidays: [
+      { name: "Midsummer Fires", when: "June", about: "Bonfires, wreaths, and nature songs." },
+      { name: "Winter Lights", when: "Dec", about: "Markets, candles, and carols." }
+    ],
+    ceremonies: [
+      "Bread-breaking to welcome travelers.",
+      "Wreath crafting for luck."
+    ]
+  },
+  {
+    id: "africania",
+    emoji: "🦁🥁",
+    title: "Africania",
+    blurb: "Mangoes & Lions",
+    beliefs: [
+      "Elders’ wisdom, drums, and star navigation.",
+      "Respect for savanna spirits and great cats."
+    ],
+    holidays: [
+      { name: "First Rains", when: "Seasonal", about: "Dances for renewal; seed blessings." }
+    ],
+    ceremonies: [
+      "Drum circles to mark milestones.",
+      "Griot storytelling nights."
+    ]
+  }
+  // More kingdoms can be appended later without code changes.
+];
+

--- a/src/pages/zones/Culture.tsx
+++ b/src/pages/zones/Culture.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { cultureData } from "../../data/culture";
+
+export default function Culture() {
+  return (
+    <div>
+      <h1>🏮 Culture</h1>
+      <p>Beliefs, holidays, and ceremonies across the 14 kingdoms.</p>
+
+      <div className="grid">
+        {cultureData.map((k) => (
+          <div key={k.id} className="card">
+            <h3>
+              <span aria-hidden>{k.emoji}</span> {k.title}
+            </h3>
+            <p className="small">{k.blurb}</p>
+
+            <div className="split">
+              <div>
+                <h4>Beliefs</h4>
+                <ul>
+                  {k.beliefs.map((b, i) => (
+                    <li key={i}>{b}</li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h4>Holidays</h4>
+                <ul>
+                  {k.holidays.map((h, i) => (
+                    <li key={i}>
+                      <strong>{h.name}</strong> — <em>{h.when}</em>. {h.about}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+
+            <div>
+              <h4>Ceremonies</h4>
+              <ul>
+                {k.ceremonies.map((c, i) => (
+                  <li key={i}>{c}</li>
+                ))}
+              </ul>
+            </div>
+
+            <p className="small coming">
+              Coming Soon: seasonal quests, festival badges, and limited-time items.
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <p style={{ marginTop: 16 }}>
+        <Link to="/zones" className="btn">
+          ← Back to Zones
+        </Link>
+      </p>
+    </div>
+  );
+}
+

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -13,6 +13,7 @@ import Stories from "./pages/zones/Stories";
 import Quizzes from "./pages/zones/Quizzes";
 import Observations from "./pages/zones/Observations";
 import Community from "./pages/zones/Community";
+import Culture from "./pages/zones/Culture";
 import Marketplace from "./routes/marketplace";
 import Catalog from "./pages/marketplace/Catalog";
 import Wishlist from "./pages/marketplace/Wishlist";
@@ -49,6 +50,7 @@ export const router = createBrowserRouter([
       { path: "zones/stories", element: <Stories /> },
       { path: "zones/quizzes", element: <Quizzes /> },
       { path: "zones/observations", element: <Observations /> },
+      { path: "zones/culture", element: <Culture /> },
       { path: "zones/community", element: <Community /> },
       { path: "marketplace", element: <Marketplace /> },
       { path: "marketplace/catalog", element: <Catalog /> },

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -40,6 +40,12 @@ const ZONES = [
     sub: 'Upload nature pics; tag, learn, earn.',
   },
   {
+    to: '/zones/culture',
+    emoji: '🏮',
+    title: 'Culture',
+    sub: 'Beliefs, holidays, & ceremonies.',
+  },
+  {
     to: '/zones/community',
     emoji: '🗳️',
     title: 'Community',

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,3 +23,5 @@
 .btn{display:inline-block;padding:8px 12px;border:1px solid var(--ring);border-radius:10px;text-decoration:none}
 .input{width:100%;padding:10px;border:1px solid var(--ring);border-radius:10px}
 .row{display:flex;gap:8px;align-items:center}
+.card .split{display:grid;grid-template-columns:1fr 1fr;gap:12px 16px}
+.card .coming{margin-top:8px}


### PR DESCRIPTION
## Summary
- add cultural data file for kingdoms
- introduce culture zone page showing beliefs, holidays, and ceremonies
- link new Culture zone in hub and routing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a71d46f2748329a37185eb352c5b18