### PR TITLE
Make AuthMenu mobile-friendly

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,17 +1,18 @@
-import React, { useEffect, useState } from "react";
-import CartButton from "./cart/CartButton";
-import Img from "./Img";
+import React, { useEffect, useState } from 'react';
+import CartButton from './cart/CartButton';
+import Img from './Img';
+import AuthMenu from './AuthMenu';
 
 const LINKS = [
-  { href: "/worlds", label: "Worlds" },
-  { href: "/zones", label: "Zones" },
-  { href: "/marketplace", label: "Marketplace" },
-  { href: "/naturversity", label: "Naturversity" },
-  { href: "/naturbank", label: "Naturbank" },
-  { href: "/navatar", label: "Navatar" },
-  { href: "/passport", label: "Passport" },
-  { href: "/turian", label: "Turian" },
-  { href: "/profile", label: "Profile" },
+  { href: '/worlds', label: 'Worlds' },
+  { href: '/zones', label: 'Zones' },
+  { href: '/marketplace', label: 'Marketplace' },
+  { href: '/naturversity', label: 'Naturversity' },
+  { href: '/naturbank', label: 'Naturbank' },
+  { href: '/navatar', label: 'Navatar' },
+  { href: '/passport', label: 'Passport' },
+  { href: '/turian', label: 'Turian' },
+  { href: '/profile', label: 'Profile' },
 ];
 
 export default function Header() {
@@ -20,11 +21,11 @@ export default function Header() {
   // close drawer on route change (hash/path)
   useEffect(() => {
     const onChange = () => setOpen(false);
-    window.addEventListener("hashchange", onChange);
-    window.addEventListener("popstate", onChange);
+    window.addEventListener('hashchange', onChange);
+    window.addEventListener('popstate', onChange);
     return () => {
-      window.removeEventListener("hashchange", onChange);
-      window.removeEventListener("popstate", onChange);
+      window.removeEventListener('hashchange', onChange);
+      window.removeEventListener('popstate', onChange);
     };
   }, []);
 
@@ -33,61 +34,59 @@ export default function Header() {
     const onResize = () => {
       if (window.innerWidth >= 1024) setOpen(false);
     };
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
   }, []);
 
   return (
-      <header className="nv-header">
-        <div className="nv-shell">
-            <a href="/" className="header-logo-link" aria-label="Naturverse home">
-              <Img
-                src="/Turianmedia-logo-footer.png"
-                alt="Turian Media"
-                className="site-logo"n              />
-              <span className="site-title">Naturverse</span>
-            </a>
+    <header className="nv-header">
+      <div className="nv-shell">
+        <a href="/" className="header-logo-link" aria-label="Naturverse home">
+          <Img src="/Turianmedia-logo-footer.png" alt="Turian Media" className="site-logo" n />
+          <span className="site-title">Naturverse</span>
+        </a>
 
-          <div className="nv-right">
-            {/* desktop nav */}
-            <nav className="nv-nav">
-              <ul>
-                {LINKS.map((l) => (
-                  <li key={l.href}>
-                    <a href={l.href}>{l.label}</a>
-                  </li>
-                ))}
-              </ul>
-            </nav>
+        <div className="nv-right">
+          {/* desktop nav */}
+          <nav className="nv-nav">
+            <ul>
+              {LINKS.map((l) => (
+                <li key={l.href}>
+                  <a href={l.href}>{l.label}</a>
+                </li>
+              ))}
+            </ul>
+          </nav>
 
-            <CartButton />
+          <CartButton />
+          <AuthMenu />
 
-            {/* mobile button */}
-            <button
-              className="nv-burger"
-              aria-label="Open menu"
-              aria-expanded={open}
-              onClick={() => setOpen((v) => !v)}
-            >
-              <span/>
-              <span/>
-              <span/>
-            </button>
-          </div>
-
-          {/* mobile drawer */}
-          {open && (
-            <div className="nv-drawer" role="dialog" aria-modal="true">
-              <ul>
-                {LINKS.map((l) => (
-                  <li key={l.href}>
-                    <a href={l.href}>{l.label}</a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+          {/* mobile button */}
+          <button
+            className="nv-burger"
+            aria-label="Open menu"
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+          >
+            <span />
+            <span />
+            <span />
+          </button>
         </div>
-      </header>
+
+        {/* mobile drawer */}
+        {open && (
+          <div className="nv-drawer" role="dialog" aria-modal="true">
+            <ul>
+              {LINKS.map((l) => (
+                <li key={l.href}>
+                  <a href={l.href}>{l.label}</a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </header>
   );
 }

--- a/src/styles/auth-menu.css
+++ b/src/styles/auth-menu.css
@@ -1,0 +1,98 @@
+.auth-menu {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  position: relative;
+}
+
+.auth-avatar {
+  border-radius: 6px;
+  width: 28px;
+  height: 28px;
+  object-fit: cover;
+  background: #e8eefb;
+}
+
+.auth-initials {
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 13px;
+  color: #2f6fec;
+}
+
+.auth-label {
+  font-weight: 600;
+}
+
+.auth-linklike {
+  appearance: none;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.auth-icon {
+  display: none; /* shown on mobile only */
+}
+
+/* Overflow (kebab) for mobile; hidden on desktop */
+.auth-kebab {
+  display: none;
+  appearance: none;
+  background: none;
+  border: 0;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 4px;
+}
+
+.auth-popover {
+  position: absolute;
+  top: 36px;
+  right: 0;
+  background: #fff;
+  border: 1px solid #e4e7ee;
+  box-shadow: 0 6px 22px rgba(20, 24, 40, 0.16);
+  border-radius: 10px;
+  padding: 8px;
+  min-width: 140px;
+  z-index: 40;
+  display: grid;
+  gap: 6px;
+}
+
+.auth-popover a,
+.auth-popover button {
+  text-align: left;
+  padding: 6px 8px;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.auth-popover a:hover,
+.auth-popover button:hover {
+  background: #f3f6ff;
+}
+
+/* =========== Mobile =========== */
+@media (max-width: 560px) {
+  /* hide text labels; keep avatar + icon + kebab */
+  .auth-label {
+    display: none;
+  }
+  .auth-icon {
+    display: inline;
+    font-size: 18px;
+  }
+  .auth-kebab {
+    display: inline-block;
+  }
+  .auth-menu {
+    gap: 8px;
+  }
+}


### PR DESCRIPTION
## Summary
- collapse account menu labels on narrow screens with an overflow menu
- add dedicated CSS for auth menu styling
- include AuthMenu in Header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: numerous TS errors e.g., Argument of type 'Partial<Omit<...>>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68a99912dd9c8329a202379bea50f632