### PR TITLE
UI polish: blue CTA buttons, mobile nav scroll, active link, skip link

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,7 +7,7 @@ export default function Layout({ title, breadcrumbs, children }: Props) {
   return (
     <>
       <NavBar />
-      <main className="nv-page">
+      <main id="main" className="nv-page">
         <div className="nv-container">
           {title ? <h1 className="nv-title">{title}</h1> : null}
           {breadcrumbs ? <div className="nv-breadcrumbs">{breadcrumbs}</div> : null}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,44 +1,17 @@
-import { useState } from 'react';
-import { Link, NavLink } from 'react-router-dom';
-import './NavBar.css';
+import { NavLink } from "react-router-dom";
 
 export default function NavBar() {
-  const [open, setOpen] = useState(false);
-
   return (
-    <header className="nv-header">
-      <div className="nv-header__inner">
-        {/* Home link restored (clickable brand) */}
-        <Link to="/" className="nv-brand" aria-label="Naturverse Home">
-          <img src="/favicon-32x32.png" alt="Turian" className="nv-logo" width="24" height="24" />
-          <strong>Naturverse</strong>
-        </Link>
-
-        {/* MOBILE TOGGLE */}
-        <button
-          type="button"
-          className="nv-nav-toggle"
-          aria-label="Open menu"
-          aria-expanded={open}
-          aria-controls="nv-mobile-menu"
-          onClick={() => setOpen((v) => !v)}
-        >
-          <span className="nv-burger" />
-        </button>
-
-        {/* LINKS */}
-        <nav id="nv-mobile-menu" className={`nv-nav ${open ? 'is-open' : ''}`}>
-          <NavLink to="/worlds" data-topnav>Worlds</NavLink>
-          <NavLink to="/zones" data-topnav>Zones</NavLink>
-          <NavLink to="/marketplace" data-topnav>Marketplace</NavLink>
-          <NavLink to="/naturversity" data-topnav>Naturversity</NavLink>
-          <NavLink to="/naturbank" data-topnav>Naturbank</NavLink>
-          <NavLink to="/navatar" data-topnav>Navatar</NavLink>
-          <NavLink to="/passport" data-topnav>Passport</NavLink>
-          <NavLink to="/turian" data-topnav>Turian</NavLink>
-          <NavLink to="/profile" data-topnav>Profile</NavLink>
-        </nav>
-      </div>
-    </header>
+    <nav className="topnav" aria-label="Primary">
+      <a className="skip-link" href="#main">Skip to content</a>
+      <NavLink to="/worlds" className={({isActive})=>isActive?"active":""}>Worlds</NavLink>
+      <NavLink to="/zones" className={({isActive})=>isActive?"active":""}>Zones</NavLink>
+      <NavLink to="/marketplace" className={({isActive})=>isActive?"active":""}>Marketplace</NavLink>
+      <NavLink to="/naturversity" className={({isActive})=>isActive?"active":""}>Naturversity</NavLink>
+      <NavLink to="/passport" className={({isActive})=>isActive?"active":""}>Passport</NavLink>
+      <NavLink to="/turian" className={({isActive})=>isActive?"active":""}>Turian</NavLink>
+      <NavLink to="/profile" className={({isActive})=>isActive?"active":""} aria-label="Profile">👤</NavLink>
+      <NavLink to="/cart" className={({isActive})=>isActive?"active":""} aria-label="Cart">🛒</NavLink>
+    </nav>
   );
 }

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -7,7 +7,7 @@ export default function Page({
   children,
 }: { title: string; subtitle?: string; children: ReactNode }) {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8">
+    <main id="main" className="mx-auto max-w-6xl px-4 py-8">
       <Breadcrumbs />
       <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight">{title}</h1>
       {subtitle && <p className="mt-2 text-slate-600">{subtitle}</p>}

--- a/src/components/WorldLayout.tsx
+++ b/src/components/WorldLayout.tsx
@@ -9,7 +9,7 @@ export default function WorldLayout({ id }: Props) {
   const folder = k.title; // TitleCase matches your public folder name
 
   return (
-    <div className="world-wrap">
+    <main id="main" className="world-wrap">
       <h1 className="world-title">{k.title}</h1>
 
       {/* Map hero */}
@@ -60,6 +60,6 @@ export default function WorldLayout({ id }: Props) {
           </ul>
         )}
       </section>
-    </div>
+    </main>
   );
 }

--- a/src/layouts/Root.tsx
+++ b/src/layouts/Root.tsx
@@ -7,7 +7,7 @@ export default function RootLayout() {
   return (
     <div className="nv-root">
       <SiteHeader />
-      <main className="container">
+      <main id="main" className="container">
         <Outlet />
       </main>
       <Footer />

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,8 +1,8 @@
 export default function About() {
   return (
-    <div>
+    <main id="main">
       <h1>About Naturverse</h1>
       <p>Naturverse is a playful, educational world built by Turian Media. More info coming soon.</p>
-    </div>
+    </main>
   );
 }

--- a/src/pages/Accessibility.tsx
+++ b/src/pages/Accessibility.tsx
@@ -1,8 +1,8 @@
 export default function Accessibility() {
   return (
-    <div>
+    <main id="main">
       <h1>Accessibility</h1>
       <p>We’re working to make Naturverse usable for everyone. If you encounter issues, contact us at <a href="mailto:accessibility@naturverse.com">accessibility@naturverse.com</a>.</p>
-    </div>
+    </main>
   );
 }

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,9 +1,9 @@
 export default function Contact() {
   return (
-    <div>
+    <main id="main">
       <h1>Contact</h1>
       <p>Email: <a href="mailto:info@naturverse.com">info@naturverse.com</a></p>
       <p>X / Twitter: <a href="https://x.com/turianthedurian" target="_blank" rel="noreferrer">@turianthedurian</a></p>
-    </div>
+    </main>
   );
 }

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -3,7 +3,7 @@ import { HubGrid } from "../components/HubGrid";
 
 export default function MarketplacePage() {
   return (
-    <div>
+    <main id="main">
       <h1>Marketplace</h1>
       <p className="muted">Shop creations and merch.</p>
 
@@ -18,6 +18,6 @@ export default function MarketplacePage() {
       <p className="muted" style={{ marginTop: 12 }}>
         Coming soon: AI assistance for sizing, bundles, and gift ideas.
       </p>
-    </div>
+    </main>
   );
 }

--- a/src/pages/Naturbank.tsx
+++ b/src/pages/Naturbank.tsx
@@ -3,7 +3,7 @@ import { HubGrid } from "../components/HubGrid";
 
 export default function NaturbankPage() {
   return (
-    <div>
+    <main id="main">
       <h1>Naturbank</h1>
       <p className="muted">Wallets, token, and collectibles.</p>
 
@@ -19,6 +19,6 @@ export default function NaturbankPage() {
       <p className="muted" style={{ marginTop: 12 }}>
         Coming soon: live wallets, on-chain mints, and payouts.
       </p>
-    </div>
+    </main>
   );
 }

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -3,7 +3,7 @@ import { HubGrid } from "../components/HubGrid";
 
 export default function NaturversityPage() {
   return (
-    <div>
+    <main id="main">
       <h1>Naturversity</h1>
       <p className="muted">Teachers, partners, and courses.</p>
 
@@ -23,6 +23,6 @@ export default function NaturversityPage() {
       <p className="muted" style={{ marginTop: 12 }}>
         Coming soon: AI tutors and step-by-step lessons.
       </p>
-    </div>
+    </main>
   );
 }

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -62,7 +62,7 @@ export default function NavatarPage() {
   }
 
   return (
-    <div className="wrap">
+    <main id="main" className="wrap">
       <h1>Navatar Creator</h1>
       <p>Choose a base type, customize details, and save your character card.</p>
 
@@ -157,6 +157,6 @@ export default function NavatarPage() {
         .linklike{background:none;border:none;padding:0;color:#0b62d6;cursor:pointer}
         .note{opacity:.75;margin-top:24px}
       `}</style>
-    </div>
+    </main>
   );
 }

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,8 +1,8 @@
 export default function Privacy() {
   return (
-    <div>
+    <main id="main">
       <h1>Privacy Policy</h1>
       <p>We respect your privacy. This is placeholder content until the full policy is ready.</p>
-    </div>
+    </main>
   );
 }

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,8 +1,8 @@
 export default function Terms() {
   return (
-    <div>
+    <main id="main">
       <h1>Terms of Service</h1>
       <p>These are placeholder terms. Full legal copy will be added later.</p>
-    </div>
+    </main>
   );
 }

--- a/src/pages/Worlds.tsx
+++ b/src/pages/Worlds.tsx
@@ -4,7 +4,7 @@ import { KINGDOMS } from "../content/kingdoms";
 
 export default function Worlds() {
   return (
-    <main className="container">
+    <main id="main" className="container">
       <div className="breadcrumb">Home / Worlds</div>
       <h2 className="section-title">Worlds</h2>
       <p className="section-lead">Explore the 14 kingdoms.</p>

--- a/src/pages/_layout/Page.tsx
+++ b/src/pages/_layout/Page.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from "react";
 import "../page.css";
 export default function Page({ children }: PropsWithChildren) {
-  return <main className="nv-page">{children}</main>;
+  return <main id="main" className="nv-page">{children}</main>;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Home() {
   return (
-    <main className="home">
+    <main id="main" className="home">
       {/* Hero */}
       <section className="home-hero">
         <div className="home-hero-badge">

--- a/src/pages/marketplace/Catalog.tsx
+++ b/src/pages/marketplace/Catalog.tsx
@@ -25,7 +25,7 @@ export default function Catalog() {
   );
 
   return (
-    <div>
+    <main id="main">
       <h1>🛍️ Catalog</h1>
       <p>Browse items. Add to wishlist or cart.</p>
 
@@ -70,7 +70,7 @@ export default function Catalog() {
       </div>
 
       <p className="meta">Note: Demo only; checkout is simulated. AI shopping help connects later.</p>
-    </div>
+    </main>
   );
 }
 

--- a/src/pages/marketplace/Checkout.tsx
+++ b/src/pages/marketplace/Checkout.tsx
@@ -8,7 +8,7 @@ export default function CheckoutPage() {
   const [code, setCode] = useState(cart.state.coupon ?? "");
 
   return (
-    <div className="checkout">
+    <main id="main" className="checkout">
       <h1>Checkout</h1>
 
       {!cart.state.items.length && (
@@ -66,6 +66,6 @@ export default function CheckoutPage() {
           </div>
         </>
       )}
-    </div>
+    </main>
   );
 }

--- a/src/pages/marketplace/Wishlist.tsx
+++ b/src/pages/marketplace/Wishlist.tsx
@@ -9,7 +9,7 @@ export default function Wishlist() {
   const items = CATALOG.filter(i => ids.includes(i.id));
 
   return (
-    <div>
+    <main id="main">
       <h1>❤️ Wishlist</h1>
       {items.length === 0 && <p>No favorites yet. Add some from the Catalog.</p>}
       <div className="shop-list">
@@ -27,7 +27,7 @@ export default function Wishlist() {
           </div>
         ))}
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/src/pages/naturbank/Learn.tsx
+++ b/src/pages/naturbank/Learn.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Learn() {
   return (
-    <div>
+    <main id="main">
       <h1>📘 Learn</h1>
       <ul className="bullet">
         <li><b>Safety:</b> keep keys private, avoid DM links, verify sites.</li>
@@ -10,6 +10,6 @@ export default function Learn() {
         <li><b>NATUR:</b> earn via quests; spend on merch, cards, and passes.</li>
       </ul>
       <p className="meta">AI tutor lessons and quizzes plug in here later.</p>
-    </div>
+    </main>
   );
 }

--- a/src/pages/naturbank/NFTs.tsx
+++ b/src/pages/naturbank/NFTs.tsx
@@ -8,7 +8,7 @@ const items = [
 
 export default function NFTs() {
   return (
-    <div>
+    <main id="main">
       <h1>🖼️ NFTs</h1>
       <p>Preview collectibles. Minting connects later.</p>
       <div className="hub-grid">
@@ -21,6 +21,6 @@ export default function NFTs() {
           </div>
         ))}
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/pages/naturbank/Token.tsx
+++ b/src/pages/naturbank/Token.tsx
@@ -18,7 +18,7 @@ export default function Token() {
   };
 
   return (
-    <div>
+    <main id="main">
       <h1>🪙 NATUR Token</h1>
 
       <div className="panel">
@@ -52,6 +52,6 @@ export default function Token() {
       </div>
 
       <p className="meta">Redemptions & real transactions connect here later.</p>
-    </div>
+    </main>
   );
 }

--- a/src/pages/naturbank/Wallet.tsx
+++ b/src/pages/naturbank/Wallet.tsx
@@ -8,7 +8,7 @@ export default function Wallet() {
   const create = () => { const nw = createDemoWallet(); setW(nw); setBal(getBalance()); };
 
   return (
-    <div>
+    <main id="main">
       <h1>🪪 Wallet</h1>
       {!w ? (
         <div className="panel">
@@ -31,6 +31,6 @@ export default function Wallet() {
         </div>
       )}
       <p className="meta">Real wallet connect arrives later.</p>
-    </div>
+    </main>
   );
 }

--- a/src/pages/naturversity/CourseDetail.tsx
+++ b/src/pages/naturversity/CourseDetail.tsx
@@ -9,12 +9,12 @@ export default function CourseDetail() {
   const [enrolled, setEnrolled] = useState<string[]>(loadEnrollments());
   const [done, setDone] = useState<string[]>(loadProgress(slug));
 
-  if (!course) return <div><h1>Course</h1><p>Not found.</p></div>;
+  if (!course) return <main id="main"><h1>Course</h1><p>Not found.</p></main>;
 
   const on = enrolled.includes(course.slug);
 
   return (
-    <div>
+    <main id="main">
       <h1>{course.emoji ?? "📘"} {course.title}</h1>
       <p className="lead">{course.summary}</p>
       <div className="row">
@@ -50,7 +50,7 @@ export default function CourseDetail() {
       </div>
 
       <p className="meta">Lessons, video, and AI tutoring connect here later.</p>
-    </div>
+    </main>
   );
 }
 

--- a/src/pages/naturversity/Courses.tsx
+++ b/src/pages/naturversity/Courses.tsx
@@ -17,7 +17,7 @@ export default function Courses() {
   }, [q]);
 
   return (
-    <div>
+    <main id="main">
       <h1>📚 Courses</h1>
       <div className="edu-toolbar">
         <input className="input" placeholder="Search courses…" value={q} onChange={e=>setQ(e.target.value)} />
@@ -45,7 +45,7 @@ export default function Courses() {
         })}
       </div>
       <p className="meta">Coming soon: pacing plans, reminders, and AI tutors.</p>
-    </div>
+    </main>
   );
 }
 

--- a/src/pages/naturversity/Partners.tsx
+++ b/src/pages/naturversity/Partners.tsx
@@ -3,7 +3,7 @@ import { PARTNERS } from "../../lib/naturversity/data";
 
 export default function Partners() {
   return (
-    <div>
+    <main id="main">
       <h1>🤝 Partners</h1>
       <div className="edu-list">
         {PARTNERS.map(p => (
@@ -17,7 +17,7 @@ export default function Partners() {
           </div>
         ))}
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/src/pages/naturversity/Teachers.tsx
+++ b/src/pages/naturversity/Teachers.tsx
@@ -14,7 +14,7 @@ export default function Teachers() {
   }, [q]);
 
   return (
-    <div>
+    <main id="main">
       <h1>👩‍🏫 Teachers</h1>
       <div className="edu-toolbar">
         <input className="input" placeholder="Search mentors…" value={q} onChange={e=>setQ(e.target.value)} />
@@ -31,7 +31,7 @@ export default function Teachers() {
           </div>
         ))}
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/src/pages/worlds/WorldLayout.tsx
+++ b/src/pages/worlds/WorldLayout.tsx
@@ -11,7 +11,7 @@ export default function WorldLayout({
   children?: React.ReactNode;
 }) {
   return (
-    <div className="page-wrap">
+    <main id="main" className="page-wrap">
       <h1>{title}</h1>
       <div className="cards">
         <div className="card">
@@ -29,6 +29,6 @@ export default function WorldLayout({
         </div>
       </div>
       {children}
-    </div>
+    </main>
   );
 }

--- a/src/pages/zones/Community.tsx
+++ b/src/pages/zones/Community.tsx
@@ -130,7 +130,7 @@ export default function Community() {
   };
 
   return (
-    <div>
+    <main id="main">
       <Breadcrumbs />
       <h1>🗳️🌍 Community</h1>
       <p>Vote for new lands & characters, and join local volunteer events.</p>
@@ -289,6 +289,6 @@ export default function Community() {
           </ul>
         </section>
       )}
-    </div>
+    </main>
   );
 }

--- a/src/pages/zones/Future.tsx
+++ b/src/pages/zones/Future.tsx
@@ -3,7 +3,7 @@ import { Breadcrumbs } from "../../components/Breadcrumbs";
 
 export default function FutureZone() {
   return (
-    <div className="page">
+    <main id="main" className="page">
       <Breadcrumbs />
 
       <h1>🔮 Future Zone</h1>
@@ -48,7 +48,7 @@ export default function FutureZone() {
           <p>NATUR wallet, trading, redemptions, and seasonal global events.</p>
         </a>
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/src/pages/zones/Observations.tsx
+++ b/src/pages/zones/Observations.tsx
@@ -144,7 +144,7 @@ export default function Observations() {
   }, [list]);
 
   return (
-    <div>
+    <main id="main">
       <Breadcrumbs />
       <h1>📷🌿 Observations</h1>
       <p>Upload nature pics; tag, learn, earn. (Local & offline; data stays in your browser.)</p>
@@ -340,6 +340,6 @@ export default function Observations() {
           </ul>
         </section>
       )}
-    </div>
+    </main>
   );
 }

--- a/src/pages/zones/Quizzes.tsx
+++ b/src/pages/zones/Quizzes.tsx
@@ -51,7 +51,7 @@ export default function Quizzes() {
   };
 
   return (
-    <div>
+    <main id="main">
       <Breadcrumbs />
       <h1>🎯 Quizzes</h1>
       <p>Solo & party quiz play with scoring (client-only; no backend).</p>
@@ -160,6 +160,6 @@ export default function Quizzes() {
           </ul>
         </section>
       )}
-    </div>
+    </main>
   );
 }

--- a/src/pages/zones/Stories.tsx
+++ b/src/pages/zones/Stories.tsx
@@ -66,7 +66,7 @@ export default function Stories() {
   };
 
   return (
-    <div>
+    <main id="main">
       <Breadcrumbs />
       <h1>📚✨ Stories</h1>
       <p>AI story paths set in all 14 kingdoms (local, no-backend version).</p>
@@ -186,6 +186,6 @@ export default function Stories() {
           </ul>
         </section>
       )}
-    </div>
+    </main>
   );
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -21,3 +21,54 @@ svg[aria-label="hero-face"],
   object-fit: contain;
   display: block;
 }
+
+:root{
+  --cta-bg:#1e90ff;
+  --cta-bg-hover:#1677d8;
+  --cta-fg:#ffffff;
+}
+
+/* CTA buttons (home hero, generic .btn-primary) */
+.btn-primary,
+.cta {
+  background: var(--cta-bg);
+  color: var(--cta-fg);
+  border: none;
+}
+.btn-primary:hover,
+.cta:hover { background: var(--cta-bg-hover); }
+
+/* Mobile top nav: scrollable row, no wrap */
+.topnav {
+  display:flex;
+  gap:16px;
+  overflow-x:auto;
+  white-space:nowrap;
+  -webkit-overflow-scrolling:touch;
+  scrollbar-width:none;
+}
+.topnav::-webkit-scrollbar { display:none; }
+
+/* Highlight active route */
+.topnav a.active {
+  font-weight:700;
+  text-decoration:underline;
+  text-underline-offset: 4px;
+}
+
+/* Skip to content */
+.skip-link {
+  position:absolute;
+  left:-9999px;
+  top:auto;
+  width:1px; height:1px;
+  overflow:hidden;
+}
+.skip-link:focus {
+  left:16px; top:12px;
+  width:auto; height:auto;
+  padding:8px 12px;
+  background:#000; color:#fff;
+  border-radius:8px;
+  z-index:1000;
+}


### PR DESCRIPTION
## Summary
- style CTA buttons with blue theme and hover states
- replace top nav with scrollable links, active styling, and skip link
- assign `id="main"` to page wrappers for accessible skip target

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a89eb82b6483298d98a0836f6e280f