### PR TITLE
feat: add protected routes and login redirect

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -67,7 +67,20 @@ export default function Header() {
             ) : user ? (
               <UserChip email={user.email} />
             ) : (
-              <a className="btn" href="/login">Sign in</a>
+              <a
+                className="btn"
+                href="/login"
+                onClick={() => {
+                  try {
+                    sessionStorage.setItem(
+                      'naturverse.returnTo',
+                      window.location.pathname + window.location.search,
+                    );
+                  } catch {}
+                }}
+              >
+                Sign in
+              </a>
             )}
           </nav>
 

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,49 @@
+import { ComponentType, useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+
+type Props = { component: ComponentType<any> };
+
+export default function ProtectedRoute({ component: C }: Props) {
+  const [ok, setOk] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let on = true;
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      if (!on) return;
+      if (data.session) {
+        setOk(true);
+      } else {
+        try {
+          sessionStorage.setItem('naturverse.returnTo', window.location.pathname + window.location.search);
+        } catch {}
+        setOk(false);
+      }
+    })();
+    return () => {
+      on = false;
+    };
+  }, []);
+
+  if (ok === null) return null;
+
+  return ok ? <C /> : <UnauthedFallback />;
+}
+
+function UnauthedFallback() {
+  return (
+    <div className="guard">
+      <h1>Sign in required</h1>
+      <p className="muted">Please sign in to access this page.</p>
+      <div className="row">
+        <a className="btn" href="/login">
+          Sign in
+        </a>
+        <a className="btn outline" href="/">
+          Back home
+        </a>
+      </div>
+    </div>
+  );
+}
+

--- a/src/main.css
+++ b/src/main.css
@@ -13,6 +13,7 @@
 @import './styles/img.css';
 @import './styles/skeleton.css';
 @import './styles/a11y.css';
+@import './styles/guard.css';
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,35 @@
+import { useEffect } from 'react';
 import LoginForm from '../components/LoginForm';
+import { supabase } from '../lib/supabaseClient';
+
+function redirectAfterLogin() {
+  try {
+    const dest = sessionStorage.getItem('naturverse.returnTo');
+    if (dest) {
+      sessionStorage.removeItem('naturverse.returnTo');
+      window.location.replace(dest);
+      return;
+    }
+  } catch {}
+  window.location.replace('/profile');
+}
 
 export default function LoginPage() {
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      if (mounted && data.session) redirectAfterLogin();
+    })();
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session) redirectAfterLogin();
+    });
+    return () => {
+      mounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
   return (
     <main className="page">
       <header className="page-header">

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -62,6 +62,7 @@ import Accessibility from './pages/Accessibility';
 import About from './pages/About';
 import NotFound from './pages/NotFound';
 import RootLayout from './layouts/Root';
+import ProtectedRoute from './components/ProtectedRoute';
 
 export const router = createBrowserRouter([
   {
@@ -98,8 +99,8 @@ export const router = createBrowserRouter([
       { path: 'zones/future', element: <FutureZone /> },
       { path: 'marketplace', element: <Marketplace /> },
       { path: 'marketplace/catalog', element: <Catalog /> },
-      { path: 'marketplace/wishlist', element: <Wishlist /> },
-      { path: 'marketplace/checkout', element: <Checkout /> },
+        { path: 'marketplace/wishlist', element: <ProtectedRoute component={Wishlist} /> },
+        { path: 'marketplace/checkout', element: <ProtectedRoute component={Checkout} /> },
       { path: 'naturversity', element: <Naturversity /> },
       { path: 'naturversity/teachers', element: <Teachers /> },
       { path: 'naturversity/partners', element: <Partners /> },
@@ -122,12 +123,12 @@ export const router = createBrowserRouter([
       { path: 'contact', element: <Contact /> },
       { path: 'accessibility', element: <Accessibility /> },
       { path: 'about', element: <About /> },
-      { path: 'navatar', element: <NavatarPage /> },
-      { path: 'passport', element: <Passport /> },
-      { path: 'login', element: <LoginPage /> },
-      { path: 'turian', element: <Turian /> },
-      { path: 'profile', element: <ProfilePage /> },
-      { path: '*', element: <NotFound /> },
+        { path: 'navatar', element: <ProtectedRoute component={NavatarPage} /> },
+        { path: 'passport', element: <ProtectedRoute component={Passport} /> },
+        { path: 'login', element: <LoginPage /> },
+        { path: 'turian', element: <Turian /> },
+        { path: 'profile', element: <ProtectedRoute component={ProfilePage} /> },
+        { path: '*', element: <NotFound /> },
     ],
   },
 ]);

--- a/src/styles/guard.css
+++ b/src/styles/guard.css
@@ -1,0 +1,8 @@
+.guard{
+  max-width:680px; margin:32px auto; padding:24px;
+  background:#ffffff; border:1px solid #e5e7eb; border-radius:16px;
+  text-align:center;
+}
+.guard h1{ margin:0 0 8px; }
+.guard .muted{ color:#64748b; margin-bottom:14px; }
+.guard .row{ display:flex; gap:10px; justify-content:center; flex-wrap:wrap; }


### PR DESCRIPTION
## Summary
- add ProtectedRoute component to guard user-only pages and show sign-in fallback
- remember last location and redirect after successful login
- wrap profile, passport, navatar, wishlist, and checkout routes with auth guard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS errors in src/lib/api)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9b8cf25fc832985b6c126ec65bfac