### PR TITLE
Blue theme pass – unify buttons, links, cards

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -45,6 +45,7 @@ export default function Header() {
                 alt="Turian Media"
                 className="site-logo"
               />
+              <span className="site-title">Naturverse</span>
             </a>
 
           <div className="nv-right">

--- a/src/components/HubCard.tsx
+++ b/src/components/HubCard.tsx
@@ -9,8 +9,8 @@ type HubCardProps = {
 
 export default function HubCard({ to, emoji, title, sub }: HubCardProps) {
   return (
-    <Link to={to} className="hub-card" aria-label={`${title}${sub ? ` – ${sub}` : ''}`}>
-      <div className="hub-title">
+    <Link to={to} className="hub-card card" aria-label={`${title}${sub ? ` – ${sub}` : ''}`}>
+      <div className="hub-title card-header">
         <span className="hub-emoji" aria-hidden>
           {emoji}
         </span>

--- a/src/components/HubGrid.tsx
+++ b/src/components/HubGrid.tsx
@@ -14,16 +14,16 @@ export function HubGrid({ items, children }: { items?: Item[]; children?: React.
       <div className="hub-grid">
         {items.map((it, i) =>
           it.to ? (
-            <Link key={i} to={it.to} className="hub-card">
-              <span className="hub-card-title">
+            <Link key={i} to={it.to} className="hub-card card">
+              <span className="hub-card-title card-header">
                 {it.icon && <span className="hub-ico">{it.icon}</span>}
                 {it.title}
               </span>
               {it.desc && <span className="hub-card-desc">{it.desc}</span>}
             </Link>
           ) : (
-            <div key={i} className="hub-card">
-              <span className="hub-card-title">
+            <div key={i} className="hub-card card">
+              <span className="hub-card-title card-header">
                 {it.icon && <span className="hub-ico">{it.icon}</span>}
                 {it.title}
               </span>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,9 +21,8 @@ export default function Home() {
           A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.
         </p>
         <div className="hero-cta">
-          <Link className="btn primary" to="/signup">Create account</Link>
-          <Link className="btn primary" to="/worlds">Explore Worlds</Link>
-          {/* buttons keep .primary class for blue styling */}
+          <a className="btn btn-primary" href="/signup">Create account</a>
+          <a className="btn btn-outline" href="/worlds">Explore Worlds</a>
         </div>
       </section>
 
@@ -68,27 +67,27 @@ export default function Home() {
 
       {/* Hubs */}
       <section className="home-grid">
-        <a className="hub-card" href="/worlds">
+        <a className="hub-card card" href="/worlds">
           <div className="hub-emoji">🌍</div>
-          <h3>Worlds</h3>
+          <h3 className="card-header">Worlds</h3>
           <p>Travel the 14 magical kingdoms.</p>
         </a>
 
-        <a className="hub-card" href="/zones">
+        <a className="hub-card card" href="/zones">
           <div className="hub-emoji">🎮</div>
-          <h3>Zones</h3>
+          <h3 className="card-header">Zones</h3>
           <p>Arcade, music, wellness, creator lab.</p>
         </a>
 
-        <a className="hub-card" href="/marketplace">
+        <a className="hub-card card" href="/marketplace">
           <div className="hub-emoji">🛍️</div>
-          <h3>Marketplace</h3>
+          <h3 className="card-header">Marketplace</h3>
           <p>Wishlists, catalog, checkout.</p>
         </a>
 
-        <a className="hub-card" href="/passport">
+        <a className="hub-card card" href="/passport">
           <div className="hub-emoji">📘</div>
-          <h3>Passport</h3>
+          <h3 className="card-header">Passport</h3>
           <p>Track stamps, badges, XP &amp; coins.</p>
         </a>
       </section>
@@ -97,7 +96,7 @@ export default function Home() {
       <section className="home-cta">
         <h2>Ready to join the journey?</h2>
         <div className="hero-cta">
-          <Link className="btn primary" to="/signup">Sign up free</Link>
+          <Link className="btn btn-primary" to="/signup">Sign up free</Link>
           <Link className="btn" to="/signin">Sign in</Link>
         </div>
       </section>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,128 +1,66 @@
-/* ===== Naturverse Blue Theme (CSS-only; safe) ===== */
+/* Global brand variables & base styles */
 :root{
-  /* base */
+  /* Brand blues */
+  --brand-25: #f2f8ff;
+  --brand-50: #e6f1ff;
+  --brand-100:#d6e9ff;
+  --brand-200:#bcdcff;
+  --brand-300:#8ec3ff;
+  --brand-400:#5ea9ff;
+  --brand-500:#348ef7;   /* primary */
+  --brand-600:#2b7bd6;
+  --brand-700:#1f5aa3;   /* headings / brand text */
+  --brand-800:#1a467f;
+
+  /* UI tokens */
+  --ink:#0f172a;
+  --ink-muted:#475569;
+  --muted: var(--ink-muted);
   --bg:#ffffff;
-  --text:#0f172a;                 /* slate-900 */
-  --muted:#334155;                /* slate-700 */
-  --card:#ffffff;
-  --radius:14px;
-  --gap:16px;
 
-  /* blue scale */
-  --blue-50:#eff6ff;
-  --blue-100:#dbeafe;
-  --blue-200:#bfdbfe;
-  --blue-300:#93c5fd;
-  --blue-400:#60a5fa;
-  --blue-500:#3b82f6;
-  --blue-600:#2563eb;
-  --blue-700:#1d4ed8;
-  --blue-800:#1e40af;
-
-  /* brand hooks */
-  --brand-50:var(--blue-50);
-  --brand-100:var(--blue-100);
-  --brand-200:var(--blue-200);
-  --brand-300:var(--blue-300);
-  --brand-400:var(--blue-400);
-  --brand-500:var(--blue-500);
-  --brand-600:var(--blue-600);
-  --brand-700:var(--blue-700);
-  --brand-800:var(--blue-800);
-
-  /* accents */
-  --link:var(--brand-700);
-  --link-hover:var(--brand-800);
-  --cta-bg:var(--brand-600);
-  --cta-bg-hover:var(--brand-700);
-  --cta-text:#ffffff;
-  --card-ring:color-mix(in srgb, var(--brand-600) 18%, transparent);
-  --chip-bg:var(--brand-50);
-  --chip-border:var(--brand-200);
+  --card: var(--bg);
+  --card-border: var(--brand-200);
+  --card-ring: rgba(52, 142, 247, .18);
+  --radius: 14px;
+  --gap: 16px;
 }
 
-body{
-  background:var(--bg);
-  color:var(--text);
-}
+/* Text & links */
+body{ color: var(--ink); background: var(--bg); }
+a{ color: var(--brand-700); }
+a:hover{ color: var(--brand-600); text-decoration: underline; }
 
-/* headings */
-h1,h2,h3{
-  color:var(--brand-800);
-}
-.page-title,.site-title{
-  color:var(--brand-800);
-}
+/* Site title (Naturverse) */
+.site-title{ color: var(--brand-700); }
 
-/* links */
-a{
-  color:var(--link);
-  text-decoration:underline;
-  text-underline-offset:2px;
-}
-a:hover{color:var(--link-hover);}
-a:focus-visible{outline:3px solid var(--brand-300);outline-offset:2px;}
-
-/* buttons */
+/* Buttons */
 .btn{
-  --_bg:var(--cta-bg);
-  --_bg-hover:var(--cta-bg-hover);
-  --_fg:var(--cta-text);
-  background:var(--_bg);
-  color:var(--_fg);
-  border-radius:12px;
-  padding:.9rem 1.25rem;
-  border:0;
-  box-shadow:0 1px 0 rgba(0,0,0,.06), 0 0 0 2px transparent;
-  transition:background .15s ease, box-shadow .15s ease, transform .02s ease-in;
+  display:inline-flex; align-items:center; justify-content:center;
+  border-radius:12px; padding:.75rem 1.25rem; font-weight:700;
+  border:1px solid transparent; transition:all .15s ease;
 }
-.btn:hover{background:var(--_bg-hover);}
-.btn:active{transform:translateY(1px);}
-.btn--secondary{
-  --_bg:var(--brand-50);
-  --_bg-hover:var(--brand-100);
-  --_fg:var(--brand-700);
-  color:var(--_fg);
-  border:1px solid var(--brand-200);
+.btn-primary{
+  background: var(--brand-500); color:#fff; border-color: var(--brand-500);
 }
-.btn:focus-visible{box-shadow:0 0 0 3px var(--brand-200);}
+.btn-primary:hover{ background: var(--brand-600); border-color: var(--brand-600); }
+.btn-outline{
+  background:#fff; color: var(--brand-700); border-color: var(--brand-300);
+}
+.btn-outline:hover{ background: var(--brand-50); border-color: var(--brand-500); color: var(--brand-700); }
 
-/* cards */
+/* Cards (zones, marketplace, naturversity, etc.) */
 .card{
-  background:var(--card);
-  border-radius:var(--radius);
-  border:1px solid var(--brand-200);
-  padding:var(--gap);
-  box-shadow:0 0 0 1px var(--card-ring);
+  background:#fff;
+  border:1px solid var(--card-border);
+  border-radius: var(--radius);
+  box-shadow: 0 0 0 0 var(--card-ring);
 }
-.card:hover{
-  box-shadow:0 0 0 2px color-mix(in srgb, var(--brand-600) 25%, transparent);
-}
+.card:hover{ box-shadow: 0 0 0 4px var(--card-ring); }
+.card-header{ color: var(--brand-700); }
+.card-subtle{ background: var(--brand-25); }
 
-/* chips / tabs */
-.chip,.tab{
-  border:1px solid var(--chip-border);
-  background:var(--chip-bg);
-  border-radius:999px;
-  padding:.4rem .7rem;
-}
-.tab--active{
-  background:var(--brand-100);
-  border-color:var(--brand-300);
-  color:var(--brand-800);
-}
+/* Section headings pop slightly blue */
+h1,h2,h3{ color: var(--brand-700); }
 
-/* breadcrumbs & small UI */
-.breadcrumb a{color:var(--brand-700);}
-.breadcrumb a:hover{color:var(--brand-800);}
-
-/* header brand & mobile menu */
-.brand,.logo-text{color:var(--brand-800);}
-.hamburger{color:var(--brand-700);}
-.hamburger:active{color:var(--brand-800);}
-
-/* focus helpers */
-.focus-ring:focus-visible{
-  outline:3px solid var(--brand-300);
-  outline-offset:2px;
-}
+/* “pill” chips/tabs light blue */
+.pill{ background: var(--brand-50); border:1px solid var(--brand-200); color: var(--brand-700); }


### PR DESCRIPTION
## Summary
- Add global brand blue palette and UI tokens for text, buttons, and cards
- Style site header title with brand blue
- Make home page buttons and hub cards use shared `.btn` and `.card` styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8b5917e8883299c26659f8886823a