### PR TITLE
Worlds — add character galleries for 4 worlds (uses existing assets)

### DIFF
--- a/src/components/CharacterGrid.tsx
+++ b/src/components/CharacterGrid.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+export type CharacterItem = { name: string; file: string }; // file includes extension
+
+export default function CharacterGrid({ items, basePath }: {
+  items: CharacterItem[];
+  basePath: string; // e.g. "/kingdoms/Thailandia"
+}) {
+  if (!items?.length) return null;
+  return (
+    <div className="char-grid">
+      {items.map((it) => {
+        const src = `${basePath}/${encodeURIComponent(it.file)}`;
+        return (
+          <figure className="char" key={it.file}>
+            <img src={src} alt={it.name} loading="lazy" />
+            <figcaption>{it.name}</figcaption>
+          </figure>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/content/characters.ts
+++ b/src/content/characters.ts
@@ -1,0 +1,67 @@
+import type { CharacterItem } from "../components/CharacterGrid";
+
+export const ThailandiaChars: CharacterItem[] = [
+  { name: "2kay", file: "2kay.png" },
+  { name: "Blu Butterfly", file: "Blu Butterfly.png" },
+  { name: "Coconut Cruze", file: "Coconut Cruze.png" },
+  { name: "Dow-Mean", file: "Dow-Mean.png" },
+  { name: "Dr P", file: "Dr P.png" },
+  { name: "Frankie Frogs", file: "Frankie Frogs.png" },
+  { name: "Guide", file: "Guide.png" },
+  { name: "Inkie", file: "Inkie.png" },
+  { name: "Jay-Sing", file: "Jay-Sing.png" },
+  { name: "Jen-Suex", file: "Jen-Suex.png" },
+  { name: "Lao Cow", file: "Lao Cow.png" },
+  { name: "Mango Mike", file: "Mango Mike.png" },
+  { name: "Nikki MT", file: "Nikki MT.png" },
+  { name: "Non-Bua", file: "Non-Bua.png" },
+  { name: "Pineapple Pa-Pa", file: "Pineapple Pa-Pa.png" },
+  { name: "Pineapple Petey", file: "Pineapple Petey.png" },
+  { name: "Slitherkin", file: "Slitherkin.png" },
+  { name: "Snakers", file: "Snakers.png" },
+  { name: "Teeyor", file: "Teeyor.png" },
+  { name: "Tommy Tuk Tuk", file: "Tommy Tuk Tuk.png" },
+];
+
+export const AmerilandiaChars: CharacterItem[] = [
+  { name: "Alligator Sport", file: "Aligatorsport.png" },
+  { name: "Bald Eagle", file: "Baldeagle.png" },
+  { name: "Owl", file: "Owl.png" },
+  { name: "Pixie", file: "Pixie.png" },
+  { name: "Raccoon", file: "Racoon.png" },
+  { name: "Sunflower Sue", file: "Sunflowersue.png" },
+];
+
+export const AustralandiaChars: CharacterItem[] = [
+  { name: "Bird", file: "Bird.png" },
+  { name: "Group of Four", file: "Groupof four.png" },
+  { name: "Kangaroo Guide", file: "Kangarooguide.png" },
+  { name: "Kangaroo Toon", file: "Kangarotoon.png" },
+  { name: "Koala", file: "Koala.png" },
+  { name: "Koala Alt", file: "Koalalt.png" },
+  { name: "Platypus", file: "Platapus.png" },
+  { name: "Turtle Twin 1", file: "turtletwin1.png" },
+  { name: "Turtle Twin 2", file: "Turtletwin2.png" },
+  { name: "Wally Wombat", file: "Wallywombat.png" },
+  { name: "Koala Zen", file: "koalazen.png" },
+];
+
+export const BrazilandiaChars: CharacterItem[] = [
+  { name: "Amazonica Spirit", file: "Amzonicaspirit.png" },
+  { name: "Aria Macaw", file: "Ariamacaw.png" },
+  { name: "Jogo Spider Monkey", file: "Jogospidermonkey.png" },
+  { name: "Luma Tucan", file: "Lumatucan.png" },
+  { name: "Samba Sam Music", file: "Sambasammusic.png" },
+  { name: "Chamleaan", file: "chamleaan.png" },
+];
+
+export const ChilandiaChars: CharacterItem[] = [
+  { name: "Baobao Panda & Longwei Dragon", file: "Baobaopandaandlongweidragon.png" },
+  { name: "Bo Drummer", file: "Bodrummer.png" },
+  { name: "Crane Wise", file: "Cranewise.png" },
+  { name: "Lantern Fox", file: "Lanternfox.png" },
+  { name: "Li Sporty Fox", file: "Lisportyfox.png" },
+  { name: "Meihua Blossom Spirit", file: "Meihuablossomspirit.png" },
+  { name: "Rat Twins", file: "Rattwins.png" },
+  { name: "Unamamed", file: "unamamed.png" },
+];

--- a/src/pages/worlds/Amerilandia.tsx
+++ b/src/pages/worlds/Amerilandia.tsx
@@ -1,13 +1,34 @@
 import React from "react";
-import WorldPage from "../../components/WorldPage";
+import CharacterGrid from "../../components/CharacterGrid";
+import { AmerilandiaChars } from "../../content/characters";
 
 export default function Amerilandia() {
   return (
-    <WorldPage
-      title="Amerilandia"
-      intro="Welcome to Amerilandia — explore traditions, landmarks, and celebrations."
-      mapSrc="/kingdoms/Amerilandia/Amerilaniamap.png"
-    />
+    <div className="world-page">
+      <figure className="world-hero">
+        <img
+          src="/kingdoms/Amerilandia/Amerilaniamap.png"
+          alt="Amerilandia map"
+          onError={(e) => ((e.currentTarget.src = "/placeholders/world-map.svg"))}
+          loading="eager"
+        />
+        <figcaption className="sr-only">Amerilandia map</figcaption>
+      </figure>
+
+      <h1>🌍 Amerilandia</h1>
+      <p className="muted">
+        Welcome to Amerilandia — explore traditions, landmarks, and celebrations.
+      </p>
+
+      <section className="world-section">
+        <h2>Gallery</h2>
+        <div className="coming-soon">Coming soon</div>
+      </section>
+
+      <section className="world-section">
+        <h2>Characters</h2>
+        <CharacterGrid items={AmerilandiaChars} basePath="/kingdoms/Amerilandia" />
+      </section>
+    </div>
   );
 }
-

--- a/src/pages/worlds/Australandia.tsx
+++ b/src/pages/worlds/Australandia.tsx
@@ -1,13 +1,34 @@
 import React from "react";
-import WorldPage from "../../components/WorldPage";
+import CharacterGrid from "../../components/CharacterGrid";
+import { AustralandiaChars } from "../../content/characters";
 
 export default function Australandia() {
   return (
-    <WorldPage
-      title="Australandia"
-      intro="Welcome to Australandia — explore traditions, landmarks, and celebrations."
-      mapSrc="/kingdoms/Australandia/Australaniamap.png"
-    />
+    <div className="world-page">
+      <figure className="world-hero">
+        <img
+          src="/kingdoms/Australandia/Australaniamap.png"
+          alt="Australandia map"
+          onError={(e) => ((e.currentTarget.src = "/placeholders/world-map.svg"))}
+          loading="eager"
+        />
+        <figcaption className="sr-only">Australandia map</figcaption>
+      </figure>
+
+      <h1>🌍 Australandia</h1>
+      <p className="muted">
+        Welcome to Australandia — explore traditions, landmarks, and celebrations.
+      </p>
+
+      <section className="world-section">
+        <h2>Gallery</h2>
+        <div className="coming-soon">Coming soon</div>
+      </section>
+
+      <section className="world-section">
+        <h2>Characters</h2>
+        <CharacterGrid items={AustralandiaChars} basePath="/kingdoms/Australandia" />
+      </section>
+    </div>
   );
 }
-

--- a/src/pages/worlds/Brazilandia.tsx
+++ b/src/pages/worlds/Brazilandia.tsx
@@ -1,13 +1,34 @@
 import React from "react";
-import WorldPage from "../../components/WorldPage";
+import CharacterGrid from "../../components/CharacterGrid";
+import { BrazilandiaChars } from "../../content/characters";
 
 export default function Brazilandia() {
   return (
-    <WorldPage
-      title="Brazilandia"
-      intro="Welcome to Brazilandia — explore traditions, landmarks, and celebrations."
-      mapSrc="/kingdoms/Brazilandia/Brazilandiamap.png"
-    />
+    <div className="world-page">
+      <figure className="world-hero">
+        <img
+          src="/kingdoms/Brazilandia/Brazilandiamap.png"
+          alt="Brazilandia map"
+          onError={(e) => ((e.currentTarget.src = "/placeholders/world-map.svg"))}
+          loading="eager"
+        />
+        <figcaption className="sr-only">Brazilandia map</figcaption>
+      </figure>
+
+      <h1>🌍 Brazilandia</h1>
+      <p className="muted">
+        Welcome to Brazilandia — explore traditions, landmarks, and celebrations.
+      </p>
+
+      <section className="world-section">
+        <h2>Gallery</h2>
+        <div className="coming-soon">Coming soon</div>
+      </section>
+
+      <section className="world-section">
+        <h2>Characters</h2>
+        <CharacterGrid items={BrazilandiaChars} basePath="/kingdoms/Brazilandia" />
+      </section>
+    </div>
   );
 }
-

--- a/src/pages/worlds/Chilandia.tsx
+++ b/src/pages/worlds/Chilandia.tsx
@@ -1,13 +1,34 @@
 import React from "react";
-import WorldPage from "../../components/WorldPage";
+import CharacterGrid from "../../components/CharacterGrid";
+import { ChilandiaChars } from "../../content/characters";
 
 export default function Chilandia() {
   return (
-    <WorldPage
-      title="Chilandia"
-      intro="Welcome to Chilandia — explore traditions, landmarks, and celebrations."
-      mapSrc="/kingdoms/Chilandia/Chilandiamap.jpg"
-    />
+    <div className="world-page">
+      <figure className="world-hero">
+        <img
+          src="/kingdoms/Chilandia/Chilandiamap.jpg"
+          alt="Chilandia map"
+          onError={(e) => ((e.currentTarget.src = "/placeholders/world-map.svg"))}
+          loading="eager"
+        />
+        <figcaption className="sr-only">Chilandia map</figcaption>
+      </figure>
+
+      <h1>🌍 Chilandia</h1>
+      <p className="muted">
+        Welcome to Chilandia — explore traditions, landmarks, and celebrations.
+      </p>
+
+      <section className="world-section">
+        <h2>Gallery</h2>
+        <div className="coming-soon">Coming soon</div>
+      </section>
+
+      <section className="world-section">
+        <h2>Characters</h2>
+        <CharacterGrid items={ChilandiaChars} basePath="/kingdoms/Chilandia" />
+      </section>
+    </div>
   );
 }
-

--- a/src/pages/worlds/Thailandia.tsx
+++ b/src/pages/worlds/Thailandia.tsx
@@ -1,13 +1,34 @@
 import React from "react";
-import WorldPage from "../../components/WorldPage";
+import CharacterGrid from "../../components/CharacterGrid";
+import { ThailandiaChars } from "../../content/characters";
 
 export default function Thailandia() {
   return (
-    <WorldPage
-      title="Thailandia"
-      intro="Welcome to Thailandia — explore traditions, landmarks, and celebrations."
-      mapSrc="/kingdoms/Thailandia/Thailandiamap.jpg"
-    />
+    <div className="world-page">
+      <figure className="world-hero">
+        <img
+          src="/kingdoms/Thailandia/Thailandiamap.jpg"
+          alt="Thailandia map"
+          onError={(e) => ((e.currentTarget.src = "/placeholders/world-map.svg"))}
+          loading="eager"
+        />
+        <figcaption className="sr-only">Thailandia map</figcaption>
+      </figure>
+
+      <h1>🌍 Thailandia</h1>
+      <p className="muted">
+        Welcome to Thailandia — explore traditions, landmarks, and celebrations.
+      </p>
+
+      <section className="world-section">
+        <h2>Gallery</h2>
+        <div className="coming-soon">Coming soon</div>
+      </section>
+
+      <section className="world-section">
+        <h2>Characters</h2>
+        <CharacterGrid items={ThailandiaChars} basePath="/kingdoms/Thailandia" />
+      </section>
+    </div>
   );
 }
-

--- a/src/styles/worlds.css
+++ b/src/styles/worlds.css
@@ -7,3 +7,35 @@
   background:#f8fafc; color:#475569; text-align:center; font-weight:600;
 }
 .sr-only { position:absolute; left:-10000px; top:auto; width:1px; height:1px; overflow:hidden; }
+
+/* character gallery */
+.char-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill,minmax(140px,1fr));
+  gap: 16px;
+  margin: 8px 0 24px;
+}
+.char {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 10px;
+  text-align: center;
+}
+.char img {
+  width: 100%;
+  height: 120px;
+  object-fit: contain;
+  border-radius: 8px;
+  display: block;
+  background: #f8fafc;
+}
+.char figcaption {
+  margin-top: 8px;
+  font-size: 14px;
+  color: #334155;
+}
+@media (max-width:640px){
+  .char-grid { gap:12px; }
+  .char img { height: 100px; }
+}


### PR DESCRIPTION
## Summary
- add CharacterGrid component and styles for character galleries
- populate character lists and display them on Thailandia, Amerilandia, Australandia, Brazilandia, and Chilandia world pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a841cca16083299f2de1bb1a07f18c