### PR TITLE
perf(img): lazy-load non-critical images with async decode

### DIFF
--- a/src/components/BrandMark.tsx
+++ b/src/components/BrandMark.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ImageSmart from "./ImageSmart";
 
 type Props = {
   size?: "sm" | "md" | "lg";
@@ -18,7 +19,7 @@ export default function BrandMark({
 
   return (
     <span className={`brand-mark ${className}`} aria-label={title}>
-      <img
+      <ImageSmart
         src="/turianmedialogo.png"
         alt=""
         role="presentation"

--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ImageSmart from './ImageSmart';
 
 export type CardData = {
   id: string;
@@ -38,7 +39,7 @@ export const CharacterCard: React.FC<{ data: CardData }> = ({ data }) => {
       <div className="nv-card__body">
         <div className="nv-card__avatar">
           {avatarDataUrl ? (
-            <img src={avatarDataUrl} alt={`${name} avatar`} />
+            <ImageSmart src={avatarDataUrl} alt={`${name} avatar`} />
           ) : (
             <div className="nv-card__avatar--placeholder">Add image</div>
           )}

--- a/src/components/CharacterGrid.tsx
+++ b/src/components/CharacterGrid.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ImageSmart from "./ImageSmart";
 
 export type CharacterItem = { name: string; file: string }; // file includes extension
 
@@ -13,7 +14,7 @@ export default function CharacterGrid({ items, basePath }: {
         const src = `${basePath}/${encodeURIComponent(it.file)}`;
         return (
           <figure className="char" key={it.file}>
-            <img src={src} alt={it.name} loading="lazy" />
+            <ImageSmart src={src} alt={it.name} />
             <figcaption>{it.name}</figcaption>
           </figure>
         );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,15 +1,15 @@
 import React from "react";
+import ImageSmart from "./ImageSmart";
 
 export default function Footer() {
   return (
     <footer className="site-footer">
       <div className="footer-brand" aria-label="A Turian Media Company">
-        <img
+        <ImageSmart
           src="/Turianmedia-logo-footer.png"
           alt="A Turian Media Company"
           width={120}
           height={28}
-          loading="lazy"
         />
       </div>
       <nav className="footer-social">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import CartButton from "./cart/CartButton";
+import ImageSmart from "./ImageSmart";
 
 const LINKS = [
   { href: "/worlds", label: "Worlds" },
@@ -40,10 +41,11 @@ export default function Header() {
       <header className="nv-header">
         <div className="nv-shell">
             <a href="/" className="header-logo-link" aria-label="Naturverse home">
-              <img
+              <ImageSmart
                 src="/Turianmedia-logo-footer.png"
                 alt="Turian Media"
                 className="site-logo"
+                priority
               />
               <span className="site-title">Naturverse</span>
             </a>

--- a/src/components/ImageSmart.tsx
+++ b/src/components/ImageSmart.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+/**
+ * Drop-in <img> replacement with safe perf defaults.
+ * - lazy loads by default
+ * - async decodes
+ * - lets you opt-in to hero priority
+ * - never changes layout (you control size via className or width/height)
+ */
+type Props = React.ImgHTMLAttributes<HTMLImageElement> & {
+  priority?: boolean; // set true for above-the-fold/hero only
+  fetchPriority?: "auto" | "high" | "low";
+};
+
+export default function ImageSmart({ priority, loading, decoding, fetchPriority, ...rest }: Props) {
+  const isHero = Boolean(priority);
+  return (
+    <img
+      loading={loading ?? (isHero ? "eager" : "lazy")}
+      decoding={decoding ?? (isHero ? "sync" : "async")}
+      // helps browsers schedule fetches; ignored by older ones (safe)
+      fetchPriority={fetchPriority ?? (isHero ? "high" : "low")}
+      // pass everything else through (src, alt, width, height, className, etc.)
+      {...rest}
+    />
+  );
+}

--- a/src/components/KingdomImage.tsx
+++ b/src/components/KingdomImage.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import ImageSmart from "./ImageSmart";
 
 type Kind = "card" | "hero" | "logo";
 
@@ -38,13 +39,12 @@ export default function KingdomImage({
 
   return (
     // eslint-disable-next-line jsx-a11y/alt-text
-    <img
+    <ImageSmart
       src={candidates[idx]}
       onError={onErr}
       className={className}
       alt={alt || `${kingdom}`}
       style={style}
-      loading="lazy"
     />
   );
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
+import ImageSmart from "./ImageSmart";
 
 export default function Nav() {
   return (
@@ -7,7 +8,7 @@ export default function Nav() {
       <a href="#main" className="skip-link">Skip to content</a>
       <nav className="topnav container">
         <a href="/" aria-label="Naturverse Home" className="brand">
-          <img src="/favicon-32x32.png" alt="Naturverse" width={24} height={24} />
+          <ImageSmart src="/favicon-32x32.png" alt="Naturverse" width={24} height={24} priority />
         </a>
         <div className="links">
           <NavLink to="/worlds" className={({isActive})=>`nav${isActive?' active':''}`}>Worlds</NavLink>

--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { Navatar } from "../types/navatar";
+import ImageSmart from "./ImageSmart";
 
 type Props = { navatar: Navatar };
 
@@ -17,7 +18,7 @@ export default function NavatarCard({ navatar }: Props) {
 
       <div className="card__media">
         {navatar.imageDataUrl ? (
-          <img src={navatar.imageDataUrl} alt={`${navatar.name || navatar.species}`} />
+          <ImageSmart src={navatar.imageDataUrl} alt={`${navatar.name || navatar.species}`} />
         ) : (
           <div className="card__placeholder" aria-label="No photo">No photo</div>
         )}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,6 +1,7 @@
 import { Link, NavLink } from 'react-router-dom';
 import { useState } from 'react';
 import './site-header.css';
+import ImageSmart from './ImageSmart';
 
 export default function SiteHeader(){
   const [open, setOpen] = useState(false);
@@ -8,7 +9,7 @@ export default function SiteHeader(){
     <header className={`site-header ${open ? 'open' : ''}`}>
       <div className="wrap">
         <Link to="/" className="brand" onClick={() => setOpen(false)}>
-          <img src="/favicon-32x32.png" width="28" height="28" alt="Naturverse" />
+          <ImageSmart src="/favicon-32x32.png" width="28" height="28" alt="Naturverse" priority />
           <span>Naturverse</span>
         </Link>
         <button className="nav-toggle" aria-label="Menu" onClick={() => setOpen(v => !v)}>

--- a/src/components/WorldLayout.tsx
+++ b/src/components/WorldLayout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { KINGDOMS, KingdomId, imgUrl } from "../data/kingdoms";
 import "../styles/worlds.css";
+import ImageSmart from "./ImageSmart";
 
 type Props = { id: KingdomId };
 
@@ -15,12 +16,12 @@ export default function WorldLayout({ id }: Props) {
       {/* Map hero */}
       <section className="world-hero card">
         <figure className="hero-figure">
-          <img
+          <ImageSmart
             src={imgUrl(folder, k.mapFile)}
             alt={`${k.title} map`}
-            loading="eager"
             width={1280}
             height={720}
+            priority
           />
         </figure>
         <div className="hero-meta">
@@ -39,10 +40,9 @@ export default function WorldLayout({ id }: Props) {
             {k.characters.map((file) => (
               <li key={file} className="char-card">
                 <div className="char-thumb">
-                  <img
+                  <ImageSmart
                     src={imgUrl(folder, file)}
                     alt={file.replace(/\.[^.]+$/, "")}
-                    loading="lazy"
                     width={320}
                     height={420}
                     onError={(e) => {

--- a/src/components/WorldPage.tsx
+++ b/src/components/WorldPage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ImageSmart from "./ImageSmart";
 
 type Props = {
   title: string;
@@ -12,11 +13,11 @@ export default function WorldPage({ title, intro, mapSrc }: Props) {
   return (
     <div className="world-page">
       <figure className="world-hero">
-        <img
+        <ImageSmart
           src={mapSrc}
           alt={`${title} map`}
           onError={(e) => ((e.currentTarget.src = fallback))}
-          loading="eager"
+          priority
         />
         <figcaption className="sr-only">{title} map</figcaption>
       </figure>

--- a/src/components/worlds/WorldGallery.tsx
+++ b/src/components/worlds/WorldGallery.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ImageSmart from "../ImageSmart";
 
 type Char = { name: string; img: string; role?: string };
 
@@ -14,7 +15,7 @@ export default function WorldGallery({
   return (
     <>
       <figure className="world-hero">
-        <img src={mapSrc} alt={alt} />
+        <ImageSmart src={mapSrc} alt={alt} priority />
       </figure>
 
       <section aria-labelledby="gallery" className="world-section">
@@ -23,7 +24,7 @@ export default function WorldGallery({
           <div className="char-grid">
             {characters.map((c) => (
               <article key={c.name} className="char-card">
-                <img src={c.img} alt={c.name} />
+                <ImageSmart src={c.img} alt={c.name} />
                 <h3>{c.name}</h3>
                 {c.role && <p className="muted">{c.role}</p>}
               </article>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import "./home.css";
 import Meta from "../components/Meta";
 import Page from "../layouts/Page";
+import ImageSmart from "../components/ImageSmart";
 
 export default function Home() {
   return (
@@ -13,13 +14,14 @@ export default function Home() {
       <div className="home">
       {/* Hero */}
       <header className="home-hero">
-        <img
+        <ImageSmart
           src="/favicon-32x32.png"
           width={28}
           height={28}
           className="home-hero-icon"
           alt=""            /* decorative */
           aria-hidden="true"
+          priority
         />
         <h1 className="home-title">Welcome to the Naturverse™</h1>
         <p className="home-subtitle">

--- a/src/pages/Passport.tsx
+++ b/src/pages/Passport.tsx
@@ -3,6 +3,7 @@ import { getCurrent } from "../lib/navatar/store";
 import type { Badge } from "../lib/passport/store";
 import { getStamps, toggleStamp, getBadges, addBadge, getXP, addXP, getNatur, addNatur } from "../lib/passport/store";
 import Page from "../components/Page";
+import ImageSmart from "../components/ImageSmart";
 
 const KINGDOMS = [
   "Thailandia","Brazilandia","Indillandia","Amerilandia",
@@ -34,7 +35,7 @@ export default function PassportPage() {
       {/* Identity / Navatar */}
       <div className="passport-id">
         <div className="avatar">
-          {nav?.photo ? <img src={nav.photo} alt="" /> : <span className="emoji">{nav?.emoji || "🪪"}</span>}
+          {nav?.photo ? <ImageSmart src={nav.photo} alt="" /> : <span className="emoji">{nav?.emoji || "🪪"}</span>}
         </div>
         <div className="id-text">
           <div className="name">{nav?.name || "Explorer"}</div>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import Page from "../components/Page";
+import ImageSmart from "../components/ImageSmart";
 
 /** Local storage keys used around the app (demo only) */
 const K = {
@@ -150,7 +151,7 @@ export default function ProfilePage() {
         <div className="navatar-row">
           <div className="avatar">
             {nav.imageDataUrl ? (
-              <img src={nav.imageDataUrl} alt="Navatar preview" />
+              <ImageSmart src={nav.imageDataUrl} alt="Navatar preview" />
             ) : (
               <div className="avatar-placeholder">No image yet</div>
             )}

--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import Page from "../components/Page";
+import ImageSmart from "../components/ImageSmart";
 
 type Msg = { id: string; role: "user" | "turian"; text: string; ts: number };
 
@@ -84,7 +85,7 @@ export default function TurianPage() {
 
       <div className="nv-card" style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 12 }}>
         {mascotSrc ? (
-          <img src={mascotSrc} alt="Turian the Durian mascot" width={44} height={44} style={{ borderRadius: 8 }} />
+          <ImageSmart src={mascotSrc} alt="Turian the Durian mascot" width={44} height={44} style={{ borderRadius: 8 }} />
         ) : (
           <span role="img" aria-label="durian" style={{ fontSize: 32 }}>🥭</span>
         )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import Seo from "../components/Seo";
+import ImageSmart from "../components/ImageSmart";
 
 export default function Home() {
   return (
@@ -13,13 +14,13 @@ export default function Home() {
       {/* Hero */}
       <section className="home-hero">
         <div className="home-hero-badge">
-          <img
+          <ImageSmart
             src="/favicon-32x32.png"
             width={28}
             height={28}
             alt="Turian"
             className="inline-icon"
-            loading="eager"
+            priority
           />
         </div>
         <h1>Welcome to the Naturverse™</h1>

--- a/src/pages/marketplace/Checkout.tsx
+++ b/src/pages/marketplace/Checkout.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useCart } from "../../hooks/useCart";
+import ImageSmart from "../../components/ImageSmart";
 
 const money = (cents: number) => `$${(cents/100).toFixed(2)}`;
 
@@ -20,7 +21,7 @@ export default function CheckoutPage() {
           <ul className="cart-list">
             {cart.state.items.map(it => (
               <li key={`${it.id}:${it.variant || ""}`} className="cart-row">
-                <img src={it.image || "/placeholders/box.png"} alt={it.name}/>
+                <ImageSmart src={it.image || "/placeholders/box.png"} alt={it.name}/>
                 <div className="meta">
                   <strong>{it.name}</strong>
                   {it.variant && <div className="muted">{it.variant}</div>}

--- a/src/pages/worlds/Africana.tsx
+++ b/src/pages/worlds/Africana.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
+import ImageSmart from "../../components/ImageSmart";
 
 type Character = { name: string; src: string };
 
@@ -21,7 +22,7 @@ export default function AfricanaWorld() {
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <img src={c.src} alt={c.name} loading="lazy" decoding="async" />
+              <ImageSmart src={c.src} alt={c.name} />
               <div className="name">{c.name}</div>
             </article>
           ))}

--- a/src/pages/worlds/Antarctiland.tsx
+++ b/src/pages/worlds/Antarctiland.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
+import ImageSmart from "../../components/ImageSmart";
 
 type Character = { name: string; src: string };
 
@@ -21,7 +22,7 @@ export default function AntarctilandWorld() {
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <img src={c.src} alt={c.name} loading="lazy" decoding="async" />
+              <ImageSmart src={c.src} alt={c.name} />
               <div className="name">{c.name}</div>
             </article>
           ))}

--- a/src/pages/worlds/Britannula.tsx
+++ b/src/pages/worlds/Britannula.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
+import ImageSmart from "../../components/ImageSmart";
 
 type Character = { name: string; src: string };
 
@@ -21,7 +22,7 @@ export default function BritannulaWorld() {
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <img src={c.src} alt={c.name} loading="lazy" decoding="async" />
+              <ImageSmart src={c.src} alt={c.name} />
               <div className="name">{c.name}</div>
             </article>
           ))}

--- a/src/pages/worlds/Europalia.tsx
+++ b/src/pages/worlds/Europalia.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
+import ImageSmart from "../../components/ImageSmart";
 
 type Character = { name: string; src: string };
 
@@ -21,7 +22,7 @@ export default function EuropaliaWorld() {
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <img src={c.src} alt={c.name} loading="lazy" decoding="async" />
+              <ImageSmart src={c.src} alt={c.name} />
               <div className="name">{c.name}</div>
             </article>
           ))}

--- a/src/pages/worlds/Greenlandia.tsx
+++ b/src/pages/worlds/Greenlandia.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
+import ImageSmart from "../../components/ImageSmart";
 
 type Character = { name: string; src: string };
 
@@ -21,7 +22,7 @@ export default function GreenlandiaWorld() {
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <img src={c.src} alt={c.name} loading="lazy" decoding="async" />
+              <ImageSmart src={c.src} alt={c.name} />
               <div className="name">{c.name}</div>
             </article>
           ))}

--- a/src/pages/worlds/Japonica.tsx
+++ b/src/pages/worlds/Japonica.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
+import ImageSmart from "../../components/ImageSmart";
 
 type Character = { name: string; src: string };
 
@@ -21,7 +22,7 @@ export default function JaponicaWorld() {
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <img src={c.src} alt={c.name} loading="lazy" decoding="async" />
+              <ImageSmart src={c.src} alt={c.name} />
               <div className="name">{c.name}</div>
             </article>
           ))}

--- a/src/pages/worlds/Kiwilandia.tsx
+++ b/src/pages/worlds/Kiwilandia.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
+import ImageSmart from "../../components/ImageSmart";
 
 type Character = { name: string; src: string };
 
@@ -21,7 +22,7 @@ export default function KiwilandiaWorld() {
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <img src={c.src} alt={c.name} loading="lazy" decoding="async" />
+              <ImageSmart src={c.src} alt={c.name} />
               <div className="name">{c.name}</div>
             </article>
           ))}

--- a/src/pages/worlds/Madagascaria.tsx
+++ b/src/pages/worlds/Madagascaria.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
+import ImageSmart from "../../components/ImageSmart";
 
 type Character = { name: string; src: string };
 
@@ -21,7 +22,7 @@ export default function MadagascariaWorld() {
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <img src={c.src} alt={c.name} loading="lazy" decoding="async" />
+              <ImageSmart src={c.src} alt={c.name} />
               <div className="name">{c.name}</div>
             </article>
           ))}

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -3,6 +3,7 @@ import { WORLDS } from "../../data/worlds";
 import Meta from "../../components/Meta";
 import Page from "../../layouts/Page";
 import { Breadcrumbs } from "../../components/Breadcrumbs";
+import ImageSmart from "../../components/ImageSmart";
 
 export default function WorldsIndex() {
   return (
@@ -13,7 +14,7 @@ export default function WorldsIndex() {
       <div className="cards">
         {WORLDS.map(w => (
           <a className="card" key={w.slug} href={`/worlds/${w.slug}`}>
-            <img src={w.map} alt={`${w.name} map`} loading="lazy" />
+            <ImageSmart src={w.map} alt={`${w.name} map`} />
             <h2>{w.name}</h2>
             <p>{w.blurb}</p>
           </a>

--- a/src/pages/zones/Observations.tsx
+++ b/src/pages/zones/Observations.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Breadcrumbs } from '../../components/Breadcrumbs';
 import PhotoUploader from '../../components/PhotoUploader';
+import ImageSmart from '../../components/ImageSmart';
 import { Observation } from '../../lib/observations/types';
 import {
   addObservation,
@@ -188,7 +189,7 @@ export default function Observations() {
                   onClick={() => setSelected(o)}
                   aria-label={`Open ${o.title}`}
                 >
-                  <img src={o.thumb} alt={o.title} />
+                  <ImageSmart src={o.thumb} alt={o.title} />
                   <div className="obs-info">
                     <div className="obs-title">{o.title}</div>
                     <div className="tag-row">
@@ -207,7 +208,7 @@ export default function Observations() {
 
             {selected && (
               <aside className="obs-panel">
-                <img src={selected.src} alt={selected.title} className="obs-full" />
+                <ImageSmart src={selected.src} alt={selected.title} className="obs-full" />
                 <div className="form-row">
                   <input
                     className="input"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import HubCard from '../components/HubCard';
 import HubGrid from '../components/HubGrid';
 import "./Home.css";
+import ImageSmart from '../components/ImageSmart';
 
 export default function Home() {
   return (
@@ -8,7 +9,7 @@ export default function Home() {
       {/* Clean hero (no oversized emoji) */}
       <header className="home-hero">
         <h1>
-          <img
+          <ImageSmart
             className="brandmark"
             src="/favicon-32x32.png"
             srcSet="/favicon-32x32.png 1x, /favicon-64x64.png 2x"
@@ -16,6 +17,7 @@ export default function Home() {
             height={32}
             alt=""
             aria-hidden="true"
+            priority
           />
           Welcome to the Naturverse™
         </h1>


### PR DESCRIPTION
## Summary
- add `ImageSmart` helper to provide lazy loading, async decoding and optional priority
- swap non-critical `<img>` tags for `ImageSmart` across pages and components
- keep above-the-fold images eager via `priority`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "next/head")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a9367082ac83299fe56610b93e043d