### PR TITLE
Worlds — restore 14-kingdom grid (no images, no new deps)

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -1,1 +1,9 @@
 .world-page{max-width:1100px;margin:0 auto;padding:16px}
+
+/* worlds grid + card shells (no images required) */
+.worlds-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px}
+.card{display:flex;gap:12px;border:1px solid #e5e7eb;border-radius:14px;padding:12px;background:#fff}
+.card-thumb{width:64px;height:64px;border-radius:12px;background:#f8fafc;display:flex;align-items:center;justify-content:center;border:1px solid #e5e7eb}
+.card-thumb .emoji{font-size:28px}
+.card-body h2{margin:0 0 4px}
+

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -1,15 +1,42 @@
 import React from "react";
 
+type Kingdom = { name: string; emoji: string; blurb: string };
+
+const KINGDOMS: Kingdom[] = [
+  { name: "Thailandia",   emoji: "🗺️", blurb: "Coconuts & Elephants" },
+  { name: "Brazilandia",  emoji: "🍌", blurb: "Bananas & Parrots" },
+  { name: "Indilandia",   emoji: "🥭", blurb: "Mangoes & Tigers" },
+  { name: "Amerilandia",  emoji: "🍎", blurb: "Apples & Eagles" },
+  { name: "Australandia", emoji: "🍑", blurb: "Peaches & Kangaroos" },
+  { name: "Chilandia",    emoji: "🎍", blurb: "Bamboo (shoots) & Pandas" },
+  { name: "Japonica",     emoji: "🌸", blurb: "Cherry Blossoms & Foxes" },
+  { name: "Africania",    emoji: "🦁", blurb: "Mangoes & Lions" },
+  { name: "Europalia",    emoji: "🌻", blurb: "Sunflowers & Hedgehogs" },
+  { name: "Britannula",   emoji: "🌹", blurb: "Roses & Hedgehogs" },
+  { name: "Kiwilandia",   emoji: "🥝", blurb: "Kiwis & Sheep" },
+  { name: "Madagascaria", emoji: "🍋", blurb: "Lemons & Lemurs" },
+  { name: "Greenlandia",  emoji: "🧊", blurb: "Ice & Polar Bears" },
+  { name: "Antarctiland", emoji: "❄️", blurb: "Ice Crystals & Penguins" },
+];
+
 export default function WorldsIndex() {
   return (
-    <div className="world-page">
+    <div>
       <h1>Worlds</h1>
-      <div className="cards">
-        <a className="card" href="/worlds/thailandia">
-          <img src="/assets/thailandia/flag.png" alt="Thailandia" />
-          <h2>Thailandia</h2>
-          <p>Coconuts, elephants, festivals, and more.</p>
-        </a>
+      <p>Explore the 14 kingdoms.</p>
+
+      <div className="worlds-grid">
+        {KINGDOMS.map((k) => (
+          <div key={k.name} className="card">
+            <div className="card-thumb">
+              <div className="emoji" aria-hidden="true">{k.emoji}</div>
+            </div>
+            <div className="card-body">
+              <h2>{k.name}</h2>
+              <p>{k.blurb}</p>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- restore worlds index page to render all 14 kingdoms as simple emoji cards
- add minimal grid + card CSS with no image dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a805359a38832998af5dbf0933e498