### PR TITLE
feat: add basic SEO component

### DIFF
--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,0 +1,26 @@
+import Head from "next/head";
+
+interface SeoProps {
+  title: string;
+  description?: string;
+}
+
+export default function Seo({ title, description }: SeoProps) {
+  const siteName = "Naturverse";
+  const fullTitle = title ? `${title} | ${siteName}` : siteName;
+  const desc =
+    description ||
+    "A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.";
+
+  return (
+    <Head>
+      <title>{fullTitle}</title>
+      <meta name="description" content={desc} />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={desc} />
+      <meta property="twitter:card" content="summary_large_image" />
+      <meta property="twitter:title" content={fullTitle} />
+      <meta property="twitter:description" content={desc} />
+    </Head>
+  );
+}

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { HubGrid } from "../components/HubGrid";
+import Seo from "../components/Seo";
 import { breadcrumbs } from "../lib/jsonld";
 
 const labels = { '/marketplace': 'Marketplace' };
@@ -7,6 +8,10 @@ const labels = { '/marketplace': 'Marketplace' };
 export default function MarketplacePage() {
   return (
     <>
+      <Seo
+        title="Marketplace"
+        description="Shop Naturverse creations, merch, and bundles."
+      />
       <main id="main">
         <h1>Marketplace</h1>
         <p className="muted">Shop creations and merch.</p>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import Seo from "../components/Seo";
 
 export default function Home() {
   return (
-    <main id="main" className="home">
+    <>
+      <Seo
+        title="Welcome"
+        description="Explore kingdoms, quests, and characters in the Naturverse."
+      />
+      <main id="main" className="home">
       {/* Hero */}
       <section className="home-hero">
         <div className="home-hero-badge">
@@ -101,6 +107,7 @@ export default function Home() {
         </div>
       </section>
     </main>
+    </>
   );
 }
 

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -1,5 +1,6 @@
 import HubCard from '../../components/HubCard';
 import HubGrid from '../../components/HubGrid';
+import Seo from '../../components/Seo';
 import { breadcrumbs } from '../../lib/jsonld';
 
 const ZONES = [
@@ -64,6 +65,10 @@ const ZONES = [
 export default function Zones() {
   return (
     <>
+      <Seo
+        title="Zones"
+        description="Pick a zone to start games, music, wellness, and more."
+      />
       <main className="container">
         <div className="breadcrumb">Home / Zones</div>
         <h1 className="page-title text-brand">Zones</h1>

--- a/src/types/next-head.d.ts
+++ b/src/types/next-head.d.ts
@@ -1,0 +1,5 @@
+declare module "next/head" {
+  import type { FC, PropsWithChildren } from "react";
+  const Head: FC<PropsWithChildren<unknown>>;
+  export default Head;
+}


### PR DESCRIPTION
## Summary
- add Seo component for meta tags
- set titles and descriptions on Home, Zones, and Marketplace pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a93566669c832983d668de0cd8c468