### PR TITLE
feat: add shared world layout and world pages

### DIFF
--- a/src/components/WorldLayout.tsx
+++ b/src/components/WorldLayout.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+type ImgItem = { src?: string; alt: string; label?: string; href?: string };
+
+export default function WorldLayout({
+  title,
+  blurb,
+  heroSrc,
+  gallery = [],
+  characters = [],
+}: {
+  title: string;
+  blurb: string;
+  heroSrc?: string;
+  gallery?: ImgItem[];
+  characters?: ImgItem[];
+}) {
+  const hero = heroSrc || "/placeholders/world-hero.jpg";
+
+  return (
+    <div className="world-wrap">
+      <div className="world-hero">
+        <img src={hero} alt={`${title} map`} onError={(e) => ((e.currentTarget.src = "/placeholders/world-hero.jpg"))} />
+      </div>
+
+      <h1 className="world-title">{title}</h1>
+      <p className="muted">{blurb}</p>
+
+      <section className="world-section">
+        <h2>Gallery</h2>
+        <div className="world-grid">
+          {gallery.length ? (
+            gallery.map((g, i) => (
+              g.href ? (
+                <a key={i} className="world-card" href={g.href}>
+                  <img src={g.src || "/placeholders/photo.jpg"} alt={g.alt} />
+                  {g.label && <h3>{g.label}</h3>}
+                </a>
+              ) : (
+                <div key={i} className="world-card">
+                  <img src={g.src || "/placeholders/photo.jpg"} alt={g.alt} />
+                  {g.label && <h3>{g.label}</h3>}
+                </div>
+              )
+            ))
+          ) : (
+            <div className="world-empty">Coming soon</div>
+          )}
+        </div>
+      </section>
+
+      <section className="world-section">
+        <h2>Characters</h2>
+        <div className="world-grid">
+          {characters.length ? (
+            characters.map((c, i) => (
+              <div key={i} className="world-card">
+                <img src={c.src || "/placeholders/avatar.jpg"} alt={c.alt} />
+                {c.label && <h3>{c.label}</h3>}
+              </div>
+            ))
+          ) : (
+            <div className="world-empty">Coming soon</div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/src/main.css
+++ b/src/main.css
@@ -1,3 +1,5 @@
+@import "./styles/worlds.css";
+
 .world-page{max-width:1100px;margin:0 auto;padding:16px}
 
 /* worlds grid + card shells (no images required) */
@@ -6,4 +8,3 @@
 .card-thumb{width:64px;height:64px;border-radius:12px;background:#f8fafc;display:flex;align-items:center;justify-content:center;border:1px solid #e5e7eb}
 .card-thumb .emoji{font-size:28px}
 .card-body h2{margin:0 0 4px}
-

--- a/src/pages/worlds/Africania.tsx
+++ b/src/pages/worlds/Africania.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Africania() {
+  return (
+    <WorldLayout
+      title="🌏 Africania"
+      blurb="Welcome to Africania — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Africania/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Amerilandia.tsx
+++ b/src/pages/worlds/Amerilandia.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Amerilandia() {
+  return (
+    <WorldLayout
+      title="🌏 Amerilandia"
+      blurb="Welcome to Amerilandia — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Amerilandia/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Antarcticland.tsx
+++ b/src/pages/worlds/Antarcticland.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Antarcticland() {
+  return (
+    <WorldLayout
+      title="🌏 Antarcticland"
+      blurb="Welcome to Antarcticland — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Antarcticland/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Australandia.tsx
+++ b/src/pages/worlds/Australandia.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Australandia() {
+  return (
+    <WorldLayout
+      title="🌏 Australandia"
+      blurb="Welcome to Australandia — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Australandia/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Brazilandia.tsx
+++ b/src/pages/worlds/Brazilandia.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Brazilandia() {
+  return (
+    <WorldLayout
+      title="🌏 Brazilandia"
+      blurb="Welcome to Brazilandia — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Brazilandia/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Britannula.tsx
+++ b/src/pages/worlds/Britannula.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Britannula() {
+  return (
+    <WorldLayout
+      title="🌏 Britannula"
+      blurb="Welcome to Britannula — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Britannula/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Chilandia.tsx
+++ b/src/pages/worlds/Chilandia.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Chilandia() {
+  return (
+    <WorldLayout
+      title="🌏 Chilandia"
+      blurb="Welcome to Chilandia — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Chilandia/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Europalia.tsx
+++ b/src/pages/worlds/Europalia.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Europalia() {
+  return (
+    <WorldLayout
+      title="🌏 Europalia"
+      blurb="Welcome to Europalia — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Europalia/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Greenlandia.tsx
+++ b/src/pages/worlds/Greenlandia.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Greenlandia() {
+  return (
+    <WorldLayout
+      title="🌏 Greenlandia"
+      blurb="Welcome to Greenlandia — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Greenlandia/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Indilandia.tsx
+++ b/src/pages/worlds/Indilandia.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Indilandia() {
+  return (
+    <WorldLayout
+      title="🌏 Indilandia"
+      blurb="Welcome to Indilandia — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Indilandia/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Japonica.tsx
+++ b/src/pages/worlds/Japonica.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Japonica() {
+  return (
+    <WorldLayout
+      title="🌏 Japonica"
+      blurb="Welcome to Japonica — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Japonica/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Kiwilandia.tsx
+++ b/src/pages/worlds/Kiwilandia.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Kiwilandia() {
+  return (
+    <WorldLayout
+      title="🌏 Kiwilandia"
+      blurb="Welcome to Kiwilandia — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Kiwilandia/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Madagascaria.tsx
+++ b/src/pages/worlds/Madagascaria.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import WorldLayout from "../../components/WorldLayout";
+
+export default function Madagascaria() {
+  return (
+    <WorldLayout
+      title="🌏 Madagascaria"
+      blurb="Welcome to Madagascaria — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Madagascaria/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
+  );
+}

--- a/src/pages/worlds/Thailandia.tsx
+++ b/src/pages/worlds/Thailandia.tsx
@@ -1,33 +1,14 @@
 import React from "react";
+import WorldLayout from "../../components/WorldLayout";
 
-export default function ThailandiaWorld() {
+export default function Thailandia() {
   return (
-    <div className="world-page">
-      <h1>🌏 Thailandia</h1>
-      <p className="muted">
-        Welcome to Thailandia — explore traditions, landmarks, and celebrations.
-      </p>
-
-      <div className="cards">
-        <a className="card" href="/worlds/thailandia#landmarks">
-          <img src="/assets/thailandia/temple.png" alt="Thai Temple" />
-          <h2>Landmarks</h2>
-          <p>Iconic temples, rivers, and floating markets.</p>
-        </a>
-
-        <a className="card" href="/worlds/thailandia#festivals">
-          <img src="/assets/thailandia/festival.jpg" alt="Festival" />
-          <h2>Festivals</h2>
-          <p>Songkran, Loy Krathong, and seasonal holidays.</p>
-        </a>
-
-        <a className="card" href="/worlds/thailandia#culture">
-          <img src="/assets/thailandia/flag.png" alt="Flag of Thailandia" />
-          <h2>Culture</h2>
-          <p>Food, music, and traditions unique to Thailandia.</p>
-        </a>
-      </div>
-    </div>
+    <WorldLayout
+      title="🌏 Thailandia"
+      blurb="Welcome to Thailandia — explore traditions, landmarks, and celebrations."
+      heroSrc="/kingdoms/Thailandia/map.jpg"
+      gallery={[]}
+      characters={[]}
+    />
   );
 }
-

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -1,22 +1,22 @@
 import React from "react";
 
-type Kingdom = { name: string; emoji: string; blurb: string };
+type Kingdom = { name: string; emoji: string; blurb: string; slug: string };
 
 const KINGDOMS: Kingdom[] = [
-  { name: "Thailandia",   emoji: "🗺️", blurb: "Coconuts & Elephants" },
-  { name: "Brazilandia",  emoji: "🍌", blurb: "Bananas & Parrots" },
-  { name: "Indilandia",   emoji: "🥭", blurb: "Mangoes & Tigers" },
-  { name: "Amerilandia",  emoji: "🍎", blurb: "Apples & Eagles" },
-  { name: "Australandia", emoji: "🍑", blurb: "Peaches & Kangaroos" },
-  { name: "Chilandia",    emoji: "🎍", blurb: "Bamboo (shoots) & Pandas" },
-  { name: "Japonica",     emoji: "🌸", blurb: "Cherry Blossoms & Foxes" },
-  { name: "Africania",    emoji: "🦁", blurb: "Mangoes & Lions" },
-  { name: "Europalia",    emoji: "🌻", blurb: "Sunflowers & Hedgehogs" },
-  { name: "Britannula",   emoji: "🌹", blurb: "Roses & Hedgehogs" },
-  { name: "Kiwilandia",   emoji: "🥝", blurb: "Kiwis & Sheep" },
-  { name: "Madagascaria", emoji: "🍋", blurb: "Lemons & Lemurs" },
-  { name: "Greenlandia",  emoji: "🧊", blurb: "Ice & Polar Bears" },
-  { name: "Antarctiland", emoji: "❄️", blurb: "Ice Crystals & Penguins" },
+  { name: "Thailandia",   emoji: "🗺️", blurb: "Coconuts & Elephants", slug: "thailandia" },
+  { name: "Brazilandia",  emoji: "🍌", blurb: "Bananas & Parrots", slug: "brazilandia" },
+  { name: "Indilandia",   emoji: "🥭", blurb: "Mangoes & Tigers", slug: "indilandia" },
+  { name: "Amerilandia",  emoji: "🍎", blurb: "Apples & Eagles", slug: "amerilandia" },
+  { name: "Australandia", emoji: "🍑", blurb: "Peaches & Kangaroos", slug: "australandia" },
+  { name: "Chilandia",    emoji: "🎍", blurb: "Bamboo (shoots) & Pandas", slug: "chilandia" },
+  { name: "Japonica",     emoji: "🌸", blurb: "Cherry Blossoms & Foxes", slug: "japonica" },
+  { name: "Africania",    emoji: "🦁", blurb: "Mangoes & Lions", slug: "africania" },
+  { name: "Europalia",    emoji: "🌻", blurb: "Sunflowers & Hedgehogs", slug: "europalia" },
+  { name: "Britannula",   emoji: "🌹", blurb: "Roses & Hedgehogs", slug: "britannula" },
+  { name: "Kiwilandia",   emoji: "🥝", blurb: "Kiwis & Sheep", slug: "kiwilandia" },
+  { name: "Madagascaria", emoji: "🍋", blurb: "Lemons & Lemurs", slug: "madagascaria" },
+  { name: "Greenlandia",  emoji: "🧊", blurb: "Ice & Polar Bears", slug: "greenlandia" },
+  { name: "Antarcticland", emoji: "❄️", blurb: "Ice Crystals & Penguins", slug: "antarcticland" },
 ];
 
 export default function WorldsIndex() {
@@ -27,7 +27,7 @@ export default function WorldsIndex() {
 
       <div className="worlds-grid">
         {KINGDOMS.map((k) => (
-          <div key={k.name} className="card">
+          <a key={k.name} className="card" href={`/worlds/${k.slug}`}>
             <div className="card-thumb">
               <div className="emoji" aria-hidden="true">{k.emoji}</div>
             </div>
@@ -35,7 +35,7 @@ export default function WorldsIndex() {
               <h2>{k.name}</h2>
               <p>{k.blurb}</p>
             </div>
-          </div>
+          </a>
         ))}
       </div>
     </div>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -3,7 +3,20 @@ import { createBrowserRouter } from "react-router-dom";
 
 import Home from "./routes";
 import WorldsIndex from "./pages/worlds";
-import ThailandiaWorld from "./pages/worlds/Thailandia";
+import Thailandia from "./pages/worlds/Thailandia";
+import Brazilandia from "./pages/worlds/Brazilandia";
+import Indilandia from "./pages/worlds/Indilandia";
+import Amerilandia from "./pages/worlds/Amerilandia";
+import Australandia from "./pages/worlds/Australandia";
+import Chilandia from "./pages/worlds/Chilandia";
+import Japonica from "./pages/worlds/Japonica";
+import Africania from "./pages/worlds/Africania";
+import Europalia from "./pages/worlds/Europalia";
+import Britannula from "./pages/worlds/Britannula";
+import Kiwilandia from "./pages/worlds/Kiwilandia";
+import Madagascaria from "./pages/worlds/Madagascaria";
+import Greenlandia from "./pages/worlds/Greenlandia";
+import Antarcticland from "./pages/worlds/Antarcticland";
 import World from "./routes/worlds/World";
 import Zones from "./routes/zones";
 import ArcadeZone from "./routes/zones/arcade";
@@ -42,7 +55,20 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <Home /> },
       { path: "worlds", element: <WorldsIndex /> },
-      { path: "worlds/thailandia", element: <ThailandiaWorld /> },
+      { path: "worlds/thailandia", element: <Thailandia /> },
+      { path: "worlds/brazilandia", element: <Brazilandia /> },
+      { path: "worlds/indilandia", element: <Indilandia /> },
+      { path: "worlds/amerilandia", element: <Amerilandia /> },
+      { path: "worlds/australandia", element: <Australandia /> },
+      { path: "worlds/chilandia", element: <Chilandia /> },
+      { path: "worlds/japonica", element: <Japonica /> },
+      { path: "worlds/africania", element: <Africania /> },
+      { path: "worlds/europalia", element: <Europalia /> },
+      { path: "worlds/britannula", element: <Britannula /> },
+      { path: "worlds/kiwilandia", element: <Kiwilandia /> },
+      { path: "worlds/madagascaria", element: <Madagascaria /> },
+      { path: "worlds/greenlandia", element: <Greenlandia /> },
+      { path: "worlds/antarcticland", element: <Antarcticland /> },
       { path: "worlds/:slug", element: <World /> },
       { path: "zones", element: <Zones /> },
       { path: "zones/arcade", element: <ArcadeZone /> },

--- a/src/styles/worlds.css
+++ b/src/styles/worlds.css
@@ -1,0 +1,12 @@
+.world-wrap{max-width:1100px;margin:0 auto}
+.world-title{font-size:32px;font-weight:800;margin:8px 0 6px}
+.world-hero{border-radius:16px;overflow:hidden;border:1px solid #e5e7eb;background:#f8fafc;margin:6px 0 14px}
+.world-hero img{width:100%;height:280px;object-fit:cover}
+.world-section{margin:18px 0}
+.world-section h2{font-size:20px;font-weight:800;margin:6px 0 10px}
+.world-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px}
+.world-card{border:1px solid #e5e7eb;border-radius:14px;background:#fff;padding:10px;display:flex;flex-direction:column;gap:6px}
+.world-card img{width:100%;height:140px;object-fit:cover;border-radius:10px}
+.world-card h3{font-size:16px;font-weight:700;margin:0}
+.world-empty{border:1px dashed #cbd5e1;border-radius:12px;padding:24px;text-align:center;color:#64748b;background:#f8fafc}
+@media (max-width:640px){.world-hero img{height:200px}}


### PR DESCRIPTION
## Summary
- add reusable `WorldLayout` with map hero, gallery, and character slots
- create world pages for 14 kingdoms and link from worlds index
- wire individual world routes and include new styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8097650cc8329aeee3b514e9f5d63