### PR TITLE
feat: apply Naturverse blue theme

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -12,6 +12,7 @@
 @import "./styles/brandmark.css";
 @import "./pages/home.css";
 @import "./styles/site.css";
+@import "./styles/naturverse-blue.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}

--- a/src/styles/naturverse-blue.css
+++ b/src/styles/naturverse-blue.css
@@ -1,0 +1,54 @@
+/* === Naturverse Blue Theme PR === */
+
+/* Main brand color */
+:root {
+  --naturverse-blue: #1e73be; /* Adjust if you want a lighter/darker blue */
+}
+
+/* Navbar text + underline */
+.navbar,
+.navbar a,
+.navbar-brand {
+  color: var(--naturverse-blue) !important;
+  border-color: var(--naturverse-blue) !important;
+}
+
+/* Page section headers (Zones, Marketplace, etc.) */
+h1, h2, h3, h4, h5, h6 {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Card titles (like Arcade, Wellness, Catalog, Teachers, Wallet) */
+.card-title,
+.card-header,
+.card h3,
+.card h4,
+.card h5 {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Card borders */
+.card,
+.card-box,
+.box {
+  border-color: var(--naturverse-blue) !important;
+}
+
+/* Links & hover */
+a, a:visited {
+  color: var(--naturverse-blue) !important;
+}
+a:hover {
+  color: #125a96 !important; /* darker blue on hover */
+}
+
+/* Buttons already use blue — keep consistent */
+button, .btn, .btn-primary {
+  background-color: var(--naturverse-blue) !important;
+  border-color: var(--naturverse-blue) !important;
+}
+
+/* Any subtle accent lines */
+hr, .divider, .line {
+  border-color: var(--naturverse-blue) !important;
+}


### PR DESCRIPTION
## Summary
- import Naturverse blue stylesheet for global theme
- add CSS overrides to style nav, cards, links and accents with Naturverse blue

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a90896973883298ebefeca8ed1ea61