### PR TITLE
Navatar v1 — creator, photo upload, backstory + character card (no deps)

### DIFF
--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import type { Navatar } from "../types/navatar";
+
+type Props = { navatar: Navatar };
+
+export default function NavatarCard({ navatar }: Props) {
+  return (
+    <div className="card">
+      <div className="card__header">
+        <div className="card__title">
+          <span role="img" aria-label="leaf">🌿</span> {navatar.name || navatar.species}
+        </div>
+        <div className="card__meta">
+          {navatar.base} • {new Date(navatar.createdAt).toLocaleDateString()}
+        </div>
+      </div>
+
+      <div className="card__media">
+        {navatar.imageDataUrl ? (
+          <img src={navatar.imageDataUrl} alt={`${navatar.name || navatar.species}`} />
+        ) : (
+          <div className="card__placeholder" aria-label="No photo">No photo</div>
+        )}
+      </div>
+
+      <div className="card__section">
+        <strong>Species:</strong> {navatar.species}
+      </div>
+      <div className="card__section">
+        <strong>Powers:</strong> {navatar.powers.join(" · ")}
+      </div>
+      <div className="card__section">
+        <strong>Backstory:</strong>
+        <p className="card__backstory">{navatar.backstory}</p>
+      </div>
+
+      <style>{`
+        .card{border:1px solid #e6e6e6;border-radius:12px;padding:16px;background:#fff;max-width:560px}
+        .card__header{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:8px}
+        .card__title{font-weight:700}
+        .card__meta{opacity:.7;font-size:.9rem}
+        .card__media{display:flex;justify-content:center;align-items:center;background:#fafafa;border-radius:8px;height:220px;overflow:hidden;margin:8px 0}
+        .card__media img{height:100%;object-fit:cover}
+        .card__placeholder{color:#aaa}
+        .card__section{margin:8px 0}
+        .card__backstory{margin:6px 0}
+      `}</style>
+    </div>
+  );
+}

--- a/src/lib/navatarCatalog.ts
+++ b/src/lib/navatarCatalog.ts
@@ -1,0 +1,30 @@
+import type { NavatarBase } from "../types/navatar";
+
+export const SPECIES: Record<NavatarBase, string[]> = {
+  Animal: [
+    "Red Panda","Snow Leopard","Sea Turtle","Barn Owl","Dolphin","Koala","Elephant",
+    "Macaw","Hedgehog","Arctic Fox","Tiger","Camel","Kangaroo","Wolf","Penguin"
+  ],
+  Fruit: [
+    "Mango","Coconut","Banana","Dragonfruit","Pineapple","Peach","Kiwi","Lychee",
+    "Guava","Pomegranate","Blueberry","Apple","Grapes","Cherry","Lemon"
+  ],
+  Insect: [
+    "Butterfly","Firefly","Ladybug","Praying Mantis","Honeybee","Stag Beetle","Ant",
+    "Cicada","Dragonfly","Atlas Moth"
+  ],
+  Spirit: [
+    "Forest Sprite","River Nymph","Sand Wisp","Storm Djinn","Aurora Spirit",
+    "Bloom Pixie","Stone Guardian","Ember Wisp","Mist Walker"
+  ],
+};
+
+export const POWERS_BANK: string[] = [
+  "Nature Whisper","Fast Learner","Team Boost","Calm Aura","Trailblazer",
+  "Water Breathe","Leaf Shield","Night Vision","Echo Sense","Quick Craft",
+  "Lucky Charm","Ice Step","Sunbeam Heal","Song Maker","Puzzle Vision"
+];
+
+export function randomFrom<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,17 @@
+const KEY_ACTIVE = "naturverse.activeNavatar";
+const KEY_LIBRARY = "naturverse.navatarLibrary";
+
+export function loadActive<T>(): T | null {
+  try { return JSON.parse(localStorage.getItem(KEY_ACTIVE) || "null"); } catch { return null; }
+}
+export function saveActive<T>(v: T | null) {
+  if (v == null) localStorage.removeItem(KEY_ACTIVE);
+  else localStorage.setItem(KEY_ACTIVE, JSON.stringify(v));
+}
+
+export function loadLibrary<T>(): T[] {
+  try { return JSON.parse(localStorage.getItem(KEY_LIBRARY) || "[]"); } catch { return []; }
+}
+export function saveLibrary<T>(list: T[]) {
+  localStorage.setItem(KEY_LIBRARY, JSON.stringify(list));
+}

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -1,0 +1,162 @@
+import React, { useMemo, useState } from "react";
+import type { Navatar, NavatarBase } from "../types/navatar";
+import { SPECIES, POWERS_BANK, randomFrom } from "../lib/navatarCatalog";
+import { loadActive, saveActive, loadLibrary, saveLibrary } from "../lib/storage";
+import NavatarCard from "../components/NavatarCard";
+
+const BASES: NavatarBase[] = ["Animal", "Fruit", "Insect", "Spirit"];
+
+function makeId() {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+}
+
+function makeBackstory(base: NavatarBase, species: string) {
+  return `Born in the ${base.toLowerCase()} realm, this ${species} learned to help explorers `
+    + `by trading ${randomFrom(["songs","stories","maps","herb lore","riddles"])} for smiles. `
+    + `Their quest: protect habitats and cheer on friends across the 14 kingdoms.`;
+}
+
+function generate(base: NavatarBase): Navatar {
+  const species = randomFrom(SPECIES[base]);
+  const powers = Array.from(new Set([
+    randomFrom(POWERS_BANK),
+    randomFrom(POWERS_BANK),
+    randomFrom(POWERS_BANK),
+  ]));
+  return {
+    id: makeId(),
+    name: "",
+    base,
+    species,
+    powers,
+    backstory: makeBackstory(base, species),
+    imageDataUrl: undefined,
+    createdAt: Date.now(),
+  };
+}
+
+export default function NavatarPage() {
+  const initial = useMemo(() => loadActive<Navatar>() ?? generate("Animal"), []);
+  const [draft, setDraft] = useState<Navatar>(initial);
+  const [library, setLibrary] = useState<Navatar[]>(loadLibrary<Navatar>());
+
+  function setBase(b: NavatarBase) {
+    setDraft(generate(b));
+  }
+
+  function onUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    const reader = new FileReader();
+    reader.onload = () => setDraft({ ...draft, imageDataUrl: String(reader.result) });
+    reader.readAsDataURL(f);
+  }
+
+  function saveActiveAndLibrary() {
+    const toSave = { ...draft, name: draft.name.trim() };
+    saveActive(toSave);
+    const nextLib = [toSave, ...library].slice(0, 50);
+    setLibrary(nextLib);
+    saveLibrary(nextLib);
+    alert("Navatar saved locally!");
+  }
+
+  return (
+    <div className="wrap">
+      <h1>Navatar Creator</h1>
+      <p>Choose a base type, customize details, and save your character card.</p>
+
+      <div className="grid">
+        <section className="panel">
+          <h2>1) Pick a Base</h2>
+          <div className="choices">
+            {BASES.map(b => (
+              <button
+                key={b}
+                type="button"
+                className={`pill ${draft.base === b ? "pill--active" : ""}`}
+                onClick={() => setBase(b)}
+                aria-pressed={draft.base === b}
+              >
+                {b}
+              </button>
+            ))}
+          </div>
+
+          <h2>2) Details</h2>
+          <label className="field">
+            <span>Name (optional)</span>
+            <input
+              value={draft.name}
+              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+              placeholder={`${draft.species}…`}
+            />
+          </label>
+
+          <label className="field">
+            <span>Backstory</span>
+            <textarea
+              value={draft.backstory}
+              onChange={(e) => setDraft({ ...draft, backstory: e.target.value })}
+              rows={4}
+            />
+          </label>
+
+          <label className="field">
+            <span>Photo (optional)</span>
+            <input type="file" accept="image/*" onChange={onUpload} />
+          </label>
+
+          <div className="actions">
+            <button type="button" onClick={() => setDraft(generate(draft.base))}>
+              Randomize
+            </button>
+            <button type="button" onClick={saveActiveAndLibrary}>
+              Save Navatar
+            </button>
+          </div>
+        </section>
+
+        <section className="panel">
+          <h2>Character Card</h2>
+          <NavatarCard navatar={draft} />
+
+          <h3 style={{marginTop:16}}>Library (local)</h3>
+          {library.length === 0 && <p>No saved Navatars yet.</p>}
+          <ul className="lib">
+            {library.map(n => (
+              <li key={n.id}>
+                <button
+                  type="button"
+                  className="linklike"
+                  onClick={() => setDraft(n)}
+                >
+                  {n.name || n.species} — {n.base}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      <p className="note">Coming soon: AI assisted art & powers, upgrade market, and cross-app use.</p>
+
+      <style>{`
+        .wrap{max-width:1100px;margin:0 auto}
+        .grid{display:grid;grid-template-columns:1fr 1fr;gap:24px}
+        @media (max-width:900px){.grid{grid-template-columns:1fr}}
+        .panel{background:#fff;border:1px solid #e6e6e6;border-radius:12px;padding:16px}
+        .choices{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px}
+        .pill{border:1px solid #d0d0d0;background:#f8f8f8;border-radius:999px;padding:8px 12px}
+        .pill--active{background:#e9f7ef;border-color:#9ad1b1}
+        .field{display:flex;flex-direction:column;gap:6px;margin:10px 0}
+        .field input,.field textarea{padding:10px;border:1px solid #dadada;border-radius:8px}
+        .actions{display:flex;gap:10px;margin-top:10px}
+        .lib{list-style:none;padding:0;margin:8px 0}
+        .lib li{margin:4px 0}
+        .linklike{background:none;border:none;padding:0;color:#0b62d6;cursor:pointer}
+        .note{opacity:.75;margin-top:24px}
+      `}</style>
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -28,7 +28,7 @@ import BankWallet from "./pages/naturbank/Wallet";
 import BankToken from "./pages/naturbank/Token";
 import BankNFTs from "./pages/naturbank/NFTs";
 import BankLearn from "./pages/naturbank/Learn";
-import Navatar from "./routes/navatar";
+import NavatarPage from "./pages/Navatar";
 import Passport from "./pages/Passport";
 import Turian from "./routes/turian";
 import Profile from "./pages/Profile";
@@ -66,7 +66,7 @@ export const router = createBrowserRouter([
       { path: "naturbank/token", element: <BankToken /> },
       { path: "naturbank/nfts", element: <BankNFTs /> },
       { path: "naturbank/learn", element: <BankLearn /> },
-      { path: "navatar", element: <Navatar /> },
+      { path: "navatar", element: <NavatarPage /> },
       { path: "passport", element: <Passport /> },
       { path: "turian", element: <Turian /> },
       { path: "profile", element: <Profile /> },

--- a/src/types/navatar.ts
+++ b/src/types/navatar.ts
@@ -1,0 +1,12 @@
+export type NavatarBase = "Animal" | "Fruit" | "Insect" | "Spirit";
+
+export type Navatar = {
+  id: string;             // nano id (timestamp-based string)
+  name: string;
+  base: NavatarBase;
+  species: string;        // e.g., “Red Panda”, “Mango”, …
+  backstory: string;
+  powers: string[];       // short list of powers/traits
+  imageDataUrl?: string;  // optional uploaded photo (data URL)
+  createdAt: number;      // epoch ms
+};


### PR DESCRIPTION
## Summary
- add Navatar types, catalog helpers, and localStorage utilities
- implement full Navatar creator page with random generator, image upload, and library
- wire Navatar route and character card component

## Testing
- `npm run typecheck`
- `npm run build`
- `npm start` *(fails: Missing script "start")*

------
https://chatgpt.com/codex/tasks/task_e_68a720e9c9288329a436972a0ebc13ac