### PR TITLE
Mobile: remove duplicate top nav, add linked breadcrumbs

### DIFF
--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -7,7 +7,7 @@ export default function Header() {
       <div className="nv-header__inner">
         {/* Clickable brand → Home restored */}
         <Link to="/" aria-label="Naturverse Home"><span style={{fontSize:20}}>🌿</span> <strong>Naturverse</strong></Link>
-        <nav style={{marginLeft:"auto", display:"flex", gap:14, flexWrap:"wrap"}}>
+        <nav className="top-inline-nav" style={{marginLeft:"auto", gap:14, flexWrap:"wrap"}}>
           {[
             ["/worlds","Worlds"],
             ["/zones","Zones"],

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,22 @@
+import { Link } from "react-router-dom";
+
+export type Crumb = { label: string; to?: string };
+
+export function Breadcrumbs({ items }: { items: Crumb[] }) {
+  return (
+    <nav aria-label="Breadcrumb" className="mb-3 text-sm">
+      <ol className="flex flex-wrap gap-2 text-gray-600">
+        {items.map((c, i) => (
+          <li key={i} className="flex items-center">
+            {c.to ? (
+              <Link to={c.to} className="hover:underline">{c.label}</Link>
+            ) : (
+              <span className="text-gray-800">{c.label}</span>
+            )}
+            {i < items.length - 1 && <span className="mx-2 text-gray-400">/</span>}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,7 +24,7 @@ export default function Header() {
         </Link>
 
         {/* Desktop nav */}
-        <nav className="hidden md:flex items-center gap-4">
+        <nav className="hidden md:flex items-center gap-4 top-inline-nav">
           {links.map((l) => (
             <Link key={l.to} to={l.to} className="text-sm hover:underline">
               {l.label}

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,12 +1,15 @@
 import { ReactNode } from "react";
+import { Breadcrumbs, Crumb } from "./Breadcrumbs";
 
 export default function Page({
   title,
   subtitle,
+  breadcrumbs,
   children,
-}: { title: string; subtitle?: string; children: ReactNode }) {
+}: { title: string; subtitle?: string; breadcrumbs?: Crumb[]; children: ReactNode }) {
   return (
     <main className="mx-auto max-w-6xl px-4 py-8">
+      {breadcrumbs && <Breadcrumbs items={breadcrumbs} />}
       <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight">{title}</h1>
       {subtitle && <p className="mt-2 text-slate-600">{subtitle}</p>}
       <div className="mt-6">{children}</div>

--- a/src/pages/zones/Community.tsx
+++ b/src/pages/zones/Community.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { Breadcrumbs } from '../../components/Breadcrumbs';
 import '../../styles/zone-widgets.css';
 import { BoardPost, Poll } from '../../lib/community/types';
 import {
@@ -130,6 +131,11 @@ export default function Community() {
 
   return (
     <div>
+      <Breadcrumbs items={[
+        { label: 'Home', to: '/' },
+        { label: 'Zones', to: '/zones' },
+        { label: 'Community' }
+      ]} />
       <h1>🗳️🌍 Community</h1>
       <p>Vote for new lands & characters, and join local volunteer events.</p>
 

--- a/src/pages/zones/Culture.tsx
+++ b/src/pages/zones/Culture.tsx
@@ -15,6 +15,11 @@ export default function Culture() {
     <Page
       title="Culture"
       subtitle="Beliefs, holidays, and ceremonies across the 14 kingdoms."
+      breadcrumbs={[
+        { label: "Home", to: "/" },
+        { label: "Zones", to: "/zones" },
+        { label: "Culture" },
+      ]}
     >
       <div className="culture-grid grid gap-4 md:gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {kingdoms.map((k) => (

--- a/src/pages/zones/Observations.tsx
+++ b/src/pages/zones/Observations.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { Breadcrumbs } from '../../components/Breadcrumbs';
 import PhotoUploader from '../../components/PhotoUploader';
 import { Observation } from '../../lib/observations/types';
 import {
@@ -144,6 +145,11 @@ export default function Observations() {
 
   return (
     <div>
+      <Breadcrumbs items={[
+        { label: 'Home', to: '/' },
+        { label: 'Zones', to: '/zones' },
+        { label: 'Observations' }
+      ]} />
       <h1>📷🌿 Observations</h1>
       <p>Upload nature pics; tag, learn, earn. (Local & offline; data stays in your browser.)</p>
 

--- a/src/pages/zones/Quizzes.tsx
+++ b/src/pages/zones/Quizzes.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
 import { Quiz } from "../../lib/quiz/types";
 import { SAMPLE_QUIZZES } from "../../lib/quiz/sampleQuizzes";
 import { ClassicPlayer, JeopardyBoard, QuizSummary } from "../../components/QuizPlayer";
@@ -51,6 +52,11 @@ export default function Quizzes() {
 
   return (
     <div>
+      <Breadcrumbs items={[
+        { label: 'Home', to: '/' },
+        { label: 'Zones', to: '/zones' },
+        { label: 'Quizzes' }
+      ]} />
       <h1>🎯 Quizzes</h1>
       <p>Solo & party quiz play with scoring (client-only; no backend).</p>
 

--- a/src/pages/zones/Stories.tsx
+++ b/src/pages/zones/Stories.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
 import { Story } from "../../lib/story/types";
 import { SAMPLE_STORIES } from "../../lib/story/sampleStories";
 import { StoryPlayer, Progress } from "../../components/StoryPlayer";
@@ -66,6 +67,11 @@ export default function Stories() {
 
   return (
     <div>
+      <Breadcrumbs items={[
+        { label: 'Home', to: '/' },
+        { label: 'Zones', to: '/zones' },
+        { label: 'Stories' }
+      ]} />
       <h1>📚✨ Stories</h1>
       <p>AI story paths set in all 14 kingdoms (local, no-backend version).</p>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,6 +11,6 @@ svg[aria-label="hero-face"],
   display: none !important;
 }
 
-/* Ensure no duplicate top text-link row appears on small screens */
-.top-inline-nav { display: none; }
-@media (min-width:768px) { .top-inline-nav { display: flex; } }
+/* hide any legacy inline top nav on phones */
+.top-inline-nav{ display:none; }
+@media (min-width:768px){ .top-inline-nav{ display:flex; } }


### PR DESCRIPTION
## Summary
- hide text-link nav on mobile via `top-inline-nav`
- add reusable `Breadcrumbs` component and show crumbs on zone pages
- ensure legacy header navs don't appear on phones

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a79f18988c8329886c64b9f2069a0e