### PR TITLE
Make Zones card titles bold/brand-blue + ensure white text on blue CTAs

### DIFF
--- a/src/components/HubCard.tsx
+++ b/src/components/HubCard.tsx
@@ -10,12 +10,12 @@ type HubCardProps = {
 export default function HubCard({ to, emoji, title, sub }: HubCardProps) {
   return (
     <Link to={to} className="hub-card card" aria-label={`${title}${sub ? ` – ${sub}` : ''}`}>
-      <div className="hub-title card-header">
-        <span className="hub-emoji" aria-hidden>
+      <strong className="hub-card-title card-title">
+        <span className="hub-ico emoji" aria-hidden>
           {emoji}
         </span>
-        <span>{title}</span>
-      </div>
+        {title}
+      </strong>
       {sub ? <div className="hub-sub">{sub}</div> : null}
     </Link>
   );

--- a/src/components/HubGrid.tsx
+++ b/src/components/HubGrid.tsx
@@ -15,18 +15,26 @@ export function HubGrid({ items, children }: { items?: Item[]; children?: React.
         {items.map((it, i) =>
           it.to ? (
             <Link key={i} to={it.to} className="hub-card card">
-              <span className="hub-card-title card-header">
-                {it.icon && <span className="hub-ico">{it.icon}</span>}
+              <strong className="hub-card-title card-title">
+                {it.icon && (
+                  <span className="hub-ico emoji" aria-hidden>
+                    {it.icon}
+                  </span>
+                )}
                 {it.title}
-              </span>
+              </strong>
               {it.desc && <span className="hub-card-desc">{it.desc}</span>}
             </Link>
           ) : (
             <div key={i} className="hub-card card">
-              <span className="hub-card-title card-header">
-                {it.icon && <span className="hub-ico">{it.icon}</span>}
+              <strong className="hub-card-title card-title">
+                {it.icon && (
+                  <span className="hub-ico emoji" aria-hidden>
+                    {it.icon}
+                  </span>
+                )}
                 {it.title}
-              </span>
+              </strong>
               {it.desc && <span className="hub-card-desc">{it.desc}</span>}
             </div>
           )

--- a/src/styles/hub.css
+++ b/src/styles/hub.css
@@ -17,11 +17,12 @@
 }
 .hub-card:hover{ box-shadow:0 2px 10px rgba(2,6,23,.06); border-color:#dbe0e6; }
 .hub-card-title{
-  font-weight:800;
   font-size:18px;
-  color:#0f172a;
-  display:flex; align-items:center; gap:10px;
+  display:flex;
+  align-items:center;
+  gap:10px;
 }
+.hub-card-title .emoji{ margin-right:0 !important; }
 .hub-card-desc{ color:#475569; font-size:14px; }
 .hub-ico{ font-size:22px; line-height:1; }
 @media (max-width: 480px){

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3,8 +3,32 @@
 @import './components.css';
 
 :root {
+  /* brand blues already defined in your theme */
+  /* fallback in case they aren't */
+  --brand-700: #1e40af; /* deep blue */
+  --brand-600: #2563eb; /* primary blue */
+
   /* readable text on brand surfaces */
   --on-brand: #ffffff;
+}
+
+/* --- Card title: consistent bold, brand-blue across app --- */
+.card-title{
+  font-weight: 700;
+  color: var(--brand-700);
+  line-height: 1.2;
+}
+.card-title .emoji{ margin-right: 8px; }
+/* Titles inside linked cards keep brand color */
+.card a .card-title,
+.card a:visited .card-title{
+  color: var(--brand-700);
+}
+/* Zones grid titles align nicely next to emoji */
+.zones .card .card-title{
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 /* Base text & links */
@@ -62,3 +86,12 @@ a:hover{ color: var(--brand-800); text-decoration: underline; }
 
 /* Utility so we can blue a heading without changing layout/components */
 .text-brand { color: var(--brand-700); }
+
+/* --- Blue CTA buttons always have white label --- */
+.btn-primary,
+.btn-primary:visited{
+  color: #fff;
+}
+.btn-primary *{
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- style all card titles with bold Naturverse blue
- keep blue button labels white across states

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68a90e56edec83299e0df47ba6da83a8