### PR TITLE
feat: add SmartImg and unified containers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,3 +5,6 @@
   Permissions-Policy: geolocation=(), microphone=(), camera=()
   Cache-Control: public, max-age=3600
 
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { RouterProvider } from 'react-router-dom';
+import { router } from './router';
+import { CartProvider } from './hooks/useCart';
+import CartDrawer from './components/cart/CartDrawer';
+import ErrorBoundary from './components/ErrorBoundary';
+import { organizationLd, websiteLd } from './lib/jsonld';
+
+export default function App() {
+  useEffect(() => {
+    // ensure any plain <img> without loading attr is lazy
+    const imgs = document.querySelectorAll('img:not([loading])');
+    imgs.forEach((img) => img.setAttribute('loading', 'lazy'));
+  }, []);
+
+  return (
+    <ErrorBoundary>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
+      />
+      <CartProvider>
+        <RouterProvider router={router} />
+        <CartDrawer />
+      </CartProvider>
+    </ErrorBoundary>
+  );
+}

--- a/src/components/SmartImg.tsx
+++ b/src/components/SmartImg.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+
+type Props = React.ImgHTMLAttributes<HTMLImageElement> & {
+  rounded?: boolean;
+  ratio?: "square" | "wide" | "tall"; // visual placeholder box
+};
+
+export default function SmartImg({ rounded = true, ratio = "wide", className = "", ...rest }: Props) {
+  const [loaded, setLoaded] = useState(false);
+  return (
+    <div className={`smartimg ${ratio} ${rounded ? "rounded" : ""} ${loaded ? "is-loaded" : ""}`}>
+      <img
+        {...rest}
+        loading={rest.loading ?? "lazy"}
+        onLoad={(e) => {
+          rest.onLoad?.(e as any);
+          setLoaded(true);
+        }}
+        className={`smartimg-img ${className}`}
+      />
+      {!loaded && <div className="smartimg-skel" />}
+    </div>
+  );
+}

--- a/src/components/WorldLayout.tsx
+++ b/src/components/WorldLayout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { KINGDOMS, KingdomId, imgUrl } from "../data/kingdoms";
 import "../styles/worlds.css";
-import ImageSmart from "./ImageSmart";
+import SmartImg from "./SmartImg";
 
 type Props = { id: KingdomId };
 
@@ -10,18 +10,19 @@ export default function WorldLayout({ id }: Props) {
   const folder = k.title; // TitleCase matches your public folder name
 
   return (
-    <main id="main" className="world-wrap">
+    <main id="main" className="world-wrap container-narrow world-page">
       <h1 className="world-title">{k.title}</h1>
 
       {/* Map hero */}
       <section className="world-hero card">
         <figure className="hero-figure">
-          <ImageSmart
+          <SmartImg
             src={imgUrl(folder, k.mapFile)}
             alt={`${k.title} map`}
+            ratio="wide"
             width={1280}
             height={720}
-            priority
+            loading="eager"
           />
         </figure>
         <div className="hero-meta">
@@ -40,9 +41,10 @@ export default function WorldLayout({ id }: Props) {
             {k.characters.map((file) => (
               <li key={file} className="char-card">
                 <div className="char-thumb">
-                  <ImageSmart
+                  <SmartImg
                     src={imgUrl(folder, file)}
                     alt={file.replace(/\.[^.]+$/, "")}
+                    ratio="tall"
                     width={320}
                     height={420}
                     onError={(e) => {

--- a/src/main.css
+++ b/src/main.css
@@ -3,8 +3,8 @@
 @import './styles/cart.css';
 @import './styles/footer.css';
 @import './styles/home.css';
-@import './styles/skeleton.css';
 @import './styles/cards-unify.css';
+@import './styles/skeleton.css';
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,31 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { RouterProvider } from 'react-router-dom';
-import { router } from './router';
-import { CartProvider } from './hooks/useCart';
-import CartDrawer from './components/cart/CartDrawer';
+import App from './App';
 import './styles.css';
 import './styles/shop.css';
 import './styles/edu.css';
 import './main.css';
-import ErrorBoundary from './components/ErrorBoundary';
-import { organizationLd, websiteLd } from './lib/jsonld';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <ErrorBoundary>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
-      />
-      <CartProvider>
-        <RouterProvider router={router} />
-        <CartDrawer />
-      </CartProvider>
-    </ErrorBoundary>
+    <App />
   </React.StrictMode>,
 );

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -1,25 +1,24 @@
 import React from "react";
 import { WORLDS } from "../../data/worlds";
 import Meta from "../../components/Meta";
-import Page from "../../layouts/Page";
 import { Breadcrumbs } from "../../components/Breadcrumbs";
-import ImageSmart from "../../components/ImageSmart";
+import SmartImg from "../../components/SmartImg";
 
 export default function WorldsIndex() {
   return (
-    <Page title="Worlds">
+    <div className="container-narrow">
       <Meta title="Worlds — Naturverse" description="Explore the 14 kingdoms." url="https://thenaturverse.com/worlds" />
       <Breadcrumbs />
       <p className="muted">Choose a kingdom to explore.</p>
       <div className="cards">
-        {WORLDS.map(w => (
+        {WORLDS.map((w) => (
           <a className="card" key={w.slug} href={`/worlds/${w.slug}`}>
-            <ImageSmart src={w.map} alt={`${w.name} map`} />
+            <SmartImg src={w.map} alt={`${w.name} map`} ratio="wide" />
             <h2>{w.name}</h2>
             <p>{w.blurb}</p>
           </a>
         ))}
       </div>
-    </Page>
+    </div>
   );
 }

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -64,7 +64,7 @@ const ZONES = [
 
 export default function Zones() {
   return (
-    <>
+    <div className="container-narrow">
       <Seo
         title="Zones"
         description="Pick a zone to start games, music, wellness, and more."
@@ -89,6 +89,6 @@ export default function Zones() {
           ),
         }}
       />
-    </>
+    </div>
   );
 }

--- a/src/styles/skeleton.css
+++ b/src/styles/skeleton.css
@@ -1,31 +1,27 @@
-.card.sk {
-  background: #fff;
-  border: 1px solid var(--nv-border);
+/* container */
+.container-narrow { max-width: 1100px; margin: 0 auto; padding: 0 16px; }
+
+/* SmartImg skeletons */
+.smartimg { position: relative; display: block; width: 100%; overflow: hidden; background: #e6f0ff; }
+.smartimg.rounded { border-radius: 14px; }
+.smartimg.square { aspect-ratio: 1 / 1; }
+.smartimg.wide   { aspect-ratio: 16 / 9; }
+.smartimg.tall   { aspect-ratio: 3 / 4; }
+
+.smartimg-img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.smartimg-skel {
+  position: absolute; inset: 0;
+  background: linear-gradient(90deg, #e6f0ff 0%, #f3f6ff 50%, #e6f0ff 100%);
+  animation: skel 1.2s infinite;
 }
-.sk-thumb {
-  width: 100%;
-  aspect-ratio: 16/10;
-  border-radius: 12px;
-  background: linear-gradient(90deg, var(--nv-blue-50) 25%, #e2e8f0 37%, var(--nv-blue-50) 63%);
-  background-size: 400% 100%;
-  animation: sh 1.2s infinite;
+.smartimg.is-loaded .smartimg-skel { display: none; }
+
+@keyframes skel {
+  0% { transform: translateX(-30%); }
+  100% { transform: translateX(30%); }
 }
-.sk-line {
-  height: 14px;
-  margin: 10px 0;
-  border-radius: 8px;
-  background: linear-gradient(90deg, var(--nv-blue-50) 25%, #e2e8f0 37%, var(--nv-blue-50) 63%);
-  background-size: 400% 100%;
-  animation: sh 1.2s infinite;
-}
-.sk-line.small {
-  width: 60%;
-}
-@keyframes sh {
-  0% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0 50%;
-  }
-}
+
+/* unify card grids (keeps your existing look) */
+.cards { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.card  { background: #ffffff; border: 1px solid #dbeafe; border-radius: 14px; padding: 12px; }
+.card h2 { margin: 10px 0 6px; }


### PR DESCRIPTION
## Summary
- add `SmartImg` component with skeleton and lazy loading
- unify container styles and apply to worlds and zones pages
- ensure plain `<img>` tags default to lazy loading and cache assets aggressively

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a96fa052c48329b2663dae486ff4ec