### PR TITLE
feat: load profile data from supabase

### DIFF
--- a/src/lib/getProfile.ts
+++ b/src/lib/getProfile.ts
@@ -1,0 +1,23 @@
+// Tiny helper to load the current user and their profile row
+import { supabase } from './supabaseClient';
+
+export type NaturProfile = {
+  id: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  updated_at: string | null;
+};
+
+export async function getCurrentUserAndProfile() {
+  const { data: userRes, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userRes.user) return { user: null, profile: null, error: userErr ?? null };
+
+  const user = userRes.user;
+  const { data: profile, error: profErr } = await supabase
+    .from('profiles')
+    .select('id, display_name, avatar_url, updated_at')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  return { user, profile: (profile as NaturProfile | null) ?? null, error: profErr ?? null };
+}


### PR DESCRIPTION
## Summary
- add helper to fetch auth user and profile row
- replace `/profile` page with supabase-backed loader and skeleton states

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b2ae4a3c8329a1b3ff0702b3cda4