### PR TITLE
Worlds — add Thailandia world page and route (uses /assets/thailandia)

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -1,0 +1,1 @@
+.world-page{max-width:1100px;margin:0 auto;padding:16px}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { router } from './router';
 import './styles.css';
 import './styles/shop.css';
 import './styles/edu.css';
+import './main.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/pages/worlds/Thailandia.tsx
+++ b/src/pages/worlds/Thailandia.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+export default function ThailandiaWorld() {
+  return (
+    <div className="world-page">
+      <h1>🌏 Thailandia</h1>
+      <p className="muted">
+        Welcome to Thailandia — explore traditions, landmarks, and celebrations.
+      </p>
+
+      <div className="cards">
+        <a className="card" href="/worlds/thailandia#landmarks">
+          <img src="/assets/thailandia/temple.png" alt="Thai Temple" />
+          <h2>Landmarks</h2>
+          <p>Iconic temples, rivers, and floating markets.</p>
+        </a>
+
+        <a className="card" href="/worlds/thailandia#festivals">
+          <img src="/assets/thailandia/festival.jpg" alt="Festival" />
+          <h2>Festivals</h2>
+          <p>Songkran, Loy Krathong, and seasonal holidays.</p>
+        </a>
+
+        <a className="card" href="/worlds/thailandia#culture">
+          <img src="/assets/thailandia/flag.png" alt="Flag of Thailandia" />
+          <h2>Culture</h2>
+          <p>Food, music, and traditions unique to Thailandia.</p>
+        </a>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export default function WorldsIndex() {
+  return (
+    <div className="world-page">
+      <h1>Worlds</h1>
+      <div className="cards">
+        <a className="card" href="/worlds/thailandia">
+          <img src="/assets/thailandia/flag.png" alt="Thailandia" />
+          <h2>Thailandia</h2>
+          <p>Coconuts, elephants, festivals, and more.</p>
+        </a>
+      </div>
+    </div>
+  );
+}
+

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { createBrowserRouter } from "react-router-dom";
 
 import Home from "./routes";
-import Worlds from "./pages/Worlds";
+import WorldsIndex from "./pages/worlds";
+import ThailandiaWorld from "./pages/worlds/Thailandia";
 import World from "./routes/worlds/World";
 import Zones from "./routes/zones";
 import ArcadeZone from "./routes/zones/arcade";
@@ -40,7 +41,8 @@ export const router = createBrowserRouter([
     element: <RootLayout />,
     children: [
       { index: true, element: <Home /> },
-      { path: "worlds", element: <Worlds /> },
+      { path: "worlds", element: <WorldsIndex /> },
+      { path: "worlds/thailandia", element: <ThailandiaWorld /> },
       { path: "worlds/:slug", element: <World /> },
       { path: "zones", element: <Zones /> },
       { path: "zones/arcade", element: <ArcadeZone /> },


### PR DESCRIPTION
## Summary
- add Thailandia world page with landmark, festival, and culture cards
- link the Worlds index and Thailandia routes in the router
- style world pages with basic layout

## Testing
- `npm test` *(fails: Missing script)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7fdb105608329bbddd19fc46d1361