### PR TITLE
feat: add typed Supabase helpers

### DIFF
--- a/docs/supabase-usage.md
+++ b/docs/supabase-usage.md
@@ -1,0 +1,8 @@
+# Supabase Usage
+
+- Where env vars live and how to create service role (not needed client-side).
+- One-liners to verify:
+  - `select * from natur.profiles limit 1;`
+  - `select * from natur.navatars limit 1;`
+  - `select * from natur.passport_stamps limit 1;`
+- Example snippet for future wiring into Passport buttons (commented).

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^6.28.0",
+    "@supabase/supabase-js": "^2.43.4"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",

--- a/src/lib/api/navatar.ts
+++ b/src/lib/api/navatar.ts
@@ -1,0 +1,39 @@
+import { supabase } from '../db'
+import type { Database } from '../../types/db'
+
+type Navatar = Database['natur']['Tables']['navatars']['Row']
+type NavatarInsert = Database['natur']['Tables']['navatars']['Insert']
+type NavatarUpdate = Database['natur']['Tables']['navatars']['Update']
+
+export async function listMyNavatars() {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return []
+  const { data, error } = await supabase
+    .from('navatars')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
+  if (error) throw error
+  return data as Navatar[]
+}
+
+export async function createNavatar(input: NavatarInsert) {
+  const { data, error } = await supabase
+    .from('navatars')
+    .insert(input)
+    .select()
+    .single()
+  if (error) throw error
+  return data as Navatar
+}
+
+export async function updateNavatar(id: string, patch: NavatarUpdate) {
+  const { data, error } = await supabase
+    .from('navatars')
+    .update(patch)
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) throw error
+  return data as Navatar
+}

--- a/src/lib/api/passport.ts
+++ b/src/lib/api/passport.ts
@@ -1,0 +1,42 @@
+import { supabase } from '../db'
+import type { Database } from '../../types/db'
+
+type Stamp = Database['natur']['Tables']['passport_stamps']['Row']
+
+export async function listMyStamps() {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return []
+  const { data, error } = await supabase
+    .from('passport_stamps')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('stamped_at', { ascending: false })
+  if (error) throw error
+  return data as Stamp[]
+}
+
+export async function toggleStamp(kingdom: string) {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('No auth user')
+
+  // if exists -> delete, else -> insert
+  const { data: existing } = await supabase
+    .from('passport_stamps')
+    .select('id')
+    .eq('user_id', user.id)
+    .eq('kingdom', kingdom)
+    .maybeSingle()
+
+  if (existing) {
+    const { error } = await supabase.from('passport_stamps')
+      .delete()
+      .eq('id', existing.id)
+    if (error) throw error
+    return { action: 'removed' as const }
+  } else {
+    const { error } = await supabase.from('passport_stamps')
+      .insert({ user_id: user.id, kingdom })
+    if (error) throw error
+    return { action: 'added' as const }
+  }
+}

--- a/src/lib/api/profile.ts
+++ b/src/lib/api/profile.ts
@@ -1,0 +1,36 @@
+import { supabase } from '../db'
+import type { Database } from '../../types/db'
+
+type Profile = Database['natur']['Tables']['profiles']['Row']
+type ProfileInsert = Database['natur']['Tables']['profiles']['Insert']
+type ProfileUpdate = Database['natur']['Tables']['profiles']['Update']
+
+export async function getCurrentUser() {
+  const { data } = await supabase.auth.getUser()
+  return data.user ?? null
+}
+
+export async function getMyProfile() {
+  const user = await getCurrentUser()
+  if (!user) return null
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', user.id)
+    .maybeSingle()
+  if (error) throw error
+  return data as Profile | null
+}
+
+export async function upsertMyProfile(patch: ProfileUpdate | ProfileInsert) {
+  const user = await getCurrentUser()
+  if (!user) throw new Error('No auth user')
+  const row: ProfileInsert = { id: user.id, ...patch }
+  const { data, error } = await supabase
+    .from('profiles')
+    .upsert(row)
+    .select()
+    .single()
+  if (error) throw error
+  return data as Profile
+}

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -1,0 +1,17 @@
+const KEY_ACTIVE = "naturverse.activeNavatar";
+const KEY_LIBRARY = "naturverse.navatarLibrary";
+
+export function loadActive<T>(): T | null {
+  try { return JSON.parse(localStorage.getItem(KEY_ACTIVE) || "null"); } catch { return null; }
+}
+export function saveActive<T>(v: T | null) {
+  if (v == null) localStorage.removeItem(KEY_ACTIVE);
+  else localStorage.setItem(KEY_ACTIVE, JSON.stringify(v));
+}
+
+export function loadLibrary<T>(): T[] {
+  try { return JSON.parse(localStorage.getItem(KEY_LIBRARY) || "[]"); } catch { return []; }
+}
+export function saveLibrary<T>(list: T[]) {
+  localStorage.setItem(KEY_LIBRARY, JSON.stringify(list));
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,17 +1,20 @@
-const KEY_ACTIVE = "naturverse.activeNavatar";
-const KEY_LIBRARY = "naturverse.navatarLibrary";
+import { supabase } from './db'
 
-export function loadActive<T>(): T | null {
-  try { return JSON.parse(localStorage.getItem(KEY_ACTIVE) || "null"); } catch { return null; }
-}
-export function saveActive<T>(v: T | null) {
-  if (v == null) localStorage.removeItem(KEY_ACTIVE);
-  else localStorage.setItem(KEY_ACTIVE, JSON.stringify(v));
+export async function uploadAvatar(file: File, path: string) {
+  // Bucket policies created earlier allow user-specific write
+  const { data, error } = await supabase.storage
+    .from('avatars')
+    .upload(path, file, { upsert: true })
+  if (error) throw error
+  const { data: url } = supabase.storage.from('avatars').getPublicUrl(data.path)
+  return url.publicUrl
 }
 
-export function loadLibrary<T>(): T[] {
-  try { return JSON.parse(localStorage.getItem(KEY_LIBRARY) || "[]"); } catch { return []; }
-}
-export function saveLibrary<T>(list: T[]) {
-  localStorage.setItem(KEY_LIBRARY, JSON.stringify(list));
+export async function uploadNavatarImage(file: File, path: string) {
+  const { data, error } = await supabase.storage
+    .from('navatars')
+    .upload(path, file, { upsert: true })
+  if (error) throw error
+  const { data: url } = supabase.storage.from('navatars').getPublicUrl(data.path)
+  return url.publicUrl
 }

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 import type { Navatar, NavatarBase } from "../types/navatar";
 import { SPECIES, POWERS_BANK, randomFrom } from "../lib/navatarCatalog";
-import { loadActive, saveActive, loadLibrary, saveLibrary } from "../lib/storage";
+import { loadActive, saveActive, loadLibrary, saveLibrary } from "../lib/localStorage";
 import NavatarCard from "../components/NavatarCard";
 
 const BASES: NavatarBase[] = ["Animal", "Fruit", "Insect", "Spirit"];


### PR DESCRIPTION
## Summary
- add typed profile, navatar, and passport-stamp data access helpers
- add storage helpers for avatar and navatar uploads
- document supabase usage and rename local storage helpers

## Testing
- `npm run typecheck` *(fails: Cannot find module '@supabase/supabase-js'; TypeScript intrinsic attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9622c03c88329983726f5a6d9583f