### PR TITLE
feat: add quizzes and feedback helpers

### DIFF
--- a/docs/db-helpers.md
+++ b/docs/db-helpers.md
@@ -5,3 +5,14 @@
 - Stamps: `awardStamp`, `getStamps`
 - XP: `addXp`, `getXpTotal`, `getXpHistory`
 - Badges: `awardBadge`, `getBadges`
+
+### Quizzes
+- `createQuiz({ title, description?, world_slug?, zone_slug?, difficulty?, is_published? })`
+- `getQuiz(quizId)` → `{ quiz, questions }`
+- `submitQuizAttempt({ user_id, quiz_id, score, max_score, duration_ms?, detail? })`
+- `getUserQuizAttempts(userId)`
+- `getLeaderboard(quizId, limit?)`
+
+### Feedback
+- `submitFeedback({ user_id?, category, message, page_path?, meta? })`
+- `listFeedback({ userId? })`

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,0 +1,35 @@
+import { supabase } from './supabaseClient';
+
+/** Submit general app/lesson feedback */
+export async function submitFeedback(input: {
+  user_id?: string | null;
+  category: 'bug' | 'idea' | 'content' | 'other';
+  message: string;
+  page_path?: string | null;
+  meta?: unknown; // optional JSON payload
+}) {
+  const { data, error } = await supabase
+    .from('feedback')
+    .insert({
+      user_id: input.user_id ?? null,
+      category: input.category,
+      message: input.message,
+      page_path: input.page_path ?? null,
+      meta: input.meta ?? null,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+/** List feedback for a user (or all if no userId provided and RLS allows) */
+export async function listFeedback(opts?: { userId?: string }) {
+  const q = supabase
+    .from('feedback')
+    .select('*')
+    .order('created_at', { ascending: false });
+  const { data, error } = opts?.userId ? await q.eq('user_id', opts.userId) : await q;
+  if (error) throw error;
+  return data;
+}

--- a/src/lib/quizzes.ts
+++ b/src/lib/quizzes.ts
@@ -1,0 +1,89 @@
+import { supabase } from './supabaseClient';
+
+/** Create a quiz shell (title/metadata); questions inserted separately */
+export async function createQuiz(payload: {
+  title: string;
+  description?: string;
+  world_slug?: string | null;
+  zone_slug?: string | null;
+  difficulty?: 'easy' | 'medium' | 'hard';
+  is_published?: boolean;
+}) {
+  const { data, error } = await supabase
+    .from('quizzes')
+    .insert(payload)
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+/** Fetch quiz with its published questions */
+export async function getQuiz(quizId: string) {
+  const { data: quiz, error: e1 } = await supabase
+    .from('quizzes')
+    .select('*')
+    .eq('id', quizId)
+    .single();
+  if (e1) throw e1;
+
+  const { data: questions, error: e2 } = await supabase
+    .from('quiz_questions')
+    .select('*')
+    .eq('quiz_id', quizId)
+    .eq('is_active', true)
+    .order('order_index', { ascending: true });
+  if (e2) throw e2;
+
+  return { quiz, questions };
+}
+
+/** Record a user's attempt (score out of max_score) */
+export async function submitQuizAttempt(input: {
+  user_id: string;
+  quiz_id: string;
+  score: number;
+  max_score: number;
+  duration_ms?: number;
+  detail?: unknown; // optional JSON with per-question results
+}) {
+  const { data, error } = await supabase
+    .from('quiz_attempts')
+    .insert({
+      user_id: input.user_id,
+      quiz_id: input.quiz_id,
+      score: input.score,
+      max_score: input.max_score,
+      duration_ms: input.duration_ms ?? null,
+      detail: input.detail ?? null,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+/** Attempts for a user (newest first) */
+export async function getUserQuizAttempts(userId: string) {
+  const { data, error } = await supabase
+    .from('quiz_attempts')
+    .select('*, quizzes(title)')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return data;
+}
+
+/** Simple leaderboard for a quiz (top scores, fastest tiebreak) */
+export async function getLeaderboard(quizId: string, limit = 25) {
+  const { data, error } = await supabase
+    .from('quiz_attempts')
+    .select('user_id, score, max_score, duration_ms, created_at')
+    .eq('quiz_id', quizId)
+    .order('score', { ascending: false })
+    .order('duration_ms', { ascending: true, nullsFirst: true })
+    .order('created_at', { ascending: true })
+    .limit(limit);
+  if (error) throw error;
+  return data;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -6,3 +6,5 @@ export * from '../lib/storage';
 export * from '../lib/auth';
 export * from '../lib/queries';
 export * from '../lib/xp';
+export * from '../lib/quizzes';
+export * from '../lib/feedback';


### PR DESCRIPTION
## Summary
- add Supabase helpers for creating quizzes, tracking attempts, and leaderboards
- add feedback submission and listing helpers
- export new helpers and document usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module '@supabase/supabase-js')*


------
https://chatgpt.com/codex/tasks/task_e_68a96ca10cb88329b38efd12aed4b754