### PR TITLE
feat: add native robots and sitemap routes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { SITE_URL } from './lib/site';
+
+export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/lib/site.ts
+++ b/app/lib/site.ts
@@ -1,0 +1,1 @@
+export const SITE_URL = 'https://thenaturverse.com'; // ← update if needed

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from 'next';
+import { SITE_URL } from './lib/site';
+
+export const dynamic = 'force-static';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/*'], // keep private endpoints out of the index
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from 'next';
+import { SITE_URL } from './lib/site';
+
+export const dynamic = 'force-static';
+
+const PAGES = [
+  '/',               // home
+  '/worlds',
+  '/zones',
+  '/marketplace',
+  '/naturversity',
+  '/naturbank',
+  '/navatar',
+  '/passport',
+  '/turian',
+  // add more when you publish them (e.g., /community, /stories, etc.)
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  return PAGES.map((path, i) => ({
+    url: `${SITE_URL}${path}`,
+    lastModified: now,
+    changeFrequency: path === '/' ? 'weekly' : 'monthly',
+    priority: path === '/' ? 1 : 0.7 - i * 0.01, // gentle taper
+  }));
+}


### PR DESCRIPTION
## Summary
- add configurable SITE_URL constant
- serve robots.txt with static rules and sitemap reference
- generate sitemap.xml for key pages
- set metadataBase in root layout for absolute URLs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a92bd02718832989c904444bb02887