### PR TITLE
Revert homepage blob, restore header/home link, center layouts, and fix Culture bullets (restore look of #286)

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,7 +6,7 @@ type Props = { children: ReactNode; title?: ReactNode; breadcrumbs?: ReactNode }
 export default function Layout({ title, breadcrumbs, children }: Props) {
   return (
     <>
-      <NavBar /> {/* keep at top */}
+      <NavBar />
       <main className="nv-page">
         <div className="nv-container">
           {title ? <h1 className="nv-title">{title}</h1> : null}

--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -4,35 +4,28 @@
   z-index: 30;
   background: var(--nv-bg);
 }
-.nv-nav-row {
+.nv-header__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 10px 16px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 0;
+  gap: 16px;
 }
 .nv-brand {
   display: flex;
   align-items: center;
   gap: 10px;
   text-decoration: none;
-}
-.nv-brand-title {
-  font-weight: 700;
-  font-size: 18px;
-  color: var(--nv-ink);
-}
-.nv-brand-mark {
-  width: 22px;
-  height: 22px;
-  border-radius: 6px;
-  object-fit: contain;
+  color: inherit;
 }
 
 .nv-nav {
   display: flex;
   align-items: center;
-  gap: 16px;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-left: auto;
 }
 .nv-nav a {
   color: var(--nv-ink);

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -7,19 +7,11 @@ export default function NavBar() {
 
   return (
     <header className="nv-header">
-      <div className="nv-container nv-nav-row">
-        {/* BRAND — always links Home */}
-        <Link to="/" className="nv-brand">
-          {/* optional brand mark (hidden if missing) */}
-          <img
-            src="/assets/turian-media-logo.png"
-            alt="Turian Media Company"
-            className="nv-brand-mark"
-            onError={(e) => {
-              (e.target as HTMLImageElement).style.display = 'none';
-            }}
-          />
-          <span className="nv-brand-title">Naturverse</span>
+      <div className="nv-header__inner">
+        {/* Home link restored (clickable brand) */}
+        <Link to="/" className="nv-brand" aria-label="Naturverse Home">
+          <span style={{fontSize:20}}>🌿</span>{' '}
+          <strong>Naturverse</strong>
         </Link>
 
         {/* MOBILE TOGGLE */}

--- a/src/pages/zones/Culture.tsx
+++ b/src/pages/zones/Culture.tsx
@@ -29,7 +29,7 @@ export default function Culture() {
               {["Beliefs", "Holidays", "Ceremonies"].map((label) => (
                 <div key={label}>
                   <h4 className="text-sm font-semibold">{label}</h4>
-                  <ul className="mt-2 list-disc pl-4 [li]:ml-0 [li]:text-sm [li]:leading-6">
+                  <ul className="mt-2 list-reset [li]:ml-0 [li]:text-sm [li]:leading-6">
                     {k[label.toLowerCase() as "beliefs" | "holidays" | "ceremonies"].map((item, idx) => (
                       <li key={idx}>{item}</li>
                     ))}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,7 +8,6 @@ export default function Home() {
       {/* Clean hero (no oversized emoji) */}
       <header className="home-hero">
         <h1>✨ Welcome to the Naturverse™</h1>
-        <img src="/assets/turian-owl.svg" className="hero-owl" alt="Turian the owl" />
         <p>Pick a hub to begin your adventure.</p>
       </header>
 
@@ -45,7 +44,7 @@ export default function Home() {
           title="Passport"
           sub="Track stamps, badges, XP & coins."
         />
-        <HubCard to="/turian" emoji="🦉" title="Turian" sub="AI guide for tips & quests." />
+        <HubCard to="/turian" emoji="🟢" title="Turian" sub="AI guide for tips & quests." />
         <HubCard to="/profile" emoji="👤" title="Profile" sub="Your account & saved navatar." />
       </HubGrid>
     </main>

--- a/src/routes/marketplace/index.tsx
+++ b/src/routes/marketplace/index.tsx
@@ -7,7 +7,7 @@ export default function Marketplace() {
       <div className="grid gap-4 md:gap-6 sm:grid-cols-2">
         <Card to="/marketplace/catalog" title="Catalog" desc="Browse items." icon="📦" />
         <Card to="/marketplace/wishlist" title="Wishlist" desc="Your favorites." icon="❤️" />
-        <Card to="/marketplace/checkout" title="Checkout" desc="Pay & ship." icon="💳" />
+        <Card to="/marketplace/checkout" title="Checkout" desc="Pay & ship." icon="🧾" />
       </div>
     </Page>
   );

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -18,6 +18,29 @@ main{ padding:16px; }
   padding-right: var(--nv-pad);
 }
 
+/* Center all primary pages like Worlds/Zones */
+.page{
+  max-width:1024px;
+  margin:0 auto;
+  padding:24px 16px 56px;
+}
+
+/* Cards grid baseline */
+.card-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fill,minmax(280px,1fr));
+  gap:16px;
+}
+
+/* Tidy list bullets (Culture page) */
+.list-reset{
+  padding-left:1.25rem;
+  list-style:disc outside;
+}
+
+/* Hide any accidental “welcome blob” leftover */
+.welcome-blob{display:none !important;}
+
 @media (max-width: 640px){
   .nv-container{ padding-left: var(--nv-pad-sm); padding-right: var(--nv-pad-sm); }
 }


### PR DESCRIPTION
## Summary
- add layout helpers for page centering, card grids, list reset, and ensure any leftover welcome blob stays hidden
- brand link in header now uses 🌿 Naturverse and centers navigation
- simplify home hero and adjust hub cards including Turian emoji change
- align Culture page bullets with list-reset utility
- swap Marketplace checkout card icon for receipt emoji

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a75c15e4ac83298758a04b2850ad57