### PR TITLE
feat: bootstrap profiles

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabaseClient';
+import { upsertProfile } from '../lib/upsertProfile';
 
 type AuthCtx = {
   user: User | null;
@@ -27,12 +28,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setSession(data.session ?? null);
       setUser(data.session?.user ?? null);
       setLoading(false);
+
+      if (data.session?.user) {
+        await upsertProfile(data.session.user.id, data.session.user.email);
+      }
     })();
 
     const { data: sub } = supabase.auth.onAuthStateChange((_event, s) => {
       setSession(s ?? null);
       setUser(s?.user ?? null);
       setLoading(false);
+
+      if (s?.user) {
+        upsertProfile(s.user.id, s.user.email);
+      }
     });
 
     return () => {

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import { useAuth } from '../auth/AuthContext';
+
+export default function ProfileForm() {
+  const { user } = useAuth();
+  const [username, setUsername] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    (async () => {
+      const { data } = await supabase
+        .from('profiles')
+        .select('username')
+        .eq('id', user.id)
+        .single();
+      if (data?.username) setUsername(data.username);
+    })();
+  }, [user]);
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault();
+    if (!user) return;
+    setLoading(true);
+    const { error } = await supabase
+      .from('profiles')
+      .update({ username, updated_at: new Date().toISOString() })
+      .eq('id', user.id);
+    setLoading(false);
+    if (error) alert(error.message);
+    else alert('✅ Saved!');
+  }
+
+  if (!user) return null;
+
+  return (
+    <form onSubmit={save} style={{ maxWidth: 400, margin: '1rem auto' }}>
+      <h2>Profile</h2>
+      <label style={{ display: 'block', margin: '8px 0 4px' }}>Username</label>
+      <input
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder='Your name'
+        style={{ width: '100%', padding: 8, borderRadius: 8, border: '1px solid #ccc' }}
+      />
+      <button
+        type='submit'
+        disabled={loading}
+        style={{
+          marginTop: 12,
+          padding: '8px 14px',
+          borderRadius: 8,
+          border: 0,
+          background: '#2f7ae5',
+          color: '#fff',
+          fontWeight: 700,
+        }}
+      >
+        {loading ? 'Saving...' : 'Save'}
+      </button>
+    </form>
+  );
+}

--- a/src/lib/upsertProfile.ts
+++ b/src/lib/upsertProfile.ts
@@ -1,0 +1,13 @@
+import { supabase } from './supabaseClient';
+
+export async function upsertProfile(userId: string, email: string | null) {
+  const { error } = await supabase.from('profiles').upsert(
+    {
+      id: userId,
+      email,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'id' },
+  );
+  if (error) console.error('Profile upsert error:', error.message);
+}


### PR DESCRIPTION
## Summary
- create profiles on sign-in and update existing records
- add profile form for users to update their username

## Testing
- `npm run typecheck` *(fails: Argument of type 'Partial<...>' is not assignable to parameter of type 'never')*


------
https://chatgpt.com/codex/tasks/task_e_68a9810073b4832992f2d3efbdbaac63