### PR TITLE
Add Supabase storage helpers and service index

### DIFF
--- a/docs/storage-helpers.md
+++ b/docs/storage-helpers.md
@@ -1,0 +1,9 @@
+# Storage helpers
+
+- Buckets are configured in the Supabase dashboard: `avatars`, `navatars`, and `products`.
+- Helpers allow uploading files and retrieving a public URL.
+
+```ts
+const path = await uploadAvatar(user.id, file);
+const url = getPublicUrl(path);
+```

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,20 +1,37 @@
-import { supabase } from './db'
+import { supabase } from './supabaseClient';
 
-export async function uploadAvatar(file: File, path: string) {
-  // Bucket policies created earlier allow user-specific write
-  const { data, error } = await supabase.storage
-    .from('avatars')
-    .upload(path, file, { upsert: true })
-  if (error) throw error
-  const { data: url } = supabase.storage.from('avatars').getPublicUrl(data.path)
-  return url.publicUrl
+function sanitizeFilename(name: string) {
+  return name.toLowerCase().replace(/[^a-z0-9\.\-_]/g, '_');
 }
 
-export async function uploadNavatarImage(file: File, path: string) {
-  const { data, error } = await supabase.storage
-    .from('navatars')
-    .upload(path, file, { upsert: true })
-  if (error) throw error
-  const { data: url } = supabase.storage.from('navatars').getPublicUrl(data.path)
-  return url.publicUrl
+export async function uploadAvatar(userId: string, file: File) {
+  const ext = file.name.split('.').pop() ?? 'png';
+  const path = `avatars/${userId}/${Date.now()}-${sanitizeFilename(file.name)}.${ext}`;
+
+  const { data, error } = await supabase.storage.from('avatars').upload(path, file, {
+    cacheControl: '3600',
+    upsert: false,
+    contentType: file.type,
+  });
+
+  if (error) throw error;
+  return data?.path;
+}
+
+export async function getPublicUrl(path: string) {
+  const { data } = supabase.storage.from('avatars').getPublicUrl(path);
+  return data.publicUrl;
+}
+
+// Generic helper for other buckets (navatars, products)
+export async function uploadToBucket(bucket: string, userId: string, file: File) {
+  const ext = file.name.split('.').pop() ?? 'png';
+  const filePath = `${userId}/${Date.now()}-${sanitizeFilename(file.name)}.${ext}`;
+  const { data, error } = await supabase.storage.from(bucket).upload(filePath, file, {
+    cacheControl: '3600',
+    upsert: false,
+    contentType: file.type,
+  });
+  if (error) throw error;
+  return data?.path;
 }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,12 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    'Missing Supabase environment variables. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY',
+  );
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,5 @@
+// Single entrypoint for all backend helpers
+export * from '../lib/supabaseClient';
+export * from '../lib/types';
+export * from '../lib/mappers';
+export * from '../lib/storage';


### PR DESCRIPTION
## Summary
- add utilities for uploading files to Supabase storage and retrieving public URLs
- centralize service exports with a services index
- document available storage buckets and sample usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module '@supabase/supabase-js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a96846810883299cb9b7163ec762da