### PR TITLE
Worlds — wire maps & pages for Amerilandia, Australandia, Brazilandia, Chilandia

### DIFF
--- a/client/pages/zones/culture.tsx
+++ b/client/pages/zones/culture.tsx
@@ -35,7 +35,7 @@ const cards = [
   },
   {
     title: "Chilandia",
-    subtitle: "Bamboo & Pandas",
+    subtitle: "Pandas & Dragons",
     beliefs: [
       "Balance, family, and scholarly curiosity.",
       "Bamboo as a symbol of resilience."

--- a/src/content/kingdoms.ts
+++ b/src/content/kingdoms.ts
@@ -10,7 +10,7 @@ export const KINGDOMS: Kingdom[] = [
   { key: "Indillandia",   title: "Indillandia",   subtitle: "Mangoes & Tigers" },
   { key: "Amerilandia",   title: "Amerilandia",   subtitle: "Apples & Eagles" },
   { key: "Australandia",  title: "Australandia",  subtitle: "Peaches & Kangaroos" },
-  { key: "Chilandia",     title: "Chilandia",     subtitle: "Bamboo & Pandas" },
+  { key: "Chilandia",     title: "Chilandia",     subtitle: "Pandas & Dragons" },
   { key: "Japonica",      title: "Japonica",      subtitle: "Cherry Blossoms & Foxes" },
   { key: "Africana",      title: "Africana",      subtitle: "Mangoes & Lions" },
   { key: "Europalia",     title: "Europalia",     subtitle: "Sunflowers & Hedgehogs" },

--- a/src/data/culture-sections.ts
+++ b/src/data/culture-sections.ts
@@ -47,9 +47,9 @@ export const CULTURE_SECTIONS: CultureSection[] = [
   },
   {
     id: "chilandia",
-    emoji: "🎋🐼",
+    emoji: "🐼🐉",
     kingdom: "Chilandia",
-    caption: "Bamboo & Pandas",
+    caption: "Pandas & Dragons",
     beliefs: [
       "Balance, family, and scholarly curiosity.",
       "Bamboo as a symbol of resilience."

--- a/src/data/culture.ts
+++ b/src/data/culture.ts
@@ -47,9 +47,9 @@ export const cultureData: CultureItem[] = [
   },
   {
     id: "chilandia",
-    emoji: "🧧🐉",
+    emoji: "🐼🐉",
     title: "Chilandia",
-    blurb: "Bamboo & Pandas",
+    blurb: "Pandas & Dragons",
     beliefs: [
       "Balance, family, and scholarly curiosity.",
       "Bamboo as a symbol of resilience."

--- a/src/data/worlds.ts
+++ b/src/data/worlds.ts
@@ -12,7 +12,7 @@ export const WORLDS: Kingdom[] = [
   { id: "indillandia", name: "Indillandia", tagline: "Mangoes & Tigers", emoji: "🥭🐯" },
   { id: "amerilandia", name: "Amerilandia", tagline: "Apples & Eagles", emoji: "🍎🦅" },
   { id: "australandia", name: "Australandia", tagline: "Peaches & Kangaroos", emoji: "🍑🦘" },
-  { id: "chilandia", name: "Chilandia", tagline: "Bamboo (shoots) & Pandas", emoji: "🎋🐼" },
+  { id: "chilandia", name: "Chilandia", tagline: "Pandas & Dragons", emoji: "🐼🐉" },
   { id: "japonica", name: "Japonica", tagline: "Cherry Blossoms & Foxes", emoji: "🌸🦊" },
   { id: "africana", name: "Africana", tagline: "Mangoes & Lions", emoji: "🦁🌞" },
   { id: "europalia", name: "Europalia", tagline: "Sunflowers & Hedgehogs", emoji: "🌻🦔" },

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -4,7 +4,7 @@ export const worlds = [
   { slug: "indillandia",  title: "Indillandia",  emoji: "🥭🐯", blurb: "Mangoes & Tigers" },
   { slug: "amerilandia",  title: "Amerilandia",  emoji: "🍎🦅", blurb: "Apples & Eagles" },
   { slug: "australandia", title: "Australandia", emoji: "🍑🦘", blurb: "Peaches & Kangaroos" },
-  { slug: "chilandia",    title: "Chilandia",    emoji: "🎍🐼", blurb: "Bamboo (shoots) & Pandas" },
+  { slug: "chilandia",    title: "Chilandia",    emoji: "🐼🐉", blurb: "Pandas & Dragons" },
   { slug: "japonica",     title: "Japonica",     emoji: "🌸🦊", blurb: "Cherry Blossoms & Foxes" },
   { slug: "africana",     title: "Africana",     emoji: "🍋🦁", blurb: "Lemons & Lions" },
   { slug: "europalia",    title: "Europalia",    emoji: "🌻🦔", blurb: "Sunflowers & Hedgehogs" },

--- a/src/pages/worlds/Australandia.tsx
+++ b/src/pages/worlds/Australandia.tsx
@@ -6,7 +6,7 @@ export default function Australandia() {
     <WorldPage
       title="Australandia"
       intro="Welcome to Australandia — explore traditions, landmarks, and celebrations."
-      mapSrc="/kingdoms/Australandia/Australandiemap.png"
+      mapSrc="/kingdoms/Australandia/Australaniamap.png"
     />
   );
 }

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -1,21 +1,5 @@
 import React from "react";
-
-const WORLDS = [
-  ["Thailandia", "/worlds/thailandia"],
-  ["Brazilandia", "/worlds/brazilandia"],
-  ["Chilandia", "/worlds/chilandia"],
-  ["Indillandia", "/worlds/indillandia"],
-  ["Amerilandia", "/worlds/amerilandia"],
-  ["Australandia", "/worlds/australandia"],
-  ["Japonica", "/worlds/japonica"],
-  ["Africana", "/worlds/africana"],
-  ["Europalia", "/worlds/europalia"],
-  ["Britannula", "/worlds/britannula"],
-  ["Kiwilandia", "/worlds/kiwilandia"],
-  ["Madagascaria", "/worlds/madagascaria"],
-  ["Greenlandia", "/worlds/greenlandia"],
-  ["Antarctiland", "/worlds/antarctiland"],
-];
+import { WORLDS } from "../../data/worlds";
 
 export default function WorldsIndex() {
   return (
@@ -23,14 +7,13 @@ export default function WorldsIndex() {
       <h1>Worlds</h1>
       <p>Explore the 14 kingdoms.</p>
       <div className="cards">
-        {WORLDS.map(([name, href]) => (
-          <a key={name} className="card" href={href}>
+        {WORLDS.map(({ id, name, tagline }) => (
+          <a key={id} className="card" href={`/worlds/${id}`}>
             <h2>{name}</h2>
-            <p>Open {name} →</p>
+            <p>{tagline}</p>
           </a>
         ))}
       </div>
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- Import world metadata to the Worlds index, displaying each kingdom's tagline.
- Correct Australandia world map reference.
- Update Chilandia's tagline to "Pandas & Dragons" across data sources.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a83e09c0408329b5a58b0e362a69be