### PR TITLE
Navbar auth integration with user avatar

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -60,16 +60,16 @@ export default function Header() {
             </ul>
           </nav>
 
-          <CartButton />
-          {loading ? (
-            <span style={{ opacity: 0.7 }}>…</span>
-          ) : user ? (
-            <UserChip email={user.email} />
-          ) : (
-            <a className="btn" href="/login">
-              Sign in
-            </a>
-          )}
+          <nav className="site-actions" style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <CartButton />
+            {loading ? (
+              <span style={{ opacity: 0.7 }}>…</span>
+            ) : user ? (
+              <UserChip email={user.email} />
+            ) : (
+              <a className="btn" href="/login">Sign in</a>
+            )}
+          </nav>
 
           {/* mobile button */}
           <button

--- a/src/components/UserChip.tsx
+++ b/src/components/UserChip.tsx
@@ -1,9 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { supabase } from '../lib/supabaseClient';
 
-type Props = { email?: string | null };
-
-export default function UserChip({ email }: Props) {
+export default function UserChip({ email }: { email?: string | null }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -20,8 +18,6 @@ export default function UserChip({ email }: Props) {
     <div ref={ref} style={{ position: 'relative' }}>
       <button
         onClick={() => setOpen((v) => !v)}
-        aria-haspopup="menu"
-        aria-expanded={open}
         className="btn"
         style={{ display: 'inline-flex', alignItems: 'center', gap: 8, paddingInline: 10 }}
       >
@@ -31,8 +27,6 @@ export default function UserChip({ email }: Props) {
           width={20}
           height={20}
           style={{ borderRadius: 6, background: '#eef3ff' }}
-          loading="lazy"
-          decoding="async"
         />
         <span style={{ maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {email ?? 'Account'}
@@ -46,8 +40,8 @@ export default function UserChip({ email }: Props) {
             position: 'absolute',
             right: 0,
             marginTop: 8,
-            background: 'var(--card, #fff)',
-            border: '1px solid var(--border, #dbe2f0)',
+            background: 'white',
+            border: '1px solid #dbe2f0',
             borderRadius: 10,
             minWidth: 180,
             boxShadow: '0 4px 16px rgba(2,16,64,0.08)',
@@ -61,7 +55,6 @@ export default function UserChip({ email }: Props) {
             role="menuitem"
             onClick={async () => {
               await supabase.auth.signOut();
-              // Let the hook update navbar; also guard navigation on client
               window.location.href = '/';
             }}
             className="btn"
@@ -80,7 +73,6 @@ const menuItem: React.CSSProperties = {
   width: '100%',
   textAlign: 'left',
   padding: '10px 12px',
-  borderRadius: 0,
   border: 'none',
   background: 'transparent',
 };

--- a/src/lib/useAuthUser.ts
+++ b/src/lib/useAuthUser.ts
@@ -2,20 +2,16 @@ import { useEffect, useState } from 'react';
 import { supabase } from './supabaseClient';
 
 export function useAuthUser() {
-  const [user, setUser] = useState<null | { id: string; email?: string | null; avatar_url?: string | null }>(null);
+  const [user, setUser] = useState<null | { id: string; email?: string | null }>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     let active = true;
 
     (async () => {
-      const { data, error } = await supabase.auth.getUser();
+      const { data } = await supabase.auth.getUser();
       if (!active) return;
-      if (!error && data.user) {
-        setUser({ id: data.user.id, email: data.user.email });
-      } else {
-        setUser(null);
-      }
+      setUser(data.user ? { id: data.user.id, email: data.user.email } : null);
       setLoading(false);
     })();
 


### PR DESCRIPTION
## Summary
- add `useAuthUser` hook to load Supabase user
- create `UserChip` component with profile and sign out menu
- update header to show avatar or sign-in link and group actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Property 'n' does not exist on type 'IntrinsicAttributes & ImgHTMLAttributes<HTMLImageElement> & { fallbackSrc?: string | undefined; }' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b6d965c48329a25d3dcf5b989814