### PR TITLE
perf(fonts): preload Inter + preconnect gstatic for faster paint

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Naturverse</title>
 
+    <!-- Performance: Preconnect + preload main font -->
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+    />
+
     <!-- PWA + icons -->
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="manifest" href="/site.webmanifest" />
@@ -18,19 +30,6 @@
     <link rel="preload" as="style" href="/src/styles/main.css" />
     <link rel="stylesheet" href="/src/styles/main.css" />
     <link rel="stylesheet" href="/src/styles/pages.css" />
-
-    <!-- Fonts: preload + swap -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
-    />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
-    />
 
       <!-- Canonical -->
       <link rel="canonical" href="https://thenaturverse.com/" />

--- a/src/main.css
+++ b/src/main.css
@@ -6,6 +6,11 @@
 @import './styles/skeleton.css';
 @import './styles/cards-unify.css';
 
+body {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
 /* simple "Coming Soon" pill used on cards */
 .tag.soon {
   display: inline-block;


### PR DESCRIPTION
## Summary
- preload Inter font and preconnect to Google static domain for faster paint
- apply Inter font family across site body

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`
- `npm run build` *(fails: Rollup failed to resolve import "next/head")*


------
https://chatgpt.com/codex/tasks/task_e_68a938e62bd88329b2495211f49cc7e8