### PR TITLE
feat: add global error boundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import { RouterProvider } from 'react-router-dom';
 import { router } from './router';
 import { CartProvider } from './hooks/useCart';
 import CartDrawer from './components/cart/CartDrawer';
-import ErrorBoundary from './components/ErrorBoundary';
 import { organizationLd, websiteLd } from './lib/jsonld';
 
 export default function App() {
@@ -14,7 +13,7 @@ export default function App() {
   }, []);
 
   return (
-    <ErrorBoundary>
+    <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
@@ -27,6 +26,6 @@ export default function App() {
         <RouterProvider router={router} />
         <CartDrawer />
       </CartProvider>
-    </ErrorBoundary>
+    </>
   );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,21 +1,46 @@
-import React from "react";
+import React from 'react';
 
-type State = { hasError: boolean; error?: Error };
+type Props = {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+};
 
-export default class ErrorBoundary extends React.Component<React.PropsWithChildren, State> {
+type State = { hasError: boolean };
+
+export class ErrorBoundary extends React.Component<Props, State> {
   state: State = { hasError: false };
-  static getDerivedStateFromError(error: Error): State { return { hasError: true, error }; }
-  componentDidCatch() { /* no-op (could log later) */ }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, info: unknown) {
+    // Optional: send to your future logging/telemetry
+    // console.error('ErrorBoundary caught', error, info);
+  }
+
   render() {
     if (this.state.hasError) {
       return (
-        <div style={{ maxWidth: 760, margin: "40px auto", padding: 16 }}>
-          <h1>Something went wrong</h1>
-          <p className="muted">Try going back home and reloading this page.</p>
-          <a className="button" href="/">← Back to Home</a>
-        </div>
+        this.props.fallback ?? (
+          <div
+            style={{
+              padding: '16px',
+              margin: '16px',
+              borderRadius: '12px',
+              border: '1px solid rgba(0,0,0,0.08)',
+              background: 'var(--nv-surface, #fff)',
+            }}
+          >
+            <h3 style={{ marginTop: 0 }}>Something went wrong.</h3>
+            <p>Try refreshing the page. If it keeps happening, we’ll fix it fast.</p>
+          </div>
+        )
       );
     }
     return this.props.children;
   }
 }
+
+export default ErrorBoundary;
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import ErrorBoundary from './components/ErrorBoundary';
 import './styles.css';
 import './styles/shop.css';
 import './styles/edu.css';
@@ -8,6 +9,8 @@ import './main.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary component
- wrap application root with ErrorBoundary to prevent full-page crashes

## Testing
- `npm run build`
- `npm run typecheck` (fails: TS errors in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68a97658a3cc8329ba1dc4933bbbf840