### PR TITLE
Naturversity → Languages hub + 6 language pages (data-driven, no new deps)

### DIFF
--- a/src/data/languages/amerilandia.ts
+++ b/src/data/languages/amerilandia.ts
@@ -1,0 +1,36 @@
+import { LangData } from "./types";
+
+const US: LangData = {
+  slug: "amerilandia",
+  name: "Amerilandia (English)",
+  nativeName: "English",
+  flagPath: "/assets/amerilandia/flag.png",
+  heroPath: "/assets/amerilandia/map.png",
+  phrasebook: [
+    { key: "Hello", native: "Hello" },
+    { key: "Thank you", native: "Thank you" },
+    { key: "Goodbye", native: "Goodbye" },
+    { key: "Yes", native: "Yes" },
+    { key: "No", native: "No" },
+  ],
+  numbers: [
+    { value: 1, native: "one" },
+    { value: 2, native: "two" },
+    { value: 3, native: "three" },
+    { value: 4, native: "four" },
+    { value: 5, native: "five" },
+    { value: 6, native: "six" },
+    { value: 7, native: "seven" },
+    { value: 8, native: "eight" },
+    { value: 9, native: "nine" },
+    { value: 10, native: "ten" },
+  ],
+  colors: [
+    { en: "Red", native: "red" },
+    { en: "Blue", native: "blue" },
+    { en: "Green", native: "green" },
+    { en: "Yellow", native: "yellow" },
+  ],
+};
+
+export default US;

--- a/src/data/languages/australandia.ts
+++ b/src/data/languages/australandia.ts
@@ -1,0 +1,36 @@
+import { LangData } from "./types";
+
+const AU: LangData = {
+  slug: "australandia",
+  name: "Australandia (English)",
+  nativeName: "English",
+  flagPath: "/assets/australandia/flag.png",
+  heroPath: "/assets/australandia/map.png",
+  phrasebook: [
+    { key: "Hello", native: "Hello" },
+    { key: "Thank you", native: "Thank you" },
+    { key: "Goodbye", native: "Goodbye" },
+    { key: "Yes", native: "Yes" },
+    { key: "No", native: "No" },
+  ],
+  numbers: [
+    { value: 1, native: "one" },
+    { value: 2, native: "two" },
+    { value: 3, native: "three" },
+    { value: 4, native: "four" },
+    { value: 5, native: "five" },
+    { value: 6, native: "six" },
+    { value: 7, native: "seven" },
+    { value: 8, native: "eight" },
+    { value: 9, native: "nine" },
+    { value: 10, native: "ten" },
+  ],
+  colors: [
+    { en: "Red", native: "red" },
+    { en: "Blue", native: "blue" },
+    { en: "Green", native: "green" },
+    { en: "Yellow", native: "yellow" },
+  ],
+};
+
+export default AU;

--- a/src/data/languages/brazilandia.ts
+++ b/src/data/languages/brazilandia.ts
@@ -1,0 +1,36 @@
+import { LangData } from "./types";
+
+const BR: LangData = {
+  slug: "brazilandia",
+  name: "Brazilandia (Portuguese)",
+  nativeName: "Português",
+  flagPath: "/assets/brazilandia/flag.png",
+  heroPath: "/assets/brazilandia/map.png",
+  phrasebook: [
+    { key: "Hello", native: "Olá" },
+    { key: "Thank you", native: "Obrigado/Obrigada" },
+    { key: "Goodbye", native: "Tchau" },
+    { key: "Yes", native: "Sim" },
+    { key: "No", native: "Não" },
+  ],
+  numbers: [
+    { value: 1, native: "um" },
+    { value: 2, native: "dois" },
+    { value: 3, native: "três" },
+    { value: 4, native: "quatro" },
+    { value: 5, native: "cinco" },
+    { value: 6, native: "seis" },
+    { value: 7, native: "sete" },
+    { value: 8, native: "oito" },
+    { value: 9, native: "nove" },
+    { value: 10, native: "dez" },
+  ],
+  colors: [
+    { en: "Red", native: "vermelho" },
+    { en: "Blue", native: "azul" },
+    { en: "Green", native: "verde" },
+    { en: "Yellow", native: "amarelo" },
+  ],
+};
+
+export default BR;

--- a/src/data/languages/chinadia.ts
+++ b/src/data/languages/chinadia.ts
@@ -1,0 +1,37 @@
+import { LangData } from "./types";
+
+const CN: LangData = {
+  slug: "chinadia",
+  name: "Chinadia (Mandarin)",
+  nativeName: "中文",
+  flagPath: "/assets/chinadia/flag.png",
+  heroPath: "/assets/chinadia/map.png",
+  phrasebook: [
+    { key: "Hello", native: "你好", roman: "nǐ hǎo" },
+    { key: "Thank you", native: "谢谢", roman: "xièxie" },
+    { key: "Goodbye", native: "再见", roman: "zàijiàn" },
+    { key: "Yes", native: "是/对", roman: "shì/duì" },
+    { key: "No", native: "不是", roman: "bú shì" },
+  ],
+  numbers: [
+    { value: 1, native: "一", roman: "yī" },
+    { value: 2, native: "二", roman: "èr" },
+    { value: 3, native: "三", roman: "sān" },
+    { value: 4, native: "四", roman: "sì" },
+    { value: 5, native: "五", roman: "wǔ" },
+    { value: 6, native: "六", roman: "liù" },
+    { value: 7, native: "七", roman: "qī" },
+    { value: 8, native: "八", roman: "bā" },
+    { value: 9, native: "九", roman: "jiǔ" },
+    { value: 10, native: "十", roman: "shí" },
+  ],
+  colors: [
+    { en: "Red", native: "红色", roman: "hóng sè" },
+    { en: "Blue", native: "蓝色", roman: "lán sè" },
+    { en: "Green", native: "绿色", roman: "lǜ sè" },
+    { en: "Yellow", native: "黄色", roman: "huáng sè" },
+  ],
+  notes: ["Simplified characters shown."],
+};
+
+export default CN;

--- a/src/data/languages/index.ts
+++ b/src/data/languages/index.ts
@@ -1,0 +1,12 @@
+import { LangData } from "./types";
+import TH from "./thailandia";
+import CN from "./chinadia";
+import IN from "./indilandia";
+import BR from "./brazilandia";
+import AU from "./australandia";
+import US from "./amerilandia";
+
+export const LANGUAGES: LangData[] = [TH, CN, IN, BR, AU, US];
+
+export const bySlug = (slug: string): LangData | undefined =>
+  LANGUAGES.find((l) => l.slug === slug);

--- a/src/data/languages/indilandia.ts
+++ b/src/data/languages/indilandia.ts
@@ -1,0 +1,36 @@
+import { LangData } from "./types";
+
+const IN: LangData = {
+  slug: "indilandia",
+  name: "Indilandia (Hindi)",
+  nativeName: "हिन्दी",
+  flagPath: "/assets/indilandia/flag.png",
+  heroPath: "/assets/indilandia/map.png",
+  phrasebook: [
+    { key: "Hello", native: "नमस्ते", roman: "namaste" },
+    { key: "Thank you", native: "धन्यवाद", roman: "dhanyavaad" },
+    { key: "Goodbye", native: "अलविदा", roman: "alvida" },
+    { key: "Yes", native: "हाँ", roman: "haan" },
+    { key: "No", native: "नहीं", roman: "nahin" },
+  ],
+  numbers: [
+    { value: 1, native: "एक", roman: "ek" },
+    { value: 2, native: "दो", roman: "do" },
+    { value: 3, native: "तीन", roman: "teen" },
+    { value: 4, native: "चार", roman: "chaar" },
+    { value: 5, native: "पाँच", roman: "paanch" },
+    { value: 6, native: "छह", roman: "chhah" },
+    { value: 7, native: "सात", roman: "saat" },
+    { value: 8, native: "आठ", roman: "aath" },
+    { value: 9, native: "नौ", roman: "nau" },
+    { value: 10, native: "दस", roman: "das" },
+  ],
+  colors: [
+    { en: "Red", native: "लाल", roman: "laal" },
+    { en: "Blue", native: "नीला", roman: "neela" },
+    { en: "Green", native: "हरा", roman: "hara" },
+    { en: "Yellow", native: "पीला", roman: "peela" },
+  ],
+};
+
+export default IN;

--- a/src/data/languages/thailandia.ts
+++ b/src/data/languages/thailandia.ts
@@ -1,0 +1,37 @@
+import { LangData } from "./types";
+
+const TH: LangData = {
+  slug: "thailandia",
+  name: "Thailandia (Thai)",
+  nativeName: "ไทย",
+  flagPath: "/assets/thailandia/flag.png",
+  heroPath: "/assets/thailandia/ThailandiaMap.png",
+  phrasebook: [
+    { key: "Hello", native: "สวัสดี", roman: "sawasdee" },
+    { key: "Thank you", native: "ขอบคุณ", roman: "khob khun" },
+    { key: "Goodbye", native: "ลาก่อน", roman: "laa gòn" },
+    { key: "Yes", native: "ใช่", roman: "chai" },
+    { key: "No", native: "ไม่", roman: "mai" },
+  ],
+  numbers: [
+    { value: 1, native: "หนึ่ง", roman: "nèung" },
+    { value: 2, native: "สอง", roman: "sǒng" },
+    { value: 3, native: "สาม", roman: "săam" },
+    { value: 4, native: "สี่", roman: "sìi" },
+    { value: 5, native: "ห้า", roman: "hâa" },
+    { value: 6, native: "หก", roman: "hòk" },
+    { value: 7, native: "เจ็ด", roman: "jèt" },
+    { value: 8, native: "แปด", roman: "bpàet" },
+    { value: 9, native: "เก้า", roman: "gâo" },
+    { value: 10, native: "สิบ", roman: "sìp" },
+  ],
+  colors: [
+    { en: "Red", native: "แดง", roman: "daeng" },
+    { en: "Blue", native: "น้ำเงิน/ฟ้า", roman: "nam-ngern/fáa" },
+    { en: "Green", native: "เขียว", roman: "khǐao" },
+    { en: "Yellow", native: "เหลือง", roman: "lʉ̌ang" },
+  ],
+  notes: ["Thai uses its own script; romanization here is approximate."],
+};
+
+export default TH;

--- a/src/data/languages/types.ts
+++ b/src/data/languages/types.ts
@@ -1,0 +1,15 @@
+export type Phrase = { key: string; native: string; roman?: string };
+export type NumRow = { value: number; native: string; roman?: string };
+export type ColorRow = { en: string; native: string; roman?: string };
+
+export type LangData = {
+  slug: string;                 // e.g., "thailandia"
+  name: string;                 // e.g., "Thailandia (Thai)"
+  nativeName?: string;          // e.g., "ไทย"
+  flagPath: string;             // e.g., "/assets/thailandia/flag.png"
+  heroPath?: string;            // optional hero image
+  phrasebook: Phrase[];
+  numbers: NumRow[];
+  colors: ColorRow[];
+  notes?: string[];
+};

--- a/src/main.css
+++ b/src/main.css
@@ -7,6 +7,7 @@
 @import './styles/skeleton.css';
 @import './styles/auth-menu.css';
 @import './styles/buttons.css';
+@import './styles/languages.css';
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -18,6 +18,20 @@ export default function NaturversityPage() {
               desc: "Nature, art, music, wellness, crypto basics.",
               icon: "📚",
             },
+            {
+              to: "/naturversity/languages",
+              title: "Languages",
+              desc: "Phrasebooks for each kingdom.",
+              icon: (
+                <img
+                  src="/assets/amerilandia/flag.png"
+                  alt=""
+                  width={24}
+                  height={16}
+                  style={{ borderRadius: 3 }}
+                />
+              ),
+            },
           ]}
         />
 

--- a/src/pages/naturversity/languages/AmerilandiaLang.tsx
+++ b/src/pages/naturversity/languages/AmerilandiaLang.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+import LanguagePage from "./LanguagePage";
+import US from "../../../data/languages/amerilandia";
+export default function AmerilandiaLang(){ return <LanguagePage data={US} />; }

--- a/src/pages/naturversity/languages/AustralandiaLang.tsx
+++ b/src/pages/naturversity/languages/AustralandiaLang.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+import LanguagePage from "./LanguagePage";
+import AU from "../../../data/languages/australandia";
+export default function AustralandiaLang(){ return <LanguagePage data={AU} />; }

--- a/src/pages/naturversity/languages/BrazilandiaLang.tsx
+++ b/src/pages/naturversity/languages/BrazilandiaLang.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+import LanguagePage from "./LanguagePage";
+import BR from "../../../data/languages/brazilandia";
+export default function BrazilandiaLang(){ return <LanguagePage data={BR} />; }

--- a/src/pages/naturversity/languages/ChinadiaLang.tsx
+++ b/src/pages/naturversity/languages/ChinadiaLang.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+import LanguagePage from "./LanguagePage";
+import CN from "../../../data/languages/chinadia";
+export default function ChinadiaLang(){ return <LanguagePage data={CN} />; }

--- a/src/pages/naturversity/languages/IndilandiaLang.tsx
+++ b/src/pages/naturversity/languages/IndilandiaLang.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+import LanguagePage from "./LanguagePage";
+import IN from "../../../data/languages/indilandia";
+export default function IndilandiaLang(){ return <LanguagePage data={IN} />; }

--- a/src/pages/naturversity/languages/LanguagePage.tsx
+++ b/src/pages/naturversity/languages/LanguagePage.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from "react";
+import type { LangData } from "../../../data/languages/types";
+import { Breadcrumbs } from "../../../components/Breadcrumbs";
+
+export default function LanguagePage({ data }: { data: LangData }) {
+  const [showRoman, setShowRoman] = useState(true);
+
+  return (
+    <div>
+      <Breadcrumbs />
+      <div className="lang-hero">
+        <img className="flag" src={data.flagPath} alt={`${data.name} flag`} loading="lazy" />
+        <h1>{data.name}{data.nativeName ? ` — ${data.nativeName}` : ""}</h1>
+      </div>
+
+      {data.heroPath && (
+        <div className="lang-heroimg">
+          <img src={data.heroPath} alt={`${data.name} map`} loading="lazy" />
+        </div>
+      )}
+
+      <div className="lang-toggles">
+        <label className="switch">
+          <input
+            type="checkbox"
+            checked={showRoman}
+            onChange={(e) => setShowRoman(e.target.checked)}
+          />
+          <span>Show romanization</span>
+        </label>
+      </div>
+
+      <div className="cards">
+        <div className="card">
+          <h2>Phrasebook</h2>
+          <table className="table">
+            <thead><tr><th>English</th><th>Native</th><th>Romanization</th></tr></thead>
+            <tbody>
+              {data.phrasebook.map((p, i) => (
+                <tr key={i}>
+                  <td>{p.key}</td>
+                  <td>{p.native}</td>
+                  <td>{showRoman ? (p.roman || "—") : "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="card">
+          <h2>Numbers 1–10</h2>
+          <div className="grid2">
+            {data.numbers.map((n) => (
+              <div key={n.value} className="pill">
+                <strong>{n.value}</strong> — {n.native}
+                {showRoman && n.roman ? <span className="muted"> ({n.roman})</span> : null}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="card">
+          <h2>Colors</h2>
+          <div className="grid2">
+            {data.colors.map((c, i) => (
+              <div key={i} className="pill">
+                <strong>{c.en}</strong> — {c.native}
+                {showRoman && c.roman ? <span className="muted"> ({c.roman})</span> : null}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="card">
+          <h2>Flashcards & Audio</h2>
+          <p className="muted">Coming soon — practice decks and audio playback.</p>
+        </div>
+
+        {data.notes?.length ? (
+          <div className="card">
+            <h2>Notes</h2>
+            <ul>
+              {data.notes.map((n, i) => <li key={i}>{n}</li>)}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/naturversity/languages/ThailandiaLang.tsx
+++ b/src/pages/naturversity/languages/ThailandiaLang.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+import LanguagePage from "./LanguagePage";
+import TH from "../../../data/languages/thailandia";
+export default function ThailandiaLang(){ return <LanguagePage data={TH} />; }

--- a/src/pages/naturversity/languages/index.tsx
+++ b/src/pages/naturversity/languages/index.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { LANGUAGES } from "../../../data/languages";
+import { Breadcrumbs } from "../../../components/Breadcrumbs";
+
+export default function LanguagesHub() {
+  return (
+    <div>
+      <Breadcrumbs />
+      <h1>Languages</h1>
+      <p className="muted">Starter phrasebooks for each kingdom. More coming soon.</p>
+
+      <div className="cards">
+        {LANGUAGES.map((l) => (
+          <a key={l.slug} className="card" href={`/naturversity/languages/${l.slug}`}>
+            <img src={l.flagPath} alt={`${l.name} flag`} loading="lazy" />
+            <h2>{l.name}</h2>
+            <p>{l.nativeName ? `Native: ${l.nativeName}` : " "}</p>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -38,6 +38,13 @@ import Teachers from './pages/naturversity/Teachers';
 import Partners from './pages/naturversity/Partners';
 import Courses from './pages/naturversity/Courses';
 import CourseDetail from './pages/naturversity/CourseDetail';
+import LanguagesHub from './pages/naturversity/languages';
+import ThailandiaLang from './pages/naturversity/languages/ThailandiaLang';
+import ChinadiaLang from './pages/naturversity/languages/ChinadiaLang';
+import IndilandiaLang from './pages/naturversity/languages/IndilandiaLang';
+import BrazilandiaLang from './pages/naturversity/languages/BrazilandiaLang';
+import AustralandiaLang from './pages/naturversity/languages/AustralandiaLang';
+import AmerilandiaLang from './pages/naturversity/languages/AmerilandiaLang';
 import Naturbank from './pages/Naturbank';
 import BankWallet from './pages/naturbank/Wallet';
 import BankToken from './pages/naturbank/Token';
@@ -98,6 +105,13 @@ export const router = createBrowserRouter([
       { path: 'naturversity/partners', element: <Partners /> },
       { path: 'naturversity/courses', element: <Courses /> },
       { path: 'naturversity/course/:slug', element: <CourseDetail /> },
+      { path: 'naturversity/languages', element: <LanguagesHub /> },
+      { path: 'naturversity/languages/thailandia', element: <ThailandiaLang /> },
+      { path: 'naturversity/languages/chinadia', element: <ChinadiaLang /> },
+      { path: 'naturversity/languages/indilandia', element: <IndilandiaLang /> },
+      { path: 'naturversity/languages/brazilandia', element: <BrazilandiaLang /> },
+      { path: 'naturversity/languages/australandia', element: <AustralandiaLang /> },
+      { path: 'naturversity/languages/amerilandia', element: <AmerilandiaLang /> },
       { path: 'naturbank', element: <Naturbank /> },
       { path: 'naturbank/wallet', element: <BankWallet /> },
       { path: 'naturbank/natur', element: <BankToken /> },

--- a/src/styles/languages.css
+++ b/src/styles/languages.css
@@ -1,0 +1,7 @@
+.lang-hero { display:flex; align-items:center; gap:10px; margin-bottom:10px; }
+.lang-hero .flag { width:28px; height:20px; object-fit:cover; border-radius:3px; border:1px solid #dbeafe; }
+.lang-heroimg img { width:100%; max-height:320px; object-fit:cover; border-radius:12px; border:1px solid #e5e7eb; }
+.lang-toggles { margin:10px 0; }
+.table { width:100%; border-collapse: collapse; }
+.table th, .table td { border-bottom:1px solid #e5e7eb; padding:8px; text-align:left; }
+.pill { background:#eff6ff; border:1px solid #dbeafe; padding:8px 10px; border-radius:10px; }


### PR DESCRIPTION
## Summary
- add data-driven language definitions and hub listings
- build reusable language page with phrasebook, numbers, and colors
- wire up languages routes, styles, and Naturversity card

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a2d020ac83299f573e95fc3d2713