### PR TITLE
Replace navbar leaf with Turian head + wire up favicon set

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,15 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Naturverse</title>
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png" />
-    <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
-    <link rel="icon" type="image/png" sizes="128x128" href="/favicon-128x128.png" />
-    <link rel="icon" type="image/png" sizes="256x256" href="/favicon-256x256.png" />
-    <!-- stop stale cached HTML while we repair -->
-    <meta http-equiv="Cache-Control" content="no-store, max-age=0" />
+      <!-- Turian head favicons -->
+      <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+      <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png" />
+      <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
+      <link rel="icon" type="image/png" sizes="128x128" href="/favicon-128x128.png" />
+      <link rel="icon" type="image/png" sizes="256x256" href="/favicon-256x256.png" />
+      <link rel="apple-touch-icon" sizes="180x180" href="/favicon-256x256.png" />
+      <meta name="theme-color" content="#0ea5e9" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -38,10 +38,17 @@ export default function Header() {
   return (
     <header className="nv-header">
       <div className="nv-shell">
-        <a href="/" className="nv-brand" aria-label="Naturverse home">
-          <span className="nv-logo" aria-hidden="true">🌿</span>
-          <span className="nv-name">Naturverse</span>
-        </a>
+          {/* Brand: Turian head + Naturverse (links home) */}
+          <a href="/" className="brand" aria-label="Naturverse home">
+            <img
+              src="/favicon-32x32.png"
+              alt=""
+              width={24}
+              height={24}
+              className="brand__logo"
+            />
+            <span className="brand__name">Naturverse</span>
+          </a>
 
         {/* desktop nav */}
         <nav className="nv-nav">

--- a/src/styles.css
+++ b/src/styles.css
@@ -52,3 +52,17 @@
   .card-img img { width:52px; height:52px; }
 }
 
+/* brand alignment */
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+}
+.brand__logo { display: inline-block; border-radius: 6px; }
+.brand__name { font-weight: 800; color: #111827; }
+@media (max-width: 640px){
+  .brand__name { font-weight: 800; }
+  .brand__logo { width: 22px; height: 22px; }
+}
+


### PR DESCRIPTION
## Summary
- swap leaf-brand for Turian head image in header
- add full favicon set with theme color to document head
- include brand alignment styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7efa5ea3883298a4c416f72135283