### PR TITLE
Blue theme polish — CTAs + panels (safe, no binaries)

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import './styles.css';
 import './styles/shop.css';
 import './styles/edu.css';
 import './main.css';
+import './styles/brand.css'; // blue theme overrides (safe, CSS-only)
 import { ErrorBoundary } from './components/ErrorBoundary';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -1,0 +1,105 @@
+/* Kid-friendly blue theme tokens + safe overrides.
+   Scope: global. Layout unchanged. */
+
+:root{
+  /* Blues */
+  --brand-50:#eff6ff;
+  --brand-100:#dbeafe;
+  --brand-200:#bfdbfe;
+  --brand-300:#93c5fd;
+  --brand-400:#60a5fa;
+  --brand-500:#3b82f6;
+  --brand-600:#2563eb; /* primary */
+  --brand-700:#1d4ed8;
+
+  /* Neutrals used across UI */
+  --ink:#0f172a;         /* headings */
+  --muted:#475569;       /* body text */
+  --card:#ffffff;
+  --ring: rgba(37,99,235,.18); /* blue ring */
+  --radius:14px;
+  --gap:16px;
+
+  /* Button tokens */
+  --btn-bg: var(--brand-600);
+  --btn-hover: var(--brand-700);
+  --btn-text: #fff;
+
+  /* Panel tokens */
+  --panel-bg: #ffffff;
+  --panel-border: var(--brand-100);
+  --panel-hover: var(--brand-50);
+}
+
+/* Primary buttons: cover common classes without changing markup */
+button.primary,
+.btn-primary,
+.btn--primary,
+.cta button,
+.cta,
+.button-primary,
+a.button-primary{
+  background: var(--btn-bg) !important;
+  color: var(--btn-text) !important;
+  border: 1px solid transparent !important;
+  border-radius: var(--radius) !important;
+  padding: 12px 18px !important;
+}
+button.primary:hover,
+.btn-primary:hover,
+.btn--primary:hover,
+.cta button:hover,
+a.button-primary:hover{
+  background: var(--btn-hover) !important;
+}
+
+/* Panels / cards / tiles (visual only, no layout changes) */
+.card,
+.tile,
+.panel,
+.box,
+.world-tile,
+.zone-card,
+.market-card{
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  transition: box-shadow .15s ease, transform .02s ease, background .15s ease;
+}
+.card:hover,
+.tile:hover,
+.panel:hover,
+.box:hover,
+.world-tile:hover,
+.zone-card:hover,
+.market-card:hover{
+  box-shadow: 0 0 0 4px var(--ring);
+  background: var(--panel-hover);
+}
+
+/* Soft section headers keep the blue theme without changing layout */
+h1,h2{
+  color: var(--ink);
+}
+p,li{
+  color: var(--muted);
+}
+
+/* Ensure hero CTA on / uses the same style even if it’s a <a> */
+.hero .cta,
+.hero a.cta{
+  background: var(--btn-bg) !important;
+  color: var(--btn-text) !important;
+}
+
+/* Keep images smooth without resizing layout */
+img{
+  image-rendering: auto;
+}
+
+/* Respect user prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce){
+  .card,.tile,.panel,.box,.world-tile,.zone-card,.market-card{
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- switch primary CTAs to Naturverse blue
- make cards and panels softly blue with a gentle ring hover
- import brand.css for global kid-friendly theme overrides

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8ab5a683483298ea2eaece03ccc22