### PR TITLE
Supabase MVP schema + RLS (idempotent, safe)

### DIFF
--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -1,0 +1,9 @@
+# Supabase setup (30 sec)
+1) In Supabase Studio → SQL editor → run, in order:
+   - `supabase/schema.sql`
+   - `supabase/storage-policies.sql`
+   - `supabase/seed.sql`
+2) Confirm:
+   - `natur.profiles` exists; RLS enabled.
+   - Buckets `avatars`, `navatars` are public read; you can write to `<userId>/...`.
+3) App can keep using local-only demo until we wire the client.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,51 +1,271 @@
-create table if not exists profiles (
-  id uuid primary key references auth.users(id) on delete cascade,
-  username text,
-  wallet_address text,
-  avatar_url text,
-  created_at timestamptz default now()
-);
+-- ===========
+-- Naturverse MVP Schema + RLS (idempotent)
+-- Run in Supabase SQL editor as role: postgres
+-- ===========
 
-create table if not exists tips (
-  id bigserial primary key,
-  title text,
-  body text,
-  created_at timestamptz default now()
-);
+-- Extensions (idempotent)
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
-create table if not exists playlists (
-  id bigserial primary key,
-  name text,
+-- Schema
+CREATE SCHEMA IF NOT EXISTS natur;
+
+-- ---------- Helpers ----------
+-- updated_at trigger
+CREATE OR REPLACE FUNCTION natur.set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+-- ---------- PROFILES ----------
+-- One row per auth user (id mirrors auth.users.id)
+DROP TABLE IF EXISTS natur.profiles CASCADE;
+CREATE TABLE natur.profiles (
+  id          uuid PRIMARY KEY,              -- auth.uid()
+  email       text UNIQUE,
+  display_name text,
+  avatar_url  text,
+  kid_safe    boolean DEFAULT true,
+  theme       text DEFAULT 'system',
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+CREATE TRIGGER trg_profiles_updated
+BEFORE UPDATE ON natur.profiles
+FOR EACH ROW EXECUTE FUNCTION natur.set_updated_at();
+
+-- Enable RLS
+ALTER TABLE natur.profiles ENABLE ROW LEVEL SECURITY;
+
+-- (Re)create policies
+DROP POLICY IF EXISTS "Profiles: read self"   ON natur.profiles;
+DROP POLICY IF EXISTS "Profiles: upsert self" ON natur.profiles;
+DROP POLICY IF EXISTS "Profiles: update self" ON natur.profiles;
+
+CREATE POLICY "Profiles: read self"
+  ON natur.profiles FOR SELECT TO authenticated
+  USING (auth.uid() = id);
+
+CREATE POLICY "Profiles: upsert self"
+  ON natur.profiles FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "Profiles: update self"
+  ON natur.profiles FOR UPDATE TO authenticated
+  USING (auth.uid() = id) WITH CHECK (auth.uid() = id);
+
+GRANT USAGE ON SCHEMA natur TO authenticated, anon;
+GRANT SELECT, INSERT, UPDATE ON natur.profiles TO authenticated;
+REVOKE ALL ON natur.profiles FROM anon;
+
+-- ---------- NAVATARS (character cards) ----------
+DROP TABLE IF EXISTS natur.navatars CASCADE;
+CREATE TABLE natur.navatars (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid NOT NULL REFERENCES natur.profiles(id) ON DELETE CASCADE,
+  name        text,
+  base_type   text NOT NULL,        -- 'Animal' | 'Fruit' | 'Insect' | 'Spirit'
+  backstory   text,
+  image_url   text,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_navatars_user ON natur.navatars(user_id);
+CREATE TRIGGER trg_navatars_updated
+BEFORE UPDATE ON natur.navatars
+FOR EACH ROW EXECUTE FUNCTION natur.set_updated_at();
+
+ALTER TABLE natur.navatars ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Navatars: owner read"   ON natur.navatars;
+DROP POLICY IF EXISTS "Navatars: owner write"  ON natur.navatars;
+
+CREATE POLICY "Navatars: owner read"
+  ON natur.navatars FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Navatars: owner write"
+  ON natur.navatars FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON natur.navatars TO authenticated;
+
+-- ---------- PASSPORT: Stamps ----------
+DROP TABLE IF EXISTS natur.passport_stamps CASCADE;
+CREATE TABLE natur.passport_stamps (
+  id          bigserial PRIMARY KEY,
+  user_id     uuid NOT NULL REFERENCES natur.profiles(id) ON DELETE CASCADE,
+  kingdom     text NOT NULL,        -- e.g., 'Thailandia'
+  stamped_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, kingdom)
+);
+CREATE INDEX IF NOT EXISTS idx_stamps_user ON natur.passport_stamps(user_id);
+
+ALTER TABLE natur.passport_stamps ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Stamps: owner read" ON natur.passport_stamps;
+DROP POLICY IF EXISTS "Stamps: owner write" ON natur.passport_stamps;
+
+CREATE POLICY "Stamps: owner read"
+  ON natur.passport_stamps FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Stamps: owner write"
+  ON natur.passport_stamps FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON natur.passport_stamps TO authenticated;
+
+-- ---------- Badges (catalog + user_badges) ----------
+DROP TABLE IF EXISTS natur.badges CASCADE;
+CREATE TABLE natur.badges (
+  id          text PRIMARY KEY,     -- e.g., 'explorer_01'
+  name        text NOT NULL,
   description text,
-  cover_url text,
-  stream_url text,
-  created_at timestamptz default now()
+  icon        text,                 -- emoji or URL
+  active      boolean DEFAULT true
 );
 
-create table if not exists wellness_tips (
-  id bigserial primary key,
-  text text not null,
-  created_at timestamptz default now()
+DROP TABLE IF EXISTS natur.user_badges CASCADE;
+CREATE TABLE natur.user_badges (
+  user_id     uuid NOT NULL REFERENCES natur.profiles(id) ON DELETE CASCADE,
+  badge_id    text NOT NULL REFERENCES natur.badges(id),
+  awarded_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, badge_id)
 );
 
-create table if not exists feedback (
-  id bigserial primary key,
-  user_id uuid references auth.users(id),
-  message text not null,
-  created_at timestamptz default now()
+ALTER TABLE natur.badges DISABLE ROW LEVEL SECURITY; -- public read via anon
+GRANT SELECT ON natur.badges TO anon, authenticated;
+
+ALTER TABLE natur.user_badges ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "UserBadges: owner read"  ON natur.user_badges;
+DROP POLICY IF EXISTS "UserBadges: owner write" ON natur.user_badges;
+
+CREATE POLICY "UserBadges: owner read"
+  ON natur.user_badges FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "UserBadges: owner write"
+  ON natur.user_badges FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT, DELETE ON natur.user_badges TO authenticated;
+
+-- ---------- XP events + NATUR coin ledger ----------
+DROP TABLE IF EXISTS natur.xp_events CASCADE;
+CREATE TABLE natur.xp_events (
+  id          bigserial PRIMARY KEY,
+  user_id     uuid NOT NULL REFERENCES natur.profiles(id) ON DELETE CASCADE,
+  source      text NOT NULL,      -- 'quiz', 'story', etc.
+  amount      int  NOT NULL CHECK (amount <> 0),
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_xp_user ON natur.xp_events(user_id);
+
+ALTER TABLE natur.xp_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "XP: owner read"  ON natur.xp_events;
+DROP POLICY IF EXISTS "XP: owner write" ON natur.xp_events;
+
+CREATE POLICY "XP: owner read"
+  ON natur.xp_events FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "XP: owner write"
+  ON natur.xp_events FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT ON natur.xp_events TO authenticated;
+
+DROP VIEW IF EXISTS natur.user_xp;
+CREATE VIEW natur.user_xp AS
+SELECT user_id, COALESCE(SUM(amount),0)::int AS xp
+FROM natur.xp_events
+GROUP BY user_id;
+
+DROP TABLE IF EXISTS natur.natur_ledger CASCADE;
+CREATE TABLE natur.natur_ledger (
+  id          bigserial PRIMARY KEY,
+  user_id     uuid NOT NULL REFERENCES natur.profiles(id) ON DELETE CASCADE,
+  delta       int NOT NULL,       -- positive earn, negative spend
+  reason      text,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_ledger_user ON natur.natur_ledger(user_id);
+
+ALTER TABLE natur.natur_ledger ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "NATUR: owner read"  ON natur.natur_ledger;
+DROP POLICY IF EXISTS "NATUR: owner write" ON natur.natur_ledger;
+
+CREATE POLICY "NATUR: owner read"
+  ON natur.natur_ledger FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "NATUR: owner write"
+  ON natur.natur_ledger FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT ON natur.natur_ledger TO authenticated;
+
+DROP VIEW IF EXISTS natur.natur_balances;
+CREATE VIEW natur.natur_balances AS
+SELECT user_id, COALESCE(SUM(delta),0)::int AS balance
+FROM natur.natur_ledger
+GROUP BY user_id;
+
+-- ---------- Marketplace (catalog + wishlists) ----------
+DROP TABLE IF EXISTS natur.products CASCADE;
+CREATE TABLE natur.products (
+  id           bigserial PRIMARY KEY,
+  slug         text UNIQUE,
+  name         text NOT NULL,
+  description  text,
+  price_cents  int NOT NULL CHECK (price_cents >= 0),
+  active       boolean DEFAULT true,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+-- Public read
+ALTER TABLE natur.products DISABLE ROW LEVEL SECURITY;
+GRANT SELECT ON natur.products TO anon, authenticated;
+
+DROP TABLE IF EXISTS natur.wishlists CASCADE;
+CREATE TABLE natur.wishlists (
+  id          bigserial PRIMARY KEY,
+  user_id     uuid NOT NULL REFERENCES natur.profiles(id) ON DELETE CASCADE,
+  product_id  bigint NOT NULL REFERENCES natur.products(id) ON DELETE CASCADE,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, product_id)
 );
 
-alter table profiles enable row level security;
-alter table tips enable row level security;
-alter table playlists enable row level security;
-alter table wellness_tips enable row level security;
-alter table feedback enable row level security;
+ALTER TABLE natur.wishlists ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Wishlists: owner read"  ON natur.wishlists;
+DROP POLICY IF EXISTS "Wishlists: owner write" ON natur.wishlists;
 
-create policy "public read" on tips for select using (true);
-create policy "public read" on playlists for select using (true);
-create policy "public read" on wellness_tips for select using (true);
+CREATE POLICY "Wishlists: owner read"
+  ON natur.wishlists FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
 
-create policy "self read"  on profiles for select using (auth.uid() = id);
-create policy "self write" on profiles for update using (auth.uid() = id);
+CREATE POLICY "Wishlists: owner write"
+  ON natur.wishlists FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
 
-create policy "insert own" on feedback for insert with check (auth.uid() = user_id);
+GRANT SELECT, INSERT, DELETE ON natur.wishlists TO authenticated;
+
+-- ---------- Newsletter signups (public form) ----------
+DROP TABLE IF EXISTS natur.newsletter_subscribers CASCADE;
+CREATE TABLE natur.newsletter_subscribers (
+  id         bigserial PRIMARY KEY,
+  email      text UNIQUE NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE natur.newsletter_subscribers ENABLE ROW LEVEL SECURITY;
+-- Allow anyone to insert; only service role can read
+DROP POLICY IF EXISTS "Newsletter: public insert" ON natur.newsletter_subscribers;
+CREATE POLICY "Newsletter: public insert"
+  ON natur.newsletter_subscribers FOR INSERT TO anon, authenticated
+  WITH CHECK (true);
+REVOKE ALL ON natur.newsletter_subscribers FROM anon, authenticated;
+
+-- ---------- Grants (final touch) ----------
+GRANT USAGE ON SCHEMA natur TO anon, authenticated;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,9 @@
+-- Minimal seed data
+INSERT INTO natur.badges (id, name, description, icon) VALUES
+  ('explorer_01','Explorer','Created a Navatar','🧭')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO natur.products (slug, name, description, price_cents, active) VALUES
+  ('tee-classic','Classic Tee','Naturverse logo tee', 2400, true),
+  ('sticker-pack','Sticker Pack','14 kingdoms stickers', 900, true)
+ON CONFLICT (slug) DO NOTHING;

--- a/supabase/storage-policies.sql
+++ b/supabase/storage-policies.sql
@@ -1,0 +1,36 @@
+-- Storage buckets: avatars, navatars (create from Studio if not present)
+-- RLS policies so users can read public files and write their own
+
+-- Public read for these buckets
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('avatars','avatars', true)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('navatars','navatars', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Policies (idempotent)
+-- Delete existing with same names if present
+DO $$
+BEGIN
+  DELETE FROM storage.policies WHERE name IN
+    ('avatars-public-read','avatars-owner-write','navatars-public-read','navatars-owner-write');
+EXCEPTION WHEN OTHERS THEN NULL;
+END$$;
+
+-- Public read
+INSERT INTO storage.policies (name, bucket_id, definition, action)
+VALUES
+('avatars-public-read','avatars', '(bucket_id = ''avatars'')', 'SELECT'),
+('navatars-public-read','navatars', '(bucket_id = ''navatars'')', 'SELECT');
+
+-- Owner write (folder per user: userId/*)
+INSERT INTO storage.policies (name, bucket_id, definition, action)
+VALUES
+('avatars-owner-write','avatars',
+ 'auth.role() = ''authenticated'' AND (storage.foldername(name))[1] = auth.uid()::text',
+ 'INSERT'),
+('navatars-owner-write','navatars',
+ 'auth.role() = ''authenticated'' AND (storage.foldername(name))[1] = auth.uid()::text',
+ 'INSERT');


### PR DESCRIPTION
## Summary
- add idempotent SQL schema with profiles, navatars, badges, XP ledger, marketplace, and newsletter tables secured by RLS
- configure storage bucket policies for avatars and navatars
- seed sample badges and products and document setup steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Property 'title' does not exist on type 'IntrinsicAttributes')*

------
https://chatgpt.com/codex/tasks/task_e_68a95f5fe1f0832984a173e0b04bd7ff