### PR TITLE
feat: add typed models and data mappers

### DIFF
--- a/docs/data-mappers.md
+++ b/docs/data-mappers.md
@@ -1,0 +1,5 @@
+# Data mappers
+
+- What each mapper does + expected inputs/outputs.
+- Example snippet for computing passport progress and XP totals from Supabase queries (to be wired later).
+- Reminder: these files aren’t imported anywhere yet, so they are safe to merge now.

--- a/src/lib/__examples__/mapper-examples.ts
+++ b/src/lib/__examples__/mapper-examples.ts
@@ -1,0 +1,22 @@
+/* Dev-only examples to see shapes while we’re offline */
+import {
+  mapStampRowsToProgress,
+  mapXpRowsToTotals,
+  mapProductsToSections,
+  mapWishlistJoin,
+  mapNavatarRow,
+} from '../mappers'
+import {
+  ALL_KINGDOMS,
+  sampleNavatar,
+  sampleProducts,
+  sampleStamps,
+  sampleWishlist,
+  sampleXp,
+} from '../fixtures'
+
+console.log('Passport:', mapStampRowsToProgress(sampleStamps, ALL_KINGDOMS))
+console.log('XP:', mapXpRowsToTotals(sampleXp))
+console.log('Catalog:', mapProductsToSections(sampleProducts, ['headwear', 'tops']))
+console.log('Wishlist:', mapWishlistJoin(sampleWishlist, sampleProducts))
+console.log('Navatar:', mapNavatarRow(sampleNavatar))

--- a/src/lib/fixtures.ts
+++ b/src/lib/fixtures.ts
@@ -1,0 +1,99 @@
+import {
+  NavatarRow,
+  PassportStampRow,
+  ProductRow,
+  WishlistRow,
+  XpLedgerRow,
+} from './types'
+
+export const ALL_KINGDOMS = [
+  'thailandia',
+  'amerilandia',
+  'indillandia',
+  'brazilandia',
+  'australandia',
+  'chilanda',
+  'japonica',
+  'africana',
+  'europalia',
+  'britannula',
+  'kiwilandia',
+  'madagascaria',
+  'greenlandia',
+  'antarctland',
+]
+
+export const sampleStamps: PassportStampRow[] = [
+  {
+    id: 's1',
+    owner_id: 'u1',
+    kingdom: 'thailandia',
+    stamped_at: new Date().toISOString(),
+  },
+  {
+    id: 's2',
+    owner_id: 'u1',
+    kingdom: 'amerilandia',
+    stamped_at: new Date().toISOString(),
+  },
+]
+
+export const sampleXp: XpLedgerRow[] = [
+  {
+    id: 'x1',
+    owner_id: 'u1',
+    delta: 10,
+    reason: 'welcome',
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: 'x2',
+    owner_id: 'u1',
+    delta: 5,
+    reason: 'quest',
+    created_at: new Date(Date.now() - 3 * 864e5).toISOString(),
+  },
+]
+
+export const sampleProducts: ProductRow[] = [
+  {
+    id: 'p1',
+    slug: 'kiwi-cap',
+    title: 'Kiwi Cap',
+    price_cents: 1999,
+    image_url: null,
+    tags: ['headwear'],
+    active: true,
+  },
+  {
+    id: 'p2',
+    slug: 'penguin-tee',
+    title: 'Penguin Tee',
+    price_cents: 2599,
+    image_url: null,
+    tags: ['tops'],
+    active: true,
+  },
+]
+
+export const sampleWishlist: WishlistRow[] = [
+  {
+    id: 'w1',
+    owner_id: 'u1',
+    product_id: 'p2',
+    created_at: new Date().toISOString(),
+  },
+]
+
+export const sampleNavatar: NavatarRow = {
+  id: 'n1',
+  owner_id: 'u1',
+  name: 'Macaw',
+  base_type: 'animal',
+  species: 'Macaw',
+  powers: ['Puzzle Vision', 'Sunbeam Heal'],
+  backstory: 'Explorer of the 14 kingdoms.',
+  photo_url: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+}

--- a/src/lib/mappers.ts
+++ b/src/lib/mappers.ts
@@ -1,0 +1,131 @@
+import {
+  BadgeRow,
+  CatalogItem,
+  CatalogSection,
+  Navatar,
+  NavatarRow,
+  PassportProgress,
+  PassportStampRow,
+  ProductRow,
+  Profile,
+  ProfileRow,
+  WishlistItem,
+  WishlistRow,
+  XpLedgerRow,
+  XpTotals,
+} from './types'
+
+/* Utilities */
+const toDate = (iso?: string | null) => (iso ? new Date(iso) : new Date())
+const dollars = (cents: number) => Math.round(cents) / 100
+
+/* Profile */
+export function mapProfileRow(row: ProfileRow): Profile {
+  return {
+    id: row.id,
+    name: row.display_name ?? 'Explorer',
+    email: row.email ?? undefined,
+    avatar: row.photo_url ?? undefined,
+    joinedAt: toDate(row.created_at),
+    updatedAt: toDate(row.updated_at),
+  }
+}
+
+/* Navatar */
+export function mapNavatarRow(row: NavatarRow): Navatar {
+  return {
+    id: row.id,
+    ownerId: row.owner_id,
+    name: row.name ?? 'Navatar',
+    base: row.base_type,
+    species: row.species ?? undefined,
+    powers: row.powers ?? [],
+    backstory: row.backstory ?? undefined,
+    photo: row.photo_url ?? undefined,
+    createdAt: toDate(row.created_at),
+    updatedAt: toDate(row.updated_at),
+  }
+}
+
+/* Passport progress */
+export function mapStampRowsToProgress(
+  rows: PassportStampRow[],
+  allKingdoms: string[]
+): PassportProgress {
+  const stampedSet = new Set(rows.map(r => r.kingdom))
+  const stamped = allKingdoms.filter(k => stampedSet.has(k))
+  const count = stamped.length
+  const total = allKingdoms.length || 1
+  return {
+    totalKingdoms: total,
+    stamped,
+    count,
+    percent: Math.round((count / total) * 100),
+  }
+}
+
+/* XP aggregation */
+export function mapXpRowsToTotals(rows: XpLedgerRow[], now = new Date()): XpTotals {
+  const midnight = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate())
+  const startToday = midnight(now).getTime()
+  const start7 = new Date(now.getTime() - 6 * 24 * 3600 * 1000).getTime() // inclusive of today
+
+  let total = 0,
+    today = 0,
+    last7d = 0
+  for (const r of rows) {
+    const t = new Date(r.created_at).getTime()
+    total += r.delta
+    if (t >= startToday) today += r.delta
+    if (t >= start7) last7d += r.delta
+  }
+  return { total, today, last7d }
+}
+
+/* Catalog & wishlist */
+export function mapProductRow(row: ProductRow): CatalogItem {
+  return {
+    id: row.id,
+    slug: row.slug,
+    title: row.title,
+    price: dollars(row.price_cents),
+    image: row.image_url ?? undefined,
+    tags: row.tags ?? [],
+  }
+}
+
+export function mapProductsToSections(
+  rows: ProductRow[],
+  tagOrder: string[] = []
+): CatalogSection[] {
+  const items = rows.filter(r => r.active).map(mapProductRow)
+  if (!tagOrder.length) return [{ title: 'All', items }]
+  const byTag = new Map<string, CatalogItem[]>()
+  for (const t of tagOrder) byTag.set(t, [])
+  for (const it of items) {
+    const tag = it.tags.find(t => byTag.has(t)) ?? 'All'
+    if (!byTag.has(tag)) byTag.set(tag, [])
+    byTag.get(tag)!.push(it)
+  }
+  return Array.from(byTag.entries()).map(([title, items]) => ({ title, items }))
+}
+
+export function mapWishlistJoin(
+  wishlist: WishlistRow[],
+  products: ProductRow[]
+): WishlistItem[] {
+  const byId = new Map(products.map(p => [p.id, p]))
+  return wishlist
+    .map(w => {
+      const p = byId.get(w.product_id)
+      if (!p || !p.active) return null
+      const base = mapProductRow(p)
+      return { ...base, wishedAt: toDate(w.created_at) }
+    })
+    .filter((x): x is WishlistItem => Boolean(x))
+}
+
+/* Badges (simple pass-through to keep surface consistent) */
+export function mapBadgeRows(rows: BadgeRow[]) {
+  return rows.map(b => ({ ...b }))
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,116 @@
+// Core DB row shapes (what Supabase returns)
+export type ProfileRow = {
+  id: string; // uuid
+  display_name: string | null;
+  email: string | null;
+  photo_url: string | null;
+  created_at: string; // ISO
+  updated_at: string; // ISO
+};
+
+export type NavatarRow = {
+  id: string;
+  owner_id: string;
+  name: string | null;
+  base_type: 'animal' | 'fruit' | 'insect' | 'spirit';
+  species: string | null;
+  powers: string[] | null;
+  backstory: string | null;
+  photo_url: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PassportStampRow = {
+  id: string;
+  owner_id: string;
+  kingdom: string;
+  stamped_at: string;
+};
+
+export type BadgeRow = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  icon: string | null;
+};
+
+export type XpLedgerRow = {
+  id: string;
+  owner_id: string;
+  delta: number;
+  reason: string;
+  created_at: string;
+};
+
+export type ProductRow = {
+  id: string;
+  slug: string;
+  title: string;
+  price_cents: number;
+  image_url: string | null;
+  tags: string[] | null;
+  active: boolean;
+};
+
+export type WishlistRow = {
+  id: string;
+  owner_id: string;
+  product_id: string;
+  created_at: string;
+};
+
+// UI models (what components expect)
+export type Profile = {
+  id: string;
+  name: string;
+  email?: string;
+  avatar?: string;
+  joinedAt: Date;
+  updatedAt: Date;
+};
+
+export type Navatar = {
+  id: string;
+  ownerId: string;
+  name: string;
+  base: NavatarRow['base_type'];
+  species?: string;
+  powers: string[];
+  backstory?: string;
+  photo?: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type PassportProgress = {
+  totalKingdoms: number;
+  stamped: string[]; // kingdom slugs
+  count: number;
+  percent: number; // 0–100
+};
+
+export type XpTotals = {
+  total: number;
+  today: number;
+  last7d: number;
+};
+
+export type CatalogItem = {
+  id: string;
+  slug: string;
+  title: string;
+  price: number; // in dollars
+  image?: string;
+  tags: string[];
+};
+
+export type CatalogSection = {
+  title: string;
+  items: CatalogItem[];
+};
+
+export type WishlistItem = CatalogItem & {
+  wishedAt: Date;
+};


### PR DESCRIPTION
## Summary
- define Supabase row and UI model types
- normalize database rows with mappers for profiles, navatars, stamps, XP, products, wishlists, and badges
- add fixtures and examples plus brief mapper docs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module '@supabase/supabase-js' and existing type errors)*
- `npx ts-node src/lib/__examples__/mapper-examples.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68a96722d0a08329b0e0fb8f880124ec