### PR TITLE
UI polish — single mobile nav, Culture grid alignment, brand assets

### DIFF
--- a/public/assets/kingdoms/.keep
+++ b/public/assets/kingdoms/.keep
@@ -1,0 +1,1 @@
+# Drop JPG/PNG hero images here named by kingdom id (e.g., thailandia.jpg).

--- a/public/assets/logo.svg
+++ b/public/assets/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="32" viewBox="0 0 128 32" aria-labelledby="title">
+  <title>Naturverse</title>
+  <g fill="none" stroke="none">
+    <circle cx="16" cy="16" r="12" fill="#2e7d32"/>
+    <path d="M16 7c3 4 3 10 0 14-5-2-8-6-8-10 3-1 6-3 8-4z" fill="#81c784"/>
+    <rect x="36" y="8" width="84" height="16" fill="none"/>
+    <text x="36" y="22" font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial" font-size="16" fill="#1c1c1c">Naturverse</text>
+  </g>
+</svg>

--- a/public/assets/turian-owl.svg
+++ b/public/assets/turian-owl.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" aria-labelledby="title">
+  <title>Turian</title>
+  <circle cx="32" cy="32" r="30" fill="#ffe0b2"/>
+  <circle cx="24" cy="28" r="7" fill="#fff"/><circle cx="40" cy="28" r="7" fill="#fff"/>
+  <circle cx="24" cy="28" r="3.5" fill="#212121"/><circle cx="40" cy="28" r="3.5" fill="#212121"/>
+  <polygon points="32,24 27,34 37,34" fill="#ffb74d"/>
+  <path d="M12 42c6-6 34-6 40 0-1 8-13 12-20 12S13 50 12 42z" fill="#8d6e63"/>
+</svg>

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,0 +1,18 @@
+.nv-header { position: sticky; top: 0; z-index: 40; backdrop-filter: blur(6px); background: rgba(255,255,255,.85); border-bottom: 1px solid #eee; }
+.nv-bar { max-width: 1080px; margin: 0 auto; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+.nv-logo { width: 112px; height: 28px; display:block; }
+.nv-nav { margin-left: auto; display: flex; gap: 14px; flex-wrap: wrap; }
+.nv-nav a { padding: 6px 8px; border-radius: 8px; color: #1b1b1b; text-decoration: none; font-weight: 600; }
+.nv-nav a.active { background: #eef7ee; color: #205b26; }
+.nv-burger { display: none; margin-left: auto; cursor: pointer; }
+.nv-burger span { display:block; width:24px; height:2px; background:#333; margin:5px 0; border-radius:2px; }
+.nv-menu-toggle { display:none; }
+
+/* Mobile */
+@media (max-width: 760px) {
+  .nv-burger { display:block; }
+  .nv-nav { position: absolute; top: 56px; left:0; right:0; background:#fff; border-bottom:1px solid #eee;
+            display: grid; grid-template-columns: 1fr 1fr; gap:8px; padding:10px 12px; transform-origin: top; transform: scaleY(0);
+            transition: transform .18s ease; }
+  .nv-menu-toggle:checked ~ .nv-nav { transform: scaleY(1); }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,32 @@
+import { Link, NavLink } from "react-router-dom";
+import "./Header.css";
+
+export default function Header() {
+  return (
+    <header className="nv-header">
+      <div className="nv-bar">
+        <Link to="/" className="nv-brand">
+          <img src="/assets/logo.svg" alt="Naturverse logo" className="nv-logo" />
+        </Link>
+
+        <input id="nv-menu-toggle" className="nv-menu-toggle" type="checkbox" aria-label="Toggle navigation" />
+        <label htmlFor="nv-menu-toggle" className="nv-burger" aria-hidden="true">
+          <span/><span/><span/>
+        </label>
+
+        <nav className="nv-nav">
+          <NavLink to="/worlds">Worlds</NavLink>
+          <NavLink to="/zones">Zones</NavLink>
+          <NavLink to="/marketplace">Marketplace</NavLink>
+          <NavLink to="/naturversity">Naturversity</NavLink>
+          <NavLink to="/naturbank">Naturbank</NavLink>
+          <NavLink to="/navatar">Navatar</NavLink>
+          <NavLink to="/passport">Passport</NavLink>
+          <NavLink to="/turian">Turian</NavLink>
+          <NavLink to="/profile">Profile</NavLink>
+          <NavLink to="/zones/culture">Culture</NavLink>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/data/culture-sections.ts
+++ b/src/data/culture-sections.ts
@@ -1,0 +1,120 @@
+export type CultureSection = {
+  id: string;
+  emoji: string;
+  kingdom: string;
+  caption: string;
+  beliefs: string[];
+  holidays: { name: string; when: string; note: string }[];
+  ceremonies?: string[];
+};
+
+export const CULTURE_SECTIONS: CultureSection[] = [
+  {
+    id: "thailandia",
+    emoji: "🌺🛕",
+    kingdom: "Thailandia",
+    caption: "Coconuts & Elephants",
+    beliefs: [
+      "Kindness, merit, and harmony with nature.",
+      "Respect for water, forests, and elephants as guardian spirits."
+    ],
+    holidays: [
+      { name: "Songkran (Water Festival)", when: "Mid-April", note: "New year blessing with water splashing, gratitude, and renewal." },
+      { name: "Loy Krathong", when: "Full moon of the 12th lunar month", note: "Lanterns & floating baskets thanking rivers and letting go of worries." }
+    ],
+    ceremonies: [
+      "Dawn offerings to temples.",
+      "Water blessings before long journeys or new quests."
+    ]
+  },
+  {
+    id: "amerilandia",
+    emoji: "🎆🦅",
+    kingdom: "Amerilandia",
+    caption: "Apples & Eagles",
+    beliefs: [
+      "Freedom, community service, and fair play.",
+      "Stewardship of parks, trails, and wild places."
+    ],
+    holidays: [
+      { name: "Independence Festival", when: "Early July", note: "Parades, fireworks, and community clean-ups." },
+      { name: "Harvest Day", when: "Late November", note: "Gratitude feasts and food drives for neighbors." }
+    ],
+    ceremonies: [
+      "Trail pledges before expeditions.",
+      "Community flag & firelight gatherings."
+    ]
+  },
+  {
+    id: "chilandia",
+    emoji: "🎋🐼",
+    kingdom: "Chilandia",
+    caption: "Bamboo & Pandas",
+    beliefs: [
+      "Balance, family, and scholarly curiosity.",
+      "Bamboo as a symbol of resilience."
+    ],
+    holidays: [
+      { name: "Lunar New Year", when: "Late Jan / Feb", note: "Reunion dinners, red envelopes, lion & dragon dances." },
+      { name: "Mid-Autumn Festival", when: "Sep / Oct", note: "Mooncakes, lantern walks, stories of the moon." }
+    ],
+    ceremonies: [
+      "Tea sharing to begin peace talks and quests.",
+      "Lantern messages for wishes and thanks."
+    ]
+  },
+  {
+    id: "japonica",
+    emoji: "🎋🦊",
+    kingdom: "Japonica",
+    caption: "Cherry Blossoms & Foxes",
+    beliefs: [
+      "Seasonal mindfulness and craftsmanship.",
+      "Shrine paths honoring guardians of forest and sea."
+    ],
+    holidays: [
+      { name: "Hanami Blossoms", when: "Spring", note: "Picnics under blossoms; reflection on impermanence." },
+      { name: "New Year First Sunrise", when: "Jan 1", note: "Hatsumode shrine visits; first wishes and goals." }
+    ],
+    ceremonies: [
+      "Forest bell & clap at shrines before adventures.",
+      "Paper charms for safe travel."
+    ]
+  },
+  {
+    id: "europalia",
+    emoji: "🌻🦔",
+    kingdom: "Europalia",
+    caption: "Sunflowers & Hedgehogs",
+    beliefs: [
+      "Village festivals, guilds, and artistry.",
+      "Stone circles and garden lore."
+    ],
+    holidays: [
+      { name: "Midsummer Fires", when: "June", note: "Bonfires, wreaths, and nature songs." },
+      { name: "Winter Lights", when: "Dec", note: "Markets, candles, and carols." }
+    ],
+    ceremonies: [
+      "Bread-breaking to welcome travelers.",
+      "Wreath crafting for luck."
+    ]
+  },
+  {
+    id: "africania",
+    emoji: "🦁🥁",
+    kingdom: "Africania",
+    caption: "Mangoes & Lions",
+    beliefs: [
+      "Elders’ wisdom, drums, and star navigation.",
+      "Respect for savanna spirits and great cats."
+    ],
+    holidays: [
+      { name: "First Rains", when: "Seasonal", note: "Dances for renewal; seed blessings." }
+    ],
+    ceremonies: [
+      "Drum circles to mark milestones.",
+      "Griot storytelling nights."
+    ]
+  }
+  // More kingdoms can be appended later without code changes.
+];

--- a/src/data/worlds.ts
+++ b/src/data/worlds.ts
@@ -1,0 +1,24 @@
+export type Kingdom = {
+  id: string;
+  name: string;
+  tagline: string;
+  emoji: string;
+  img?: string; // optional branded image path
+};
+
+export const WORLDS: Kingdom[] = [
+  { id: "thailandia", name: "Thailandia", tagline: "Coconuts & Elephants", emoji: "🐘🌸", img: "/assets/kingdoms/thailandia.jpg" },
+  { id: "brazilandia", name: "Brazilandia", tagline: "Bananas & Parrots", emoji: "🍌🦜" },
+  { id: "indilandia", name: "Indilandia", tagline: "Mangoes & Tigers", emoji: "🥭🐯" },
+  { id: "amerilandia", name: "Amerilandia", tagline: "Apples & Eagles", emoji: "🍎🦅" },
+  { id: "australandia", name: "Australandia", tagline: "Peaches & Kangaroos", emoji: "🍑🦘" },
+  { id: "chilandia", name: "Chilandia", tagline: "Bamboo (shoots) & Pandas", emoji: "🎋🐼" },
+  { id: "japonica", name: "Japonica", tagline: "Cherry Blossoms & Foxes", emoji: "🌸🦊" },
+  { id: "africania", name: "Africania", tagline: "Mangoes & Lions", emoji: "🦁🌞" },
+  { id: "europalia", name: "Europalia", tagline: "Sunflowers & Hedgehogs", emoji: "🌻🦔" },
+  { id: "britannula", name: "Britannula", tagline: "Roses & Hedgehogs", emoji: "🌹🦔" },
+  { id: "kiwilandia", name: "Kiwilandia", tagline: "Kiwis & Sheep", emoji: "🥝🐑" },
+  { id: "madagascaria", name: "Madagascaria", tagline: "Lemons & Lemurs", emoji: "🍋🦥" },
+  { id: "greenlandia", name: "Greenlandia", tagline: "Ice & Polar Bears", emoji: "🧊🐻‍❄️" },
+  { id: "antarcticland", name: "Antarcticland", tagline: "Ice Crystals & Penguins", emoji: "❄️🐧" },
+];

--- a/src/pages/zones/Culture.css
+++ b/src/pages/zones/Culture.css
@@ -1,0 +1,31 @@
+.container { max-width: 1080px; margin: 0 auto; padding: 20px 16px 40px; }
+.muted { color:#5f6b6b; margin-top:-6px; margin-bottom:16px; }
+
+.culture-grid {
+  display:grid; gap:16px;
+  grid-template-columns: repeat(4, minmax(0,1fr));
+}
+@media (max-width: 1100px){ .culture-grid{ grid-template-columns: repeat(3,1fr); } }
+@media (max-width: 860px){ .culture-grid{ grid-template-columns: repeat(2,1fr); } }
+@media (max-width: 560px){ .culture-grid{ grid-template-columns: 1fr; } }
+
+.culture-card {
+  background:#fff; border:1px solid #ececec; border-radius:14px; padding:14px;
+  display:flex; flex-direction:column; min-height: 320px;
+  box-shadow: 0 1px 0 rgba(0,0,0,.02);
+}
+.culture-head { margin-bottom:10px; }
+.culture-title { display:flex; align-items:center; gap:10px; }
+.culture-title h3 { margin:0; }
+.caption { margin:4px 0 0; color:#7a8282; }
+.emoji { font-size:22px; }
+
+.culture-columns {
+  display:grid; gap:12px; margin-top:6px;
+  grid-template-columns: repeat(3, minmax(0,1fr));
+}
+@media (max-width: 720px){ .culture-columns{ grid-template-columns: 1fr; } }
+
+h4 { margin:.5rem 0; }
+ul { margin:0; padding-left: 18px; }
+li { margin: 6px 0; }

--- a/src/pages/zones/Culture.tsx
+++ b/src/pages/zones/Culture.tsx
@@ -1,64 +1,44 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import { cultureData } from "../../data/culture";
+import { useMemo } from "react";
+import { CULTURE_SECTIONS } from "../../data/culture-sections";
+import "./Culture.css";
 
 export default function Culture() {
+  const items = useMemo(() => CULTURE_SECTIONS, []);
   return (
-    <div>
-      <h1>🏮 Culture</h1>
-      <p>Beliefs, holidays, and ceremonies across the 14 kingdoms.</p>
+    <main className="container">
+      <h1>🪔 Culture</h1>
+      <p className="muted">Beliefs, holidays, and ceremonies across the 14 kingdoms.</p>
 
-      <div className="grid">
-        {cultureData.map((k) => (
-          <div key={k.id} className="card">
-            <h3>
-              <span aria-hidden>{k.emoji}</span> {k.title}
-            </h3>
-            <p className="small">{k.blurb}</p>
+      <section className="culture-grid">
+        {items.map((k) => (
+          <article key={k.id} className="culture-card">
+            <header className="culture-head">
+              <div className="culture-title">
+                <span className="emoji">{k.emoji}</span>
+                <h3>{k.kingdom}</h3>
+              </div>
+              <p className="caption">{k.caption}</p>
+            </header>
 
-            <div className="split">
+            <div className="culture-columns">
               <div>
                 <h4>Beliefs</h4>
-                <ul>
-                  {k.beliefs.map((b, i) => (
-                    <li key={i}>{b}</li>
-                  ))}
-                </ul>
+                <ul>{k.beliefs.map((b, i) => <li key={i}>{b}</li>)}</ul>
               </div>
               <div>
                 <h4>Holidays</h4>
-                <ul>
-                  {k.holidays.map((h, i) => (
-                    <li key={i}>
-                      <strong>{h.name}</strong> — <em>{h.when}</em>. {h.about}
-                    </li>
-                  ))}
-                </ul>
+                <ul>{k.holidays.map((h, i) => <li key={i}><strong>{h.name}</strong> — <em>{h.when}</em>. {h.note}</li>)}</ul>
               </div>
+              {k.ceremonies?.length ? (
+                <div>
+                  <h4>Ceremonies</h4>
+                  <ul>{k.ceremonies.map((c, i) => <li key={i}>{c}</li>)}</ul>
+                </div>
+              ) : null}
             </div>
-
-            <div>
-              <h4>Ceremonies</h4>
-              <ul>
-                {k.ceremonies.map((c, i) => (
-                  <li key={i}>{c}</li>
-                ))}
-              </ul>
-            </div>
-
-            <p className="small coming">
-              Coming Soon: seasonal quests, festival badges, and limited-time items.
-            </p>
-          </div>
+          </article>
         ))}
-      </div>
-
-      <p style={{ marginTop: 16 }}>
-        <Link to="/zones" className="btn">
-          ← Back to Zones
-        </Link>
-      </p>
-    </div>
+      </section>
+    </main>
   );
 }
-

--- a/src/routes/Home.css
+++ b/src/routes/Home.css
@@ -1,0 +1,6 @@
+.container { max-width:1080px; margin:0 auto; padding:20px 16px 40px; }
+.home-hero { position:relative; padding-right:84px; }
+.hero-owl { position:absolute; right:0; top:-6px; width:56px; height:56px; }
+.hub-grid { margin-top:14px; display:grid; gap:14px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+@media (max-width: 900px){ .hub-grid{ grid-template-columns: repeat(2,1fr); } }
+@media (max-width: 560px){ .hub-grid{ grid-template-columns: 1fr; } }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,11 +1,15 @@
 import HubCard from '../components/HubCard';
 import HubGrid from '../components/HubGrid';
+import "./Home.css";
 
 export default function Home() {
   return (
     <main className="container">
-      <h1 className="h1">✨ Welcome to the Naturverse™</h1>
-      <p className="lead">Pick a hub to begin your adventure.</p>
+      <header className="home-hero">
+        <h1>✨ Welcome to the Naturverse™</h1>
+        <img src="/assets/turian-owl.svg" className="hero-owl" alt="Turian the owl" />
+        <p>Pick a hub to begin your adventure.</p>
+      </header>
 
       <HubGrid>
         <HubCard to="/worlds" emoji="📚" title="Worlds" sub="Travel the 14 magical kingdoms." />

--- a/src/routes/worlds/Worlds.css
+++ b/src/routes/worlds/Worlds.css
@@ -1,0 +1,2 @@
+.world-card { display:flex; align-items:center; gap:12px; }
+.world-thumb { width:44px; height:44px; border-radius:10px; object-fit:cover; background:#eef2ee; }

--- a/src/routes/worlds/index.tsx
+++ b/src/routes/worlds/index.tsx
@@ -1,27 +1,6 @@
-import HubCard from '../../components/HubCard';
-import HubGrid from '../../components/HubGrid';
-
-const WORLDS = [
-  { to: '/worlds/thailandia', emoji: '🐘🌸', title: 'Thailandia', sub: 'Coconuts & Elephants' },
-  { to: '/worlds/brazilandia', emoji: '🍌🦜', title: 'Brazilandia', sub: 'Bananas & Parrots' },
-  { to: '/worlds/indilandia', emoji: '🥭🐯', title: 'Indilandia', sub: 'Mangoes & Tigers' },
-  { to: '/worlds/amerilandia', emoji: '🍎🦅', title: 'Amerilandia', sub: 'Apples & Eagles' },
-  { to: '/worlds/australandia', emoji: '🍑🦘', title: 'Australandia', sub: 'Peaches & Kangaroos' },
-  { to: '/worlds/chilandia', emoji: '🎋🐼', title: 'Chilandia', sub: 'Bamboo (shoots) & Pandas' },
-  { to: '/worlds/japonica', emoji: '🌸🦊', title: 'Japonica', sub: 'Cherry Blossoms & Foxes' },
-  { to: '/worlds/africania', emoji: '🦁🌞', title: 'Africania', sub: 'Mangoes & Lions' },
-  { to: '/worlds/europalia', emoji: '🌻🦔', title: 'Europalia', sub: 'Sunflowers & Hedgehogs' },
-  { to: '/worlds/britannula', emoji: '🌹🦔', title: 'Britannula', sub: 'Roses & Hedgehogs' },
-  { to: '/worlds/kiwilandia', emoji: '🥝🐑', title: 'Kiwilandia', sub: 'Kiwis & Sheep' },
-  { to: '/worlds/madagascaria', emoji: '🍋🦥', title: 'Madagascaria', sub: 'Lemons & Lemurs' },
-  { to: '/worlds/greenlandia', emoji: '🧊🐻‍❄️', title: 'Greenlandia', sub: 'Ice & Polar Bears' },
-  {
-    to: '/worlds/antarcticland',
-    emoji: '❄️🐧',
-    title: 'Antarcticland',
-    sub: 'Ice Crystals & Penguins',
-  },
-];
+import { Link } from "react-router-dom";
+import { WORLDS } from "../../data/worlds";
+import "./Worlds.css";
 
 export default function Worlds() {
   return (
@@ -30,11 +9,21 @@ export default function Worlds() {
       <h2 className="section-title">Worlds</h2>
       <p className="section-lead">Explore the 14 kingdoms.</p>
 
-      <HubGrid>
+      <div className="grid">
         {WORLDS.map((w) => (
-          <HubCard key={w.title} to={w.to} emoji={w.emoji} title={w.title} sub={w.sub} />
+          <Link key={w.id} to={`/worlds/${w.id}`} className="card world-card">
+            {w.img ? (
+              <img src={w.img} alt="" className="world-thumb" />
+            ) : (
+              <span className="emoji" aria-hidden>{w.emoji}</span>
+            )}
+            <div>
+              <h3>{w.name}</h3>
+              <p className="caption">{w.tagline}</p>
+            </div>
+          </Link>
         ))}
-      </HubGrid>
+      </div>
     </main>
   );
 }

--- a/src/shell/AppShell.tsx
+++ b/src/shell/AppShell.tsx
@@ -1,33 +1,13 @@
 import React from "react";
-import { Link, NavLink, Outlet } from "react-router-dom";
-
-const tabs = [
-  ["Worlds", "/worlds"],
-  ["Zones", "/zones"],
-  ["Marketplace", "/marketplace"],
-  ["Naturversity", "/naturversity"],
-  ["Naturbank", "/naturbank"],
-  ["Navatar", "/navatar"],
-  ["Passport", "/passport"],
-  ["Turian", "/turian"],
-  ["Profile", "/profile"],
-] as const;
+import { Outlet } from "react-router-dom";
+import Header from "../components/Header";
 
 export default function AppShell() {
   return (
-    <div className="wrap">
-      <header className="top">
-        <Link to="/" className="brand">Naturverse <span>🌿</span></Link>
-        <nav className="tabs">
-          {tabs.map(([label, to]) => (
-            <NavLink key={to} to={to} className={({isActive}) => isActive ? "tab active" : "tab"}>
-              {label}
-            </NavLink>
-          ))}
-        </nav>
-      </header>
-      <main className="main"><Outlet/></main>
+    <>
+      <Header />
+      <main className="main"><Outlet /></main>
       <footer className="foot">© {new Date().getFullYear()} Naturverse</footer>
-    </div>
+    </>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,7 +2,8 @@
 @import "./styles/passport.css";
 @import "./styles/turian.css";
 @import "./styles/profile.css";
-:root { --ink:#0b2545; --muted:#6b7280; --card:#f6f7fb; --ring:#dbe2ef; }
+@import "./styles/global.css";
+:root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}
 .top{display:flex;gap:16px;align-items:center;border-bottom:1px solid var(--ring);padding-bottom:8px}
@@ -14,7 +15,7 @@
 .h2{font-size:20px;margin:14px 0 8px;color:var(--ink)}
 .p{color:var(--muted)}
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:16px;margin-top:12px}
-.card{background:var(--card);border:1px solid var(--ring);border-radius:14px;padding:14px}
+.card{border:1px solid #ececec;border-radius:var(--radius);background:#fff;padding:14px}
 .card h3{margin:0 0 6px 0}
 .small{font-size:13px;color:var(--muted)}
 .list{margin:6px 0 0 18px}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,3 @@
+:root { --radius:14px; --muted:#6c7676; }
+.caption { color: var(--muted); margin: 2px 0 0; }
+.card { border:1px solid #ececec; border-radius: var(--radius); background:#fff; }


### PR DESCRIPTION
## Summary
- streamline navigation with sticky mobile-friendly header and brand assets
- align Culture page in responsive grid layout
- support optional world thumbnails and add Turian mascot on home hero

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a729509e5c83298a30a92a7d85bb34