### PR TITLE
Replace header and footer logos with new Turian Media asset

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -28,7 +28,12 @@ export default function Footer() {
   return (
     <footer className="site-footer">
       <div className="footer-inner">
-        <p className="brand">© {new Date().getFullYear()} Naturverse · A Turian Media Company</p>
+        <img
+          src="/Turianmedia-logo-footer.png"
+          alt="Turian Media"
+          className="site-logo"
+        />
+        <p>© {new Date().getFullYear()} Naturverse</p>
         <nav className="footer-links">
           <a href="/terms">Terms</a>
           <a href="/privacy">Privacy</a>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -39,16 +39,12 @@ export default function Header() {
   return (
       <header className="nv-header">
         <div className="nv-shell">
-            {/* Brand: Turian head + Naturverse (links home) */}
-            <a href="/" className="brand" aria-label="Naturverse home">
+            <a href="/" className="header-logo-link" aria-label="Naturverse home">
               <img
-                src="/favicon-32x32.png"
-                alt=""
-                width={24}
-                height={24}
-                className="brand__logo"
+                src="/Turianmedia-logo-footer.png"
+                alt="Turian Media"
+                className="site-logo"
               />
-              <span className="brand__name">Naturverse</span>
             </a>
 
           <div className="nv-right">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,3 +14,10 @@ svg[aria-label="hero-face"],
 /* hide any legacy inline top nav on phones */
 .top-inline-nav{ display:none; }
 @media (min-width:768px){ .top-inline-nav{ display:flex; } }
+
+.site-logo {
+  max-height: 48px;
+  width: auto;
+  object-fit: contain;
+  display: block;
+}


### PR DESCRIPTION
## Summary
- swap header logo for new Turian Media asset
- add new Turian Media logo to footer and remove old branding text
- add `.site-logo` utility for consistent logo sizing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a85d3ef86c8329835349fa6302c442