### PR TITLE
feat: add session-aware auth button

### DIFF
--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import type { Session, AuthChangeEvent } from "@supabase/supabase-js";
+import { supabase } from "../lib/supabaseClient";
+
+export default function AuthButton() {
+  const [session, setSession] = useState<Session | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    supabase.auth.getSession().then(({ data }) => {
+      if (mounted) setSession(data.session ?? null);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange(
+      (_event: AuthChangeEvent, newSession) => {
+        if (mounted) setSession(newSession);
+      }
+    );
+    return () => {
+      mounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  async function handleLogout() {
+    await supabase.auth.signOut();
+  }
+
+  if (session) {
+    return <button onClick={handleLogout}>Sign out</button>;
+  }
+
+  return (
+    <a href="/login">
+      <button>Sign in</button>
+    </a>
+  );
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -2,6 +2,7 @@ import { Link, NavLink } from 'react-router-dom';
 import { useState } from 'react';
 import './site-header.css';
 import Img from './Img';
+import AuthButton from './AuthButton';
 
 export default function SiteHeader(){
   const [open, setOpen] = useState(false);
@@ -29,6 +30,7 @@ export default function SiteHeader(){
           <NavLink to="/turian" className={({isActive})=>isActive?"nav-link active":"nav-link"} onClick={() => setOpen(false)}>Turian</NavLink>
           <NavLink to="/profile" aria-label="Profile" className={({isActive})=> (isActive?"nav-link active":"nav-link") + " icon"} onClick={() => setOpen(false)}>👤</NavLink>
           <NavLink to="/cart" aria-label="Cart" className={({isActive})=> (isActive?"nav-link active":"nav-link") + " icon"} onClick={() => setOpen(false)}>🛒</NavLink>
+          <AuthButton />
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add AuthButton component that uses Supabase session to display sign-in or sign-out
- integrate AuthButton into SiteHeader navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS2345 etc. in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a98d395c5483299ff5ed4e5013289c