### PR TITLE
Add Supabase client and type helpers

### DIFF
--- a/docs/env.example
+++ b/docs/env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '../types/db';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase environment variables');
+}
+
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    detectSessionInUrl: true,
+  },
+});

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,0 +1,57 @@
+export type Database = {
+  natur: {
+    Tables: {
+      profiles: {
+        Row: {
+          id: string;
+          email: string | null;
+          display_name: string | null;
+          avatar_url: string | null;
+          kid_safe: boolean | null;
+          theme: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id: string;
+          email?: string | null;
+          display_name?: string | null;
+          avatar_url?: string | null;
+          kid_safe?: boolean | null;
+          theme?: string | null;
+        };
+        Update: Partial<Database['natur']['Tables']['profiles']['Insert']>;
+      };
+      navatars: {
+        Row: {
+          id: string;
+          user_id: string;
+          name: string | null;
+          base_type: string;
+          backstory: string | null;
+          image_url: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: Omit<
+          Database['natur']['Tables']['navatars']['Row'],
+          'id' | 'created_at' | 'updated_at'
+        >;
+        Update: Partial<Database['natur']['Tables']['navatars']['Insert']>;
+      };
+      passport_stamps: {
+        Row: { id: number; user_id: string; kingdom: string; stamped_at: string };
+        Insert: { user_id: string; kingdom: string };
+        Update: Partial<{ kingdom: string }>;
+      };
+    };
+    Views: {
+      user_xp: {
+        Row: { user_id: string; xp: number };
+      };
+      natur_balances: {
+        Row: { user_id: string; balance: number };
+      };
+    };
+  };
+};


### PR DESCRIPTION
## Summary
- initialize Supabase client with environment safeguards
- add typed Database definitions for profiles, navatars, stamps, and views
- document required Supabase env vars

## Testing
- `npm run typecheck` *(fails: Cannot find module '@supabase/supabase-js'; plus existing attribute typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9609867188329ad9e629439d90714