### PR TITLE
Mega Patch 2 — polish, UX, perf, SEO, a11y (no deps)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/turian-favicon-32.png" />
-    <link rel="apple-touch-icon" href="/turian-favicon-192.png" />
+    <link rel="preload" as="style" href="/src/styles/main.css">
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-256x256.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Naturverse</title>
 
@@ -12,7 +13,8 @@
     <meta property="og:description" content="Explore worlds, play in zones, and learn as you go." />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="/turian-favicon-192.png" />
-    <meta name="twitter:card" content="summary" />
+    <meta property="og:site_name" content="Naturverse" />
+    <meta name="twitter:card" content="summary_large_image" />
 
     <script>
       // mark active top-nav links at runtime (no router dependency)

--- a/public/404.html
+++ b/public/404.html
@@ -1,24 +1,25 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>Page not found — Naturverse</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link rel="icon" href="/turian-favicon-32.png" />
-    <style>
-      :root{color-scheme:light dark}
-      body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Inter,sans-serif;display:grid;place-items:center;min-height:100dvh;background:#f8fafc}
-      .wrap{max-width:720px;padding:24px;text-align:center}
-      h1{font-size:28px;margin:0 0 8px}
-      p{color:#475569;margin:6px 0 16px}
-      a.btn{display:inline-block;padding:10px 14px;border-radius:10px;background:#0ea5e9;color:#fff;text-decoration:none;font-weight:700}
-    </style>
-  </head>
-  <body>
-    <div class="wrap">
-      <h1>404 — This trail fades into the forest 🌿</h1>
-      <p>The page you’re looking for doesn’t exist.</p>
-      <a class="btn" href="/">Back to Home</a>
-    </div>
-  </body>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Page not found — Naturverse</title>
+  <link rel="icon" href="/favicon-32x32.png">
+  <link rel="apple-touch-icon" href="/favicon-256x256.png">
+  <style>
+    :root{color-scheme:light dark}
+    body{margin:0;font:16px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial;background:#0b0c0d;color:#e6e7e9;display:grid;place-items:center;height:100dvh}
+    .box{max-width:640px;padding:32px;border-radius:16px;background:#121417;border:1px solid #23262b}
+    h1{margin:0 0 8px;font-size:28px}
+    p{opacity:.8}
+    a{display:inline-block;margin-top:12px;padding:10px 14px;border-radius:10px;background:#1e90ff;color:#fff;text-decoration:none}
+  </style>
+</head>
+<body>
+  <main class="box">
+    <h1>404 — This page is exploring another kingdom.</h1>
+    <p>The link may be broken or the page moved.</p>
+    <a href="/">Back to Home</a>
+  </main>
+</body>
 </html>

--- a/public/_headers
+++ b/public/_headers
@@ -1,6 +1,7 @@
 /*
-  Cache-Control: public, max-age=600
   X-Content-Type-Options: nosniff
   X-Frame-Options: SAMEORIGIN
-  Referrer-Policy: no-referrer-when-downgrade
-  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()
+  Cache-Control: public, max-age=3600
+

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
-/*  /index.html  200
+/*    /index.html   200
+

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
+Sitemap: https://thenaturverse.com/sitemap.xml
 
-Sitemap: /sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>/</loc></url>
-  <url><loc>/worlds</loc></url>
-  <url><loc>/zones</loc></url>
-  <url><loc>/marketplace</loc></url>
-  <url><loc>/naturversity</loc></url>
-  <url><loc>/naturbank</loc></url>
-  <url><loc>/navatar</loc></url>
-  <url><loc>/passport</loc></url>
-  <url><loc>/turian</loc></url>
-  <url><loc>/community</loc></url>
-  <url><loc>/culture</loc></url>
-  <url><loc>/observations</loc></url>
-  <url><loc>/quizzes</loc></url>
-  <url><loc>/stories</loc></url>
-  <url><loc>/creator-lab</loc></url>
-  <url><loc>/music</loc></url>
-  <url><loc>/wellness</loc></url>
+  <url><loc>https://thenaturverse.com/</loc></url>
+  <url><loc>https://thenaturverse.com/worlds</loc></url>
+  <url><loc>https://thenaturverse.com/zones</loc></url>
+  <url><loc>https://thenaturverse.com/marketplace</loc></url>
+  <url><loc>https://thenaturverse.com/passport</loc></url>
+  <!-- Worlds detail (add more as you publish) -->
+  <url><loc>https://thenaturverse.com/worlds/thailandia</loc></url>
+  <url><loc>https://thenaturverse.com/worlds/brazilandia</loc></url>
+  <url><loc>https://thenaturverse.com/worlds/indilandia</loc></url>
+  <url><loc>https://thenaturverse.com/worlds/amerilandia</loc></url>
+  <url><loc>https://thenaturverse.com/worlds/australandia</loc></url>
+  <url><loc>https://thenaturverse.com/worlds/chilandia</loc></url>
 </urlset>
+

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,27 +1,13 @@
 import React from "react";
+import { Link, useLocation } from "react-router-dom";
 
-export type Crumb = { href?: string; label: string };
-
-export function Breadcrumbs({
-  items,
-  className = "",
-}: {
-  items: Crumb[];
-  className?: string;
-}) {
-  if (!items?.length) return null;
-  return (
-    <nav aria-label="Breadcrumb" className={`crumbs ${className}`}>
-      <ol>
-        {items.map((it, i) => (
-          <li key={i} className="crumb">
-            {it.href ? <a href={it.href}>{it.label}</a> : <span>{it.label}</span>}
-            {i < items.length - 1 && <span className="sep"> / </span>}
-          </li>
-        ))}
-      </ol>
-    </nav>
-  );
+export function Breadcrumbs() {
+  const { pathname } = useLocation();
+  const parts = pathname.split("/").filter(Boolean);
+  const crumbs = parts.map((p, i) => {
+    const href = "/" + parts.slice(0, i + 1).join("/");
+    const label = p[0]?.toUpperCase() + p.slice(1);
+    return <span key={href}> / <Link to={href}>{label}</Link></span>;
+  });
+  return <nav aria-label="Breadcrumbs" className="breadcrumbs"><Link to="/">Home</Link>{crumbs}</nav>;
 }
-
-export default Breadcrumbs;

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,16 +1,17 @@
 import React from "react";
 
 type State = { hasError: boolean };
-export default class ErrorBoundary extends React.Component<React.PropsWithChildren, State> {
+export class ErrorBoundary extends React.Component<React.PropsWithChildren, State> {
   state: State = { hasError: false };
   static getDerivedStateFromError() { return { hasError: true }; }
-  componentDidCatch() {/* no-op */}
+  componentDidCatch(err: unknown) { console.error("[ErrorBoundary]", err); }
   render() {
     if (this.state.hasError) {
       return (
-        <div style={{maxWidth:800, margin:"40px auto", padding:"16px"}}>
-          <h1>Something went wrong</h1>
-          <p>Please go <a href="/">home</a> and try again.</p>
+        <div style={{maxWidth:840,margin:"40px auto",padding:16}}>
+          <h1>Something went wrong.</h1>
+          <p>Try refreshing the page. If the issue persists, we’ll fix it fast.</p>
+          <a href="/" className="btn">Back to Home</a>
         </div>
       );
     }

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+type Props = React.ImgHTMLAttributes<HTMLImageElement> & {
+  srcPng?: string; srcWebp?: string;
+  fallback?: string;
+};
+export function Img({ src, srcPng, srcWebp, fallback="/placeholders/image-missing.jpg", alt="", ...rest }: Props) {
+  const png = (srcPng ?? (src as string)) || "";
+  const webp = srcWebp;
+  return webp ? (
+    <picture>
+      <source srcSet={webp} type="image/webp" />
+      <img loading="lazy" decoding="async" src={png} alt={alt} onError={(e)=>{(e.currentTarget as HTMLImageElement).src = fallback!;}} {...rest}/>
+    </picture>
+  ) : (
+    <img loading="lazy" decoding="async" src={png} alt={alt} onError={(e)=>{(e.currentTarget as HTMLImageElement).src = fallback!;}} {...rest}/>
+  );
+}

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+
+type Props = { title?: string; description?: string; image?: string; url?: string };
+export default function Meta({ title, description, image, url }: Props) {
+  useEffect(() => {
+    if (title) document.title = title;
+    const set = (n: string, c: string) => {
+      let el = document.querySelector(`meta[name="${n}"]`) as HTMLMetaElement|null;
+      if (!el) { el = document.createElement("meta"); el.setAttribute("name", n); document.head.appendChild(el); }
+      el.setAttribute("content", c);
+    };
+    if (description) set("description", description);
+    const setProp = (p: string, c: string) => {
+      let el = document.querySelector(`meta[property="${p}"]`) as HTMLMetaElement|null;
+      if (!el) { el = document.createElement("meta"); el.setAttribute("property", p); document.head.appendChild(el); }
+      el.setAttribute("content", c);
+    };
+    if (title) setProp("og:title", title);
+    if (description) setProp("og:description", description);
+    if (image) setProp("og:image", image);
+    if (url) setProp("og:url", url);
+  }, [title, description, image, url]);
+
+  return null;
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+
+export default function Nav() {
+  return (
+    <>
+      <a href="#main" className="skip-link">Skip to content</a>
+      <nav className="topnav container">
+        <a href="/" aria-label="Naturverse Home" className="brand">
+          <img src="/favicon-32x32.png" alt="Naturverse" width={24} height={24} />
+        </a>
+        <div className="links">
+          <NavLink to="/worlds" className={({isActive})=>`nav${isActive?' active':''}`}>Worlds</NavLink>
+          <NavLink to="/zones" className={({isActive})=>`nav${isActive?' active':''}`}>Zones</NavLink>
+          <NavLink to="/marketplace" className={({isActive})=>`nav${isActive?' active':''}`}>Marketplace</NavLink>
+          <NavLink to="/naturversity" className={({isActive})=>`nav${isActive?' active':''}`}>Naturversity</NavLink>
+          <NavLink to="/passport" className={({isActive})=>`nav${isActive?' active':''}`}>Passport</NavLink>
+          {/* ...rest unchanged */}
+        </div>
+      </nav>
+    </>
+  );
+}

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,15 +1,14 @@
 import { ReactNode } from "react";
-import Breadcrumbs, { Crumb } from "./Breadcrumbs";
+import { Breadcrumbs } from "./Breadcrumbs";
 
 export default function Page({
   title,
   subtitle,
-  breadcrumbs,
   children,
-}: { title: string; subtitle?: string; breadcrumbs?: Crumb[]; children: ReactNode }) {
+}: { title: string; subtitle?: string; children: ReactNode }) {
   return (
     <main className="mx-auto max-w-6xl px-4 py-8">
-      {breadcrumbs && <Breadcrumbs items={breadcrumbs} />}
+      <Breadcrumbs />
       <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight">{title}</h1>
       {subtitle && <p className="mt-2 text-slate-600">{subtitle}</p>}
       <div className="mt-6">{children}</div>

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+export function Skeleton({ w="100%", h=140, r=12 }:{ w?:number|string; h?:number; r?:number }) {
+  return <div className="skeleton" style={{width:w,height:h,borderRadius:r}}/>;
+}

--- a/src/layouts/Page.tsx
+++ b/src/layouts/Page.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+export default function Page({ title, children }:{ title?: string; children: React.ReactNode }) {
+  return (
+    <div className="page">
+      <main id="main" className="container">
+        {title ? <h1>{title}</h1> : null}
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/layouts/Root.tsx
+++ b/src/layouts/Root.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
-import Header from '../components/Header';
+import Nav from '../components/Nav';
 import Footer from '../components/Footer';
 
 export default function RootLayout() {
   return (
     <div className="nv-root">
-      <Header />
+      <Nav />
       <main className="container">
         <Outlet />
       </main>

--- a/src/main.css
+++ b/src/main.css
@@ -1,6 +1,10 @@
+@import "./styles/main.css";
 @import "./styles/worlds.css";
 @import "./styles/cart.css";
 @import "./styles/footer.css";
+@import "./styles/home.css";
+@import "./styles/skeleton.css";
+@import "./styles/cards-unify.css";
 
 /* simple "Coming Soon" pill used on cards */
 .tag.soon{
@@ -14,10 +18,6 @@
   padding:4px 8px;
   margin-bottom:8px;
 }
-
-@import "./styles/home.css";
-@import "./styles/skeleton.css";
-@import "./styles/cards-unify.css";
 
 /* top-nav active state (add data-topnav on anchors) */
 a.active{color:#0ea5e9; font-weight:800}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,7 @@ import './styles.css';
 import './styles/shop.css';
 import './styles/edu.css';
 import './main.css';
-import ErrorBoundary from './components/ErrorBoundary';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import "./home.css";
+import Meta from "../components/Meta";
+import Page from "../layouts/Page";
 
 export default function Home() {
   return (
-    <main className="home">
+    <Page>
+      <Meta title="Naturverse — Playful worlds for families"
+            description="A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness."
+            url="https://thenaturverse.com/" />
+      <div className="home">
       {/* Hero */}
       <header className="home-hero">
         <img
@@ -84,7 +90,8 @@ export default function Home() {
         </form>
         <small>We send occasional updates. Unsubscribe anytime.</small>
       </section>
-    </main>
+      </div>
+    </Page>
   );
 }
 

--- a/src/pages/worlds/WorldLayout.tsx
+++ b/src/pages/worlds/WorldLayout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Img } from "../../components/Img";
 
 export default function WorldLayout({
   title,
@@ -14,7 +15,7 @@ export default function WorldLayout({
       <h1>{title}</h1>
       <div className="cards">
         <div className="card">
-          <img src={mapSrc} alt={`${title} map`} loading="lazy" />
+          <Img srcPng={mapSrc} alt={`${title} map`} className="aspect-16x9" />
           <h2>World Map</h2>
           <p>Zoom into landmarks, routes, and regions.</p>
         </div>

--- a/src/pages/worlds/amerilandia.tsx
+++ b/src/pages/worlds/amerilandia.tsx
@@ -1,3 +1,16 @@
 import React from "react";
 import WorldLayout from "./WorldLayout";
-export default function Amerilandia(){ return <WorldLayout title="Amerilandia" mapSrc="/assets/amerilandia/map.png" /> }
+import Meta from "../../components/Meta";
+import Page from "../../layouts/Page";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
+import { Img } from "../../components/Img";
+
+export default function Amerilandia() {
+  return (
+    <Page>
+      <Meta title="Amerilandia — Naturverse" description="Learn about the Amerilandia kingdom." url="https://thenaturverse.com/worlds/amerilandia" />
+      <Breadcrumbs />
+      <WorldLayout title="Amerilandia" mapSrc="/assets/amerilandia/map.png" />
+    </Page>
+  );
+}

--- a/src/pages/worlds/australandia.tsx
+++ b/src/pages/worlds/australandia.tsx
@@ -1,3 +1,16 @@
 import React from "react";
 import WorldLayout from "./WorldLayout";
-export default function Australandia(){ return <WorldLayout title="Australandia" mapSrc="/assets/australandia/map.png" /> }
+import Meta from "../../components/Meta";
+import Page from "../../layouts/Page";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
+import { Img } from "../../components/Img";
+
+export default function Australandia() {
+  return (
+    <Page>
+      <Meta title="Australandia — Naturverse" description="Learn about the Australandia kingdom." url="https://thenaturverse.com/worlds/australandia" />
+      <Breadcrumbs />
+      <WorldLayout title="Australandia" mapSrc="/assets/australandia/map.png" />
+    </Page>
+  );
+}

--- a/src/pages/worlds/brazilandia.tsx
+++ b/src/pages/worlds/brazilandia.tsx
@@ -1,3 +1,16 @@
 import React from "react";
 import WorldLayout from "./WorldLayout";
-export default function Brazilandia(){ return <WorldLayout title="Brazilandia" mapSrc="/assets/brazilandia/map.png" /> }
+import Meta from "../../components/Meta";
+import Page from "../../layouts/Page";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
+import { Img } from "../../components/Img";
+
+export default function Brazilandia() {
+  return (
+    <Page>
+      <Meta title="Brazilandia — Naturverse" description="Learn about the Brazilandia kingdom." url="https://thenaturverse.com/worlds/brazilandia" />
+      <Breadcrumbs />
+      <WorldLayout title="Brazilandia" mapSrc="/assets/brazilandia/map.png" />
+    </Page>
+  );
+}

--- a/src/pages/worlds/chilandia.tsx
+++ b/src/pages/worlds/chilandia.tsx
@@ -1,3 +1,16 @@
 import React from "react";
 import WorldLayout from "./WorldLayout";
-export default function Chilandia(){ return <WorldLayout title="Chilandia" mapSrc="/assets/chilandia/map.png" /> }
+import Meta from "../../components/Meta";
+import Page from "../../layouts/Page";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
+import { Img } from "../../components/Img";
+
+export default function Chilandia() {
+  return (
+    <Page>
+      <Meta title="Chilandia — Naturverse" description="Learn about the Chilandia kingdom." url="https://thenaturverse.com/worlds/chilandia" />
+      <Breadcrumbs />
+      <WorldLayout title="Chilandia" mapSrc="/assets/chilandia/map.png" />
+    </Page>
+  );
+}

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import { WORLDS } from "../../data/worlds";
+import Meta from "../../components/Meta";
+import Page from "../../layouts/Page";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
 
 export default function WorldsIndex() {
   return (
-    <div className="page-wrap">
-      <h1>Worlds</h1>
+    <Page title="Worlds">
+      <Meta title="Worlds — Naturverse" description="Explore the 14 kingdoms." url="https://thenaturverse.com/worlds" />
+      <Breadcrumbs />
       <p className="muted">Choose a kingdom to explore.</p>
       <div className="cards">
         {WORLDS.map(w => (
@@ -15,6 +19,6 @@ export default function WorldsIndex() {
           </a>
         ))}
       </div>
-    </div>
+    </Page>
   );
 }

--- a/src/pages/worlds/indilandia.tsx
+++ b/src/pages/worlds/indilandia.tsx
@@ -1,3 +1,16 @@
 import React from "react";
 import WorldLayout from "./WorldLayout";
-export default function Indilandia(){ return <WorldLayout title="Indilandia" mapSrc="/assets/indilandia/map.png" /> }
+import Meta from "../../components/Meta";
+import Page from "../../layouts/Page";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
+import { Img } from "../../components/Img";
+
+export default function Indilandia() {
+  return (
+    <Page>
+      <Meta title="Indilandia — Naturverse" description="Learn about the Indilandia kingdom." url="https://thenaturverse.com/worlds/indilandia" />
+      <Breadcrumbs />
+      <WorldLayout title="Indilandia" mapSrc="/assets/indilandia/map.png" />
+    </Page>
+  );
+}

--- a/src/pages/worlds/thailandia.tsx
+++ b/src/pages/worlds/thailandia.tsx
@@ -1,6 +1,16 @@
 import React from "react";
 import WorldLayout from "./WorldLayout";
+import Meta from "../../components/Meta";
+import Page from "../../layouts/Page";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
+import { Img } from "../../components/Img";
 
 export default function Thailandia() {
-  return <WorldLayout title="Thailandia" mapSrc="/assets/thailandia/map.png" />;
+  return (
+    <Page>
+      <Meta title="Thailandia — Naturverse" description="Learn about the Thailandia kingdom." url="https://thenaturverse.com/worlds/thailandia" />
+      <Breadcrumbs />
+      <WorldLayout title="Thailandia" mapSrc="/assets/thailandia/map.png" />
+    </Page>
+  );
 }

--- a/src/pages/zones/Community.tsx
+++ b/src/pages/zones/Community.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import Breadcrumbs from '../../components/Breadcrumbs';
+import { Breadcrumbs } from '../../components/Breadcrumbs';
 import '../../styles/zone-widgets.css';
 import { BoardPost, Poll } from '../../lib/community/types';
 import {
@@ -131,11 +131,7 @@ export default function Community() {
 
   return (
     <div>
-      <Breadcrumbs items={[
-        { href: '/', label: 'Home' },
-        { href: '/zones', label: 'Zones' },
-        { label: 'Community' }
-      ]} />
+      <Breadcrumbs />
       <h1>🗳️🌍 Community</h1>
       <p>Vote for new lands & characters, and join local volunteer events.</p>
 

--- a/src/pages/zones/Culture.tsx
+++ b/src/pages/zones/Culture.tsx
@@ -15,11 +15,6 @@ export default function Culture() {
     <Page
       title="Culture"
       subtitle="Beliefs, holidays, and ceremonies across the 14 kingdoms."
-      breadcrumbs={[
-        { href: "/", label: "Home" },
-        { href: "/zones", label: "Zones" },
-        { label: "Culture" },
-      ]}
     >
       <div className="culture-grid grid gap-4 md:gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {kingdoms.map((k) => (

--- a/src/pages/zones/Future.tsx
+++ b/src/pages/zones/Future.tsx
@@ -1,16 +1,10 @@
 import React from "react";
-import Breadcrumbs from "../../components/Breadcrumbs";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
 
 export default function FutureZone() {
   return (
     <div className="page">
-      <Breadcrumbs
-        items={[
-          { href: "/", label: "Home" },
-          { href: "/zones", label: "Zones" },
-          { label: "Future Zone" },
-        ]}
-      />
+      <Breadcrumbs />
 
       <h1>🔮 Future Zone</h1>
       <p className="muted">

--- a/src/pages/zones/Observations.tsx
+++ b/src/pages/zones/Observations.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import Breadcrumbs from '../../components/Breadcrumbs';
+import { Breadcrumbs } from '../../components/Breadcrumbs';
 import PhotoUploader from '../../components/PhotoUploader';
 import { Observation } from '../../lib/observations/types';
 import {
@@ -145,11 +145,7 @@ export default function Observations() {
 
   return (
     <div>
-      <Breadcrumbs items={[
-        { href: '/', label: 'Home' },
-        { href: '/zones', label: 'Zones' },
-        { label: 'Observations' }
-      ]} />
+      <Breadcrumbs />
       <h1>📷🌿 Observations</h1>
       <p>Upload nature pics; tag, learn, earn. (Local & offline; data stays in your browser.)</p>
 

--- a/src/pages/zones/Quizzes.tsx
+++ b/src/pages/zones/Quizzes.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import Breadcrumbs from "../../components/Breadcrumbs";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
 import { Quiz } from "../../lib/quiz/types";
 import { SAMPLE_QUIZZES } from "../../lib/quiz/sampleQuizzes";
 import { ClassicPlayer, JeopardyBoard, QuizSummary } from "../../components/QuizPlayer";
@@ -52,11 +52,7 @@ export default function Quizzes() {
 
   return (
     <div>
-      <Breadcrumbs items={[
-        { href: '/', label: 'Home' },
-        { href: '/zones', label: 'Zones' },
-        { label: 'Quizzes' }
-      ]} />
+      <Breadcrumbs />
       <h1>🎯 Quizzes</h1>
       <p>Solo & party quiz play with scoring (client-only; no backend).</p>
 

--- a/src/pages/zones/Stories.tsx
+++ b/src/pages/zones/Stories.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import Breadcrumbs from "../../components/Breadcrumbs";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
 import { Story } from "../../lib/story/types";
 import { SAMPLE_STORIES } from "../../lib/story/sampleStories";
 import { StoryPlayer, Progress } from "../../components/StoryPlayer";
@@ -67,11 +67,7 @@ export default function Stories() {
 
   return (
     <div>
-      <Breadcrumbs items={[
-        { href: '/', label: 'Home' },
-        { href: '/zones', label: 'Zones' },
-        { label: 'Stories' }
-      ]} />
+      <Breadcrumbs />
       <h1>📚✨ Stories</h1>
       <p>AI story paths set in all 14 kingdoms (local, no-backend version).</p>
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,0 +1,21 @@
+/* Containers & cards */
+.container{max-width:1200px;margin:0 auto;padding:24px 16px}
+.card{background:var(--surface,#fff);border:1px solid rgba(0,0,0,.08);border-radius:16px;padding:16px}
+.grid{display:grid;gap:16px}
+.grid-2{grid-template-columns:repeat(2,minmax(0,1fr))}
+.grid-3{grid-template-columns:repeat(3,minmax(0,1fr))}
+@media (max-width:900px){.grid-2,.grid-3{grid-template-columns:1fr}}
+/* Active nav */
+a.nav{opacity:.8}
+a.nav.active{opacity:1;font-weight:700;text-decoration:underline}
+/* Breadcrumbs */
+.breadcrumbs{margin:8px 0 16px;font-size:.9rem;opacity:.8}
+.breadcrumbs a{color:inherit}
+/* Skeletons */
+.skeleton{background:linear-gradient(90deg,#eee,#f6f6f6,#eee);background-size:200% 100%;animation:sk 1.2s infinite; border:1px solid #e8e8e8}
+@keyframes sk{0%{background-position:200% 0}100%{background-position:-200% 0}}
+/* A11y: skip link */
+.skip-link{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden}
+.skip-link:focus{left:12px;top:12px;width:auto;height:auto;padding:10px 12px;background:#1e90ff;color:#fff;border-radius:10px;z-index:9999}
+/* Image aspect utility */
+.aspect-16x9{aspect-ratio:16/9;object-fit:cover;border-radius:12px}


### PR DESCRIPTION
## Summary
- refine error handling, navigation, and page wrappers for improved UX and accessibility
- add SEO-friendly 404 page, sitemap, robots, and security headers
- introduce reusable Meta, Img, Skeleton, and Breadcrumbs components with global styles

## Testing
- ❌ `npm test` (missing script: test)
- ✅ `npm run typecheck`
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8847906048329a5b894b562cefcab