### PR TITLE
Unify hubs — card grid for Marketplace, Naturversity, Naturbank (no deps)

### DIFF
--- a/src/components/HubGrid.tsx
+++ b/src/components/HubGrid.tsx
@@ -1,5 +1,41 @@
-import { ReactNode } from 'react';
+import React from "react";
+import { Link } from "react-router-dom";
 
-export default function HubGrid({ children }: { children: ReactNode }) {
+type Item = {
+  to?: string;        // Link target (optional)
+  title: string;      // Card title
+  desc?: string;      // Small description
+  icon?: React.ReactNode; // Optional emoji/icon
+};
+
+export function HubGrid({ items, children }: { items?: Item[]; children?: React.ReactNode }) {
+  if (items) {
+    return (
+      <div className="hub-grid">
+        {items.map((it, i) =>
+          it.to ? (
+            <Link key={i} to={it.to} className="hub-card">
+              <span className="hub-card-title">
+                {it.icon && <span className="hub-ico">{it.icon}</span>}
+                {it.title}
+              </span>
+              {it.desc && <span className="hub-card-desc">{it.desc}</span>}
+            </Link>
+          ) : (
+            <div key={i} className="hub-card">
+              <span className="hub-card-title">
+                {it.icon && <span className="hub-ico">{it.icon}</span>}
+                {it.title}
+              </span>
+              {it.desc && <span className="hub-card-desc">{it.desc}</span>}
+            </div>
+          )
+        )}
+      </div>
+    );
+  }
+
   return <div className="hub-grid">{children}</div>;
 }
+
+export default HubGrid;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import { router } from './router';
 import './styles.css';
-import './styles/hub.css';
 import './styles/shop.css';
 import './styles/edu.css';
 

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { HubGrid } from "../components/HubGrid";
+
+export default function MarketplacePage() {
+  return (
+    <div>
+      <h1>Marketplace</h1>
+      <p className="muted">Shop creations and merch.</p>
+
+      <HubGrid
+        items={[
+          { to: "/marketplace/catalog", title: "Catalog", desc: "Browse items.", icon: "📦" },
+          { to: "/marketplace/wishlist", title: "Wishlist", desc: "Your favorites.", icon: "❤️" },
+          { to: "/marketplace/checkout", title: "Checkout", desc: "Pay & ship.", icon: "🧾" },
+        ]}
+      />
+
+      <p className="muted" style={{ marginTop: 12 }}>
+        Coming soon: AI assistance for sizing, bundles, and gift ideas.
+      </p>
+    </div>
+  );
+}

--- a/src/pages/Naturbank.tsx
+++ b/src/pages/Naturbank.tsx
@@ -1,25 +1,24 @@
-import Page from "../components/Page";
-import { Link } from "react-router-dom";
+import React from "react";
+import { HubGrid } from "../components/HubGrid";
 
-export default function Naturbank() {
+export default function NaturbankPage() {
   return (
-    <Page title="Naturbank" subtitle="Wallet, token, and collectibles.">
-      <div className="grid gap-4 md:gap-6 sm:grid-cols-2">
-        <Card to="/naturbank/wallet" title="Wallet" desc="Create custodial wallet & view address." icon="🪪" />
-        <Card to="/naturbank/token" title="NATUR Token" desc="Earnings, redemptions, and ledger." icon="🪙" />
-        <Card to="/naturbank/nfts" title="NFTs" desc="Mint navatar cards & collectibles." icon="🖼️" />
-        <Card to="/naturbank/learn" title="Learn" desc="Crypto basics & safety guides." icon="📘" />
-      </div>
-    </Page>
+    <div>
+      <h1>Naturbank</h1>
+      <p className="muted">Wallets, token, and collectibles.</p>
+
+      <HubGrid
+        items={[
+          { to: "/naturbank/wallet", title: "Wallet", desc: "Create custodial wallet & view address.", icon: "👛" },
+          { to: "/naturbank/natur", title: "NATUR Token", desc: "Earnings, redemptions, and ledger.", icon: "🟠" },
+          { to: "/naturbank/nfts", title: "NFTs", desc: "Mint navatar cards & collectibles.", icon: "🖼️" },
+          { to: "/naturbank/learn", title: "Learn", desc: "Crypto basics & safety guides.", icon: "📘" },
+        ]}
+      />
+
+      <p className="muted" style={{ marginTop: 12 }}>
+        Coming soon: live wallets, on-chain mints, and payouts.
+      </p>
+    </div>
   );
 }
-
-function Card({ to, title, desc, icon }:{to:string; title:string; desc:string; icon:string}) {
-  return (
-    <Link to={to} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md transition">
-      <div className="text-lg font-semibold flex items-center gap-2"><span>{icon}</span>{title}</div>
-      <p className="mt-1 text-slate-600">{desc}</p>
-    </Link>
-  );
-}
-

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -1,24 +1,28 @@
-import Page from "../components/Page";
+import React from "react";
+import { HubGrid } from "../components/HubGrid";
 
-export default function Naturversity() {
+export default function NaturversityPage() {
   return (
-    <Page title="Naturversity" subtitle="Teachers, partners, and courses.">
-      <ul className="grid gap-4 md:gap-6 sm:grid-cols-2">
-        <li className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h3 className="font-semibold">Teachers</h3>
-          <p className="mt-1 text-slate-600">Mentors across the 14 kingdoms.</p>
-        </li>
-        <li className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h3 className="font-semibold">Partners</h3>
-          <p className="mt-1 text-slate-600">Brands & orgs supporting missions.</p>
-        </li>
-        <li className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm sm:col-span-2">
-          <h3 className="font-semibold">Courses</h3>
-          <p className="mt-1 text-slate-600">Nature, art, music, wellness, crypto basics.</p>
-          <p className="mt-3 text-sm text-slate-500">Coming soon: AI tutors and step-by-step lessons.</p>
-        </li>
-      </ul>
-    </Page>
+    <div>
+      <h1>Naturversity</h1>
+      <p className="muted">Teachers, partners, and courses.</p>
+
+      <HubGrid
+        items={[
+          { to: "/naturversity/teachers", title: "Teachers", desc: "Mentors across the 14 kingdoms.", icon: "🎓" },
+          { to: "/naturversity/partners", title: "Partners", desc: "Brands & orgs supporting missions.", icon: "🤝" },
+          {
+            to: "/naturversity/courses",
+            title: "Courses",
+            desc: "Nature, art, music, wellness, crypto basics.",
+            icon: "📚",
+          },
+        ]}
+      />
+
+      <p className="muted" style={{ marginTop: 12 }}>
+        Coming soon: AI tutors and step-by-step lessons.
+      </p>
+    </div>
   );
 }
-

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -14,7 +14,7 @@ import Quizzes from "./pages/zones/Quizzes";
 import Observations from "./pages/zones/Observations";
 import Community from "./pages/zones/Community";
 import Culture from "./pages/zones/Culture";
-import Marketplace from "./routes/marketplace";
+import Marketplace from "./pages/Marketplace";
 import Catalog from "./pages/marketplace/Catalog";
 import Wishlist from "./pages/marketplace/Wishlist";
 import Checkout from "./pages/marketplace/Checkout";
@@ -63,7 +63,7 @@ export const router = createBrowserRouter([
       { path: "naturversity/course/:slug", element: <CourseDetail /> },
       { path: "naturbank", element: <Naturbank /> },
       { path: "naturbank/wallet", element: <BankWallet /> },
-      { path: "naturbank/token", element: <BankToken /> },
+      { path: "naturbank/natur", element: <BankToken /> },
       { path: "naturbank/nfts", element: <BankNFTs /> },
       { path: "naturbank/learn", element: <BankLearn /> },
       { path: "navatar", element: <NavatarPage /> },

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,6 +6,7 @@
 @import "./styles/global.css";
 @import "./styles/layout.css";
 @import "./styles/topnav.css";
+@import "./styles/hub.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}

--- a/src/styles/hub.css
+++ b/src/styles/hub.css
@@ -1,113 +1,29 @@
-:root {
-  --bg: #f7f7fb;
-  --card: #ffffff;
-  --ink: #0f172a;
-  --muted: #6b7280;
-  --ring: 0 0 0 3px rgba(59, 130, 246, 0.25);
-  --radius: 14px;
-  --border: #e5e7eb;
+/* shared grid + card styling used by Worlds/Zones look */
+.hub-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fill,minmax(260px,1fr));
+  gap:16px;
+  align-items:stretch;
 }
-
-html,
-body,
-#root {
-  height: 100%;
-  background: var(--bg);
-  color: var(--ink);
+.hub-card{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  padding:14px;
+  background:#fff;
+  border:1px solid #e5e7eb;
+  border-radius:14px;
+  text-decoration:none;
 }
-
-.container {
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: 24px 16px;
+.hub-card:hover{ box-shadow:0 2px 10px rgba(2,6,23,.06); border-color:#dbe0e6; }
+.hub-card-title{
+  font-weight:800;
+  font-size:18px;
+  color:#0f172a;
+  display:flex; align-items:center; gap:10px;
 }
-
-.h1 {
-  font-size: clamp(28px, 3.6vw, 40px);
-  letter-spacing: -0.02em;
-  line-height: 1.1;
-  font-weight: 800;
-  margin: 8px 0 6px;
-}
-
-.lead {
-  color: var(--muted);
-  margin-bottom: 24px;
-}
-
-.hub-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
-}
-
-a.hub-card {
-  display: block;
-  text-decoration: none;
-  color: inherit;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 16px 18px;
-  transition:
-    transform 0.08s ease,
-    box-shadow 0.08s ease,
-    border-color 0.08s ease;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-}
-
-a.hub-card:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
-  border-color: #d1d5db;
-}
-
-.hub-title {
-  font-weight: 700;
-  font-size: 18px;
-  display: inline-flex;
-  gap: 10px;
-  align-items: baseline;
-}
-
-.hub-emoji {
-  font-size: 22px;
-  line-height: 1;
-}
-
-.hub-sub {
-  margin-top: 6px;
-  color: var(--muted);
-  font-size: 14px;
-}
-
-.breadcrumb {
-  font-size: 14px;
-  color: var(--muted);
-  margin-bottom: 8px;
-}
-
-.section-title {
-  font-weight: 800;
-  font-size: 30px;
-  margin: 6px 0 12px;
-}
-.section-lead {
-  color: var(--muted);
-  margin-bottom: 18px;
-}
-
-/* Reset underlines in lists rendered previously as raw anchors */
-a {
-  text-decoration: none;
-}
-a:hover {
-  text-decoration: underline;
-}
-
-/* Small screens spacing */
-@media (max-width: 480px) {
-  .container {
-    padding: 20px 14px;
-  }
+.hub-card-desc{ color:#475569; font-size:14px; }
+.hub-ico{ font-size:22px; line-height:1; }
+@media (max-width: 480px){
+  .hub-grid{ grid-template-columns:1fr; }
 }


### PR DESCRIPTION
## Summary
- add flexible `HubGrid` component for rendering linkable hub cards
- centralize hub styles and import `hub.css` into main stylesheet
- convert Marketplace, Naturversity, and Naturbank pages to use new grid and update router for NATUR token path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7ab4110748329b3fc575dbbe89c24