### PR TITLE
UX polish pack #2 — active nav highlight, consistent wrappers, lazy-images, card aspect-ratio, back-crumbs

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,13 +1,16 @@
 import React from "react";
-import { Link, useLocation } from "react-router-dom";
-
-export function Breadcrumbs() {
-  const { pathname } = useLocation();
-  const parts = pathname.split("/").filter(Boolean);
-  const crumbs = parts.map((p, i) => {
-    const href = "/" + parts.slice(0, i + 1).join("/");
-    const label = p[0]?.toUpperCase() + p.slice(1);
-    return <span key={href}> / <Link to={href}>{label}</Link></span>;
-  });
-  return <nav aria-label="Breadcrumbs" className="breadcrumbs"><Link to="/">Home</Link>{crumbs}</nav>;
+export default function Breadcrumbs({ items, className = "" }: { items: { href?: string; label: string }[]; className?: string; }) {
+  if (!items?.length) return null;
+  return (
+    <nav aria-label="Breadcrumb" className={`crumbs ${className}`}>
+      <ol>
+        {items.map((it, i) => (
+          <li key={i} className="crumb">
+            {it.href ? <a href={it.href}>{it.label}</a> : <span>{it.label}</span>}
+            {i < items.length - 1 && <span className="sep"> / </span>}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,25 +1,28 @@
 import React from "react";
-import { NavLink } from "react-router-dom";
-import Img from "./Img";
+import SafeImg from "./SafeImg";
+
+const isActive = (href: string) => typeof window !== "undefined" && window.location.pathname === href;
 
 export default function Nav() {
   return (
     <>
       <a href="#main-content" className="visually-hidden-focusable">Skip to content</a>
-      <nav className="topnav container">
-        <a href="/" aria-label="Naturverse Home" className="brand">
-          <Img src="/favicon-32x32.png" alt="Naturverse" width={24} height={24} />
-        </a>
-        <div className="links">
-          <NavLink to="/worlds" className={({isActive})=>`nav${isActive?' active':''}`}>Worlds</NavLink>
-          <NavLink to="/zones" className={({isActive})=>`nav${isActive?' active':''}`}>Zones</NavLink>
-          <NavLink to="/marketplace" className={({isActive})=>`nav${isActive?' active':''}`}>Marketplace</NavLink>
-          <NavLink to="/naturversity" className={({isActive})=>`nav${isActive?' active':''}`}>Naturversity</NavLink>
-          <NavLink to="/passport" className={({isActive})=>`nav${isActive?' active':''}`}>Passport</NavLink>
-          <NavLink to="/profile" className={({isActive})=>`nav${isActive?' active':''}`}>Profile</NavLink>
-          {/* ...rest unchanged */}
-        </div>
-      </nav>
-    </>
-  );
-}
+        <nav className="topnav container">
+          <a href="/" aria-label="Naturverse Home" className={`toplink brand ${isActive("/") ? "active" : ""}`}>
+            <SafeImg src="/favicon-32x32.png" alt="Naturverse" width={24} height={24} />
+          </a>
+          <div className="links">
+            <a href="/worlds" className={`toplink ${isActive("/worlds") ? "active" : ""}`}>Worlds</a>
+            <a href="/zones" className={`toplink ${isActive("/zones") ? "active" : ""}`}>Zones</a>
+            <a href="/marketplace" className={`toplink ${isActive("/marketplace") ? "active" : ""}`}>Marketplace</a>
+            <a href="/naturversity" className={`toplink ${isActive("/naturversity") ? "active" : ""}`}>Naturversity</a>
+            <a href="/naturbank" className={`toplink ${isActive("/naturbank") ? "active" : ""}`}>Naturbank</a>
+            <a href="/navatar" className={`toplink ${isActive("/navatar") ? "active" : ""}`}>Navatar</a>
+            <a href="/passport" className={`toplink ${isActive("/passport") ? "active" : ""}`}>Passport</a>
+            <a href="/turian" className={`toplink ${isActive("/turian") ? "active" : ""}`}>Turian</a>
+            <a href="/profile" className={`toplink ${isActive("/profile") ? "active" : ""}`}>Profile</a>
+          </div>
+        </nav>
+      </>
+    );
+  }

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,18 +1,21 @@
 import { ReactNode } from "react";
-import { Breadcrumbs } from "./Breadcrumbs";
+import Breadcrumbs from "./Breadcrumbs";
 
 export default function Page({
   title,
   subtitle,
   children,
-}: { title: string; subtitle?: string; children: ReactNode }) {
+  crumbs = [],
+}: { title: string; subtitle?: string; children: ReactNode; crumbs?: { href?: string; label: string }[] }) {
   return (
-    <main id="main" className="mx-auto max-w-6xl px-4 py-8">
-      <Breadcrumbs />
-      <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight">{title}</h1>
-      {subtitle && <p className="mt-2 text-slate-600">{subtitle}</p>}
-      <div className="mt-6">{children}</div>
-    </main>
+    <div className="page-wrap">
+      <Breadcrumbs items={crumbs} />
+      <main id="main" className="mx-auto max-w-6xl px-4 py-8">
+        <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight">{title}</h1>
+        {subtitle && <p className="mt-2 text-slate-600">{subtitle}</p>}
+        <div className="mt-6">{children}</div>
+      </main>
+    </div>
   );
 }
 

--- a/src/components/SafeImg.tsx
+++ b/src/components/SafeImg.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from "react";
+
+export default function SafeImg(
+  { src, alt, width, height, className }: { src: string; alt: string; width?: number; height?: number; className?: string }
+) {
+  const [err, setErr] = useState(false);
+  if (err || !src) {
+    return <div className={`img-fallback ${className || ""}`} style={{ width, height }} aria-label={alt} />;
+  }
+  return (
+    <img
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      loading="lazy"
+      onError={() => setErr(true)}
+      className={className}
+    />
+  );
+}

--- a/src/main.css
+++ b/src/main.css
@@ -4,10 +4,15 @@
 @import './styles/footer.css';
 @import './styles/home.css';
 @import './styles/cards-unify.css';
+@import './styles/cards.css';
 @import './styles/skeleton.css';
 @import './styles/auth-menu.css';
 @import './styles/buttons.css';
 @import './styles/languages.css';
+@import './styles/layout.css';
+@import './styles/nav.css';
+@import './styles/img.css';
+@import './styles/a11y.css';
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,
@@ -27,27 +32,11 @@ body {
   margin-bottom: 8px;
 }
 
-/* top-nav active state (add data-topnav on anchors) */
-a.active {
-  color: var(--nv-blue-600);
-  font-weight: 800;
-}
-
-/* centered page wrapper helper */
-.page-wrap {
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 0 16px;
-  }
-
-/* a11y + nav active */
+/* a11y */
 .skip-link {
   position:absolute; left:-999px; top:auto; width:1px; height:1px; overflow:hidden;
 }
 .skip-link:focus { position:static; width:auto; height:auto; padding:8px 12px; background:#e0f2fe; border-radius:8px; }
-
-.nav-link { padding:6px 10px; border-radius:8px; text-decoration:none; }
-.nav-link.active { background:#dbeafe; color:#1e3a8a; font-weight:700; }
 
 /* generic .button for 404/EB */
 .button { display:inline-block; padding:10px 14px; background:#0ea5e9; color:#fff; border-radius:10px; border:1px solid #0ea5e9; text-decoration:none; }

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -2,19 +2,22 @@ import React from "react";
 import { HubGrid } from "../components/HubGrid";
 import Seo from "../components/Seo";
 import { breadcrumbs } from "../lib/jsonld";
+import Breadcrumbs from "../components/Breadcrumbs";
 
 const labels = { '/marketplace': 'Marketplace' };
 
 export default function MarketplacePage() {
-  return (
-    <>
-      <Seo
-        title="Marketplace"
-        description="Shop Naturverse creations, merch, and bundles."
-      />
-      <main id="main">
-        <h1>Marketplace</h1>
-        <p className="muted">Shop creations and merch.</p>
+    return (
+      <>
+        <Seo
+          title="Marketplace"
+          description="Shop Naturverse creations, merch, and bundles."
+        />
+        <div className="page-wrap">
+          <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Marketplace" }]} />
+          <main id="main">
+          <h1>Marketplace</h1>
+          <p className="muted">Shop creations and merch.</p>
 
         <HubGrid
           items={[
@@ -27,7 +30,8 @@ export default function MarketplacePage() {
         <p className="muted" style={{ marginTop: 12 }}>
           Coming soon: AI assistance for sizing, bundles, and gift ideas.
         </p>
-      </main>
+          </main>
+        </div>
 
       <script
         type="application/ld+json"
@@ -37,6 +41,6 @@ export default function MarketplacePage() {
           ),
         }}
       />
-    </>
-  );
+      </>
+    );
 }

--- a/src/pages/Naturbank.tsx
+++ b/src/pages/Naturbank.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import { HubGrid } from "../components/HubGrid";
+import Breadcrumbs from "../components/Breadcrumbs";
 
 export default function NaturbankPage() {
   return (
-    <main id="main">
-      <h1>Naturbank</h1>
-      <p className="muted">Wallets, token, and collectibles.</p>
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Naturbank" }]} />
+        <main id="main">
+        <h1>Naturbank</h1>
+        <p className="muted">Wallets, token, and collectibles.</p>
 
       <HubGrid
         items={[
@@ -19,6 +22,7 @@ export default function NaturbankPage() {
       <p className="muted" style={{ marginTop: 12 }}>
         Coming soon: live wallets, on-chain mints, and payouts.
       </p>
-    </main>
-  );
+        </main>
+      </div>
+    );
 }

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { HubGrid } from "../components/HubGrid";
+import Breadcrumbs from "../components/Breadcrumbs";
 
 export default function NaturversityPage() {
   return (
-    <>
-      <main id="main">
-        <h1>Naturversity</h1>
-        <p className="muted">Teachers, partners, and courses.</p>
+      <>
+        <div className="page-wrap">
+          <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Naturversity" }]} />
+          <main id="main">
+          <h1>Naturversity</h1>
+          <p className="muted">Teachers, partners, and courses.</p>
 
         <HubGrid
           items={[
@@ -23,13 +26,14 @@ export default function NaturversityPage() {
               title: "Languages",
               desc: "Phrasebooks for each kingdom.",
               icon: (
-                <img
-                  src="/assets/amerilandia/flag.png"
-                  alt=""
-                  width={24}
-                  height={16}
-                  style={{ borderRadius: 3 }}
-                />
+                  <img
+                    src="/assets/amerilandia/flag.png"
+                    alt=""
+                    width={24}
+                    height={16}
+                    loading="lazy"
+                    style={{ borderRadius: 3 }}
+                  />
               ),
             },
           ]}
@@ -38,7 +42,8 @@ export default function NaturversityPage() {
         <p className="muted" style={{ marginTop: 12 }}>
           Coming soon: AI tutors and step-by-step lessons.
         </p>
-      </main>
-    </>
+          </main>
+        </div>
+      </>
   );
 }

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -3,6 +3,7 @@ import type { Navatar, NavatarBase } from "../types/navatar";
 import { SPECIES, POWERS_BANK, randomFrom } from "../lib/navatarCatalog";
 import { loadActive, saveActive, loadLibrary, saveLibrary } from "../lib/localStorage";
 import NavatarCard from "../components/NavatarCard";
+import Breadcrumbs from "../components/Breadcrumbs";
 
 const BASES: NavatarBase[] = ["Animal", "Fruit", "Insect", "Spirit"];
 
@@ -62,9 +63,11 @@ export default function NavatarPage() {
   }
 
   return (
-    <main id="main" className="wrap">
-      <h1>Navatar Creator</h1>
-      <p>Choose a base type, customize details, and save your character card.</p>
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Navatar" }]} />
+      <main id="main" className="wrap">
+        <h1>Navatar Creator</h1>
+        <p>Choose a base type, customize details, and save your character card.</p>
 
       <div className="grid">
         <section className="panel">
@@ -157,6 +160,7 @@ export default function NavatarPage() {
         .linklike{background:none;border:none;padding:0;color:#0b62d6;cursor:pointer}
         .note{opacity:.75;margin-top:24px}
       `}</style>
-    </main>
-  );
+      </main>
+    </div>
+    );
 }

--- a/src/pages/Passport.tsx
+++ b/src/pages/Passport.tsx
@@ -30,8 +30,8 @@ export default function PassportPage() {
   const earnXP = (n: number) => { addXP(n); setXp(getXP()); };
   const earnNatur = (n: number) => { addNatur(n); setNatur(getNatur()); };
 
-  return (
-    <Page title="Passport" subtitle="Badges, stamps, XP, and NATUR coin.">
+    return (
+      <Page title="Passport" subtitle="Badges, stamps, XP, and NATUR coin." crumbs={[{ href:"/", label:"Home" }, { label:"Passport" }]}>
       {/* Identity / Navatar */}
       <div className="passport-id">
         <div className="avatar">

--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -81,7 +81,7 @@ export default function TurianPage() {
 
   return (
     <>
-      <Page title="Turian the Durian" subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet.">
+        <Page title="Turian the Durian" subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet." crumbs={[{ href:"/", label:"Home" }, { label:"Turian" }]}>
 
       <div className="nv-card" style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 12 }}>
         {mascotSrc ? (

--- a/src/pages/naturversity/languages/LanguagePage.tsx
+++ b/src/pages/naturversity/languages/LanguagePage.tsx
@@ -1,23 +1,24 @@
 import React, { useState } from "react";
 import type { LangData } from "../../../data/languages/types";
-import { Breadcrumbs } from "../../../components/Breadcrumbs";
+import Breadcrumbs from "../../../components/Breadcrumbs";
+import SafeImg from "../../../components/SafeImg";
 
 export default function LanguagePage({ data }: { data: LangData }) {
   const [showRoman, setShowRoman] = useState(true);
 
   return (
-    <div>
-      <Breadcrumbs />
-      <div className="lang-hero">
-        <img className="flag" src={data.flagPath} alt={`${data.name} flag`} loading="lazy" />
-        <h1>{data.name}{data.nativeName ? ` — ${data.nativeName}` : ""}</h1>
-      </div>
-
-      {data.heroPath && (
-        <div className="lang-heroimg">
-          <img src={data.heroPath} alt={`${data.name} map`} loading="lazy" />
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/naturversity", label:"Naturversity" }, { href:"/naturversity/languages", label:"Languages" }, { label: data.name }]} />
+        <div className="lang-hero">
+          <SafeImg className="flag" src={data.flagPath} alt={`${data.name} flag`} width={800} height={450} />
+          <h1>{data.name}{data.nativeName ? ` — ${data.nativeName}` : ""}</h1>
         </div>
-      )}
+
+        {data.heroPath && (
+          <div className="lang-heroimg">
+            <SafeImg src={data.heroPath} alt={`${data.name} map`} width={800} height={450} />
+          </div>
+        )}
 
       <div className="lang-toggles">
         <label className="switch">

--- a/src/pages/naturversity/languages/index.tsx
+++ b/src/pages/naturversity/languages/index.tsx
@@ -1,18 +1,19 @@
 import React from "react";
 import { LANGUAGES } from "../../../data/languages";
-import { Breadcrumbs } from "../../../components/Breadcrumbs";
+import Breadcrumbs from "../../../components/Breadcrumbs";
+import SafeImg from "../../../components/SafeImg";
 
 export default function LanguagesHub() {
   return (
-    <div>
-      <Breadcrumbs />
-      <h1>Languages</h1>
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/naturversity", label:"Naturversity" }, { label:"Languages" }]} />
+        <h1>Languages</h1>
       <p className="muted">Starter phrasebooks for each kingdom. More coming soon.</p>
 
       <div className="cards">
         {LANGUAGES.map((l) => (
           <a key={l.slug} className="card" href={`/naturversity/languages/${l.slug}`}>
-            <img src={l.flagPath} alt={`${l.name} flag`} loading="lazy" />
+              <SafeImg src={l.flagPath} alt={`${l.name} flag`} width={800} height={450} />
             <h2>{l.name}</h2>
             <p>{l.nativeName ? `Native: ${l.nativeName}` : " "}</p>
           </a>

--- a/src/pages/worlds/Africana.tsx
+++ b/src/pages/worlds/Africana.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
 import { Img } from "../../components";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 type Character = { name: string; src: string };
 
@@ -15,14 +16,16 @@ export default function AfricanaWorld() {
   }, []);
 
   return (
-    <WorldLayout title="Africana" mapSrc="/kingdoms/Africana/Africanamap.png">
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Africana" }]} />
+      <WorldLayout title="Africana" mapSrc="/kingdoms/Africana/Africanamap.png">
       {/* Characters */}
       <section className="characters">
         <h2>Characters</h2>
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <Img src={c.src} alt={c.name} />
+                <Img src={c.src} alt={c.name} width={800} height={450} />
               <div className="name">{c.name}</div>
             </article>
           ))}
@@ -34,6 +37,7 @@ export default function AfricanaWorld() {
         <h2>Gallery</h2>
         <div className="gallery-placeholder">Coming soon</div>
       </section>
-    </WorldLayout>
+      </WorldLayout>
+    </div>
   );
 }

--- a/src/pages/worlds/Antarctiland.tsx
+++ b/src/pages/worlds/Antarctiland.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
 import { Img } from "../../components";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 type Character = { name: string; src: string };
 
@@ -14,15 +15,17 @@ export default function AntarctilandWorld() {
       .catch(() => setChars([]));
   }, []);
 
-  return (
-    <WorldLayout title="Antarctiland" mapSrc="/kingdoms/Antarctiland/Antarctilandmap.png">
+    return (
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Antarctiland" }]} />
+        <WorldLayout title="Antarctiland" mapSrc="/kingdoms/Antarctiland/Antarctilandmap.png">
       {/* Characters */}
       <section className="characters">
         <h2>Characters</h2>
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <Img src={c.src} alt={c.name} />
+                <Img src={c.src} alt={c.name} width={800} height={450} />
               <div className="name">{c.name}</div>
             </article>
           ))}
@@ -34,6 +37,7 @@ export default function AntarctilandWorld() {
         <h2>Gallery</h2>
         <div className="gallery-placeholder">Coming soon</div>
       </section>
-    </WorldLayout>
-  );
+        </WorldLayout>
+      </div>
+    );
 }

--- a/src/pages/worlds/Britannula.tsx
+++ b/src/pages/worlds/Britannula.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
 import { Img } from "../../components";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 type Character = { name: string; src: string };
 
@@ -14,15 +15,17 @@ export default function BritannulaWorld() {
       .catch(() => setChars([]));
   }, []);
 
-  return (
-    <WorldLayout title="Britannula" mapSrc="/kingdoms/Britannula/Britannulamap.png">
+    return (
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Britannula" }]} />
+        <WorldLayout title="Britannula" mapSrc="/kingdoms/Britannula/Britannulamap.png">
       {/* Characters */}
       <section className="characters">
         <h2>Characters</h2>
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <Img src={c.src} alt={c.name} />
+                <Img src={c.src} alt={c.name} width={800} height={450} />
               <div className="name">{c.name}</div>
             </article>
           ))}
@@ -34,6 +37,7 @@ export default function BritannulaWorld() {
         <h2>Gallery</h2>
         <div className="gallery-placeholder">Coming soon</div>
       </section>
-    </WorldLayout>
-  );
+        </WorldLayout>
+      </div>
+    );
 }

--- a/src/pages/worlds/Europalia.tsx
+++ b/src/pages/worlds/Europalia.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
 import { Img } from "../../components";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 type Character = { name: string; src: string };
 
@@ -14,15 +15,17 @@ export default function EuropaliaWorld() {
       .catch(() => setChars([]));
   }, []);
 
-  return (
-    <WorldLayout title="Europalia" mapSrc="/kingdoms/Europalia/Europaliamap.png">
+    return (
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Europalia" }]} />
+        <WorldLayout title="Europalia" mapSrc="/kingdoms/Europalia/Europaliamap.png">
       {/* Characters */}
       <section className="characters">
         <h2>Characters</h2>
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <Img src={c.src} alt={c.name} />
+                <Img src={c.src} alt={c.name} width={800} height={450} />
               <div className="name">{c.name}</div>
             </article>
           ))}
@@ -34,6 +37,7 @@ export default function EuropaliaWorld() {
         <h2>Gallery</h2>
         <div className="gallery-placeholder">Coming soon</div>
       </section>
-    </WorldLayout>
-  );
+        </WorldLayout>
+      </div>
+    );
 }

--- a/src/pages/worlds/Greenlandia.tsx
+++ b/src/pages/worlds/Greenlandia.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
 import { Img } from "../../components";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 type Character = { name: string; src: string };
 
@@ -14,15 +15,17 @@ export default function GreenlandiaWorld() {
       .catch(() => setChars([]));
   }, []);
 
-  return (
-    <WorldLayout title="Greenlandia" mapSrc="/kingdoms/Greenlandia/Greenlandiamap.png">
+    return (
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Greenlandia" }]} />
+        <WorldLayout title="Greenlandia" mapSrc="/kingdoms/Greenlandia/Greenlandiamap.png">
       {/* Characters */}
       <section className="characters">
         <h2>Characters</h2>
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <Img src={c.src} alt={c.name} />
+                <Img src={c.src} alt={c.name} width={800} height={450} />
               <div className="name">{c.name}</div>
             </article>
           ))}
@@ -34,6 +37,7 @@ export default function GreenlandiaWorld() {
         <h2>Gallery</h2>
         <div className="gallery-placeholder">Coming soon</div>
       </section>
-    </WorldLayout>
-  );
+        </WorldLayout>
+      </div>
+    );
 }

--- a/src/pages/worlds/Japonica.tsx
+++ b/src/pages/worlds/Japonica.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
 import { Img } from "../../components";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 type Character = { name: string; src: string };
 
@@ -14,15 +15,17 @@ export default function JaponicaWorld() {
       .catch(() => setChars([]));
   }, []);
 
-  return (
-    <WorldLayout title="Japonica" mapSrc="/kingdoms/Japonica/Japonicamap.png">
+    return (
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Japonica" }]} />
+        <WorldLayout title="Japonica" mapSrc="/kingdoms/Japonica/Japonicamap.png">
       {/* Characters */}
       <section className="characters">
         <h2>Characters</h2>
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <Img src={c.src} alt={c.name} />
+                <Img src={c.src} alt={c.name} width={800} height={450} />
               <div className="name">{c.name}</div>
             </article>
           ))}
@@ -34,6 +37,7 @@ export default function JaponicaWorld() {
         <h2>Gallery</h2>
         <div className="gallery-placeholder">Coming soon</div>
       </section>
-    </WorldLayout>
-  );
+        </WorldLayout>
+      </div>
+    );
 }

--- a/src/pages/worlds/Kiwilandia.tsx
+++ b/src/pages/worlds/Kiwilandia.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
 import { Img } from "../../components";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 type Character = { name: string; src: string };
 
@@ -14,15 +15,17 @@ export default function KiwilandiaWorld() {
       .catch(() => setChars([]));
   }, []);
 
-  return (
-    <WorldLayout title="Kiwilandia" mapSrc="/kingdoms/Kiwilandia/Kiwilandiamap.png">
+    return (
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Kiwilandia" }]} />
+        <WorldLayout title="Kiwilandia" mapSrc="/kingdoms/Kiwilandia/Kiwilandiamap.png">
       {/* Characters */}
       <section className="characters">
         <h2>Characters</h2>
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <Img src={c.src} alt={c.name} />
+                <Img src={c.src} alt={c.name} width={800} height={450} />
               <div className="name">{c.name}</div>
             </article>
           ))}
@@ -34,6 +37,7 @@ export default function KiwilandiaWorld() {
         <h2>Gallery</h2>
         <div className="gallery-placeholder">Coming soon</div>
       </section>
-    </WorldLayout>
-  );
+        </WorldLayout>
+      </div>
+    );
 }

--- a/src/pages/worlds/Madagascaria.tsx
+++ b/src/pages/worlds/Madagascaria.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import WorldLayout from "./_WorldLayout";
 import { Img } from "../../components";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 type Character = { name: string; src: string };
 
@@ -14,15 +15,17 @@ export default function MadagascariaWorld() {
       .catch(() => setChars([]));
   }, []);
 
-  return (
-    <WorldLayout title="Madagascaria" mapSrc="/kingdoms/Madagascaria/Madagascariamap.png">
+    return (
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Madagascaria" }]} />
+        <WorldLayout title="Madagascaria" mapSrc="/kingdoms/Madagascaria/Madagascariamap.png">
       {/* Characters */}
       <section className="characters">
         <h2>Characters</h2>
         <div className="characters-grid">
           {chars.map((c) => (
             <article key={c.src} className="character-card">
-              <Img src={c.src} alt={c.name} />
+                <Img src={c.src} alt={c.name} width={800} height={450} />
               <div className="name">{c.name}</div>
             </article>
           ))}
@@ -34,6 +37,7 @@ export default function MadagascariaWorld() {
         <h2>Gallery</h2>
         <div className="gallery-placeholder">Coming soon</div>
       </section>
-    </WorldLayout>
-  );
+        </WorldLayout>
+      </div>
+    );
 }

--- a/src/pages/worlds/amerilandia.tsx
+++ b/src/pages/worlds/amerilandia.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import WorldLayout from "../../components/WorldLayout";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function AmerilandiaPage() {
-  return <WorldLayout id="amerilandia" />;
+  return (
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Amerilandia" }]} />
+      <WorldLayout id="amerilandia" />
+    </div>
+  );
 }

--- a/src/pages/worlds/australandia.tsx
+++ b/src/pages/worlds/australandia.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import WorldLayout from "../../components/WorldLayout";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function AustralandiaPage() {
-  return <WorldLayout id="australandia" />;
+  return (
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Australandia" }]} />
+      <WorldLayout id="australandia" />
+    </div>
+  );
 }

--- a/src/pages/worlds/brazilandia.tsx
+++ b/src/pages/worlds/brazilandia.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import WorldLayout from "../../components/WorldLayout";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function BrazilandiaPage() {
-  return <WorldLayout id="brazilandia" />;
+  return (
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Brazilandia" }]} />
+      <WorldLayout id="brazilandia" />
+    </div>
+  );
 }

--- a/src/pages/worlds/chilandia.tsx
+++ b/src/pages/worlds/chilandia.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import WorldLayout from "../../components/WorldLayout";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function ChilandiaPage() {
-  return <WorldLayout id="chilandia" />;
+  return (
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Chilandia" }]} />
+      <WorldLayout id="chilandia" />
+    </div>
+  );
 }

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -1,22 +1,22 @@
 import React from "react";
 import { WORLDS } from "../../data/worlds";
 import Meta from "../../components/Meta";
-import { Breadcrumbs } from "../../components/Breadcrumbs";
+import Breadcrumbs from "../../components/Breadcrumbs";
 import SmartImg from "../../components/SmartImg";
 
 export default function WorldsIndex() {
   return (
-    <div className="container-narrow">
-      <Meta title="Worlds — Naturverse" description="Explore the 14 kingdoms." />
-      <Breadcrumbs />
+      <div className="page-wrap">
+        <Meta title="Worlds — Naturverse" description="Explore the 14 kingdoms." />
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Worlds" }]} />
       <p className="muted">Choose a kingdom to explore.</p>
       <div className="cards">
         {WORLDS.map((w) => (
-          <a className="card" key={w.slug} href={`/worlds/${w.slug}`}>
-            <SmartImg src={w.map} alt={`${w.name} map`} ratio="wide" />
-            <h2>{w.name}</h2>
-            <p>{w.blurb}</p>
-          </a>
+            <a className="card" key={w.slug} href={`/worlds/${w.slug}`}>
+              <SmartImg src={w.map} alt={`${w.name} map`} ratio="wide" width={800} height={450} />
+              <h2>{w.name}</h2>
+              <p>{w.blurb}</p>
+            </a>
         ))}
       </div>
     </div>

--- a/src/pages/worlds/indillandia.tsx
+++ b/src/pages/worlds/indillandia.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import WorldLayout from "../../components/WorldLayout";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function IndillandiaPage() {
-  return <WorldLayout id="indillandia" />;
+  return (
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Indillandia" }]} />
+      <WorldLayout id="indillandia" />
+    </div>
+  );
 }

--- a/src/pages/worlds/thailandia.tsx
+++ b/src/pages/worlds/thailandia.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import WorldLayout from "../../components/WorldLayout";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function ThailandiaPage() {
-  return <WorldLayout id="thailandia" />;
+  return (
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Thailandia" }]} />
+      <WorldLayout id="thailandia" />
+    </div>
+  );
 }

--- a/src/pages/zones/Community.tsx
+++ b/src/pages/zones/Community.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Breadcrumbs } from '../../components/Breadcrumbs';
+import Breadcrumbs from '../../components/Breadcrumbs';
 import '../../styles/zone-widgets.css';
 import { BoardPost, Poll } from '../../lib/community/types';
 import {
@@ -130,8 +130,9 @@ export default function Community() {
   };
 
   return (
-    <main id="main">
-      <Breadcrumbs />
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Community" }]} />
+      <main id="main">
       <h1>🗳️🌍 Community</h1>
       <p>Vote for new lands & characters, and join local volunteer events.</p>
 
@@ -289,6 +290,7 @@ export default function Community() {
           </ul>
         </section>
       )}
-    </main>
+      </main>
+    </div>
   );
 }

--- a/src/pages/zones/Culture.tsx
+++ b/src/pages/zones/Culture.tsx
@@ -12,10 +12,11 @@ const kingdoms = CULTURE_SECTIONS.map(k => ({
 
 export default function Culture() {
   return (
-    <Page
-      title="Culture"
-      subtitle="Beliefs, holidays, and ceremonies across the 14 kingdoms."
-    >
+      <Page
+        title="Culture"
+        subtitle="Beliefs, holidays, and ceremonies across the 14 kingdoms."
+        crumbs={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Culture" }]}
+      >
       <div className="culture-grid grid gap-4 md:gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {kingdoms.map((k) => (
           <section key={k.name} className="nv-card rounded-xl border border-slate-200 bg-white p-5 shadow-sm">

--- a/src/pages/zones/Future.tsx
+++ b/src/pages/zones/Future.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { Breadcrumbs } from "../../components/Breadcrumbs";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function FutureZone() {
   return (
-    <main id="main" className="page">
-      <Breadcrumbs />
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Future" }]} />
+        <main id="main" className="page">
 
-      <h1>🔮 Future Zone</h1>
+        <h1>🔮 Future Zone</h1>
       <p className="muted">
         A sneak peek at what's coming to the Naturverse. These features are in active design.
       </p>
@@ -48,7 +49,8 @@ export default function FutureZone() {
           <p>NATUR wallet, trading, redemptions, and seasonal global events.</p>
         </a>
       </div>
-    </main>
-  );
+        </main>
+      </div>
+    );
 }
 

--- a/src/pages/zones/Observations.tsx
+++ b/src/pages/zones/Observations.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Breadcrumbs } from '../../components/Breadcrumbs';
+import Breadcrumbs from '../../components/Breadcrumbs';
 import PhotoUploader from '../../components/PhotoUploader';
 import { Img } from '../../components';
 import { Observation } from '../../lib/observations/types';
@@ -145,8 +145,9 @@ export default function Observations() {
   }, [list]);
 
   return (
-    <main id="main">
-      <Breadcrumbs />
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Observations" }]} />
+      <main id="main">
       <h1>📷🌿 Observations</h1>
       <p>Upload nature pics; tag, learn, earn. (Local & offline; data stays in your browser.)</p>
 
@@ -341,6 +342,7 @@ export default function Observations() {
           </ul>
         </section>
       )}
-    </main>
+      </main>
+    </div>
   );
 }

--- a/src/pages/zones/Quizzes.tsx
+++ b/src/pages/zones/Quizzes.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Breadcrumbs } from '../../components/Breadcrumbs';
+import Breadcrumbs from '../../components/Breadcrumbs';
 import { Quiz } from '../../lib/quiz/types';
 import { SAMPLE_QUIZZES } from '../../lib/quiz/sampleQuizzes';
 import { ClassicPlayer, JeopardyBoard, QuizSummary } from '../../components/QuizPlayer';
@@ -64,8 +64,9 @@ export default function Quizzes() {
   };
 
   return (
-    <main id="main">
-      <Breadcrumbs />
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Quizzes" }]} />
+      <main id="main">
       <h1>🎯 Quizzes</h1>
       <p>Solo & party quiz play with scoring (client-only; no backend).</p>
 
@@ -228,6 +229,7 @@ export default function Quizzes() {
           </ul>
         </section>
       )}
-    </main>
+      </main>
+    </div>
   );
 }

--- a/src/pages/zones/Stories.tsx
+++ b/src/pages/zones/Stories.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Breadcrumbs } from '../../components/Breadcrumbs';
+import Breadcrumbs from '../../components/Breadcrumbs';
 import { Story } from '../../lib/story/types';
 import { SAMPLE_STORIES } from '../../lib/story/sampleStories';
 import { StoryPlayer, Progress } from '../../components/StoryPlayer';
@@ -85,9 +85,10 @@ export default function Stories() {
   };
 
   return (
-    <main id="main">
-      <Breadcrumbs />
-      <h1>📚✨ Stories</h1>
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Stories" }]} />
+        <main id="main">
+        <h1>📚✨ Stories</h1>
       <p>AI story paths set in all 14 kingdoms (local, no-backend version).</p>
 
       <div className="tabs" role="tablist" aria-label="Stories">
@@ -286,6 +287,7 @@ export default function Stories() {
           </ul>
         </section>
       )}
-    </main>
-  );
+        </main>
+      </div>
+    );
 }

--- a/src/styles/a11y.css
+++ b/src/styles/a11y.css
@@ -1,0 +1,1 @@
+:focus-visible { outline: 3px solid #93c5fd; outline-offset: 2px; border-radius: 8px; }

--- a/src/styles/cards-unify.css
+++ b/src/styles/cards-unify.css
@@ -14,12 +14,14 @@
   text-decoration: none;
   color: inherit;
 }
-.card img {
-  width: 100%;
-  aspect-ratio: 16/10;
-  object-fit: cover;
-  border-radius: 12px;
-}
+.cards .card img {
+    width: 100%;
+    height: auto;
+    display: block;
+    aspect-ratio: 16/9;
+    object-fit: cover;
+    border-radius: 10px;
+  }
 .card h2 {
   font-size: 18px;
   margin: 10px 0 4px;

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,0 +1,8 @@
+.cards .card img {
+  width: 100%;
+  height: auto;
+  display: block;
+  aspect-ratio: 16/9;
+  object-fit: cover;
+  border-radius: 10px;
+}

--- a/src/styles/crumbs.css
+++ b/src/styles/crumbs.css
@@ -1,8 +1,8 @@
 /* compact, numberless breadcrumbs */
 .crumbs {
-  margin: 4px 0 12px;
-  color: var(--nv-text-muted);
-  font-size: 14px;
+  margin: 2px 0 12px;
+  color:#475569;
+  font-size:14px;
 }
 .crumbs ol {
   list-style: none;

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -95,6 +95,9 @@
   border-radius: 10px;
 }
 
+.home-cta .btn { background:#2563eb; border-color:#2563eb; color:#fff; }
+.home-cta .btn.outline { background:#e0ecff; color:#1e3a8a; border-color:#bfdbfe; }
+
 .home .cta-block {
   text-align: center;
   background: var(--nv-surface);

--- a/src/styles/img.css
+++ b/src/styles/img.css
@@ -1,0 +1,4 @@
+.img-fallback {
+  background: repeating-linear-gradient(45deg, #eaf2ff, #eaf2ff 10px, #fff 10px, #fff 20px);
+  border-radius: 10px;
+}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -53,3 +53,6 @@ nav[aria-label='Breadcrumb'] {
     display: flex;
   }
 }
+
+.page-wrap { max-width: 1100px; margin: 0 auto; padding: 8px 14px; }
+.page-head { display:flex; align-items:baseline; justify-content:space-between; gap:10px; margin:8px 0 12px; }

--- a/src/styles/nav.css
+++ b/src/styles/nav.css
@@ -1,0 +1,2 @@
+.toplink { padding: 8px 10px; border-radius: 8px; }
+.toplink.active { background: #dbeafe; color: #1e40af; font-weight: 800; }


### PR DESCRIPTION
## Summary
- highlight active top-level nav links with `toplink` helper and brand-safe fallback image
- add reusable `Breadcrumbs`, page-wrapper utilities, and consistent lazy-loaded card images
- improve home CTAs, focus styling, and provide runtime-safe `<SafeImg>` fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a9a83573488329aeb539fc374c50cf