### PR TITLE
Add XP ledger and badges helpers

### DIFF
--- a/docs/db-helpers.md
+++ b/docs/db-helpers.md
@@ -3,3 +3,5 @@
 - Profiles: `getProfile`, `updateProfile`
 - Navatars: `createNavatar`, `getNavatarsByUser`
 - Stamps: `awardStamp`, `getStamps`
+- XP: `addXp`, `getXpTotal`, `getXpHistory`
+- Badges: `awardBadge`, `getBadges`

--- a/src/lib/xp.ts
+++ b/src/lib/xp.ts
@@ -1,0 +1,59 @@
+import { supabase } from './supabaseClient';
+
+// --------------------
+// XP Ledger
+// --------------------
+export async function addXp(userId: string, amount: number, reason: string) {
+  const { data, error } = await supabase
+    .from('xp_ledger')
+    .insert({ user_id: userId, amount, reason })
+    .select();
+  if (error) throw error;
+  return data;
+}
+
+export async function getXpTotal(userId: string) {
+  const { data, error } = await supabase
+    .from('xp_ledger')
+    .select('amount')
+    .eq('user_id', userId);
+
+  if (error) throw error;
+  return (
+    data?.reduce(
+      (sum: number, row: { amount: number }) => sum + row.amount,
+      0,
+    ) || 0
+  );
+}
+
+export async function getXpHistory(userId: string) {
+  const { data, error } = await supabase
+    .from('xp_ledger')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return data;
+}
+
+// --------------------
+// Badges
+// --------------------
+export async function awardBadge(userId: string, badgeName: string) {
+  const { data, error } = await supabase
+    .from('badges')
+    .insert({ user_id: userId, badge_name: badgeName })
+    .select();
+  if (error) throw error;
+  return data;
+}
+
+export async function getBadges(userId: string) {
+  const { data, error } = await supabase
+    .from('badges')
+    .select('*')
+    .eq('user_id', userId);
+  if (error) throw error;
+  return data;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,3 +5,4 @@ export * from '../lib/mappers';
 export * from '../lib/storage';
 export * from '../lib/auth';
 export * from '../lib/queries';
+export * from '../lib/xp';


### PR DESCRIPTION
## Summary
- add Supabase helpers for XP ledger with history and totals
- allow awarding and querying badges
- document XP and badge helpers and expose them via service entry point

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module '@supabase/supabase-js' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a96b57d9c08329881e98c099ad7376