### PR TITLE
feat: add mobile nav drawer and blue CTAs

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,31 +1,34 @@
-import React from "react";
-import { NavLink, Link } from "react-router-dom";
+import { Link, NavLink } from 'react-router-dom';
+import { useState } from 'react';
+import './site-header.css';
 
-export default function SiteHeader() {
+export default function SiteHeader(){
+  const [open, setOpen] = useState(false);
   return (
-    <header className="nv-header">
-      <div className="nv-wrap">
-        <Link to="/" className="nv-brand">
-          <img src="/favicon-32x32.png" alt="Naturverse" width={28} height={28} />
-          <span className="nv-brand-text">Naturverse</span>
+    <header className={`site-header ${open ? 'open' : ''}`}>
+      <div className="wrap">
+        <Link to="/" className="brand" onClick={() => setOpen(false)}>
+          <img src="/favicon-32x32.png" width="28" height="28" alt="Naturverse" />
+          <span>Naturverse</span>
         </Link>
-
-        <nav className="nv-nav" aria-label="Main">
-          <NavLink to="/worlds" className="nv-link">Worlds</NavLink>
-          <NavLink to="/zones" className="nv-link">Zones</NavLink>
-          <NavLink to="/marketplace" className="nv-link">Marketplace</NavLink>
-          <NavLink to="/naturversity" className="nv-link">Naturversity</NavLink>
-          <NavLink to="/naturbank" className="nv-link">Naturbank</NavLink>
-          <NavLink to="/navatar" className="nv-link">Navatar</NavLink>
-          <NavLink to="/passport" className="nv-link">Passport</NavLink>
-          <NavLink to="/turian" className="nv-link">Turian</NavLink>
+        <button className="nav-toggle" aria-label="Menu" onClick={() => setOpen(v => !v)}>
+          <span/>
+          <span/>
+          <span/>
+        </button>
+        <nav className="nav">
+          <NavLink to="/worlds" onClick={() => setOpen(false)}>Worlds</NavLink>
+          <NavLink to="/zones" onClick={() => setOpen(false)}>Zones</NavLink>
+          <NavLink to="/marketplace" onClick={() => setOpen(false)}>Marketplace</NavLink>
+          <NavLink to="/naturversity" onClick={() => setOpen(false)}>Naturversity</NavLink>
+          <NavLink to="/naturbank" onClick={() => setOpen(false)}>Naturbank</NavLink>
+          <NavLink to="/navatar" onClick={() => setOpen(false)}>Navatar</NavLink>
+          <NavLink to="/passport" onClick={() => setOpen(false)}>Passport</NavLink>
+          <NavLink to="/turian" onClick={() => setOpen(false)}>Turian</NavLink>
+          <NavLink to="/profile" aria-label="Profile" className="icon" onClick={() => setOpen(false)}>👤</NavLink>
+          <NavLink to="/cart" aria-label="Cart" className="icon" onClick={() => setOpen(false)}>🛒</NavLink>
         </nav>
-
-        <div className="nv-actions">
-          <NavLink to="/profile" className="nv-icon" aria-label="Profile">👤</NavLink>
-          <NavLink to="/cart" className="nv-icon" aria-label="Cart">🛒</NavLink>
-        </div>
       </div>
     </header>
-  );
+  )
 }

--- a/src/components/site-header.css
+++ b/src/components/site-header.css
@@ -1,0 +1,21 @@
+.site-header{position:sticky;top:0;z-index:50;background:#fff;border-bottom:1px solid #eef2f7}
+.site-header .wrap{max-width:1100px;margin:0 auto;padding:.75rem 1rem;display:flex;align-items:center;gap:16px}
+.site-header .brand{display:flex;align-items:center;gap:.5rem;font-weight:800;color:var(--ink);text-decoration:none}
+.site-header .nav{margin-left:auto;display:flex;gap:18px;align-items:center}
+.site-header .nav a{color:#1f2937;text-decoration:none;font-weight:600;opacity:.9}
+.site-header .nav a.active{color:var(--brand-blue-700);}
+
+.nav-toggle{display:none;margin-left:auto;border:0;background:transparent;width:40px;height:40px;padding:6px}
+.nav-toggle span{display:block;height:3px;background:#111;border-radius:3px;margin:5px 0;transition:.2s}
+
+@media (max-width: 820px){
+  .nav-toggle{display:block}
+  .site-header .nav{
+    position:fixed;inset:64px 12px auto 12px;
+    display:flex;flex-direction:column;gap:12px;
+    background:#fff;border:1px solid #e5e7eb;border-radius:14px;
+    padding:12px;box-shadow:0 10px 30px rgba(0,0,0,.08);
+    transform:translateY(-16px);opacity:0;pointer-events:none;transition:.15s ease;
+  }
+  .site-header.open .nav{transform:translateY(0);opacity:1;pointer-events:auto}
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 export default function Home() {
   return (
@@ -20,8 +21,9 @@ export default function Home() {
           A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.
         </p>
         <div className="hero-cta">
-          <a className="btn btn-primary" href="/signup">Create account</a>
-          <a className="btn" href="/worlds">Explore Worlds</a>
+          <Link className="btn primary" to="/signup">Create account</Link>
+          <Link className="btn primary" to="/worlds">Explore Worlds</Link>
+          {/* buttons keep .primary class for blue styling */}
         </div>
       </section>
 
@@ -95,8 +97,8 @@ export default function Home() {
       <section className="home-cta">
         <h2>Ready to join the journey?</h2>
         <div className="hero-cta">
-          <a className="btn btn-primary" href="/signup">Sign up free</a>
-          <a className="btn" href="/signin">Sign in</a>
+          <Link className="btn primary" to="/signup">Sign up free</Link>
+          <Link className="btn" to="/signin">Sign in</Link>
         </div>
       </section>
     </main>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,3 +1,54 @@
+/* Brand tokens */
+:root{
+  /* Brand */
+  --brand: #0f766e;
+  --brand-blue-600: #0284c7;     /* primary CTA */
+  --brand-blue-700: #0369a1;
+  --brand-blue-800: #075985;
+
+  /* Text */
+  --ink: #111827;
+  --ink-2: #374151;
+  --bg: #f8fafc;
+  --card: #ffffff;
+  --ring: rgba(2,132,199,.18);
+  --radius: 14px;
+  --gap: 16px;
+}
+
+/* Buttons (shared) */
+.btn, button.btn, a.btn{
+  display:inline-flex;align-items:center;justify-content:center;
+  border-radius:12px;padding:.75rem 1rem;font-weight:700;
+  text-decoration:none;gap:.5rem;border:0;cursor:pointer;
+  transition:transform .05s ease, filter .15s ease, background-color .15s ease;
+}
+.btn:active{ transform:translateY(1px); }
+
+/* Primary (blue) */
+.btn.primary, button.btn.primary, a.btn.primary{
+  background:var(--brand-blue-600);color:#fff;
+}
+.btn.primary:hover{ background:var(--brand-blue-700); }
+.btn.primary:active{ background:var(--brand-blue-800); }
+
+/* Secondary (outline) */
+.btn.ghost{ background:#eef2f7;color:var(--ink); }
+.btn.ghost:hover{ filter:brightness(1.03); }
+
+/* Hero CTA fallback (if a page didn't use .btn classes) */
+.hero .actions a,
+.hero .actions button{
+  background:var(--brand-blue-600) !important;
+  color:#fff !important;
+  border:0 !important;
+  border-radius:12px !important;
+  padding:.75rem 1rem !important;
+  font-weight:700 !important;
+}
+.hero .actions a:hover,
+.hero .actions button:hover{ background:var(--brand-blue-700) !important; }
+
 /* Containers & cards */
 .container{max-width:1200px;margin:0 auto;padding:24px 16px}
 .card{background:var(--surface,#fff);border:1px solid rgba(0,0,0,.08);border-radius:16px;padding:16px}


### PR DESCRIPTION
## Summary
- introduce brand color tokens and shared blue primary button styles
- add mobile-friendly navigation drawer with toggle button
- ensure home hero uses new blue primary buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8a7744b788329ae72cb65fe500c69