### PR TITLE
feat: add Img component with lazy loading and skeleton

### DIFF
--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -7,7 +7,7 @@ type ImgProps = React.ImgHTMLAttributes<HTMLImageElement> & {
 export default function Img({
   src,
   alt,
-  fallbackSrc = "/assets/placeholders/world-bg.svg",
+  fallbackSrc = "/placeholder.png",
   ...rest
 }: ImgProps) {
   const [loaded, setLoaded] = useState(false);


### PR DESCRIPTION
## Summary
- add an Img component with lazy-loading and async decoding
- show a skeleton until the image loads and fall back to a placeholder if it fails

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: TS2345, TS2339, TS2769, TS2322)


------
https://chatgpt.com/codex/tasks/task_e_68a978bb89708329bbbdeea18a99afa6