### PR TITLE
Add Supabase auth helpers

### DIFF
--- a/docs/auth-helpers.md
+++ b/docs/auth-helpers.md
@@ -1,0 +1,9 @@
+# Auth helpers
+
+Available helpers:
+
+- `signUp(email, password)`
+- `signIn(email, password)`
+- `signOut()`
+- `getCurrentUser()`
+- `onAuthStateChange(cb)`

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,16 +1,26 @@
 // Thin wrappers around supabase-js so pages/components don't touch the client directly
-import { supabase } from './db';
+import { supabase } from './supabaseClient';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 
-export async function getSession() {
-  const { data, error } = await supabase.auth.getSession();
+/**
+ * Sign up a new user with email + password
+ */
+export async function signUp(email: string, password: string) {
+  const { data, error } = await supabase.auth.signUp({ email, password });
   if (error) throw error;
-  return data.session ?? null;
+  return data;
 }
 
-export async function getUser() {
-  const { data, error } = await supabase.auth.getUser();
+/**
+ * Sign in existing user
+ */
+export async function signIn(email: string, password: string) {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
   if (error) throw error;
-  return data.user ?? null;
+  return data;
 }
 
 export async function signInWithEmail(email: string, redirectTo?: string) {
@@ -23,7 +33,44 @@ export async function signInWithEmail(email: string, redirectTo?: string) {
   return true;
 }
 
+/**
+ * Sign out current user
+ */
 export async function signOut() {
   const { error } = await supabase.auth.signOut();
   if (error) throw error;
+}
+
+/**
+ * Get current user (session aware)
+ */
+export async function getCurrentUser() {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error) throw error;
+  return user;
+}
+
+// Legacy helper, keep for compatibility
+export async function getUser() {
+  return getCurrentUser();
+}
+
+export async function getSession() {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) throw error;
+  return data.session ?? null;
+}
+
+/**
+ * Subscribe to auth state changes
+ */
+export function onAuthStateChange(callback: Function) {
+  return supabase.auth.onAuthStateChange(
+    (_event: AuthChangeEvent, session: Session | null) => {
+      callback(session?.user ?? null);
+    },
+  );
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,3 +3,4 @@ export * from '../lib/supabaseClient';
 export * from '../lib/types';
 export * from '../lib/mappers';
 export * from '../lib/storage';
+export * from '../lib/auth';


### PR DESCRIPTION
## Summary
- add Supabase auth helpers for signing up, signing in, and user session handling
- expose auth helpers via service exports
- document available auth helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module '@supabase/supabase-js' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a9696bca4c832989cd4a3e0ed53cc2