### PR TITLE
Unify blue theme across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <!-- Preload main CSS -->
     <link rel="preload" as="style" href="/src/styles/main.css" />
     <link rel="stylesheet" href="/src/styles/main.css" />
+    <link rel="stylesheet" href="/src/styles/pages.css" />
 
     <!-- Canonical + description -->
     <link rel="canonical" href="https://thenaturverse.com/" />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,6 @@ import './styles.css';
 import './styles/shop.css';
 import './styles/edu.css';
 import './main.css';
-import './styles/brand.css'; // blue theme overrides (safe, CSS-only)
 import { ErrorBoundary } from './components/ErrorBoundary';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,0 +1,32 @@
+/* Primary CTA = Naturverse blue */
+.btn-primary{
+  background: var(--cta-bg);
+  color: var(--cta-text);
+  border-color: transparent;
+}
+.btn-primary:hover,
+.btn-primary:focus{
+  background: var(--cta-bg-hover);
+}
+
+/* Secondary = soft blue (so no black buttons remain) */
+.btn-secondary{
+  background: var(--brand-800);
+  color: #fff;
+  border-color: transparent;
+}
+.btn-secondary:hover,
+.btn-secondary:focus{
+  background: var(--brand-900);
+}
+
+/* Card outline uses brand ring */
+.card{
+  box-shadow: 0 0 0 1px var(--card-ring);
+}
+
+/* Soft blue panel variant used on Arcade/Passport etc. */
+.panel{
+  border: 1px solid var(--brand-100);
+  box-shadow: 0 0 0 4px var(--brand-50);
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,66 +1,14 @@
-/* Global brand variables & base styles */
-:root{
-  /* Brand blues */
-  --brand-25: #f2f8ff;
-  --brand-50: #e6f1ff;
-  --brand-100:#d6e9ff;
-  --brand-200:#bcdcff;
-  --brand-300:#8ec3ff;
-  --brand-400:#5ea9ff;
-  --brand-500:#348ef7;   /* primary */
-  --brand-600:#2b7bd6;
-  --brand-700:#1f5aa3;   /* headings / brand text */
-  --brand-800:#1a467f;
+@import './tokens.css';
+@import './typography.css';
+@import './components.css';
 
-  /* UI tokens */
-  --ink:#0f172a;
-  --ink-muted:#475569;
-  --muted: var(--ink-muted);
-  --bg:#ffffff;
-
-  --card: var(--bg);
-  --card-border: var(--brand-200);
-  --card-ring: rgba(52, 142, 247, .18);
-  --radius: 14px;
-  --gap: 16px;
-}
-
-/* Text & links */
-body{ color: var(--ink); background: var(--bg); }
+/* Base text & links */
+body{ color:#0f172a; background:#ffffff; }
 a{ color: var(--brand-700); }
-a:hover{ color: var(--brand-600); text-decoration: underline; }
+a:hover{ color: var(--brand-800); text-decoration: underline; }
 
-/* Site title (Naturverse) */
-.site-title{ color: var(--brand-700); }
-
-/* Buttons */
-.btn{
-  display:inline-flex; align-items:center; justify-content:center;
-  border-radius:12px; padding:.75rem 1.25rem; font-weight:700;
-  border:1px solid transparent; transition:all .15s ease;
-}
-.btn-primary{
-  background: var(--brand-500); color:#fff; border-color: var(--brand-500);
-}
-.btn-primary:hover{ background: var(--brand-600); border-color: var(--brand-600); }
-.btn-outline{
-  background:#fff; color: var(--brand-700); border-color: var(--brand-300);
-}
-.btn-outline:hover{ background: var(--brand-50); border-color: var(--brand-500); color: var(--brand-700); }
-
-/* Cards (zones, marketplace, naturversity, etc.) */
-.card{
-  background:#fff;
-  border:1px solid var(--card-border);
-  border-radius: var(--radius);
-  box-shadow: 0 0 0 0 var(--card-ring);
-}
-.card:hover{ box-shadow: 0 0 0 4px var(--card-ring); }
-.card-header{ color: var(--brand-700); }
-.card-subtle{ background: var(--brand-25); }
-
-/* Section headings pop slightly blue */
-h1,h2,h3{ color: var(--brand-700); }
+/* Site title */
+.site-title{ color: var(--heading-color); }
 
 /* “pill” chips/tabs light blue */
 .pill{ background: var(--brand-50); border:1px solid var(--brand-200); color: var(--brand-700); }

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -1,0 +1,14 @@
+/* Shared page-level tweaks so headings never fall back to black */
+.page h1,
+.page h2 { color: var(--heading-color); }
+
+/* Link accents within feature lists */
+.feature-list a { color: var(--brand-700); }
+.feature-list a:hover { color: var(--brand-800); }
+
+/* Zones/Naturversity/Naturbank tiles keep a subtle blue outline */
+.tile {
+  box-shadow: 0 0 0 1px var(--card-ring);
+  border-radius: 14px;
+}
+.tile:hover { box-shadow: 0 0 0 2px var(--brand-200); }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,23 @@
+:root{
+  /* Core spacing */
+  --gap: 16px;
+
+  /* Brand blues (Naturverse) */
+  --brand-50:  #eff6ff;
+  --brand-100: #dbeafe;
+  --brand-200: #bfdbfe;
+  --brand-300: #93c5fd;
+  --brand-400: #60a5fa;
+  --brand-500: #3b82f6; /* primary */
+  --brand-600: #2563eb;
+  --brand-700: #1d4ed8;
+  --brand-800: #1e40af;
+  --brand-900: #1e3a8a;
+
+  /* Theme usage tokens */
+  --heading-color: var(--brand-800);
+  --cta-bg:        var(--brand-600);
+  --cta-bg-hover:  var(--brand-700);
+  --cta-text:      #ffffff;
+  --card-ring:     rgba(37, 99, 235, .18); /* brand-600 @ 18% */
+}

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,0 +1,12 @@
+/* Global heading color & rhythm */
+h1,h2,h3{
+  line-height:1.2;
+  color: var(--heading-color);
+}
+
+/* Common title helpers some pages use */
+.section-title,
+.page-title,
+.card-title{
+  color: var(--heading-color);
+}


### PR DESCRIPTION
## Summary
- add brand palette tokens and theme usage variables
- unify heading, button, and card styles across pages
- wire shared page overrides stylesheet for consistent blue accents

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a905e35b80832982d5b82b46637a17