### PR TITLE
feat: add Supabase auth scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-# Frontend (optional – app works without them)
-VITE_SUPABASE_URL=
-VITE_SUPABASE_ANON_KEY=
+# Supabase (client-side)
+VITE_SUPABASE_URL=your-url
+VITE_SUPABASE_ANON_KEY=your-anon-key
 NEXT_PUBLIC_SITE_URL=https://thenaturverse.com
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN=thenaturverse.com
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.28.0",
-    "@supabase/supabase-js": "^2.43.4"
+    "@supabase/supabase-js": "^2.45.4"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,0 +1,70 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabaseClient';
+
+type AuthCtx = {
+  user: User | null;
+  session: Session | null;
+  loading: boolean;
+  signInWithEmail: (email: string) => Promise<{ error?: string }>;
+  signOut: () => Promise<void>;
+};
+
+const Ctx = createContext<AuthCtx | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Pick up existing session and listen for changes
+  useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      if (!mounted) return;
+      setSession(data.session ?? null);
+      setUser(data.session?.user ?? null);
+      setLoading(false);
+    })();
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, s) => {
+      setSession(s ?? null);
+      setUser(s?.user ?? null);
+      setLoading(false);
+    });
+
+    return () => {
+      sub.subscription.unsubscribe();
+      mounted = false;
+    };
+  }, []);
+
+  // Email magic link
+  const signInWithEmail: AuthCtx['signInWithEmail'] = async (email) => {
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: window.location.origin }, // safe default
+    });
+    return { error: error?.message };
+  };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  const value = useMemo<AuthCtx>(
+    () => ({ user, session, loading, signInWithEmail, signOut }),
+    [user, session, loading],
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useAuth must be used inside <AuthProvider>');
+  return ctx;
+}
+

--- a/src/components/AccountButton.tsx
+++ b/src/components/AccountButton.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { useAuth } from '../auth/AuthContext';
+import AuthModal from './AuthModal';
+
+export default function AccountButton() {
+  const { user, signOut, loading } = useAuth();
+  const [open, setOpen] = useState(false);
+
+  if (loading) return null;
+
+  if (!user) {
+    return (
+      <>
+        <button onClick={() => setOpen(true)} style={btn}>
+          Create account / Sign in
+        </button>
+        <AuthModal open={open} onClose={() => setOpen(false)} />
+      </>
+    );
+  }
+
+  const name = user.user_metadata?.name || user.email?.split('@')[0] || 'Explorer';
+  return (
+    <div style={{ display: 'inline-flex', gap: 8, alignItems: 'center' }}>
+      <span style={{ fontWeight: 700 }}>{name}</span>
+      <button onClick={signOut} style={btnSecondary}>Sign out</button>
+    </div>
+  );
+}
+
+const btn: React.CSSProperties = {
+  padding: '8px 12px',
+  borderRadius: 10,
+  border: 0,
+  background: '#2f7ae5',
+  color: '#fff',
+  fontWeight: 700,
+  cursor: 'pointer',
+};
+const btnSecondary: React.CSSProperties = {
+  padding: '8px 12px',
+  borderRadius: 10,
+  border: '1px solid #94a3b8',
+  background: '#fff',
+  color: '#0f172a',
+  fontWeight: 700,
+  cursor: 'pointer',
+};
+

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { useAuth } from '../auth/AuthContext';
+
+type Props = { open: boolean; onClose: () => void; title?: string };
+
+export default function AuthModal({ open, onClose, title = 'Sign in' }: Props) {
+  const { signInWithEmail } = useAuth();
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  if (!open) return null;
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const { error } = await signInWithEmail(email.trim());
+    if (error) setError(error);
+    else setSent(true);
+  }
+
+  return (
+    <div style={overlay}>
+      <div style={card}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h3 style={{ margin: 0 }}>{title}</h3>
+          <button onClick={onClose} aria-label='Close' style={xBtn}>×</button>
+        </div>
+
+        {!sent ? (
+          <form onSubmit={submit} style={{ marginTop: 12 }}>
+            <label style={label}>Email</label>
+            <input
+              type='email'
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder='you@example.com'
+              style={input}
+            />
+            {error && <p style={err}>{error}</p>}
+            <button type='submit' style={primaryBtn}>Send magic link</button>
+          </form>
+        ) : (
+          <div style={{ marginTop: 12 }}>
+            <p>✅ Check your inbox for a sign-in link.</p>
+            <button onClick={onClose} style={primaryBtn}>Done</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const overlay: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.4)',
+  display: 'grid',
+  placeItems: 'center',
+  zIndex: 1000,
+};
+const card: React.CSSProperties = {
+  width: 'min(92vw, 420px)',
+  background: '#fff',
+  borderRadius: 12,
+  padding: 16,
+  boxShadow: '0 10px 30px rgba(0,0,0,0.15)',
+};
+const xBtn: React.CSSProperties = { background: 'transparent', border: 0, fontSize: 24, cursor: 'pointer' };
+const label: React.CSSProperties = { display: 'block', fontWeight: 700, margin: '8px 0 4px' };
+const input: React.CSSProperties = { width: '100%', padding: 10, borderRadius: 8, border: '1px solid #cbd5e1' };
+const primaryBtn: React.CSSProperties = {
+  marginTop: 12,
+  padding: '10px 14px',
+  borderRadius: 10,
+  border: 0,
+  background: '#2f7ae5',
+  color: '#fff',
+  fontWeight: 700,
+  cursor: 'pointer',
+};
+const err: React.CSSProperties = { color: '#b00020', marginTop: 8 };
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
+import { AuthProvider } from './auth/AuthContext';
 import './styles.css';
 import './styles/shop.css';
 import './styles/edu.css';
@@ -9,8 +10,10 @@ import './main.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <ErrorBoundary>
-      <App />
-    </ErrorBoundary>
+    <AuthProvider>
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    </AuthProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- set up AuthProvider powered by Supabase with email magic link support
- add AuthModal and AccountButton components for signing in/out
- document Supabase env vars and upgrade supabase-js

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a97ef1a3248329bb5d7dad9e760507