### PR TITLE
Fix Worlds layout styles import & resize elements

### DIFF
--- a/src/pages/worlds/_WorldLayout.tsx
+++ b/src/pages/worlds/_WorldLayout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import "../styles/worlds.css";
+import "../../styles/worlds.css";
 
 type Props = {
   title: string;

--- a/src/styles/worlds.css
+++ b/src/styles/worlds.css
@@ -68,3 +68,27 @@
   .world-hero{ max-height:320px; aspect-ratio:auto; }
   .character-card img{ height:140px; }
 }
+.worlds-hero {
+  max-width: 900px;
+  margin: 0 auto 24px;
+}
+
+.worlds-map {
+  max-width: 100%;
+  height: auto;
+  border-radius: 12px;
+}
+
+.worlds-characters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.worlds-characters img {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- add stylesheet for world hero, map, and character grid sizing
- correct `_WorldLayout` to import styles from `src/styles/worlds.css`

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a86ecc872c8329bd11949f2d68bd71