### PR TITLE
Zones — add “Future Zone” hub (AR/VR, Console, Multiplayer, 3D, AI, Marketplace upgrades)

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -1,3 +1,17 @@
 @import "./styles/worlds.css";
 @import "./styles/cart.css";
 @import "./styles/footer.css";
+
+/* simple "Coming Soon" pill used on cards */
+.tag.soon{
+  display:inline-block;
+  font-size:12px;
+  font-weight:700;
+  color:#0ea5e9;
+  background:#e0f2fe;
+  border:1px solid #bae6fd;
+  border-radius:999px;
+  padding:4px 8px;
+  margin-bottom:8px;
+}
+

--- a/src/pages/zones/Future.tsx
+++ b/src/pages/zones/Future.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
+
+export default function FutureZone() {
+  return (
+    <div className="page">
+      <Breadcrumbs
+        items={[
+          { href: "/", label: "Home" },
+          { href: "/zones", label: "Zones" },
+          { label: "Future Zone" },
+        ]}
+      />
+
+      <h1>🔮 Future Zone</h1>
+      <p className="muted">
+        A sneak peek at what's coming to the Naturverse. These features are in active design.
+      </p>
+
+      <div className="cards">
+        <a className="card" href="#" aria-disabled="true">
+          <div className="tag soon">Coming Soon</div>
+          <h2>AR / VR</h2>
+          <p>Immersive augmented & virtual reality adventures inside the Naturverse.</p>
+        </a>
+
+        <a className="card" href="#" aria-disabled="true">
+          <div className="tag soon">Coming Soon</div>
+          <h2>Console Play</h2>
+          <p>Cross-platform gaming with console integration and family profiles.</p>
+        </a>
+
+        <a className="card" href="#" aria-disabled="true">
+          <div className="tag soon">Coming Soon</div>
+          <h2>Worldwide Multiplayer</h2>
+          <p>Compete and collaborate across the globe in real-time events.</p>
+        </a>
+
+        <a className="card" href="#" aria-disabled="true">
+          <div className="tag soon">Coming Soon</div>
+          <h2>3D Worlds</h2>
+          <p>Explore fully 3D kingdoms and environments with your Navatar.</p>
+        </a>
+
+        <a className="card" href="#" aria-disabled="true">
+          <div className="tag soon">Coming Soon</div>
+          <h2>AI Companions</h2>
+          <p>Your Navatar learns, grows, and evolves with you across zones.</p>
+        </a>
+
+        <a className="card" href="#" aria-disabled="true">
+          <div className="tag soon">Coming Soon</div>
+          <h2>Marketplace Upgrades</h2>
+          <p>NATUR wallet, trading, redemptions, and seasonal global events.</p>
+        </a>
+      </div>
+    </div>
+  );
+}
+

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -28,6 +28,7 @@ import Quizzes from "./pages/zones/Quizzes";
 import Observations from "./pages/zones/Observations";
 import Community from "./pages/zones/Community";
 import Culture from "./pages/zones/Culture";
+import FutureZone from "./pages/zones/Future";
 import Marketplace from "./pages/Marketplace";
 import Catalog from "./pages/marketplace/Catalog";
 import Wishlist from "./pages/marketplace/Wishlist";
@@ -85,6 +86,7 @@ export const router = createBrowserRouter([
       { path: "zones/observations", element: <Observations /> },
       { path: "zones/culture", element: <Culture /> },
       { path: "zones/community", element: <Community /> },
+      { path: "zones/future", element: <FutureZone /> },
       { path: "marketplace", element: <Marketplace /> },
       { path: "marketplace/catalog", element: <Catalog /> },
       { path: "marketplace/wishlist", element: <Wishlist /> },

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -51,6 +51,12 @@ const ZONES = [
     title: 'Community',
     sub: 'Voting, events, & volunteering.',
   },
+  {
+    to: '/zones/future',
+    emoji: '🔮',
+    title: 'Future Zone',
+    sub: 'AR/VR, Console, Multiplayer, 3D, AI companions, wallet upgrades.',
+  },
 ];
 
 export default function Zones() {


### PR DESCRIPTION
## Summary
- add Future Zone page highlighting upcoming AR/VR, console, multiplayer, 3D, AI, and marketplace features
- expose Future Zone in the Zones hub and router
- style "Coming Soon" pills for future features

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a853c0b1a08329baa362fec16a4695