### PR TITLE
Restore header — brand left, desktop tabs, mobile hamburger drawer (no deps)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 const LINKS = [
   { href: "/worlds", label: "Worlds" },
@@ -15,65 +15,70 @@ const LINKS = [
 export default function Header() {
   const [open, setOpen] = useState(false);
 
+  // close drawer on route change (hash/path)
+  useEffect(() => {
+    const onChange = () => setOpen(false);
+    window.addEventListener("hashchange", onChange);
+    window.addEventListener("popstate", onChange);
+    return () => {
+      window.removeEventListener("hashchange", onChange);
+      window.removeEventListener("popstate", onChange);
+    };
+  }, []);
+
+  // close on resize to desktop
+  useEffect(() => {
+    const onResize = () => {
+      if (window.innerWidth >= 1024) setOpen(false);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
   return (
-    <header className="site-header">
-      <div className="site-header__inner">
-        {/* Brand (left) — links home */}
-        <a href="/" className="brand" aria-label="Naturverse home">
-          <span className="brand__logo" aria-hidden="true">
-            {/* inline durian dot — tiny, not the big face */}
-            <svg width="22" height="22" viewBox="0 0 24 24" role="img">
-              <defs>
-                <linearGradient id="dv" x1="0" y1="0" x2="1" y2="1">
-                  <stop offset="0" stopColor="#34d399" />
-                  <stop offset="1" stopColor="#16a34a" />
-                </linearGradient>
-              </defs>
-              <circle cx="12" cy="12" r="10" fill="url(#dv)" />
-              <path d="M6 12l3-3m9 0l-3 3m-6 6l3-3m3 3l-3-3" stroke="#065f46" strokeWidth="1.5" strokeLinecap="round"/>
-            </svg>
-          </span>
-          <span className="brand__name">Naturverse</span>
+    <header className="nv-header">
+      <div className="nv-shell">
+        <a href="/" className="nv-brand" aria-label="Naturverse home">
+          <span className="nv-logo" aria-hidden="true">🌿</span>
+          <span className="nv-name">Naturverse</span>
         </a>
 
-        {/* Desktop nav (right) */}
-        <nav className="main-nav md:flex hidden">
-          {LINKS.map((l) => (
-            <a key={l.href} href={l.href} className="main-nav__link">
-              {l.label}
-            </a>
-          ))}
+        {/* desktop nav */}
+        <nav className="nv-nav">
+          <ul>
+            {LINKS.map((l) => (
+              <li key={l.href}>
+                <a href={l.href}>{l.label}</a>
+              </li>
+            ))}
+          </ul>
         </nav>
 
-        {/* Mobile toggle (right) */}
+        {/* mobile button */}
         <button
-          type="button"
-          className="hamburger md:hidden"
+          className="nv-burger"
           aria-label="Open menu"
           aria-expanded={open}
           onClick={() => setOpen((v) => !v)}
         >
-          <span />
-          <span />
-          <span />
+          <span/>
+          <span/>
+          <span/>
         </button>
-      </div>
 
-      {/* Mobile drawer */}
-      <div className={`mobile-menu md:hidden ${open ? "open" : ""}`} role="menu">
-        {LINKS.map((l) => (
-          <a
-            key={l.href}
-            href={l.href}
-            className="mobile-menu__link"
-            role="menuitem"
-            onClick={() => setOpen(false)}
-          >
-            {l.label}
-          </a>
-        ))}
+        {/* mobile drawer */}
+        {open && (
+          <div className="nv-drawer" role="dialog" aria-modal="true">
+            <ul>
+              {LINKS.map((l) => (
+                <li key={l.href}>
+                  <a href={l.href}>{l.label}</a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
     </header>
   );
 }
-

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,9 +5,9 @@
 @import "./styles/profile.css";
 @import "./styles/global.css";
 @import "./styles/layout.css";
-@import "./styles/topnav.css";
 @import "./styles/hub.css";
 @import "./styles/crumbs.css";
+@import "./styles/header.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}
@@ -31,5 +31,3 @@
 .row{display:flex;gap:8px;align-items:center}
 .card .split{display:grid;grid-template-columns:1fr 1fr;gap:12px 16px}
 .card .coming{margin-top:8px}
-
-@import "./styles/header.css";

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -1,28 +1,34 @@
-/* Header bar */
-.site-header { position: sticky; top: 0; z-index: 40; background: #ffffffd9; backdrop-filter: blur(6px); border-bottom: 1px solid #eef2f7; }
-.site-header__inner { max-width: 72rem; margin: 0 auto; padding: 10px 16px; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+/* container */
+.nv-header{ position:sticky; top:0; z-index:40; backdrop-filter:saturate(180%) blur(10px); background:rgba(255,255,255,.75); border-bottom:1px solid #eef2f7; }
+.nv-shell{ max-width: 1200px; margin:0 auto; padding:10px 16px; display:flex; align-items:center; justify-content:space-between; }
 
-/* Brand */
-.brand { display: inline-flex; align-items: center; gap: 8px; text-decoration: none; }
-.brand__logo { display: inline-flex; }
-.brand__name { font-weight: 800; font-size: 20px; color: #0f172a; }
+/* brand */
+.nv-brand{ display:flex; align-items:center; gap:8px; text-decoration:none; }
+.nv-logo{ font-size:20px; line-height:1; }
+.nv-name{ font-weight:800; letter-spacing:.2px; color:#111827; }
 
-/* Desktop nav */
-.main-nav { display: flex; gap: 18px; align-items: center; }
-.main-nav__link { text-decoration: none; color: #374151; font-weight: 600; }
-.main-nav__link:hover { color: #111827; }
+/* desktop nav */
+.nv-nav{ display:none; }
+.nv-nav ul{ display:flex; gap:18px; list-style:none; margin:0; padding:0; }
+.nv-nav a{ color:#1f2937; text-decoration:none; font-weight:500; }
+.nv-nav a:hover{ text-decoration:underline; }
 
-/* Hamburger */
-.hamburger { display: inline-flex; flex-direction: column; gap: 4px; padding: 8px; border-radius: 10px; border: 1px solid #e5e7eb; background: #fff; }
-.hamburger span { width: 20px; height: 2px; background: #111827; border-radius: 2px; display: block; }
+/* burger */
+.nv-burger{ display:inline-flex; width:38px; height:34px; align-items:center; justify-content:center; border:1px solid #e5e7eb; border-radius:10px; background:#fff; }
+.nv-burger span{ display:block; width:18px; height:2px; background:#111827; margin:2px 0; border-radius:2px; }
 
-/* Mobile drawer */
-.mobile-menu { position: absolute; inset-inline-end: 12px; top: 56px; width: min(88vw, 320px); border: 1px solid #e5e7eb; border-radius: 12px; background: #fff; box-shadow: 0 10px 30px rgba(0,0,0,.08); padding: 8px; display: none; }
-.mobile-menu.open { display: block; }
-.mobile-menu__link { display: block; padding: 10px 12px; border-radius: 8px; text-decoration: none; color: #111827; font-weight: 600; }
-.mobile-menu__link:hover { background: #f3f4f6; }
+/* drawer */
+.nv-drawer{ position:absolute; right:16px; top:58px; background:#fff; border:1px solid #e5e7eb; border-radius:12px; box-shadow:0 10px 30px rgba(0,0,0,.08); padding:8px; }
+.nv-drawer ul{ list-style:none; margin:0; padding:4px; min-width:220px; }
+.nv-drawer li{ margin:0; }
+.nv-drawer a{ display:block; padding:10px 12px; border-radius:8px; color:#111827; text-decoration:none; }
+.nv-drawer a:hover{ background:#f3f4f6; }
 
-/* Reset list-style/blue bullets inside header (in case UA styles leak) */
-.site-header ul, .site-header li { list-style: none; margin: 0; padding: 0; }
-.site-header a { color: inherit; }
+/* responsive */
+@media (min-width: 1024px){
+  .nv-nav{ display:block; }
+  .nv-burger, .nv-drawer{ display:none; }
+}
 
+/* safety: hide any legacy top-link list if present */
+header + nav.legacy-top-links { display:none !important; }


### PR DESCRIPTION
## Summary
- Replace header component with responsive version featuring left-aligned brand, desktop links, and mobile hamburger drawer
- Add dedicated header stylesheet and include it in global styles, removing legacy topnav import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7c58e253c8329a16150006ff8b0eb