### PR TITLE
Nuke green blob, restore #286 home layout, center pages, fix Culture bullets

### DIFF
--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -1,48 +1,29 @@
-import Link from "next/link";
-import { useState } from "react";
+import React from "react";
+import { Link, NavLink } from "react-router-dom";
 
-export default function Header(){
-  const [open, setOpen] = useState(false);
+export default function Header() {
   return (
     <header className="nv-header">
-      <div className="nv-header__row">
-        <Link href="/" className="nv-brand" aria-label="Naturverse home">
-          <span className="nv-brand__mark" aria-hidden>🌿</span>
-          <span className="nv-brand__name">Naturverse</span>
-        </Link>
-        <nav className="nv-nav nv-nav--desktop" aria-label="Primary">
-          <Link href="/worlds">Worlds</Link>
-          <Link href="/zones">Zones</Link>
-          <Link href="/marketplace">Marketplace</Link>
-          <Link href="/naturversity">Naturversity</Link>
-          <Link href="/naturbank">Naturbank</Link>
-          <Link href="/navatar">Navatar</Link>
-          <Link href="/passport">Passport</Link>
-          <Link href="/turian">Turian</Link>
-          <Link href="/profile">Profile</Link>
+      <div className="nv-header__inner">
+        {/* Clickable brand → Home restored */}
+        <Link to="/" aria-label="Naturverse Home"><span style={{fontSize:20}}>🌿</span> <strong>Naturverse</strong></Link>
+        <nav style={{marginLeft:"auto", display:"flex", gap:14, flexWrap:"wrap"}}>
+          {[
+            ["/worlds","Worlds"],
+            ["/zones","Zones"],
+            ["/marketplace","Marketplace"],
+            ["/naturversity","Naturversity"],
+            ["/naturbank","Naturbank"],
+            ["/navatar","Navatar"],
+            ["/passport","Passport"],
+            ["/turian","Turian"],
+            ["/profile","Profile"],
+          ].map(([to,label])=> (
+            <NavLink key={to} to={to} className={({isActive})=>isActive?"active":undefined}>{label}</NavLink>
+          ))}
         </nav>
-        {/* batch 286: small apps square, opens simple mobile list */}
-        <button
-          type="button"
-          className="nv-nav__apps"
-          aria-label="Open menu"
-          aria-expanded={open}
-          onClick={() => setOpen(v=>!v)}
-        >▢</button>
       </div>
-      {open && (
-        <nav className="nv-nav nv-nav--mobile" aria-label="Mobile">
-          <Link href="/worlds" onClick={()=>setOpen(false)}>Worlds</Link>
-          <Link href="/zones" onClick={()=>setOpen(false)}>Zones</Link>
-          <Link href="/marketplace" onClick={()=>setOpen(false)}>Marketplace</Link>
-          <Link href="/naturversity" onClick={()=>setOpen(false)}>Naturversity</Link>
-          <Link href="/naturbank" onClick={()=>setOpen(false)}>Naturbank</Link>
-          <Link href="/navatar" onClick={()=>setOpen(false)}>Navatar</Link>
-          <Link href="/passport" onClick={()=>setOpen(false)}>Passport</Link>
-          <Link href="/turian" onClick={()=>setOpen(false)}>Turian</Link>
-          <Link href="/profile" onClick={()=>setOpen(false)}>Profile</Link>
-        </nav>
-      )}
     </header>
   );
 }
+

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -1,3 +1,3 @@
 export default function Layout({children}:{children:React.ReactNode}){
-  return <main className="nv-page nv-container">{children}</main>;
+  return <main className="page">{children}</main>;
 }

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -1,13 +1,23 @@
-export default function Home(){
+import React from "react";
+import { Link } from "react-router-dom";
+
+export default function Home() {
   return (
-    <>
-      <section className="nv-hero">
-        <h1>✨ Welcome to the Naturverse™</h1>
-        <p>Pick a hub to begin your adventure.</p>
-      </section>
-      <section className="nv-grid-hubs">
-        {/* cards unchanged from 286 */}
-      </section>
-    </>
+    <div className="page">
+      <h1 style={{marginBottom:8}}>✨ Welcome to the Naturverse™</h1>
+      <p>Pick a hub to begin your adventure.</p>
+      <div className="card-grid" style={{marginTop:16}}>
+        <Link className="card" to="/worlds">📚 <strong>Worlds</strong><br/>Travel the 14 magical kingdoms.</Link>
+        <Link className="card" to="/zones">🎮 🎵 🧘 <strong>Zones</strong><br/>Arcade, Music, Wellness, Creator Lab, Stories, Quizzes.</Link>
+        <Link className="card" to="/marketplace">🛍️ <strong>Marketplace</strong><br/>Wishlists, catalog, checkout.</Link>
+        <Link className="card" to="/naturversity">🎓 <strong>Naturversity</strong><br/>Teachers, partners, and courses.</Link>
+        <Link className="card" to="/naturbank">🪙 <strong>Naturbank</strong><br/>Wallets, NATUR token, and crypto basics.</Link>
+        <Link className="card" to="/navatar">❎ <strong>Navatar</strong><br/>Create your character.</Link>
+        <Link className="card" to="/passport">📘 <strong>Passport</strong><br/>Track stamps, badges, XP & coins.</Link>
+        <Link className="card" to="/turian">🟢 <strong>Turian</strong><br/>Guide for tips & quests.</Link>
+        <Link className="card" to="/profile">👤 <strong>Profile</strong><br/>Your account & saved navatar.</Link>
+      </div>
+    </div>
   );
 }
+

--- a/client/pages/zones/culture.tsx
+++ b/client/pages/zones/culture.tsx
@@ -61,9 +61,12 @@ export default function Culture(){
           <article key={c.title} className="nv-card">
             <h3>{c.title}</h3>
             <p className="muted">{c.subtitle}</p>
-            <h4>Beliefs</h4><ul className="culture-list">{c.beliefs.map(b=><li key={b}>{b}</li>)}</ul>
-            <h4>Holidays</h4><ul className="culture-list">{c.holidays.map(h=><li key={h}>{h}</li>)}</ul>
-            <h4>Ceremonies</h4><ul className="culture-list">{c.ceremonies.map(x=><li key={x}>{x}</li>)}</ul>
+            <h4>Beliefs</h4>
+            <ul className="list-reset">{c.beliefs.map(b=><li key={b}>{b}</li>)}</ul>
+            <h4>Holidays</h4>
+            <ul className="list-reset">{c.holidays.map(h=><li key={h}>{h}</li>)}</ul>
+            <h4>Ceremonies</h4>
+            <ul className="list-reset">{c.ceremonies.map(x=><li key={x}>{x}</li>)}</ul>
           </article>
         ))}
       </div>

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -1,36 +1,30 @@
-/* restore batch 286 — no hero blobs/faces */
-
-/* Layout containers */
-.nv-container{max-width:1100px;margin:0 auto;padding:0 16px;}
-.nv-page{padding:16px 0;}
-
-/* Header */
-.nv-header{position:sticky;top:0;z-index:40;background:var(--bg);border-bottom:1px solid var(--border);}
-.nv-header__row{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:12px 16px;}
-.nv-brand{display:inline-flex;align-items:center;gap:8px;font-weight:700;text-decoration:none;color:inherit;}
-.nv-brand__mark{font-size:18px;}
-.nv-nav a{padding:8px 10px;border-radius:10px;text-decoration:none;color:inherit;}
-.nv-nav__apps{display:none;}
-.nv-nav--mobile{display:none;flex-direction:column;gap:8px;padding:12px 16px;border-top:1px solid var(--border);}
-@media (max-width:920px){
-  .nv-nav--desktop{display:none;}
-  .nv-nav__apps{display:inline-flex;}
-  .nv-nav--mobile{display:flex;}
+html, body, #root {
+  height: 100%;
+  background: var(--bg);
+  color: var(--fg);
 }
 
-.nv-hero::before,
-.home-blob,
-.hero-blob{display:none !important;content:none !important;}
+/* Center pages like Worlds/Zones baseline from #286 */
+.page {
+  max-width: 1024px;
+  margin: 0 auto;
+  padding: 24px 16px 56px;
+}
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
 
-/* Hero */
-.nv-hero h1{margin:8px 0 4px;font-size:clamp(28px,5vw,40px);}
-.nv-hero p{margin:0 0 16px;opacity:.85;}
+/* Header */
+.nv-header { position: sticky; top:0; z-index:50; background:rgba(255,255,255,.9); backdrop-filter: blur(6px); border-bottom:1px solid #e5e7eb;}
+.nv-header__inner { max-width:1100px; margin:0 auto; padding:10px 16px; display:flex; align-items:center; gap:16px;}
+.nv-header a { text-decoration:none; color:inherit;}
+.nv-header .active { font-weight:600; }
 
-/* Grid hubs/cards remain centered like Zones/Worlds */
-.nv-grid-hubs{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px;margin-top:8px;}
-.nv-card{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:14px;box-shadow:var(--shadow-soft);}
+/* Culture bullets align under column titles */
+.list-reset { padding-left:1.25rem; }
 
-/* Lists + culture alignment (match 286) */
-ul{margin:0 0 8px 0;padding-left:1.1rem;list-style:disc outside;}
-li{margin:0 0 6px 0;}
-.culture-grid .nv-card ul{padding-left:1.1rem;}
+/* Kill any leftover hero/blob from older HTML/CSS */
+.welcome-blob, #hero, .hero-blob, .smiley, .blob, .face { display:none !important; height:0 !important; width:0 !important; }
+

--- a/index.html
+++ b/index.html
@@ -4,9 +4,19 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Naturverse</title>
+    <!-- stop stale cached HTML while we repair -->
+    <meta http-equiv="Cache-Control" content="no-store, max-age=0" />
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <!-- safety: purge stray blobs injected by old builds -->
+    <script>
+      (function () {
+        const killers = ['welcome-blob','hero-blob','hero','blob','face','smiley'];
+        killers.forEach(id => { const el = document.getElementById(id); if (el) el.remove(); });
+        document.querySelectorAll(killers.map(k=>'.'+k).join(',')).forEach(el=>el.remove());
+      })();
+    </script>
   </body>
 </html>

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,6 @@
+/index.html
+  Cache-Control: no-store
+
+/*
+  Cache-Control: public, max-age=600
+


### PR DESCRIPTION
## Summary
- Prevent stale caching and strip stray hero blobs from index.html
- Rebuild header with clickable brand and nav links, restore card-based Home layout
- Center pages with `.page` wrapper, align Culture lists, and enforce no-cache headers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a760213e14832981d9292646f3d2a8