### PR TITLE
Zones — replace numbered breadcrumbs with clean “Home / …” trail

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^6.28.0",
+    "wouter": "^2.12.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,22 +1,26 @@
-import { Link } from "react-router-dom";
+import React from "react";
+import { Link } from "wouter";
 
-export type Crumb = { label: string; to?: string };
-
-export function Breadcrumbs({ items }: { items: Crumb[] }) {
+/** Slash-separated breadcrumb trail (no numbers). */
+export default function Breadcrumbs({
+  items,
+  className = "",
+}: {
+  items: { href?: string; label: string }[];
+  className?: string;
+}) {
+  if (!items?.length) return null;
   return (
-    <nav aria-label="Breadcrumb" className="mb-3 text-sm">
-      <ol className="flex flex-wrap gap-2 text-gray-600">
-        {items.map((c, i) => (
-          <li key={i} className="flex items-center">
-            {c.to ? (
-              <Link to={c.to} className="hover:underline">{c.label}</Link>
-            ) : (
-              <span className="text-gray-800">{c.label}</span>
-            )}
-            {i < items.length - 1 && <span className="mx-2 text-gray-400">/</span>}
+    <nav aria-label="Breadcrumb" className={`crumbs ${className}`}>
+      <ol>
+        {items.map((it, i) => (
+          <li key={i} className="crumb">
+            {it.href ? <Link href={it.href}>{it.label}</Link> : <span>{it.label}</span>}
+            {i < items.length - 1 && <span className="sep"> / </span>}
           </li>
         ))}
       </ol>
     </nav>
   );
 }
+

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from "react";
-import { Breadcrumbs, Crumb } from "./Breadcrumbs";
+import Breadcrumbs from "./Breadcrumbs";
+
+export type Crumb = { href?: string; label: string };
 
 export default function Page({
   title,

--- a/src/pages/zones/Community.tsx
+++ b/src/pages/zones/Community.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Breadcrumbs } from '../../components/Breadcrumbs';
+import Breadcrumbs from '../../components/Breadcrumbs';
 import '../../styles/zone-widgets.css';
 import { BoardPost, Poll } from '../../lib/community/types';
 import {
@@ -132,8 +132,8 @@ export default function Community() {
   return (
     <div>
       <Breadcrumbs items={[
-        { label: 'Home', to: '/' },
-        { label: 'Zones', to: '/zones' },
+        { href: '/', label: 'Home' },
+        { href: '/zones', label: 'Zones' },
         { label: 'Community' }
       ]} />
       <h1>🗳️🌍 Community</h1>

--- a/src/pages/zones/Culture.tsx
+++ b/src/pages/zones/Culture.tsx
@@ -16,8 +16,8 @@ export default function Culture() {
       title="Culture"
       subtitle="Beliefs, holidays, and ceremonies across the 14 kingdoms."
       breadcrumbs={[
-        { label: "Home", to: "/" },
-        { label: "Zones", to: "/zones" },
+        { href: "/", label: "Home" },
+        { href: "/zones", label: "Zones" },
         { label: "Culture" },
       ]}
     >

--- a/src/pages/zones/Observations.tsx
+++ b/src/pages/zones/Observations.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Breadcrumbs } from '../../components/Breadcrumbs';
+import Breadcrumbs from '../../components/Breadcrumbs';
 import PhotoUploader from '../../components/PhotoUploader';
 import { Observation } from '../../lib/observations/types';
 import {
@@ -146,8 +146,8 @@ export default function Observations() {
   return (
     <div>
       <Breadcrumbs items={[
-        { label: 'Home', to: '/' },
-        { label: 'Zones', to: '/zones' },
+        { href: '/', label: 'Home' },
+        { href: '/zones', label: 'Zones' },
         { label: 'Observations' }
       ]} />
       <h1>📷🌿 Observations</h1>

--- a/src/pages/zones/Quizzes.tsx
+++ b/src/pages/zones/Quizzes.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Breadcrumbs } from "../../components/Breadcrumbs";
+import Breadcrumbs from "../../components/Breadcrumbs";
 import { Quiz } from "../../lib/quiz/types";
 import { SAMPLE_QUIZZES } from "../../lib/quiz/sampleQuizzes";
 import { ClassicPlayer, JeopardyBoard, QuizSummary } from "../../components/QuizPlayer";
@@ -53,8 +53,8 @@ export default function Quizzes() {
   return (
     <div>
       <Breadcrumbs items={[
-        { label: 'Home', to: '/' },
-        { label: 'Zones', to: '/zones' },
+        { href: '/', label: 'Home' },
+        { href: '/zones', label: 'Zones' },
         { label: 'Quizzes' }
       ]} />
       <h1>🎯 Quizzes</h1>

--- a/src/pages/zones/Stories.tsx
+++ b/src/pages/zones/Stories.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Breadcrumbs } from "../../components/Breadcrumbs";
+import Breadcrumbs from "../../components/Breadcrumbs";
 import { Story } from "../../lib/story/types";
 import { SAMPLE_STORIES } from "../../lib/story/sampleStories";
 import { StoryPlayer, Progress } from "../../components/StoryPlayer";
@@ -68,8 +68,8 @@ export default function Stories() {
   return (
     <div>
       <Breadcrumbs items={[
-        { label: 'Home', to: '/' },
-        { label: 'Zones', to: '/zones' },
+        { href: '/', label: 'Home' },
+        { href: '/zones', label: 'Zones' },
         { label: 'Stories' }
       ]} />
       <h1>📚✨ Stories</h1>

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,6 +7,7 @@
 @import "./styles/layout.css";
 @import "./styles/topnav.css";
 @import "./styles/hub.css";
+@import "./styles/crumbs.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}

--- a/src/styles/crumbs.css
+++ b/src/styles/crumbs.css
@@ -1,0 +1,11 @@
+/* compact, numberless breadcrumbs */
+.crumbs { margin: 4px 0 12px; color:#475569; font-size:14px; }
+.crumbs ol { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; }
+.crumbs .crumb { display: inline-flex; align-items: center; }
+.crumbs a { color:#2563eb; text-decoration: none; }
+.crumbs a:hover { text-decoration: underline; }
+.crumbs .sep { color:#94a3b8; margin: 0 6px; }
+@media (max-width: 640px){
+  .crumbs { font-size:13px; margin-top: 0; }
+}
+


### PR DESCRIPTION
## Summary
- add shared Breadcrumbs component with slash-separated trail
- style breadcrumbs and import into global styles
- use Breadcrumbs across zone pages replacing numbered lists

## Testing
- `npm run typecheck` *(fails: Cannot find module 'wouter')*
- `npm run build` *(fails: Rollup failed to resolve import "wouter")*

------
https://chatgpt.com/codex/tasks/task_e_68a7afc54cc0832994e013ca08028f5d