### PR TITLE
Navigation v2 — responsive header, brand home link, and mobile menu (no deps)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import React, { useEffect, useRef, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
 
-const links = [
+/** Central list of site links */
+const LINKS = [
   { to: "/worlds", label: "Worlds" },
   { to: "/zones", label: "Zones" },
   { to: "/marketplace", label: "Marketplace" },
@@ -15,49 +16,60 @@ const links = [
 
 export default function Header() {
   const [open, setOpen] = useState(false);
+  const { pathname } = useLocation();
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // close menu on route change
+  useEffect(() => setOpen(false), [pathname]);
+
+  // close when clicking outside
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (!menuRef.current) return;
+      if (!menuRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    if (open) document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
 
   return (
-    <header className="sticky top-0 z-40 bg-white/90 backdrop-blur">
-      <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
-        <Link className="flex items-center gap-2 shrink-0" aria-label="Naturverse home" to="/">
-          <span className="font-semibold tracking-tight">Naturverse</span>
+    <header className="nv-header" aria-label="Primary">
+      <div className="nv-header__inner">
+        {/* Brand — always goes home */}
+        <Link to="/" className="nv-brand" aria-label="Naturverse home">
+          <span className="nv-brand__leaf" aria-hidden>🌿</span>
+          <span className="nv-brand__text">Naturverse</span>
         </Link>
 
         {/* Desktop nav */}
-        <nav className="hidden md:flex items-center gap-4 top-inline-nav">
-          {links.map((l) => (
-            <Link key={l.to} to={l.to} className="text-sm hover:underline">
+        <nav className="nv-nav">
+          {LINKS.map((l) => (
+            <Link key={l.to} to={l.to} className="nv-link">
               {l.label}
             </Link>
           ))}
         </nav>
 
         {/* Mobile menu button */}
-        <div className="md:hidden relative">
+        <div className="nv-menu" ref={menuRef}>
           <button
             type="button"
+            className="nv-menu__btn"
             aria-label="Open menu"
             aria-expanded={open}
             onClick={() => setOpen((v) => !v)}
-            className="inline-flex items-center justify-center rounded-full border px-3 py-2"
           >
-            <span className="sr-only">Menu</span>
-            {/* simple hamburger */}
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-            </svg>
+            <span className="nv-menu__bars" />
           </button>
 
-          {/* Dropdown */}
           {open && (
-            <div role="menu" className="absolute right-0 mt-2 w-48 rounded-lg border bg-white shadow-lg p-1">
-              {links.map((l) => (
+            <div className="nv-menu__sheet" role="menu">
+              {LINKS.map((l) => (
                 <Link
                   key={l.to}
                   to={l.to}
                   role="menuitem"
-                  onClick={() => setOpen(false)}
-                  className="block rounded-md px-3 py-2 text-sm hover:bg-gray-100"
+                  className="nv-menu__item"
                 >
                   {l.label}
                 </Link>
@@ -69,4 +81,3 @@ export default function Header() {
     </header>
   );
 }
-

--- a/src/layouts/Root.tsx
+++ b/src/layouts/Root.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import { Outlet } from "react-router-dom";
 import Header from "../components/Header";
 
-export default function AppShell() {
+export default function RootLayout() {
   return (
-    <>
+    <div className="nv-root">
       <Header />
-      <Outlet />
-    </>
+      <main className="container">
+        <Outlet />
+      </main>
+    </div>
   );
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -32,12 +32,12 @@ import NavatarPage from "./pages/Navatar";
 import Passport from "./pages/Passport";
 import Turian from "./routes/turian";
 import Profile from "./pages/Profile";
-import AppShell from "./shell/AppShell";
+import RootLayout from "./layouts/Root";
 
 export const router = createBrowserRouter([
   {
     path: "/",
-    element: <AppShell />,
+    element: <RootLayout />,
     children: [
       { index: true, element: <Home /> },
       { path: "worlds", element: <Worlds /> },

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,6 +5,7 @@
 @import "./styles/profile.css";
 @import "./styles/global.css";
 @import "./styles/layout.css";
+@import "./styles/topnav.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}

--- a/src/styles/topnav.css
+++ b/src/styles/topnav.css
@@ -1,0 +1,35 @@
+/* container */
+.nv-header { position: sticky; top: 0; z-index: 50; backdrop-filter: saturate(120%) blur(6px); }
+.nv-header::before { content:""; position:absolute; inset:0; background:rgba(255,255,255,.75); }
+.nv-header * { box-sizing: border-box; }
+.nv-header__inner { position:relative; display:flex; align-items:center; justify-content:space-between; max-width: 1120px; margin:0 auto; padding:10px 16px; }
+
+/* brand */
+.nv-brand { display:inline-flex; align-items:center; gap:10px; text-decoration:none; }
+.nv-brand__leaf { font-size:18px; }
+.nv-brand__text { font-weight:800; color:#0f172a; }
+.nv-brand:focus-visible { outline:2px solid #0ea5e9; outline-offset:2px; border-radius:8px; }
+
+/* desktop links */
+.nv-nav { display:none; gap:14px; }
+.nv-link { color:#334155; text-decoration:none; font-weight:600; padding:8px 10px; border-radius:8px; }
+.nv-link:hover { background:#f1f5f9; }
+@media (min-width: 900px) { .nv-nav { display:flex; } }
+
+/* mobile menu button */
+.nv-menu { position:relative; }
+.nv-menu__btn { appearance:none; border:1px solid #cbd5e1; background:#fff; padding:8px 10px; border-radius:10px; display:flex; align-items:center; justify-content:center; }
+.nv-menu__bars, .nv-menu__bars::before, .nv-menu__bars::after {
+  content:""; display:block; width:18px; height:2px; background:#0f172a; border-radius:2px;
+}
+.nv-menu__bars::before { margin-top:-6px; }
+.nv-menu__bars::after { margin-top:4px; }
+@media (min-width: 900px) { .nv-menu { display:none; } }
+
+/* mobile sheet */
+.nv-menu__sheet {
+  position:absolute; right:0; margin-top:8px; min-width:200px; background:#fff; border:1px solid #e5e7eb; border-radius:12px; box-shadow:0 10px 26px rgba(2,6,23,.12);
+  padding:6px;
+}
+.nv-menu__item { display:block; padding:10px 12px; border-radius:10px; color:#0f172a; text-decoration:none; font-weight:600; }
+.nv-menu__item:hover { background:#f1f5f9; }


### PR DESCRIPTION
## Summary
- replace inline nav bar with a responsive `Header` component
- add `RootLayout` and wire it into the router
- include new topnav styles and imports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7a84ada48832980a9aa088796d209