### PR TITLE
Restore styled navbar (with Cart & Profile) and blue CTAs

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { NavLink, Link } from "react-router-dom";
+
+export default function SiteHeader() {
+  return (
+    <header className="nv-header">
+      <div className="nv-wrap">
+        <Link to="/" className="nv-brand">
+          <img src="/favicon-32x32.png" alt="Naturverse" width={28} height={28} />
+          <span className="nv-brand-text">Naturverse</span>
+        </Link>
+
+        <nav className="nv-nav" aria-label="Main">
+          <NavLink to="/worlds" className="nv-link">Worlds</NavLink>
+          <NavLink to="/zones" className="nv-link">Zones</NavLink>
+          <NavLink to="/marketplace" className="nv-link">Marketplace</NavLink>
+          <NavLink to="/naturversity" className="nv-link">Naturversity</NavLink>
+          <NavLink to="/naturbank" className="nv-link">Naturbank</NavLink>
+          <NavLink to="/navatar" className="nv-link">Navatar</NavLink>
+          <NavLink to="/passport" className="nv-link">Passport</NavLink>
+          <NavLink to="/turian" className="nv-link">Turian</NavLink>
+        </nav>
+
+        <div className="nv-actions">
+          <NavLink to="/profile" className="nv-icon" aria-label="Profile">👤</NavLink>
+          <NavLink to="/cart" className="nv-icon" aria-label="Cart">🛒</NavLink>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/layouts/Root.tsx
+++ b/src/layouts/Root.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
-import Nav from '../components/Nav';
+import SiteHeader from '../components/SiteHeader';
 import Footer from '../components/Footer';
 
 export default function RootLayout() {
   return (
     <div className="nv-root">
-      <Nav />
+      <SiteHeader />
       <main className="container">
         <Outlet />
       </main>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -27,7 +27,7 @@ export default function Home() {
         </p>
         <div className="home-cta">
           <Link className="btn btn-primary" to="/signup">Create account</Link>
-          <Link className="btn" to="/worlds">Explore Worlds</Link>
+          <Link className="btn btn-outline" to="/worlds">Explore Worlds</Link>
         </div>
       </header>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,6 +11,7 @@
 @import "./styles/kingdom.css";
 @import "./styles/brandmark.css";
 @import "./pages/home.css";
+@import "./styles/site.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1,0 +1,26 @@
+/* ---------- Header / Nav ---------- */
+.nv-header { position: sticky; top: 0; z-index: 30; backdrop-filter: saturate(140%) blur(6px); background: rgba(255,255,255,.85); border-bottom: 1px solid #eef0f3; }
+.nv-wrap { max-width: 1200px; margin: 0 auto; padding: 10px 16px; display: flex; align-items: center; gap: 16px; }
+.nv-brand { display: flex; align-items: center; gap: 10px; text-decoration: none; }
+.nv-brand-text { font-weight: 700; color: #111; }
+.nv-nav { display: flex; gap: 16px; margin-left: 8px; }
+.nv-link { color: #4a5568; text-decoration: none; padding: 6px 8px; border-radius: 8px; }
+.nv-link.active { color: #0b63c9; background: #e9f2ff; }
+.nv-actions { margin-left: auto; display: flex; align-items: center; gap: 10px; }
+.nv-icon { font-size: 20px; text-decoration: none; padding: 6px 8px; border-radius: 8px; }
+.nv-icon:hover, .nv-link:hover { background: #f3f5f7; }
+
+/* ---------- Buttons (restore blue) ---------- */
+:root {
+  --btn-primary-bg: #1e90ff;
+  --btn-primary-fg: #fff;
+  --btn-primary-bg-hover: #1378d9;
+}
+.btn { display:inline-flex; align-items:center; gap:.5rem; font-weight:600; border-radius:10px; padding:.6rem .9rem; border:1px solid transparent; text-decoration:none; cursor:pointer; }
+.btn-primary { background: var(--btn-primary-bg); color: var(--btn-primary-fg); }
+.btn-primary:hover { background: var(--btn-primary-bg-hover); }
+.btn-outline { background:#fff; border-color:#d7dee6; color:#26323f; }
+.btn-outline:hover { background:#f6f8fa; }
+
+/* Prevent any global link reset from collapsing the nav */
+header .nv-link, header .nv-icon { display:inline-flex; }


### PR DESCRIPTION
## Summary
- add responsive SiteHeader with main nav links, profile, and cart icons
- restore blue button theme and header/nav styles
- switch hero CTA to primary and outline buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a88b462a288329b2713f1c1dac16d1