### PR TITLE
Add ErrorBoundary and NotFound fallback

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,25 +1,9 @@
 <!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Page not found — Naturverse</title>
-  <link rel="icon" href="/favicon-32x32.png">
-  <link rel="apple-touch-icon" href="/favicon-256x256.png">
-  <style>
-    :root{color-scheme:light dark}
-    body{margin:0;font:16px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial;background:#0b0c0d;color:#e6e7e9;display:grid;place-items:center;height:100dvh}
-    .box{max-width:640px;padding:32px;border-radius:16px;background:#121417;border:1px solid #23262b}
-    h1{margin:0 0 8px;font-size:28px}
-    p{opacity:.8}
-    a{display:inline-block;margin-top:12px;padding:10px 14px;border-radius:10px;background:#1e90ff;color:#fff;text-decoration:none}
-  </style>
-</head>
-<body>
-  <main class="box">
-    <h1>404 — This page is exploring another kingdom.</h1>
-    <p>The link may be broken or the page moved.</p>
-    <a href="/">Back to Home</a>
-  </main>
-</body>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=/" />
+    <title>Not found</title>
+  </head>
+  <body></body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from 'react-router-dom';
 import { router } from './router';
 import { CartProvider } from './hooks/useCart';
 import CartDrawer from './components/cart/CartDrawer';
+import ErrorBoundary from './components/ErrorBoundary';
 import { organizationLd, websiteLd } from './lib/jsonld';
 
 export default function App() {
@@ -22,10 +23,12 @@ export default function App() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
       />
-      <CartProvider>
-        <RouterProvider router={router} />
-        <CartDrawer />
-      </CartProvider>
+      <ErrorBoundary>
+        <CartProvider>
+          <RouterProvider router={router} />
+          <CartDrawer />
+        </CartProvider>
+      </ErrorBoundary>
     </>
   );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,46 +1,33 @@
 import React from 'react';
 
-type Props = {
-  children: React.ReactNode;
-  fallback?: React.ReactNode;
-};
+type State = { hasError: boolean; msg?: string };
 
-type State = { hasError: boolean };
-
-export class ErrorBoundary extends React.Component<Props, State> {
+export default class ErrorBoundary extends React.Component<{ children: React.ReactNode }, State> {
   state: State = { hasError: false };
 
-  static getDerivedStateFromError() {
-    return { hasError: true };
+  static getDerivedStateFromError(err: unknown): State {
+    return { hasError: true, msg: err instanceof Error ? err.message : String(err) };
   }
 
-  componentDidCatch(error: unknown, info: unknown) {
-    // Optional: send to your future logging/telemetry
-    // console.error('ErrorBoundary caught', error, info);
+  componentDidCatch(err: unknown, info: unknown) {
+    // noop (can log later)
   }
 
   render() {
     if (this.state.hasError) {
       return (
-        this.props.fallback ?? (
-          <div
-            style={{
-              padding: '16px',
-              margin: '16px',
-              borderRadius: '12px',
-              border: '1px solid rgba(0,0,0,0.08)',
-              background: 'var(--nv-surface, #fff)',
-            }}
-          >
-            <h3 style={{ marginTop: 0 }}>Something went wrong.</h3>
-            <p>Try refreshing the page. If it keeps happening, we’ll fix it fast.</p>
-          </div>
-        )
+        <div className="page">
+          <h1>Something went wrong</h1>
+          <p className="muted">The page failed to render. Try going back home.</p>
+          <a className="btn" href="/">Back to Home</a>
+          {this.state.msg && (
+            <pre className="muted" style={{ whiteSpace: 'pre-wrap' }}>
+              {this.state.msg}
+            </pre>
+          )}
+        </div>
       );
     }
-    return this.props.children;
+    return this.props.children as React.ReactElement;
   }
 }
-
-export default ErrorBoundary;
-

--- a/src/main.css
+++ b/src/main.css
@@ -49,3 +49,8 @@ a.active {
 /* generic .button for 404/EB */
 .button { display:inline-block; padding:10px 14px; background:#0ea5e9; color:#fff; border-radius:10px; border:1px solid #0ea5e9; text-decoration:none; }
 .button:hover { filter: brightness(0.95); }
+
+/* not-found / error styles */
+.page .btn { padding:10px 14px; border-radius:10px; background:#0ea5e9; color:#fff; border:1px solid #0ea5e9; font-weight:700; }
+.page .btn:hover { filter: brightness(0.95); }
+.page .muted { color:#6b7280; }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import ErrorBoundary from './components/ErrorBoundary';
 import { AuthProvider } from './auth/AuthContext';
 import './styles.css';
 import './styles/shop.css';
@@ -11,9 +10,7 @@ import './main.css';
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <AuthProvider>
-      <ErrorBoundary>
-        <App />
-      </ErrorBoundary>
+      <App />
     </AuthProvider>
   </React.StrictMode>,
 );

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import React from 'react';
 
 export default function NotFound() {
   return (
-    <div id="main" style={{ maxWidth: 760, margin: "40px auto", padding: 16 }}>
+    <div className="page">
       <h1>Page not found</h1>
-      <p className="muted">This path doesn’t exist in the Naturverse yet.</p>
-      <a className="button" href="/">← Back to Home</a>
+      <p className="muted">The link you followed doesn’t exist yet.</p>
+      <a className="btn" href="/">Back to Home</a>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace generic ErrorBoundary with user-friendly message and back-home link
- add streamlined NotFound page and wrap app with ErrorBoundary
- add simple 404.html redirect and supporting styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TS2345 etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a982c8db4c832985a59e364ba47a7b