### PR TITLE
feat: add auth-aware menu

### DIFF
--- a/src/components/AuthMenu.tsx
+++ b/src/components/AuthMenu.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+
+type MiniUser = { id: string; email: string | null; avatar_url?: string | null };
+
+export default function AuthMenu() {
+  const [user, setUser] = useState<MiniUser | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function load() {
+      const { data } = await supabase.auth.getUser();
+      const sUser = data.user;
+      if (!sUser) {
+        if (mounted) setUser(null);
+        return;
+      }
+
+      // Optional profile fetch; ignore if table not present
+      const { data: prof } = await supabase
+        .from('profiles')
+        .select('avatar_url')
+        .eq('id', sUser.id)
+        .maybeSingle();
+
+      if (mounted) {
+        setUser({
+          id: sUser.id,
+          email: sUser.email ?? null,
+          avatar_url: prof?.avatar_url ?? null,
+        });
+      }
+    }
+
+    load();
+    const { data: sub } = supabase.auth.onAuthStateChange(() => load());
+    return () => sub.subscription.unsubscribe();
+  }, []);
+
+  async function signOut() {
+    await supabase.auth.signOut();
+    setUser(null);
+  }
+
+  if (!user) {
+    // Signed out → simple CTA; we start auth on /profile page
+    return (
+      <a href="/profile" style={{ fontWeight: 600 }}>
+        Sign in
+      </a>
+    );
+  }
+
+  // Signed in → small inline menu
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+      {user.avatar_url ? (
+        <img
+          src={user.avatar_url}
+          alt="Avatar"
+          width={28}
+          height={28}
+          style={{ borderRadius: 6, objectFit: 'cover' }}
+          loading="lazy"
+          decoding="async"
+        />
+      ) : null}
+      <a href="/profile" style={{ fontWeight: 600 }}>
+        Profile
+      </a>
+      <button onClick={signOut} style={{ marginLeft: 6 }}>
+        Sign out
+      </button>
+    </div>
+  );
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -2,37 +2,101 @@ import { Link, NavLink } from 'react-router-dom';
 import { useState } from 'react';
 import './site-header.css';
 import Img from './Img';
-import AuthButton from './AuthButton';
+import AuthMenu from './AuthMenu';
 
-export default function SiteHeader(){
+export default function SiteHeader() {
   const [open, setOpen] = useState(false);
   return (
     <header className={`site-header ${open ? 'open' : ''}`}>
-      <a href="#main" className="skip-link">Skip to content</a>
+      <a href="#main" className="skip-link">
+        Skip to content
+      </a>
       <div className="wrap">
         <Link to="/" className="brand" onClick={() => setOpen(false)}>
           <Img src="/favicon-32x32.png" width="28" height="28" alt="Naturverse" />
           <span>Naturverse</span>
         </Link>
-        <button className="nav-toggle" aria-label="Menu" onClick={() => setOpen(v => !v)}>
-          <span/>
-          <span/>
-          <span/>
+        <button className="nav-toggle" aria-label="Menu" onClick={() => setOpen((v) => !v)}>
+          <span />
+          <span />
+          <span />
         </button>
         <nav className="nav">
-          <NavLink to="/worlds" className={({isActive})=>isActive?"nav-link active":"nav-link"} onClick={() => setOpen(false)}>Worlds</NavLink>
-          <NavLink to="/zones" className={({isActive})=>isActive?"nav-link active":"nav-link"} onClick={() => setOpen(false)}>Zones</NavLink>
-          <NavLink to="/marketplace" className={({isActive})=>isActive?"nav-link active":"nav-link"} onClick={() => setOpen(false)}>Marketplace</NavLink>
-          <NavLink to="/naturversity" className={({isActive})=>isActive?"nav-link active":"nav-link"} onClick={() => setOpen(false)}>Naturversity</NavLink>
-          <NavLink to="/naturbank" className={({isActive})=>isActive?"nav-link active":"nav-link"} onClick={() => setOpen(false)}>Naturbank</NavLink>
-          <NavLink to="/navatar" className={({isActive})=>isActive?"nav-link active":"nav-link"} onClick={() => setOpen(false)}>Navatar</NavLink>
-          <NavLink to="/passport" className={({isActive})=>isActive?"nav-link active":"nav-link"} onClick={() => setOpen(false)}>Passport</NavLink>
-          <NavLink to="/turian" className={({isActive})=>isActive?"nav-link active":"nav-link"} onClick={() => setOpen(false)}>Turian</NavLink>
-          <NavLink to="/profile" aria-label="Profile" className={({isActive})=> (isActive?"nav-link active":"nav-link") + " icon"} onClick={() => setOpen(false)}>👤</NavLink>
-          <NavLink to="/cart" aria-label="Cart" className={({isActive})=> (isActive?"nav-link active":"nav-link") + " icon"} onClick={() => setOpen(false)}>🛒</NavLink>
-          <AuthButton />
+          <NavLink
+            to="/worlds"
+            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+            onClick={() => setOpen(false)}
+          >
+            Worlds
+          </NavLink>
+          <NavLink
+            to="/zones"
+            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+            onClick={() => setOpen(false)}
+          >
+            Zones
+          </NavLink>
+          <NavLink
+            to="/marketplace"
+            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+            onClick={() => setOpen(false)}
+          >
+            Marketplace
+          </NavLink>
+          <NavLink
+            to="/naturversity"
+            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+            onClick={() => setOpen(false)}
+          >
+            Naturversity
+          </NavLink>
+          <NavLink
+            to="/naturbank"
+            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+            onClick={() => setOpen(false)}
+          >
+            Naturbank
+          </NavLink>
+          <NavLink
+            to="/navatar"
+            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+            onClick={() => setOpen(false)}
+          >
+            Navatar
+          </NavLink>
+          <NavLink
+            to="/passport"
+            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+            onClick={() => setOpen(false)}
+          >
+            Passport
+          </NavLink>
+          <NavLink
+            to="/turian"
+            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+            onClick={() => setOpen(false)}
+          >
+            Turian
+          </NavLink>
+          <NavLink
+            to="/profile"
+            aria-label="Profile"
+            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link') + ' icon'}
+            onClick={() => setOpen(false)}
+          >
+            👤
+          </NavLink>
+          <NavLink
+            to="/cart"
+            aria-label="Cart"
+            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link') + ' icon'}
+            onClick={() => setOpen(false)}
+          >
+            🛒
+          </NavLink>
+          <AuthMenu />
         </nav>
       </div>
     </header>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add AuthMenu component that fetches user and optional avatar from Supabase and handles sign in/out
- display AuthMenu in SiteHeader instead of placeholder auth button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string | null')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a996e0acbc832985ae7de06c28ccc7