### PR TITLE
Home hero — replace ✨ with Turian head (uses existing favicons; no new deps)

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,18 @@ export default function Home() {
     <main className="container">
       {/* Clean hero (no oversized emoji) */}
       <header className="home-hero">
-        <h1>✨ Welcome to the Naturverse™</h1>
+        <h1>
+          <img
+            className="brandmark"
+            src="/favicon-32x32.png"
+            srcSet="/favicon-32x32.png 1x, /favicon-64x64.png 2x"
+            width={32}
+            height={32}
+            alt=""
+            aria-hidden="true"
+          />
+          Welcome to the Naturverse™
+        </h1>
         <p>Pick a hub to begin your adventure.</p>
       </header>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -10,6 +10,7 @@
 @import "./styles/header.css";
 @import "./styles/footer.css";
 @import "./styles/kingdom.css";
+@import "./styles/brandmark.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}

--- a/src/styles/brandmark.css
+++ b/src/styles/brandmark.css
@@ -1,0 +1,12 @@
+/* Tiny image “emoji” used beside hero titles */
+.brandmark {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  margin-right: 10px;
+  vertical-align: -5px; /* visually centers with H1 */
+  border-radius: 6px;
+}
+@media (min-width: 640px){
+  .brandmark { width: 32px; height: 32px; vertical-align: -6px; }
+}


### PR DESCRIPTION
## Summary
- add brandmark stylesheet for hero icons
- swap home hero sparkle for Turian favicon brandmark

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7f1aa3540832997675c3b36ee31a9