### PR TITLE
Infra pack #3 — 404 route, ErrorBoundary, SkeletonGrid, Meta tags, sitemap/robots, preloads (no new deps)

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,8 @@
     <!-- Naturverse: UI polish -->
     <meta name="theme-color" content="#2F7AE5" />
     <meta name="color-scheme" content="light" />
+    <link rel="preload" as="style" href="/main.css" />
+    <link rel="preload" as="image" href="/turian-favicon-64.png" imagesrcset="/turian-favicon-32.png 32w, /turian-favicon-64.png 64w" imagesizes="64px" />
 
       <!-- Preload main CSS -->
       <link rel="preload" as="style" href="/src/styles/main.css" />

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -10,5 +10,4 @@
   <url><loc>/passport</loc></url>
   <url><loc>/turian</loc></url>
   <url><loc>/profile</loc></url>
-  <url><loc>/naturversity/languages</loc></url>
 </urlset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import { RouterProvider } from 'react-router-dom';
 import { router } from './router';
 import { CartProvider } from './hooks/useCart';
 import CartDrawer from './components/cart/CartDrawer';
-import ErrorBoundary from './components/ErrorBoundary';
 import { organizationLd, websiteLd } from './lib/jsonld';
 
 export default function App() {
@@ -23,12 +22,10 @@ export default function App() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
       />
-      <ErrorBoundary>
-        <CartProvider>
-          <RouterProvider router={router} />
-          <CartDrawer />
-        </CartProvider>
-      </ErrorBoundary>
+      <CartProvider>
+        <RouterProvider router={router} />
+        <CartDrawer />
+      </CartProvider>
     </>
   );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,28 +1,26 @@
 import React from "react";
 
-type State = { hasError: boolean };
+type State = { hasError: boolean; err?: unknown };
 
 export default class ErrorBoundary extends React.Component<React.PropsWithChildren, State> {
   state: State = { hasError: false };
 
-  static getDerivedStateFromError() {
-    return { hasError: true };
+  static getDerivedStateFromError(err: unknown) {
+    return { hasError: true, err };
   }
 
-  componentDidCatch(err: unknown) {
-    // eslint-disable-next-line no-console
-    console.error("ErrorBoundary caught:", err);
+  componentDidCatch(error: unknown, info: unknown) {
+    // no-op; could log to Supabase later
+    void error; void info;
   }
 
   render() {
     if (this.state.hasError) {
       return (
-        <div style={{ maxWidth: 820, margin: "30px auto" }}>
+        <div className="page-wrap" style={{ paddingTop: 24 }}>
           <h1>Something went wrong</h1>
-          <p className="muted">
-            A page component crashed. Try reloading or going back home.
-          </p>
-          <a className="btn" href="/">← Back to Home</a>
+          <p className="muted">Try refreshing, or head back home.</p>
+          <a className="btn" href="/">Back to Home</a>
         </div>
       );
     }

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,30 +1,29 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 
-type Props = {
-  title?: string;
-  description?: string;
-};
+type Props = { title?: string; description?: string; image?: string; url?: string };
 
-export default function Meta({ title, description }: Props) {
+export default function Meta({ title, description, image, url }: Props) {
   useEffect(() => {
-    const prevTitle = document.title;
-    if (title) document.title = title + " • Naturverse";
-    const meta =
-      document.querySelector('meta[name="description"]') ||
-      (() => {
-        const m = document.createElement("meta");
-        m.setAttribute("name", "description");
-        document.head.appendChild(m);
-        return m;
-      })();
-    const prevDesc = meta.getAttribute("content") || "";
-    if (description) meta.setAttribute("content", description);
-
-    return () => {
-      document.title = prevTitle;
-      meta.setAttribute("content", prevDesc);
+    if (title) document.title = title;
+    const set = (n: string, c: string) => {
+      let el = document.querySelector<HTMLMetaElement>(`meta[name="${n}"]`);
+      if (!el) { el = document.createElement("meta"); el.setAttribute("name", n); document.head.appendChild(el); }
+      el.setAttribute("content", c);
     };
-  }, [title, description]);
+    const setProp = (p: string, c: string) => {
+      let el = document.querySelector<HTMLMetaElement>(`meta[property="${p}"]`);
+      if (!el) { el = document.createElement("meta"); el.setAttribute("property", p); document.head.appendChild(el); }
+      el.setAttribute("content", c);
+    };
+    if (description) set("description", description);
+    if (title) { setProp("og:title", title); setProp("twitter:title", title); }
+    if (description) { setProp("og:description", description); setProp("twitter:description", description); }
+    if (image) { setProp("og:image", image); setProp("twitter:image", image); }
+    if (url) { setProp("og:url", url); }
+    setProp("og:type", "website");
+    setProp("twitter:card", "summary_large_image");
+  }, [title, description, image, url]);
 
   return null;
 }
+

--- a/src/components/SkeletonGrid.tsx
+++ b/src/components/SkeletonGrid.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
-export default function SkeletonGrid({ rows = 6 }: { rows?: number }) {
+export default function SkeletonGrid({ count = 6 }: { count?: number }) {
   return (
     <div className="cards">
-      {Array.from({ length: rows }).map((_, i) => (
-        <div className="card skeleton" key={i} aria-hidden="true">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="card skeleton">
           <div className="sk-img" />
           <div className="sk-line" />
-          <div className="sk-line short" />
+          <div className="sk-line small" />
         </div>
       ))}
     </div>

--- a/src/components/SmartImg.tsx
+++ b/src/components/SmartImg.tsx
@@ -7,11 +7,15 @@ type Props = React.ImgHTMLAttributes<HTMLImageElement> & {
 
 export default function SmartImg({ rounded = true, ratio = "wide", className = "", ...rest }: Props) {
   const [loaded, setLoaded] = useState(false);
+  const width = rest.width ?? 800;
+  const height = rest.height ?? 450;
   return (
     <div className={`smartimg ${ratio} ${rounded ? "rounded" : ""} ${loaded ? "is-loaded" : ""}`}>
       <img
         {...rest}
         loading={rest.loading ?? "lazy"}
+        width={width}
+        height={height}
         onLoad={(e) => {
           rest.onLoad?.(e as any);
           setLoaded(true);

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,9 @@
     <!-- Naturverse: UI polish -->
     <meta name="theme-color" content="#2F7AE5" />
     <meta name="color-scheme" content="light" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" as="style" href="/main.css">
+    <link rel="preload" as="image" href="/turian-favicon-64.png" imagesrcset="/turian-favicon-32.png 32w, /turian-favicon-64.png 64w" imagesizes="64px">
   </head>
   <body>
     <a class="visually-hidden-focusable" href="#main-content">Skip to content</a>

--- a/src/main.css
+++ b/src/main.css
@@ -5,7 +5,6 @@
 @import './styles/home.css';
 @import './styles/cards-unify.css';
 @import './styles/cards.css';
-@import './styles/skeleton.css';
 @import './styles/auth-menu.css';
 @import './styles/buttons.css';
 @import './styles/languages.css';
@@ -13,6 +12,7 @@
 @import './styles/nav.css';
 @import './styles/img.css';
 @import './styles/a11y.css';
+@import './styles/skeleton.css';
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { AuthProvider } from './auth/AuthContext';
+import ErrorBoundary from './components/ErrorBoundary';
 import './styles.css';
 import './styles/shop.css';
 import './styles/edu.css';
@@ -9,8 +10,10 @@ import './main.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <ErrorBoundary>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,8 +8,12 @@ import { Img } from "../components";
 export default function Home() {
   return (
     <Page>
-      <Meta title="Naturverse — Playful worlds for families"
-            description="A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness." />
+      <Meta
+        title="Naturverse — Learn & Play Across 14 Magical Kingdoms"
+        description="Explore worlds, play games, create your Navatar, and learn with Naturversity."
+        image="/og-home.png"
+        url="https://naturverse.netlify.app/"
+      />
       <div className="home">
       {/* Hero */}
       <header className="home-hero">

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { HubGrid } from "../components/HubGrid";
-import Seo from "../components/Seo";
+import Meta from "../components/Meta";
 import { breadcrumbs } from "../lib/jsonld";
 import Breadcrumbs from "../components/Breadcrumbs";
 
@@ -9,10 +9,7 @@ const labels = { '/marketplace': 'Marketplace' };
 export default function MarketplacePage() {
     return (
       <>
-        <Seo
-          title="Marketplace"
-          description="Shop Naturverse creations, merch, and bundles."
-        />
+        <Meta title="Marketplace — Naturverse" description="Shop Naturverse creations, merch, and bundles." />
         <div className="page-wrap">
           <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Marketplace" }]} />
           <main id="main">

--- a/src/pages/Naturbank.tsx
+++ b/src/pages/Naturbank.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { HubGrid } from "../components/HubGrid";
+import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
 
 export default function NaturbankPage() {
   return (
       <div className="page-wrap">
+        <Meta title="Naturbank — Naturverse" description="Wallets, token, and collectibles." />
         <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Naturbank" }]} />
         <main id="main">
         <h1>Naturbank</h1>

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { HubGrid } from "../components/HubGrid";
+import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
 
 export default function NaturversityPage() {
   return (
       <>
         <div className="page-wrap">
+          <Meta title="Naturversity — Naturverse" description="Teachers, partners, and courses." />
           <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Naturversity" }]} />
           <main id="main">
           <h1>Naturversity</h1>

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -3,6 +3,7 @@ import type { Navatar, NavatarBase } from "../types/navatar";
 import { SPECIES, POWERS_BANK, randomFrom } from "../lib/navatarCatalog";
 import { loadActive, saveActive, loadLibrary, saveLibrary } from "../lib/localStorage";
 import NavatarCard from "../components/NavatarCard";
+import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
 
 const BASES: NavatarBase[] = ["Animal", "Fruit", "Insect", "Spirit"];
@@ -64,6 +65,7 @@ export default function NavatarPage() {
 
   return (
     <div className="page-wrap">
+      <Meta title="Navatar Creator — Naturverse" description="Design your character and save cards." />
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Navatar" }]} />
       <main id="main" className="wrap">
         <h1>Navatar Creator</h1>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -2,13 +2,17 @@ import React from "react";
 
 export default function NotFound() {
   return (
-    <div style={{ maxWidth: 820, margin: "30px auto" }}>
-      <h1>404 — Page not found</h1>
-      <p className="muted">That path doesn’t exist. It might have moved or been renamed.</p>
-      <div className="row" style={{ marginTop: 12 }}>
-        <a className="btn" href="/">← Back to Home</a>
-        <a className="btn outline" href="/worlds">Explore Worlds</a>
-        <a className="btn outline" href="/zones">Explore Zones</a>
+    <div className="page-wrap" style={{ paddingTop: 24 }}>
+      <h1>Page not found</h1>
+      <p className="muted">That path doesn’t exist. Try one of these hubs:</p>
+      <div className="cards">
+        <a className="card" href="/worlds"><h2>Worlds</h2><p>Explore all kingdoms.</p></a>
+        <a className="card" href="/zones"><h2>Zones</h2><p>Arcade, Music, Wellness, and more.</p></a>
+        <a className="card" href="/marketplace"><h2>Marketplace</h2><p>Shop, Wishlist, Checkout.</p></a>
+        <a className="card" href="/naturversity"><h2>Naturversity</h2><p>Learn, courses, languages.</p></a>
+      </div>
+      <div style={{ marginTop: 16 }}>
+        <a className="btn" href="/">Back to Home</a>
       </div>
     </div>
   );

--- a/src/pages/Passport.tsx
+++ b/src/pages/Passport.tsx
@@ -3,6 +3,7 @@ import { getCurrent } from "../lib/navatar/store";
 import type { Badge } from "../lib/passport/store";
 import { getStamps, toggleStamp, getBadges, addBadge, getXP, addXP, getNatur, addNatur } from "../lib/passport/store";
 import Page from "../components/Page";
+import Meta from "../components/Meta";
 import { Img } from "../components";
 
 const KINGDOMS = [
@@ -31,7 +32,8 @@ export default function PassportPage() {
   const earnNatur = (n: number) => { addNatur(n); setNatur(getNatur()); };
 
     return (
-      <Page title="Passport" subtitle="Badges, stamps, XP, and NATUR coin." crumbs={[{ href:"/", label:"Home" }, { label:"Passport" }]}>
+      <Page title="Passport" subtitle="Badges, stamps, XP, and NATUR coin." crumbs={[{ href:"/", label:"Home" }, { label:"Passport" }]}> 
+      <Meta title="Passport — Naturverse" description="Track stamps, badges, XP, and NATUR." />
       {/* Identity / Navatar */}
       <div className="passport-id">
         <div className="avatar">

--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import Page from "../components/Page";
+import Meta from "../components/Meta";
 import { Img } from "../components";
 
 type Msg = { id: string; role: "user" | "turian"; text: string; ts: number };
@@ -81,7 +82,8 @@ export default function TurianPage() {
 
   return (
     <>
-        <Page title="Turian the Durian" subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet." crumbs={[{ href:"/", label:"Home" }, { label:"Turian" }]}>
+        <Page title="Turian the Durian" subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet." crumbs={[{ href:"/", label:"Home" }, { label:"Turian" }]}> 
+      <Meta title="Turian — Naturverse" description="Offline AI assistant demo." />
 
       <div className="nv-card" style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 12 }}>
         {mascotSrc ? (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import Seo from "../components/Seo";
+import Meta from "../components/Meta";
 import { Img } from "../components";
 
 export default function Home() {
   return (
     <>
-      <Seo
-        title="Welcome"
-        description="Explore kingdoms, quests, and characters in the Naturverse."
+      <Meta
+        title="Naturverse — Learn & Play Across 14 Magical Kingdoms"
+        description="Explore worlds, play games, create your Navatar, and learn with Naturversity."
+        image="/og-home.png"
+        url="https://naturverse.netlify.app/"
       />
       <main id="main" className="home">
       {/* Hero */}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -127,7 +127,6 @@ export const router = createBrowserRouter([
       { path: 'login', element: <LoginPage /> },
       { path: 'turian', element: <Turian /> },
       { path: 'profile', element: <ProfilePage /> },
-      { path: '404', element: <NotFound /> },
       { path: '*', element: <NotFound /> },
     ],
   },

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -1,6 +1,6 @@
 import HubCard from '../../components/HubCard';
 import HubGrid from '../../components/HubGrid';
-import Seo from '../../components/Seo';
+import Meta from '../../components/Meta';
 import { breadcrumbs } from '../../lib/jsonld';
 
 const ZONES = [
@@ -65,10 +65,7 @@ const ZONES = [
 export default function Zones() {
   return (
     <div className="container-narrow">
-      <Seo
-        title="Zones"
-        description="Pick a zone to start games, music, wellness, and more."
-      />
+      <Meta title="Zones — Naturverse" description="Pick a zone to start games, music, wellness, and more." />
       <main className="container">
         <div className="breadcrumb">Home / Zones</div>
         <h1 className="page-title text-brand">Zones</h1>

--- a/src/styles/skeleton.css
+++ b/src/styles/skeleton.css
@@ -26,13 +26,16 @@
 .card  { background: #ffffff; border: 1px solid #dbeafe; border-radius: 14px; padding: 12px; }
 .card h2 { margin: 10px 0 6px; }
 
-.card.skeleton { position: relative; overflow: hidden; }
-.sk-img { height: 140px; background: #eaf2ff; border-radius: 10px; }
-.sk-line { height: 12px; margin-top: 10px; border-radius: 8px; background: #eaf2ff; }
-.sk-line.short { width: 60%; }
-.card.skeleton::after {
-  content: ""; position: absolute; inset: 0;
-  background: linear-gradient(90deg, transparent, rgba(255,255,255,.6), transparent);
-  transform: translateX(-100%); animation: sk 1.4s infinite;
+.card.skeleton { pointer-events:none; }
+.sk-img {
+  width:100%; aspect-ratio:16/9; border-radius:10px;
+  background: linear-gradient(90deg, #eaf2ff 25%, #f4f7ff 37%, #eaf2ff 63%);
+  background-size: 400% 100%; animation: sk 1.2s ease-in-out infinite;
 }
-@keyframes sk { to { transform: translateX(100%); } }
+.sk-line {
+  height:14px; margin-top:10px; border-radius:8px;
+  background: linear-gradient(90deg, #eaf2ff 25%, #f4f7ff 37%, #eaf2ff 63%);
+  background-size: 400% 100%; animation: sk 1.2s ease-in-out infinite;
+}
+.sk-line.small { width:60%; height:12px; }
+@keyframes sk { 0%{background-position:100% 0} 100%{background-position:0 0} }


### PR DESCRIPTION
## Summary
- add ErrorBoundary wrapper and NotFound catch-all
- introduce reusable Meta component and wire up page metadata
- include skeleton grid, image defaults, preloads, and sitemap

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS errors in navatar/passport APIs)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9aaaef6dc83298c615f8d832ed76a