### PR TITLE
Navbar auth state (avatar, Profile, Sign out) + fallback when signed out

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import CartButton from './cart/CartButton';
 import Img from './Img';
-import AuthMenu from './AuthMenu';
+import { useAuthUser } from '../lib/useAuthUser';
+import UserChip from './UserChip';
 
 const LINKS = [
   { href: '/worlds', label: 'Worlds' },
@@ -17,6 +18,7 @@ const LINKS = [
 
 export default function Header() {
   const [open, setOpen] = useState(false);
+  const { user, loading } = useAuthUser();
 
   // close drawer on route change (hash/path)
   useEffect(() => {
@@ -59,7 +61,15 @@ export default function Header() {
           </nav>
 
           <CartButton />
-          <AuthMenu />
+          {loading ? (
+            <span style={{ opacity: 0.7 }}>…</span>
+          ) : user ? (
+            <UserChip email={user.email} />
+          ) : (
+            <a className="btn" href="/login">
+              Sign in
+            </a>
+          )}
 
           {/* mobile button */}
           <button

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -2,10 +2,12 @@ import { Link, NavLink } from 'react-router-dom';
 import { useState } from 'react';
 import './site-header.css';
 import Img from './Img';
-import AuthMenu from './AuthMenu';
+import { useAuthUser } from '../lib/useAuthUser';
+import UserChip from './UserChip';
 
 export default function SiteHeader() {
   const [open, setOpen] = useState(false);
+  const { user, loading } = useAuthUser();
   return (
     <header className={`site-header ${open ? 'open' : ''}`}>
       <div className="wrap">
@@ -76,14 +78,6 @@ export default function SiteHeader() {
             Turian
           </NavLink>
           <NavLink
-            to="/profile"
-            aria-label="Profile"
-            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link') + ' icon'}
-            onClick={() => setOpen(false)}
-          >
-            👤
-          </NavLink>
-          <NavLink
             to="/cart"
             aria-label="Cart"
             className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link') + ' icon'}
@@ -91,7 +85,15 @@ export default function SiteHeader() {
           >
             🛒
           </NavLink>
-          <AuthMenu />
+          {loading ? (
+            <span style={{ opacity: 0.7 }}>…</span>
+          ) : user ? (
+            <UserChip email={user.email} />
+          ) : (
+            <a className="btn" href="/login">
+              Sign in
+            </a>
+          )}
         </nav>
       </div>
     </header>

--- a/src/components/UserChip.tsx
+++ b/src/components/UserChip.tsx
@@ -1,0 +1,86 @@
+import { useState, useRef, useEffect } from 'react';
+import { supabase } from '../lib/supabaseClient';
+
+type Props = { email?: string | null };
+
+export default function UserChip({ email }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (!ref.current) return;
+      if (!ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('click', onDoc);
+    return () => document.removeEventListener('click', onDoc);
+  }, []);
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="btn"
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 8, paddingInline: 10 }}
+      >
+        <img
+          src="/favicon.svg"
+          alt="Avatar"
+          width={20}
+          height={20}
+          style={{ borderRadius: 6, background: '#eef3ff' }}
+          loading="lazy"
+          decoding="async"
+        />
+        <span style={{ maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {email ?? 'Account'}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          style={{
+            position: 'absolute',
+            right: 0,
+            marginTop: 8,
+            background: 'var(--card, #fff)',
+            border: '1px solid var(--border, #dbe2f0)',
+            borderRadius: 10,
+            minWidth: 180,
+            boxShadow: '0 4px 16px rgba(2,16,64,0.08)',
+            zIndex: 20,
+          }}
+        >
+          <a role="menuitem" href="/profile" className="btn" style={menuItem}>
+            Profile
+          </a>
+          <button
+            role="menuitem"
+            onClick={async () => {
+              await supabase.auth.signOut();
+              // Let the hook update navbar; also guard navigation on client
+              window.location.href = '/';
+            }}
+            className="btn"
+            style={menuItem}
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const menuItem: React.CSSProperties = {
+  display: 'block',
+  width: '100%',
+  textAlign: 'left',
+  padding: '10px 12px',
+  borderRadius: 0,
+  border: 'none',
+  background: 'transparent',
+};

--- a/src/lib/useAuthUser.ts
+++ b/src/lib/useAuthUser.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { supabase } from './supabaseClient';
+
+export function useAuthUser() {
+  const [user, setUser] = useState<null | { id: string; email?: string | null; avatar_url?: string | null }>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    (async () => {
+      const { data, error } = await supabase.auth.getUser();
+      if (!active) return;
+      if (!error && data.user) {
+        setUser({ id: data.user.id, email: data.user.email });
+      } else {
+        setUser(null);
+      }
+      setLoading(false);
+    })();
+
+    const { data: sub } = supabase.auth.onAuthStateChange(async () => {
+      setLoading(true);
+      const { data } = await supabase.auth.getUser();
+      if (!active) return;
+      setUser(data.user ? { id: data.user.id, email: data.user.email } : null);
+      setLoading(false);
+    });
+
+    return () => {
+      active = false;
+      sub?.subscription?.unsubscribe();
+    };
+  }, []);
+
+  return { user, loading };
+}


### PR DESCRIPTION
## Summary
- add `useAuthUser` hook to track Supabase auth changes
- show user avatar chip with profile & sign-out options when logged in
- display Sign in link while auth loads or user is signed out

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: argument type errors in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68a9b54617c0832983b46dfffd622e28