### PR TITLE
Add user avatar menu to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import CartButton from './cart/CartButton';
 import Img from './Img';
-import { useAuthUser } from '../lib/useAuthUser';
-import UserChip from './UserChip';
+import UserMenu from './UserMenu';
 
 const LINKS = [
   { href: '/worlds', label: 'Worlds' },
@@ -18,7 +17,6 @@ const LINKS = [
 
 export default function Header() {
   const [open, setOpen] = useState(false);
-  const { user, loading } = useAuthUser();
 
   // close drawer on route change (hash/path)
   useEffect(() => {
@@ -62,26 +60,7 @@ export default function Header() {
 
           <nav className="site-actions" style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <CartButton />
-            {loading ? (
-              <span style={{ opacity: 0.7 }}>…</span>
-            ) : user ? (
-              <UserChip email={user.email} />
-            ) : (
-              <a
-                className="btn"
-                href="/login"
-                onClick={() => {
-                  try {
-                    sessionStorage.setItem(
-                      'naturverse.returnTo',
-                      window.location.pathname + window.location.search,
-                    );
-                  } catch {}
-                }}
-              >
-                Sign in
-              </a>
-            )}
+            <UserMenu />
           </nav>
 
           {/* mobile button */}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from "react";
+import { supabase } from "../lib/supabaseClient";
+
+type SessionUser = {
+  email?: string | null;
+  user_metadata?: { name?: string; full_name?: string; picture?: string };
+};
+
+function initials(name?: string, email?: string | null) {
+  const n = (name || email || "U").trim();
+  const parts = n.split(/\s+/).slice(0, 2);
+  return parts.map(p => p[0]?.toUpperCase() || "").join("") || "U";
+}
+
+export default function UserMenu() {
+  const [user, setUser] = useState<SessionUser | null>(null);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      if (!mounted) return;
+      setUser(data.session?.user ?? null);
+    })();
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    const onDoc = (e: MouseEvent) => {
+      if (!ref.current) return;
+      if (!ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("click", onDoc);
+    return () => {
+      mounted = false;
+      document.removeEventListener("click", onDoc);
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  if (!user) {
+    return (
+      <a
+        className="btn"
+        href="/login"
+        onClick={() => {
+          try {
+            sessionStorage.setItem("naturverse.returnTo", window.location.pathname + window.location.search);
+          } catch {}
+        }}
+      >
+        Sign in
+      </a>
+    );
+  }
+
+  const name = user.user_metadata?.name || user.user_metadata?.full_name || user.email || "You";
+  const pic  = user.user_metadata?.picture as string | undefined;
+
+  return (
+    <div className="usermenu" ref={ref}>
+      <button className="avatar-btn" onClick={() => setOpen(v => !v)} aria-expanded={open}>
+        {pic ? <img src={pic} alt={name} /> : <span>{initials(name, user.email)}</span>}
+      </button>
+      {open && (
+        <div className="menu">
+          <div className="who">
+            {pic ? <img src={pic} alt={name} /> : <span className="circle">{initials(name, user.email)}</span>}
+            <div className="meta">
+              <strong>{name}</strong>
+              <small>{user.email}</small>
+            </div>
+          </div>
+          <a href="/profile" className="item">Profile</a>
+          <a href="/passport" className="item">Passport</a>
+          <a href="/marketplace/wishlist" className="item">Wishlist</a>
+          <button
+            className="item danger"
+            onClick={async () => {
+              await supabase.auth.signOut();
+              window.location.replace("/");
+            }}
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/main.css
+++ b/src/main.css
@@ -14,6 +14,7 @@
 @import './styles/skeleton.css';
 @import './styles/a11y.css';
 @import './styles/guard.css';
+@import "./styles/user-menu.css";
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/styles/user-menu.css
+++ b/src/styles/user-menu.css
@@ -1,0 +1,27 @@
+.usermenu { position: relative; }
+.avatar-btn {
+  display:inline-flex; align-items:center; justify-content:center;
+  width:36px; height:36px; border-radius:50%; border:1px solid #cbd5e1;
+  background:#fff; cursor:pointer; overflow:hidden;
+}
+.avatar-btn img { width:100%; height:100%; object-fit:cover; }
+.avatar-btn span { font-weight:800; color:#0ea5e9; }
+
+.usermenu .menu {
+  position:absolute; right:0; top:44px; min-width:220px; z-index:50;
+  background:#fff; border:1px solid #e5e7eb; border-radius:12px;
+  box-shadow:0 8px 24px rgba(2,6,23,.12); padding:8px;
+}
+.usermenu .who { display:flex; gap:10px; align-items:center; padding:8px; border-bottom:1px solid #eef2f7; }
+.usermenu .who img, .usermenu .who .circle {
+  width:36px; height:36px; border-radius:50%; background:#e0f2fe; display:inline-flex; align-items:center; justify-content:center; font-weight:800; color:#0ea5e9;
+}
+.usermenu .who .meta small { color:#64748b; display:block; }
+
+.usermenu .item {
+  width:100%; text-align:left; display:block; padding:10px 12px;
+  border-radius:8px; background:#fff; border:0; color:#0f172a; text-decoration:none;
+}
+.usermenu .item:hover { background:#f1f5f9; }
+.usermenu .item.danger { color:#dc2626; }
+


### PR DESCRIPTION
## Summary
- add UserMenu component with avatar, profile links, and sign-out
- wire UserMenu into Header and import styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string | null', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a9baca66f08329968c7dc35ee636a8