### PR TITLE
feat: add PWA manifest and SVG favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Naturverse</title>
 
-    <!-- Favicon / icons (files already exist) -->
-    <link rel="icon" href="/favicon-256x256.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-256x256.png" />
+    <!-- PWA + icons -->
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#2F7AE5" />
+    <link rel="mask-icon" href="/favicon.svg" color="#2F7AE5" />
 
     <!-- Preload main CSS -->
     <link rel="preload" as="style" href="/src/styles/main.css" />
@@ -53,8 +55,6 @@
     />
     <meta name="twitter:image" content="/assets/og-card.png" />
 
-    <!-- Theme color -->
-    <meta name="theme-color" content="#4a87ff" />
 
     <!-- Plausible: cookieless analytics -->
     <script

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2F7AE5"/>
+      <stop offset="1" stop-color="#1C56B6"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="88" height="88" rx="20" fill="url(#g)"/>
+  <g fill="#ffffff" font-family="system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, 'Helvetica Neue', Arial" font-weight="700">
+    <text x="50%" y="58%" font-size="44" text-anchor="middle">N</text>
+  </g>
+</svg>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Naturverse",
+  "short_name": "Naturverse",
+  "description": "Playful worlds of kingdoms, characters, and quests that teach wellness, creativity, and kindness.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#2F7AE5",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Progressive Web App manifest with SVG favicon
- update HTML head to load manifest, SVG icon, mask icon, and theme color

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a9310a9ef08329b5fd2a320a4ef281