### PR TITLE
Add “A Turian Media Company” badge (uses saved asset, no navbar/layout changes)

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default function Footer() {
+  return (
+    <footer className="site-footer">
+      <div className="footer-inner">
+        <p className="muted">© {new Date().getFullYear()} Naturverse</p>
+
+        <a
+          className="tmc-badge"
+          href="https://turian.media" /* or your canonical company URL */
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="A Turian Media Company"
+        >
+          <img
+            src="/attached_assets/turian_media_logo_transparent.png"
+            alt="Turian Media logo"
+            className="tmc-logo"
+            width={20}
+            height={20}
+            loading="lazy"
+            decoding="async"
+          />
+          <span>A Turian Media Company</span>
+        </a>
+      </div>
+    </footer>
+  );
+}

--- a/src/layouts/Root.tsx
+++ b/src/layouts/Root.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { Outlet } from "react-router-dom";
-import Header from "../components/Header";
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
 
 export default function RootLayout() {
   return (
@@ -9,6 +10,7 @@ export default function RootLayout() {
       <main className="container">
         <Outlet />
       </main>
+      <Footer />
     </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,6 +8,7 @@
 @import "./styles/hub.css";
 @import "./styles/crumbs.css";
 @import "./styles/header.css";
+@import "./styles/footer.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}

--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -1,0 +1,36 @@
+.site-footer {
+  margin-top: 32px;
+  padding: 16px 0;
+  border-top: 1px solid #e5e7eb;
+  background: #fff;
+}
+.footer-inner {
+  max-width: 1024px;
+  margin: 0 auto;
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.tmc-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: #111827;
+  text-decoration: none;
+}
+.tmc-badge:hover {
+  text-decoration: underline;
+}
+.tmc-logo {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+}
+.muted {
+  color: #6b7280;
+}


### PR DESCRIPTION
## Summary
- add reusable Footer component with Turian Media badge
- mount Footer at bottom of root layout
- include footer styles and global import

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7cb36bcd88329979af73c70382779