### PR TITLE
Footer branding — use existing /attached_assets/turian_media_logo_transparent.png (no new assets)

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,29 +1,22 @@
-import React from 'react';
+import React from "react";
 
 export default function Footer() {
   return (
     <footer className="site-footer">
-      <div className="footer-inner">
-        <p className="muted">© {new Date().getFullYear()} Naturverse</p>
+      <div className="site-footer__inner">
+        <div className="site-footer__left">© 2025 Naturverse</div>
 
-        <a
-          className="tmc-badge"
-          href="https://turian.media" /* or your canonical company URL */
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="A Turian Media Company"
-        >
+        <div className="site-footer__right footer-brand" role="contentinfo" aria-label="Publisher">
           <img
             src="/attached_assets/turian_media_logo_transparent.png"
-            alt="Turian Media logo"
-            className="tmc-logo"
-            width={20}
-            height={20}
+            alt="Turian Media"
+            className="footer-brand__img"
             loading="lazy"
             decoding="async"
+            onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
           />
-          <span>A Turian Media Company</span>
-        </a>
+          <span className="footer-brand__text">A Turian Media Company</span>
+        </div>
       </div>
     </footer>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,3 +32,14 @@
 .row{display:flex;gap:8px;align-items:center}
 .card .split{display:grid;grid-template-columns:1fr 1fr;gap:12px 16px}
 .card .coming{margin-top:8px}
+
+/* Footer brand (shared) */
+.site-footer { margin-top: 32px; padding: 16px 0; color:#64748b; }
+.site-footer__inner {
+  max-width: 72rem; margin: 0 auto; padding: 0 1rem;
+  display:flex; align-items:center; justify-content:space-between;
+}
+.footer-brand { display:flex; align-items:center; gap:10px; opacity:0.95; }
+.footer-brand__img { height:18px; width:auto; display:block; }
+.footer-brand__text { font-weight:700; color:#475569; }
+@media (max-width:640px){ .site-footer__inner { flex-direction:column; gap:8px; } }


### PR DESCRIPTION
## Summary
- Replace `Footer` component to display Turian Media branding with existing logo asset.
- Append shared styles for footer layout and brand presentation.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7d0382dfc832983f0bc055eea9e20