### PR TITLE
Add auth UI skeleton and Supabase auth helpers

### DIFF
--- a/docs/auth-usage.md
+++ b/docs/auth-usage.md
@@ -1,0 +1,5 @@
+# Auth Components Usage
+
+- Example of mounting `<AuthModal />` with a local `useState` in any page.
+- How to add `<SessionBadge />` to the header.
+- Note about `emailRedirectTo` and where to put the success route later (e.g., `/passport`).

--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -1,0 +1,76 @@
+/* Lightweight, framework-agnostic TSX. It doesn’t mount itself.
+   Import and render it where you want later. */
+import { useState } from 'react';
+import { signInWithEmail } from '../../lib/auth';
+import './auth.css';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  successMessage?: string;
+  redirectTo?: string;
+};
+
+export default function AuthModal({
+  isOpen,
+  onClose,
+  successMessage = 'Check your email for a sign-in link.',
+  redirectTo,
+}: Props) {
+  const [email, setEmail] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setErr(null);
+    setMsg(null);
+    try {
+      await signInWithEmail(email.trim(), redirectTo);
+      setMsg(successMessage);
+    } catch (e: any) {
+      setErr(e?.message ?? 'Sign-in failed.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="nv-auth-backdrop" role="dialog" aria-modal="true">
+      <div className="nv-auth-modal">
+        <button className="nv-auth-close" onClick={onClose} aria-label="Close">
+          ×
+        </button>
+        <h3>Sign in</h3>
+        <p className="nv-auth-sub">Use your email to get a magic link.</p>
+        <form onSubmit={onSubmit}>
+          <label className="nv-auth-label">
+            Email
+            <input
+              type="email"
+              inputMode="email"
+              autoComplete="email"
+              placeholder="you@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.currentTarget.value)}
+              required
+              className="nv-auth-input"
+            />
+          </label>
+          <button className="nv-auth-button" disabled={busy}>
+            {busy ? 'Sending…' : 'Send magic link'}
+          </button>
+        </form>
+        {msg && <p className="nv-auth-ok">{msg}</p>}
+        {err && <p className="nv-auth-err">{err}</p>}
+        <p className="nv-auth-small">
+          We never post without permission. One-click sign out anytime.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/SessionBadge.tsx
+++ b/src/components/auth/SessionBadge.tsx
@@ -1,0 +1,26 @@
+// Tiny status chip you can drop in the header later
+import { useEffect, useState } from 'react';
+import { getUser, signOut } from '../../lib/auth';
+import './auth.css';
+
+export default function SessionBadge() {
+  const [email, setEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    getUser()
+      .then((u) => setEmail(u?.email ?? null))
+      .catch(() => setEmail(null));
+  }, []);
+
+  if (!email) return null;
+
+  return (
+    <div className="nv-session-chip" title={email}>
+      <span className="nv-session-dot" />
+      <span className="nv-session-email">{email}</span>
+      <button className="nv-session-out" onClick={() => signOut().then(() => location.reload())}>
+        Sign out
+      </button>
+    </div>
+  );
+}

--- a/src/components/auth/auth.css
+++ b/src/components/auth/auth.css
@@ -1,0 +1,103 @@
+/* Minimal, neutral styles; isolated class names */
+
+.nv-auth-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: grid;
+  place-items: center;
+  z-index: 50;
+}
+
+.nv-auth-modal {
+  width: 92%;
+  max-width: 420px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+  padding: 20px 22px;
+}
+
+.nv-auth-close {
+  float: right;
+  border: 0;
+  background: transparent;
+  font-size: 20px;
+  cursor: pointer;
+}
+.nv-auth-sub {
+  margin-top: 4px;
+  color: #667085;
+}
+.nv-auth-label {
+  display: block;
+  font-weight: 600;
+  margin: 12px 0 6px;
+}
+.nv-auth-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #c9d4f5;
+  border-radius: 8px;
+  outline: none;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0);
+}
+.nv-auth-input:focus {
+  border-color: #6aa0ff;
+}
+
+.nv-auth-button {
+  margin-top: 12px;
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 0;
+  background: linear-gradient(#5ea1ff, #2873e6);
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.nv-auth-ok {
+  color: #067647;
+  margin-top: 10px;
+}
+.nv-auth-err {
+  color: #b42318;
+  margin-top: 10px;
+}
+.nv-auth-small {
+  color: #98a2b3;
+  font-size: 12px;
+  margin-top: 12px;
+}
+
+/* Session chip */
+.nv-session-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #eef4ff;
+  border: 1px solid #c9d4f5;
+  font-size: 12px;
+}
+.nv-session-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22c55e;
+}
+.nv-session-email {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.nv-session-out {
+  border: 0;
+  background: transparent;
+  color: #2463eb;
+  cursor: pointer;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,29 @@
+// Thin wrappers around supabase-js so pages/components don't touch the client directly
+import { supabase } from './db';
+
+export async function getSession() {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) throw error;
+  return data.session ?? null;
+}
+
+export async function getUser() {
+  const { data, error } = await supabase.auth.getUser();
+  if (error) throw error;
+  return data.user ?? null;
+}
+
+export async function signInWithEmail(email: string, redirectTo?: string) {
+  if (!/^\S+@\S+\.\S+$/.test(email)) throw new Error('Please enter a valid email.');
+  const { error } = await supabase.auth.signInWithOtp({
+    email,
+    options: { emailRedirectTo: redirectTo },
+  });
+  if (error) throw error;
+  return true;
+}
+
+export async function signOut() {
+  const { error } = await supabase.auth.signOut();
+  if (error) throw error;
+}


### PR DESCRIPTION
## Summary
- add thin Supabase auth wrappers (getSession, getUser, signInWithEmail, signOut)
- include AuthModal and SessionBadge components with minimal styling
- document basic usage of new auth components

## Testing
- `npm run typecheck` *(fails: Cannot find module '@supabase/supabase-js' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9644d799c8329a52181eef34175c8