### PR TITLE
Full restore to Batch #286 (exact layout, hero, nav, culture)

### DIFF
--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { useState } from "react";
 
-export default function Header() {
+export default function Header(){
   const [open, setOpen] = useState(false);
   return (
     <header className="nv-header">
@@ -21,8 +21,14 @@ export default function Header() {
           <Link href="/turian">Turian</Link>
           <Link href="/profile">Profile</Link>
         </nav>
-        {/* batch-286 mobile: small apps button, not hamburger */}
-        <button type="button" className="nv-nav__apps" aria-label="Menu" onClick={() => setOpen(v=>!v)}>▢</button>
+        {/* batch 286: small apps square, opens simple mobile list */}
+        <button
+          type="button"
+          className="nv-nav__apps"
+          aria-label="Open menu"
+          aria-expanded={open}
+          onClick={() => setOpen(v=>!v)}
+        >▢</button>
       </div>
       {open && (
         <nav className="nv-nav nv-nav--mobile" aria-label="Mobile">

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -1,5 +1,3 @@
-export default function Layout({ children }: { children: React.ReactNode }) {
-  return (
-    <main className="nv-page nv-container">{children}</main>
-  );
+export default function Layout({children}:{children:React.ReactNode}){
+  return <main className="nv-page nv-container">{children}</main>;
 }

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -1,14 +1,12 @@
-export default function Home() {
+export default function Home(){
   return (
     <>
-      {/* batch-286 hero (no giant background emoji) */}
       <section className="nv-hero">
         <h1>✨ Welcome to the Naturverse™</h1>
         <p>Pick a hub to begin your adventure.</p>
       </section>
       <section className="nv-grid-hubs">
-        {/* hubs list kept as in 286 */}
-        {/* Worlds, Zones, Marketplace, Naturversity, Naturbank, Navatar, Passport, Turian, Profile */}
+        {/* cards unchanged from 286 */}
       </section>
     </>
   );

--- a/client/pages/zones/culture.tsx
+++ b/client/pages/zones/culture.tsx
@@ -51,28 +51,19 @@ const cards = [
   }
 ];
 
-export default function Culture() {
+export default function Culture(){
   return (
     <Layout>
       <h1>🪔 Culture</h1>
       <p>Beliefs, holidays, and ceremonies across the 14 kingdoms.</p>
       <div className="culture-grid grid-3">
-        {cards.map((c) => (
+        {cards.map((c)=>(
           <article key={c.title} className="nv-card">
             <h3>{c.title}</h3>
             <p className="muted">{c.subtitle}</p>
-            <h4>Beliefs</h4>
-            <ul className="culture-list">
-              {c.beliefs.map((b) => <li key={b}>{b}</li>)}
-            </ul>
-            <h4>Holidays</h4>
-            <ul className="culture-list">
-              {c.holidays.map((h) => <li key={h}>{h}</li>)}
-            </ul>
-            <h4>Ceremonies</h4>
-            <ul className="culture-list">
-              {c.ceremonies.map((ce) => <li key={ce}>{ce}</li>)}
-            </ul>
+            <h4>Beliefs</h4><ul className="culture-list">{c.beliefs.map(b=><li key={b}>{b}</li>)}</ul>
+            <h4>Holidays</h4><ul className="culture-list">{c.holidays.map(h=><li key={h}>{h}</li>)}</ul>
+            <h4>Ceremonies</h4><ul className="culture-list">{c.ceremonies.map(x=><li key={x}>{x}</li>)}</ul>
           </article>
         ))}
       </div>

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -1,35 +1,36 @@
-/* Containers — batch 286 */
-.nv-container { max-width: 1100px; margin: 0 auto; padding: 0 16px; }
-.nv-page { padding: 16px 0; }
+/* restore batch 286 — no hero blobs/faces */
+
+/* Layout containers */
+.nv-container{max-width:1100px;margin:0 auto;padding:0 16px;}
+.nv-page{padding:16px 0;}
 
 /* Header */
-.nv-header { position: sticky; top:0; z-index:40; background:var(--bg); border-bottom:1px solid var(--border); }
-.nv-header__row { display:flex; align-items:center; gap:16px; justify-content:space-between; padding:12px 16px; }
-.nv-brand { display:inline-flex; align-items:center; gap:8px; font-weight:700; text-decoration:none; color:inherit; }
-.nv-brand__mark { font-size:18px; }
-.nv-nav a { padding:8px 10px; border-radius:10px; text-decoration:none; color:inherit; }
-.nv-nav--mobile { display:none; flex-direction:column; gap:8px; padding:12px 16px; border-top:1px solid var(--border); }
-.nv-nav__apps { display:none; }
-@media (max-width: 920px) {
-  .nv-nav--desktop { display:none; }
-  .nv-nav__apps { display:inline-flex; }
-  .nv-nav--mobile { display:flex; }
+.nv-header{position:sticky;top:0;z-index:40;background:var(--bg);border-bottom:1px solid var(--border);}
+.nv-header__row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:12px 16px;}
+.nv-brand{display:inline-flex;align-items:center;gap:8px;font-weight:700;text-decoration:none;color:inherit;}
+.nv-brand__mark{font-size:18px;}
+.nv-nav a{padding:8px 10px;border-radius:10px;text-decoration:none;color:inherit;}
+.nv-nav__apps{display:none;}
+.nv-nav--mobile{display:none;flex-direction:column;gap:8px;padding:12px 16px;border-top:1px solid var(--border);}
+@media (max-width:920px){
+  .nv-nav--desktop{display:none;}
+  .nv-nav__apps{display:inline-flex;}
+  .nv-nav--mobile{display:flex;}
 }
 
-/* No giant emoji backgrounds in batch 286 */
-.nv-hero__emoji{display:none!important;}
+.nv-hero::before,
+.home-blob,
+.hero-blob{display:none !important;content:none !important;}
 
-/* Standard hero */
-.nv-hero h1 { margin: 8px 0 4px; font-size: clamp(28px, 5vw, 40px); }
-.nv-hero p { margin: 0 0 16px; opacity:.85; }
+/* Hero */
+.nv-hero h1{margin:8px 0 4px;font-size:clamp(28px,5vw,40px);}
+.nv-hero p{margin:0 0 16px;opacity:.85;}
 
-/* Lists (286 spacing) */
-ul { margin:0 0 8px 0; padding-left: 1.1rem; list-style: disc outside; }
-li { margin:0 0 6px 0; }
+/* Grid hubs/cards remain centered like Zones/Worlds */
+.nv-grid-hubs{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px;margin-top:8px;}
+.nv-card{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:14px;box-shadow:var(--shadow-soft);}
 
-/* Cards */
-.nv-card { background: var(--card); border:1px solid var(--border); border-radius:14px; padding:14px; box-shadow: var(--shadow-soft); }
-
-/* Culture page alignment */
-.culture-grid .nv-card ul.culture-list { padding-left: 1.1rem; }
-.culture-grid .nv-card h4 { margin-top: 8px; }
+/* Lists + culture alignment (match 286) */
+ul{margin:0 0 8px 0;padding-left:1.1rem;list-style:disc outside;}
+li{margin:0 0 6px 0;}
+.culture-grid .nv-card ul{padding-left:1.1rem;}


### PR DESCRIPTION
## Summary
- Restore batch 286 header with apps-square menu and mobile nav list
- Remove hero face and blob styling, revert layout containers and list spacing
- Align culture page lists and adjust layout wrapper

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68a74b0d365083298802935ec2d1da1c