### PR TITLE
Remove unused SVG logos and point footer to Turian media logo

### DIFF
--- a/public/assets/logo.svg
+++ b/public/assets/logo.svg
@@ -1,9 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="128" height="32" viewBox="0 0 128 32" aria-labelledby="title">
-  <title>Naturverse</title>
-  <g fill="none" stroke="none">
-    <circle cx="16" cy="16" r="12" fill="#2e7d32"/>
-    <path d="M16 7c3 4 3 10 0 14-5-2-8-6-8-10 3-1 6-3 8-4z" fill="#81c784"/>
-    <rect x="36" y="8" width="84" height="16" fill="none"/>
-    <text x="36" y="22" font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial" font-size="16" fill="#1c1c1c">Naturverse</text>
-  </g>
-</svg>

--- a/public/assets/turian-owl.svg
+++ b/public/assets/turian-owl.svg
@@ -1,8 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" aria-labelledby="title">
-  <title>Turian</title>
-  <circle cx="32" cy="32" r="30" fill="#ffe0b2"/>
-  <circle cx="24" cy="28" r="7" fill="#fff"/><circle cx="40" cy="28" r="7" fill="#fff"/>
-  <circle cx="24" cy="28" r="3.5" fill="#212121"/><circle cx="40" cy="28" r="3.5" fill="#212121"/>
-  <polygon points="32,24 27,34 37,34" fill="#ffb74d"/>
-  <path d="M12 42c6-6 34-6 40 0-1 8-13 12-20 12S13 50 12 42z" fill="#8d6e63"/>
-</svg>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,26 +2,32 @@ import React from "react";
 
 export default function Footer() {
   return (
-    <footer className="footer">
-      <div className="footer__left">
+    <footer className="site-footer">
+      <div className="footer-brand" aria-label="A Turian Media Company">
         <img
           src="/Turianmedia-logo-footer.png"
-          alt="Turian Media"
-          className="footer__brand"
-          height={24}
-          width={100}
+          alt="A Turian Media Company"
+          width={120}
+          height={28}
+          loading="lazy"
         />
-
-        <nav className="footer__social">
-          <a href="https://x.com/turianthedurian" target="_blank" rel="noreferrer">X</a>
-          <a href="https://instagram.com" target="_blank" rel="noreferrer">Instagram</a>
-          <a href="https://youtube.com" target="_blank" rel="noreferrer">YouTube</a>
-          <a href="https://discord.gg" target="_blank" rel="noreferrer">Discord</a>
-          <a href="mailto:info@naturverse.com">info@naturverse.com</a>
-        </nav>
       </div>
-
-      <nav className="footer__right">
+      <nav className="footer-social">
+        <a href="https://x.com/turianthedurian" target="_blank" rel="noreferrer">
+          X
+        </a>
+        <a href="https://instagram.com" target="_blank" rel="noreferrer">
+          Instagram
+        </a>
+        <a href="https://youtube.com" target="_blank" rel="noreferrer">
+          YouTube
+        </a>
+        <a href="https://discord.gg" target="_blank" rel="noreferrer">
+          Discord
+        </a>
+        <a href="mailto:info@naturverse.com">info@naturverse.com</a>
+      </nav>
+      <nav className="footer-links">
         <span>© 2025 Naturverse</span>
         <a href="/terms">Terms</a>
         <a href="/privacy">Privacy</a>
@@ -32,3 +38,4 @@ export default function Footer() {
     </footer>
   );
 }
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,7 +8,6 @@
 @import "./styles/hub.css";
 @import "./styles/crumbs.css";
 @import "./styles/header.css";
-@import "./styles/footer.css";
 @import "./styles/kingdom.css";
 @import "./styles/brandmark.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
@@ -35,16 +34,6 @@
 .card .split{display:grid;grid-template-columns:1fr 1fr;gap:12px 16px}
 .card .coming{margin-top:8px}
 
-/* Footer brand (shared) */
-.site-footer { margin-top: 32px; padding: 16px 0; color:#64748b; }
-.site-footer__inner {
-  max-width: 72rem; margin: 0 auto; padding: 0 1rem;
-  display:flex; align-items:center; justify-content:space-between;
-}
-.footer-brand { display:flex; align-items:center; gap:10px; opacity:0.95; }
-.footer-brand__img { height:18px; width:auto; display:block; }
-.footer-brand__text { font-weight:700; color:#475569; }
-@media (max-width:640px){ .site-footer__inner { flex-direction:column; gap:8px; } }
 
 /* card image block */
 .card-img { display:flex; align-items:center; justify-content:center; margin-right:12px; }
@@ -68,15 +57,6 @@
 }
 
 
-/* footer layout (already present for you; ensure these exist) */
-.footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem;
-  font-size: 0.9rem;
-  color: #555;
-}
 
 /* reusable brand */
 .brand-mark { display: inline-flex; align-items: center; }
@@ -84,43 +64,4 @@
 .sr-only {
   position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
   overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
-}
-
-/* ---- footer layout ---- */
-.footer{
-  border-top:1px solid #e5e7eb;
-  background:#fff;
-  color:#475569;
-  font-size:14px;
-  padding:14px 16px;
-}
-
-/* one row, centered vertically */
-.footer, .footer__left, .footer__right{
-  display:flex;
-  align-items:center;
-}
-
-.footer{
-  justify-content:space-between;
-  gap:16px;
-  flex-wrap:nowrap;           /* keep one line on desktop */
-}
-
-.footer__left{ gap:16px; }
-.footer__right{ gap:16px; flex-wrap:wrap; }
-
-.footer__brand{
-  height:24px;                /* shrink logo to sit inline */
-  width:auto;
-  display:block;
-}
-
-.footer__social{ display:flex; gap:12px; flex-wrap:wrap; }
-.footer a{ color:#475569; text-decoration:none; }
-.footer a:hover{ text-decoration:underline; }
-
-/* small screens: allow wrap nicely */
-@media (max-width:640px){
-  .footer{ flex-wrap:wrap; row-gap:10px; }
 }

--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -1,42 +1,45 @@
 .site-footer {
-  margin-top: 40px;
-  border-top: 1px solid #e5e7eb;
-  background: #f8fafc;
-  color: #475569;
-  font-size: 14px;
-}
-.footer-inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 20px 16px;
-  display: grid;
-  gap: 10px;
-  grid-template-columns: 1fr;
-}
-.footer-links,
-.footer-socials {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 16px;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-wrap: nowrap;
 }
-.footer-links a,
-.footer-socials a {
-  color: #2563eb;
-  text-decoration: none;
-  display: inline-flex;
-  gap: 8px;
-  align-items: center;
-}
-.footer-links a:hover,
-.footer-socials a:hover { text-decoration: underline; }
 
-@media (min-width: 800px) {
-  .footer-inner {
-    grid-template-columns: 1fr auto auto;
-    align-items: center;
+.footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 120px; /* keeps logo from shrinking to zero */
+}
+
+.footer-brand img {
+  height: 28px;
+  width: auto;
+  display: block;
+}
+
+.footer-links,
+.footer-social {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  white-space: nowrap;
+}
+
+/* small screens: allow wrap but keep logo tidy */
+@media (max-width: 640px) {
+  .site-footer {
+    flex-wrap: wrap;
+    row-gap: 8px;
   }
-  .brand { order: 1; }
-  .footer-links { order: 2; }
-  .footer-socials { order: 3; }
+  .footer-brand {
+    order: 0;
+  }
+  .footer-social {
+    order: 1;
+  }
+  .footer-links {
+    order: 2;
+  }
 }


### PR DESCRIPTION
## Summary
- remove unused logo.svg and turian-owl.svg assets
- show Turian Media branding in footer with fixed dimensions
- lock footer layout to a single line and keep mobile wrap tidy

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a86265bbc08329afa18cfa38426add