### PR TITLE
feat: add supabase query helpers

### DIFF
--- a/docs/db-helpers.md
+++ b/docs/db-helpers.md
@@ -1,0 +1,5 @@
+# DB query helpers
+
+- Profiles: `getProfile`, `updateProfile`
+- Navatars: `createNavatar`, `getNavatarsByUser`
+- Stamps: `awardStamp`, `getStamps`

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,0 +1,66 @@
+import { supabase } from './supabaseClient';
+
+// --------------------
+// Profiles
+// --------------------
+export async function getProfile(userId: string) {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', userId)
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+export async function updateProfile(userId: string, updates: Record<string, unknown>) {
+  const { data, error } = await supabase
+    .from('profiles')
+    .update(updates)
+    .eq('id', userId)
+    .select();
+  if (error) throw error;
+  return data;
+}
+
+// --------------------
+// Navatars
+// --------------------
+export async function createNavatar(navatar: Record<string, unknown>) {
+  const { data, error } = await supabase
+    .from('navatars')
+    .insert(navatar)
+    .select();
+  if (error) throw error;
+  return data;
+}
+
+export async function getNavatarsByUser(userId: string) {
+  const { data, error } = await supabase
+    .from('navatars')
+    .select('*')
+    .eq('user_id', userId);
+  if (error) throw error;
+  return data;
+}
+
+// --------------------
+// Passport Stamps
+// --------------------
+export async function awardStamp(userId: string, region: string) {
+  const { data, error } = await supabase
+    .from('stamps')
+    .insert({ user_id: userId, region })
+    .select();
+  if (error) throw error;
+  return data;
+}
+
+export async function getStamps(userId: string) {
+  const { data, error } = await supabase
+    .from('stamps')
+    .select('*')
+    .eq('user_id', userId);
+  if (error) throw error;
+  return data;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -4,3 +4,4 @@ export * from '../lib/types';
 export * from '../lib/mappers';
 export * from '../lib/storage';
 export * from '../lib/auth';
+export * from '../lib/queries';


### PR DESCRIPTION
## Summary
- add reusable profile, navatar, and stamp query helpers
- export query helpers through service index
- document available db helpers

## Testing
- `npm run typecheck` *(fails: Cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_68a96a7f7754832982b0c1bf54a98cb6