### PR TITLE
feat(analytics+seo): add Plausible and JSON-LD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Frontend (optional – app works without them)
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
+NEXT_PUBLIC_SITE_URL=https://thenaturverse.com
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN=thenaturverse.com
 
 # Serverless only (set in Netlify UI → Site settings → Environment):
 OPENAI_API_KEY=

--- a/index.html
+++ b/index.html
@@ -42,6 +42,13 @@
 
     <!-- Theme color -->
     <meta name="theme-color" content="#4a87ff" />
+
+    <!-- Plausible: cookieless analytics -->
+    <script
+      defer
+      data-domain="%NEXT_PUBLIC_PLAUSIBLE_DOMAIN%"
+      src="https://plausible.io/js/script.outbound-links.js"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -1,0 +1,63 @@
+export const siteUrl = import.meta.env.NEXT_PUBLIC_SITE_URL || 'https://thenaturverse.com';
+
+export function ld<T extends object>(obj: T) {
+  return { __html: JSON.stringify(obj) };
+}
+
+export const organizationLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'Naturverse',
+  url: siteUrl,
+  logo: `${siteUrl}/favicons/android-chrome-192x192.png`,
+  sameAs: [
+    'https://x.com/naturverse',
+    'https://instagram.com/naturverse',
+    'https://youtube.com/@naturverse',
+    'https://discord.gg'
+  ],
+};
+
+export const websiteLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  url: siteUrl,
+  name: 'Naturverse',
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: `${siteUrl}/search?q={search_term_string}`,
+    'query-input': 'required name=search_term_string',
+  },
+};
+
+export function breadcrumbsLd(path: string, labels: Record<string, string>) {
+  const parts = path.split('/').filter(Boolean);
+  const itemListElement = parts.map((seg, i) => {
+    const slug = '/' + parts.slice(0, i + 1).join('/');
+    return {
+      '@type': 'ListItem',
+      position: i + 1,
+      name: labels[slug] || seg[0]?.toUpperCase() + seg.slice(1),
+      item: `${siteUrl}${slug}`,
+    };
+  });
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement,
+  };
+}
+
+export function itemListLd(name: string, items: { name: string; path: string }[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name,
+    itemListElement: items.map((it, idx) => ({
+      '@type': 'ListItem',
+      position: idx + 1,
+      name: it.name,
+      url: `${siteUrl}${it.path}`,
+    })),
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,10 +9,13 @@ import './styles/shop.css';
 import './styles/edu.css';
 import './main.css';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { ld, organizationLd, websiteLd } from './lib/jsonld';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       <ErrorBoundary>
+        <script type="application/ld+json" dangerouslySetInnerHTML={ld(organizationLd)} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={ld(websiteLd)} />
         <CartProvider>
           <RouterProvider router={router} />
           <CartDrawer />

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -1,23 +1,42 @@
 import React from "react";
 import { HubGrid } from "../components/HubGrid";
+import { ld, breadcrumbsLd, itemListLd } from "../lib/jsonld";
+
+const labels = { '/marketplace': 'Marketplace' };
+const items = [
+  { name: 'Catalog', path: '/marketplace/catalog' },
+  { name: 'Wishlist', path: '/marketplace/wishlist' },
+  { name: 'Checkout', path: '/marketplace/checkout' },
+];
 
 export default function MarketplacePage() {
   return (
-    <main id="main">
-      <h1>Marketplace</h1>
-      <p className="muted">Shop creations and merch.</p>
+    <>
+      <main id="main">
+        <h1>Marketplace</h1>
+        <p className="muted">Shop creations and merch.</p>
 
-      <HubGrid
-        items={[
-          { to: "/marketplace/catalog", title: "Catalog", desc: "Browse items.", icon: "📦" },
-          { to: "/marketplace/wishlist", title: "Wishlist", desc: "Your favorites.", icon: "❤️" },
-          { to: "/marketplace/checkout", title: "Checkout", desc: "Pay & ship.", icon: "🧾" },
-        ]}
+        <HubGrid
+          items={[
+            { to: "/marketplace/catalog", title: "Catalog", desc: "Browse items.", icon: "📦" },
+            { to: "/marketplace/wishlist", title: "Wishlist", desc: "Your favorites.", icon: "❤️" },
+            { to: "/marketplace/checkout", title: "Checkout", desc: "Pay & ship.", icon: "🧾" },
+          ]}
+        />
+
+        <p className="muted" style={{ marginTop: 12 }}>
+          Coming soon: AI assistance for sizing, bundles, and gift ideas.
+        </p>
+      </main>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ld(breadcrumbsLd('/marketplace', labels))}
       />
-
-      <p className="muted" style={{ marginTop: 12 }}>
-        Coming soon: AI assistance for sizing, bundles, and gift ideas.
-      </p>
-    </main>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ld(itemListLd('Marketplace', items))}
+      />
+    </>
   );
 }

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -1,28 +1,47 @@
 import React from "react";
 import { HubGrid } from "../components/HubGrid";
+import { ld, breadcrumbsLd, itemListLd } from "../lib/jsonld";
+
+const labels = { '/naturversity': 'Naturversity' };
+const items = [
+  { name: 'Teachers', path: '/naturversity/teachers' },
+  { name: 'Partners', path: '/naturversity/partners' },
+  { name: 'Courses', path: '/naturversity/courses' },
+];
 
 export default function NaturversityPage() {
   return (
-    <main id="main">
-      <h1>Naturversity</h1>
-      <p className="muted">Teachers, partners, and courses.</p>
+    <>
+      <main id="main">
+        <h1>Naturversity</h1>
+        <p className="muted">Teachers, partners, and courses.</p>
 
-      <HubGrid
-        items={[
-          { to: "/naturversity/teachers", title: "Teachers", desc: "Mentors across the 14 kingdoms.", icon: "🎓" },
-          { to: "/naturversity/partners", title: "Partners", desc: "Brands & orgs supporting missions.", icon: "🤝" },
-          {
-            to: "/naturversity/courses",
-            title: "Courses",
-            desc: "Nature, art, music, wellness, crypto basics.",
-            icon: "📚",
-          },
-        ]}
+        <HubGrid
+          items={[
+            { to: "/naturversity/teachers", title: "Teachers", desc: "Mentors across the 14 kingdoms.", icon: "🎓" },
+            { to: "/naturversity/partners", title: "Partners", desc: "Brands & orgs supporting missions.", icon: "🤝" },
+            {
+              to: "/naturversity/courses",
+              title: "Courses",
+              desc: "Nature, art, music, wellness, crypto basics.",
+              icon: "📚",
+            },
+          ]}
+        />
+
+        <p className="muted" style={{ marginTop: 12 }}>
+          Coming soon: AI tutors and step-by-step lessons.
+        </p>
+      </main>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ld(breadcrumbsLd('/naturversity', labels))}
       />
-
-      <p className="muted" style={{ marginTop: 12 }}>
-        Coming soon: AI tutors and step-by-step lessons.
-      </p>
-    </main>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ld(itemListLd('Naturversity', items))}
+      />
+    </>
   );
 }

--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import Page from "../components/Page";
+import { ld, breadcrumbsLd } from "../lib/jsonld";
 
 type Msg = { id: string; role: "user" | "turian"; text: string; ts: number };
 
@@ -79,7 +80,8 @@ export default function TurianPage() {
   const groupedSuggestions = useMemo(() => SUGGESTIONS, []);
 
   return (
-    <Page title="Turian the Durian" subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet.">
+    <>
+      <Page title="Turian the Durian" subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet.">
 
       <div className="nv-card" style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 12 }}>
         {mascotSrc ? (
@@ -149,7 +151,12 @@ export default function TurianPage() {
       </div>
 
       <p className="meta">Coming soon: real AI tutor connected across Worlds, Zones, Marketplace, and Naturbank; context-aware hints; quest generation; and Supabase history.</p>
-    </Page>
+      </Page>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ld(breadcrumbsLd('/turian', { '/turian': 'Turian the Durian' }))}
+      />
+    </>
   );
 }
 

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -1,5 +1,17 @@
 import HubCard from '../../components/HubCard';
 import HubGrid from '../../components/HubGrid';
+import { ld, breadcrumbsLd, itemListLd } from '../../lib/jsonld';
+
+const labels = {
+  '/worlds': 'Worlds',
+  '/zones': 'Zones',
+  '/marketplace': 'Marketplace',
+  '/naturversity': 'Naturversity',
+  '/naturbank': 'Naturbank',
+  '/navatar': 'Navatar',
+  '/passport': 'Passport',
+  '/turian': 'Turian the Durian',
+};
 
 const ZONES = [
   {
@@ -59,18 +71,42 @@ const ZONES = [
   },
 ];
 
+const zoneItems = [
+  { name: 'Arcade', path: '/zones/arcade' },
+  { name: 'Music', path: '/zones/music' },
+  { name: 'Wellness', path: '/zones/wellness' },
+  { name: 'Creator Lab', path: '/zones/creator-lab' },
+  { name: 'Stories', path: '/zones/stories' },
+  { name: 'Quizzes', path: '/zones/quizzes' },
+  { name: 'Observations', path: '/zones/observations' },
+  { name: 'Culture', path: '/zones/culture' },
+  { name: 'Community', path: '/zones/community' },
+  { name: 'Future Zone', path: '/zones/future' },
+];
+
 export default function Zones() {
   return (
-    <main className="container">
-      <div className="breadcrumb">Home / Zones</div>
-      <h1 className="page-title text-brand">Zones</h1>
-      <p className="section-lead">Pick a zone to start an activity.</p>
+    <>
+      <main className="container">
+        <div className="breadcrumb">Home / Zones</div>
+        <h1 className="page-title text-brand">Zones</h1>
+        <p className="section-lead">Pick a zone to start an activity.</p>
 
-      <HubGrid>
-        {ZONES.map((z) => (
-          <HubCard key={z.title} to={z.to} emoji={z.emoji} title={z.title} sub={z.sub} />
-        ))}
-      </HubGrid>
-    </main>
+        <HubGrid>
+          {ZONES.map((z) => (
+            <HubCard key={z.title} to={z.to} emoji={z.emoji} title={z.title} sub={z.sub} />
+          ))}
+        </HubGrid>
+      </main>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ld(breadcrumbsLd('/zones', labels))}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ld(itemListLd('Zones', zoneItems))}
+      />
+    </>
   );
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly NEXT_PUBLIC_SITE_URL?: string;
+  readonly NEXT_PUBLIC_PLAUSIBLE_DOMAIN?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from "@vitejs/plugin-react-swc";
 
 export default defineConfig({
   plugins: [react()],
+  envPrefix: ["VITE_", "NEXT_PUBLIC_"],
   build: { outDir: "dist" }
 });


### PR DESCRIPTION
## Summary
- add NEXT_PUBLIC env vars for site URL and Plausible domain
- inject Plausible analytics and global JSON-LD metadata
- expose page-level BreadcrumbList and ItemList JSON-LD for Zones, Marketplace, Naturversity, and Turian

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9254dc28c832984a4cc93bdf39cf9