### PR TITLE
Brand bar polish — inline logo, tidy header, zero binaries

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,83 +1,80 @@
-import React, { useEffect, useRef, useState } from "react";
-import { Link, useLocation } from "react-router-dom";
-
-/** Central list of site links */
-const LINKS = [
-  { to: "/worlds", label: "Worlds" },
-  { to: "/zones", label: "Zones" },
-  { to: "/marketplace", label: "Marketplace" },
-  { to: "/naturversity", label: "Naturversity" },
-  { to: "/naturbank", label: "Naturbank" },
-  { to: "/navatar", label: "Navatar" },
-  { to: "/passport", label: "Passport" },
-  { to: "/turian", label: "Turian" },
-  { to: "/profile", label: "Profile" },
-];
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
 
 export default function Header() {
   const [open, setOpen] = useState(false);
-  const { pathname } = useLocation();
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  // close menu on route change
-  useEffect(() => setOpen(false), [pathname]);
-
-  // close when clicking outside
-  useEffect(() => {
-    const onDoc = (e: MouseEvent) => {
-      if (!menuRef.current) return;
-      if (!menuRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    if (open) document.addEventListener("mousedown", onDoc);
-    return () => document.removeEventListener("mousedown", onDoc);
-  }, [open]);
 
   return (
-    <header className="nv-header" aria-label="Primary">
+    <header className="nv-header">
       <div className="nv-header__inner">
-        {/* Brand — always goes home */}
-        <Link to="/" className="nv-brand" aria-label="Naturverse home">
-          <span className="nv-brand__leaf" aria-hidden>🌿</span>
-          <span className="nv-brand__text">Naturverse</span>
+        <Link to="/" className="brand" aria-label="Naturverse home">
+          {/* tiny inline durian logo (no external asset) */}
+          <svg
+            className="brand__logo"
+            viewBox="0 0 24 24"
+            width="24"
+            height="24"
+            aria-hidden="true"
+          >
+            <defs>
+              <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+                <stop offset="0" stopColor="#84cc16" />
+                <stop offset="1" stopColor="#16a34a" />
+              </linearGradient>
+            </defs>
+            <circle cx="12" cy="12" r="9" fill="url(#g)" />
+            {Array.from({ length: 12 }).map((_, i) => {
+              const a = (i * Math.PI) / 6;
+              const x = 12 + Math.cos(a) * 9.6;
+              const y = 12 + Math.sin(a) * 9.6;
+              return <circle key={i} cx={x} cy={y} r="1" fill="#166534" />;
+            })}
+            <circle cx="9" cy="11" r="1.2" fill="#14532d" />
+            <circle cx="15" cy="11" r="1.2" fill="#14532d" />
+            <path d="M8 15c1.5 1 6.5 1 8 0" stroke="#14532d" strokeWidth="1.4" fill="none" />
+          </svg>
+          <span className="brand__name">Naturverse</span>
         </Link>
 
-        {/* Desktop nav */}
         <nav className="nv-nav">
-          {LINKS.map((l) => (
-            <Link key={l.to} to={l.to} className="nv-link">
-              {l.label}
-            </Link>
-          ))}
+          <Link to="/worlds">Worlds</Link>
+          <Link to="/zones">Zones</Link>
+          <Link to="/marketplace">Marketplace</Link>
+          <Link to="/naturversity">Naturversity</Link>
+          <Link to="/naturbank">Naturbank</Link>
+          <Link to="/navatar">Navatar</Link>
+          <Link to="/passport">Passport</Link>
+          <Link to="/turian">Turian</Link>
+          <Link to="/profile">Profile</Link>
         </nav>
 
-        {/* Mobile menu button */}
-        <div className="nv-menu" ref={menuRef}>
-          <button
-            type="button"
-            className="nv-menu__btn"
-            aria-label="Open menu"
-            aria-expanded={open}
-            onClick={() => setOpen((v) => !v)}
-          >
-            <span className="nv-menu__bars" />
-          </button>
-
-          {open && (
-            <div className="nv-menu__sheet" role="menu">
-              {LINKS.map((l) => (
-                <Link
-                  key={l.to}
-                  to={l.to}
-                  role="menuitem"
-                  className="nv-menu__item"
-                >
-                  {l.label}
-                </Link>
-              ))}
-            </div>
-          )}
-        </div>
+        <button
+          type="button"
+          className="nv-menu"
+          aria-label="Open menu"
+          aria-expanded={open}
+          onClick={() => setOpen(!open)}
+        >
+          <span />
+          <span />
+          <span />
+        </button>
       </div>
+
+      {open && (
+        <div className="nv-drawer" role="menu" onClick={() => setOpen(false)}>
+          <Link to="/worlds">Worlds</Link>
+          <Link to="/zones">Zones</Link>
+          <Link to="/marketplace">Marketplace</Link>
+          <Link to="/naturversity">Naturversity</Link>
+          <Link to="/naturbank">Naturbank</Link>
+          <Link to="/navatar">Navatar</Link>
+          <Link to="/passport">Passport</Link>
+          <Link to="/turian">Turian</Link>
+          <Link to="/profile">Profile</Link>
+        </div>
+      )}
     </header>
   );
 }
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -31,3 +31,28 @@
 .row{display:flex;gap:8px;align-items:center}
 .card .split{display:grid;grid-template-columns:1fr 1fr;gap:12px 16px}
 .card .coming{margin-top:8px}
+
+/* Brand/header polish (no images) */
+.nv-header { position: sticky; top: 0; z-index: 40; background: #fff; border-bottom: 1px solid #e5e7eb; }
+.nv-header__inner { max-width: 80rem; margin: 0 auto; padding: .75rem 1rem; display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.brand { display: inline-flex; align-items: center; gap: .5rem; text-decoration: none; }
+.brand__logo { flex: 0 0 auto; border-radius: 9999px; box-shadow: 0 1px 0 rgba(0,0,0,.05) inset; }
+.brand__name { font-weight: 700; letter-spacing: .2px; color: #111827; }
+
+.nv-nav { display: none; gap: 1rem; }
+.nv-nav a { color: #374151; text-decoration: none; padding: .35rem .5rem; border-radius: .5rem; }
+.nv-nav a:hover { background: #f3f4f6; }
+
+.nv-menu { display: inline-flex; flex-direction: column; gap: 3px; width: 34px; height: 30px; align-items: center; justify-content: center; border: 1px solid #e5e7eb; border-radius: .5rem; background: #fff; }
+.nv-menu span { width: 18px; height: 2px; background: #111827; display: block; border-radius: 2px; }
+
+.nv-drawer { display: grid; gap: .5rem; padding: .75rem 1rem 1rem; border-top: 1px solid #e5e7eb; background: #fff; }
+.nv-drawer a { color: #1f2937; text-decoration: none; padding: .5rem; border-radius: .5rem; }
+.nv-drawer a:hover { background: #f3f4f6; }
+
+/* ≥768px show full nav, hide hamburger */
+@media (min-width: 768px) {
+  .nv-nav { display: inline-flex; }
+  .nv-menu, .nv-drawer { display: none; }
+}
+


### PR DESCRIPTION
## Summary
- inline SVG durian logo links home alongside brand name
- persistent right-aligned navigation with mobile hamburger drawer
- CSS tweaks for brand bar and responsive menu

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7bad757c88329b4b3ffaf6edf6f12