### PR TITLE
perf(a11y): preload fonts + add font-display swap + reduced motion respect

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -21,6 +21,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Fredoka+One:wght@400&family=Inter:wght@400;500;600;700&display=swap"
+    />
+    <link
       href="https://fonts.googleapis.com/css2?family=Fredoka+One:wght@400&family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
@@ -63,6 +68,14 @@
         width: 100%;
         max-width: 360px;
         margin: 0 auto;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        * {
+          animation-duration: 0.001ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.001ms !important;
+          scroll-behavior: auto !important;
+        }
       }
     </style>
   </head>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,19 @@
     <link rel="stylesheet" href="/src/styles/main.css" />
     <link rel="stylesheet" href="/src/styles/pages.css" />
 
+    <!-- Fonts: preload + swap -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+    />
+
     <!-- Canonical + description -->
     <link rel="canonical" href="https://thenaturverse.com/" />
     <meta

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -122,3 +122,12 @@ a:hover {
 .text-brand {
   color: var(--nv-blue-700);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- preload Google Inter fonts and set `display=swap` for faster, fallback-friendly rendering
- honor motion preferences with a `prefers-reduced-motion` media query

## Testing
- `npm run build`
- `npm run typecheck` *(fails: process did not exit, likely env issue)*

------
https://chatgpt.com/codex/tasks/task_e_68a92ab3c0c483298beff9e77b520e21