### PR TITLE
Replace all “A Turian Media Company” text with Turian logo (site-wide)

### DIFF
--- a/src/components/BrandMark.tsx
+++ b/src/components/BrandMark.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+type Props = {
+  size?: "sm" | "md" | "lg";
+  className?: string;
+  title?: string; // optional tooltip/accessible label
+};
+
+/** Turian Media mark as an inline, responsive img (no link). */
+export default function BrandMark({
+  size = "md",
+  className = "",
+  title = "Turian Media Company",
+}: Props) {
+  const h =
+    size === "sm" ? 18 :
+    size === "lg" ? 36 : 28;
+
+  return (
+    <span className={`brand-mark ${className}`} aria-label={title}>
+      <img
+        src="/turianmedialogo.png"
+        alt=""
+        role="presentation"
+        className="brand-logo"
+        style={{ height: h, width: "auto", objectFit: "contain" }}
+      />
+      <span className="sr-only">{title}</span>
+    </span>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,23 +1,11 @@
 import React from "react";
+import BrandMark from "./BrandMark";
 
 export default function Footer() {
   return (
-    <footer className="site-footer">
-      <div className="site-footer__inner">
-        <div className="site-footer__left">© 2025 Naturverse</div>
-
-        <div className="site-footer__right footer-brand" role="contentinfo" aria-label="Publisher">
-          <img
-            src="/attached_assets/turian_media_logo_transparent.png"
-            alt="Turian Media"
-            className="footer-brand__img"
-            loading="lazy"
-            decoding="async"
-            onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
-          />
-          <span className="footer-brand__text">A Turian Media Company</span>
-        </div>
-      </div>
+    <footer className="footer">
+      <p>© 2025 Naturverse</p>
+      <BrandMark size="md" />
     </footer>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -67,3 +67,21 @@
   .brand__logo { width: 22px; height: 22px; }
 }
 
+
+/* footer layout (already present for you; ensure these exist) */
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+/* reusable brand */
+.brand-mark { display: inline-flex; align-items: center; }
+.brand-logo { display: block; }
+.sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}


### PR DESCRIPTION
## Summary
- add reusable `<BrandMark />` for Turian Media logo
- swap "A Turian Media Company" text for the new logo in the footer
- append basic footer and brand styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7f6d629f8832999912470b0e7f92f