### PR TITLE
Routing guards + 404 + skeleton loader (no deps)

### DIFF
--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,0 +1,36 @@
+import { ReactNode, useEffect, useState } from "react";
+import { supabase } from "../lib/supabaseClient";
+
+export default function RequireAuth({ children }: { children: ReactNode }) {
+  const [ready, setReady] = useState(false);
+  const [authed, setAuthed] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      const ok = !!data.session;
+      if (!mounted) return;
+      setAuthed(ok);
+      setReady(true);
+      if (!ok) {
+        try {
+          sessionStorage.setItem("naturverse.returnTo", location.pathname + location.search);
+        } catch {}
+        location.replace("/login");
+      }
+    })();
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
+      setAuthed(!!session);
+    });
+    return () => {
+      mounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  if (!ready) return <div className="center-pad"><div className="spinner" /></div>;
+  if (!authed) return null;
+  return <>{children}</>;
+}
+

--- a/src/components/SkeletonGrid.tsx
+++ b/src/components/SkeletonGrid.tsx
@@ -1,15 +1,14 @@
-import React from "react";
-
 export default function SkeletonGrid({ count = 6 }: { count?: number }) {
   return (
     <div className="cards">
       {Array.from({ length: count }).map((_, i) => (
-        <div key={i} className="card skeleton">
+        <div className="card skeleton" key={i}>
           <div className="sk-img" />
+          <div className="sk-line short" />
           <div className="sk-line" />
-          <div className="sk-line small" />
         </div>
       ))}
     </div>
   );
 }
+

--- a/src/main.css
+++ b/src/main.css
@@ -15,6 +15,7 @@
 @import './styles/a11y.css';
 @import './styles/guard.css';
 @import "./styles/user-menu.css";
+@import "./styles/system.css";
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/pages/Naturbank.tsx
+++ b/src/pages/Naturbank.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import { HubGrid } from "../components/HubGrid";
 import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
+import RequireAuth from "../components/RequireAuth";
 
 export default function NaturbankPage() {
   return (
+    <RequireAuth>
       <div className="page-wrap">
         <Meta title="Naturbank — Naturverse" description="Wallets, token, and collectibles." />
         <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Naturbank" }]} />
@@ -26,5 +28,6 @@ export default function NaturbankPage() {
       </p>
         </main>
       </div>
-    );
+    </RequireAuth>
+  );
 }

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -1,9 +1,15 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { HubGrid } from "../components/HubGrid";
 import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
+import SkeletonGrid from "../components/SkeletonGrid";
 
 export default function NaturversityPage() {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setReady(true), 250);
+    return () => clearTimeout(t);
+  }, []);
   return (
       <>
         <div className="page-wrap">
@@ -13,6 +19,7 @@ export default function NaturversityPage() {
           <h1>Naturversity</h1>
           <p className="muted">Teachers, partners, and courses.</p>
 
+        {ready ? (
         <HubGrid
           items={[
             { to: "/naturversity/teachers", title: "Teachers", desc: "Mentors across the 14 kingdoms.", icon: "🎓" },
@@ -40,6 +47,9 @@ export default function NaturversityPage() {
             },
           ]}
         />
+        ) : (
+          <SkeletonGrid count={4} />
+        )}
 
         <p className="muted" style={{ marginTop: 12 }}>
           Coming soon: AI tutors and step-by-step lessons.

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,19 +1,10 @@
-import React from "react";
-
 export default function NotFound() {
   return (
-    <div className="page-wrap" style={{ paddingTop: 24 }}>
-      <h1>Page not found</h1>
-      <p className="muted">That path doesn’t exist. Try one of these hubs:</p>
-      <div className="cards">
-        <a className="card" href="/worlds"><h2>Worlds</h2><p>Explore all kingdoms.</p></a>
-        <a className="card" href="/zones"><h2>Zones</h2><p>Arcade, Music, Wellness, and more.</p></a>
-        <a className="card" href="/marketplace"><h2>Marketplace</h2><p>Shop, Wishlist, Checkout.</p></a>
-        <a className="card" href="/naturversity"><h2>Naturversity</h2><p>Learn, courses, languages.</p></a>
-      </div>
-      <div style={{ marginTop: 16 }}>
-        <a className="btn" href="/">Back to Home</a>
-      </div>
+    <div className="page">
+      <h1>404 — Lost in the Naturverse</h1>
+      <p className="muted">That page doesn’t exist (yet).</p>
+      <a className="btn" href="/">Back to Home</a>
     </div>
   );
 }
+

--- a/src/pages/Passport.tsx
+++ b/src/pages/Passport.tsx
@@ -5,6 +5,7 @@ import { getStamps, toggleStamp, getBadges, addBadge, getXP, addXP, getNatur, ad
 import Page from "../components/Page";
 import Meta from "../components/Meta";
 import { Img } from "../components";
+import RequireAuth from "../components/RequireAuth";
 
 const KINGDOMS = [
   "Thailandia","Brazilandia","Indillandia","Amerilandia",
@@ -32,6 +33,7 @@ export default function PassportPage() {
   const earnNatur = (n: number) => { addNatur(n); setNatur(getNatur()); };
 
     return (
+      <RequireAuth>
       <Page title="Passport" subtitle="Badges, stamps, XP, and NATUR coin." crumbs={[{ href:"/", label:"Home" }, { label:"Passport" }]}> 
       <Meta title="Passport — Naturverse" description="Track stamps, badges, XP, and NATUR." />
       {/* Identity / Navatar */}
@@ -89,5 +91,6 @@ export default function PassportPage() {
 
       <p className="meta">Coming soon: travel logs, per-kingdom progress, leaderboard, wallet-linked NATUR ledger, and verifiable stamp NFTs.</p>
     </Page>
+    </RequireAuth>
   );
 }

--- a/src/pages/marketplace/Checkout.tsx
+++ b/src/pages/marketplace/Checkout.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useCart } from "../../hooks/useCart";
 import { Img } from "../../components";
+import RequireAuth from "../../components/RequireAuth";
 
 const money = (cents: number) => `$${(cents/100).toFixed(2)}`;
 
@@ -9,6 +10,7 @@ export default function CheckoutPage() {
   const [code, setCode] = useState(cart.state.coupon ?? "");
 
   return (
+    <RequireAuth>
     <main id="main" className="page-wrap checkout">
       <h1>Checkout</h1>
 
@@ -68,5 +70,6 @@ export default function CheckoutPage() {
         </>
       )}
     </main>
+    </RequireAuth>
   );
 }

--- a/src/pages/marketplace/Wishlist.tsx
+++ b/src/pages/marketplace/Wishlist.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { CATALOG } from "../../lib/shop/data";
 import { addToCart, loadWishlist, toggleWish } from "../../lib/shop/store";
+import RequireAuth from "../../components/RequireAuth";
 
 export default function Wishlist() {
   const [ids, setIds] = useState<string[]>([]);
@@ -9,6 +10,7 @@ export default function Wishlist() {
   const items = CATALOG.filter(i => ids.includes(i.id));
 
   return (
+    <RequireAuth>
     <main id="main" className="page-wrap">
       <h1>❤️ Wishlist</h1>
       {items.length === 0 && <p>No favorites yet. Add some from the Catalog.</p>}
@@ -28,6 +30,7 @@ export default function Wishlist() {
         ))}
       </div>
     </main>
+    </RequireAuth>
   );
 }
 

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import { getCurrentUserAndProfile, NaturProfile } from '../lib/getProfile';
+import RequireAuth from '../components/RequireAuth';
 
 type ViewState =
   | { kind: 'loading' }
@@ -49,8 +50,9 @@ export default function ProfilePage() {
     };
   }, []);
 
+  let content: JSX.Element;
   if (state.kind === 'loading') {
-    return (
+    content = (
       <section>
         <h1>Profile</h1>
         <div style={s.card}>
@@ -64,63 +66,60 @@ export default function ProfilePage() {
         </div>
       </section>
     );
-  }
-
-  if (state.kind === 'signedOut') {
-    return (
+  } else if (state.kind === 'signedOut') {
+    content = (
       <section>
         <h1>Profile</h1>
         <p>You’re not signed in.</p>
         <a className="btn" href="/login">Sign in with Google</a>
       </section>
     );
-  }
-
-  if (state.kind === 'error') {
-    return (
+  } else if (state.kind === 'error') {
+    content = (
       <section>
         <h1>Profile</h1>
         <p role="alert">Oops — {state.message}</p>
       </section>
     );
-  }
-
-  // ready
-  const { user, profile } = state;
-  return (
-    <section>
-      <h1>Profile</h1>
-      <div style={s.card}>
-        <div style={s.row}>
-          <img
-            src={profile?.avatar_url || '/favicon.svg'}
-            alt="Avatar"
-            width={64}
-            height={64}
-            style={{ borderRadius: 12, background: '#eef3ff' }}
-            loading="lazy"
-            decoding="async"
-          />
-          <div style={{ marginLeft: 12 }}>
-            <div style={{ fontWeight: 700, fontSize: 18 }}>
-              {profile?.display_name || 'Explorer'}
-            </div>
-            <div style={{ opacity: 0.8 }}>{user.email || 'No email on file'}</div>
-            {profile?.updated_at && (
-              <div style={{ opacity: 0.6, fontSize: 12, marginTop: 4 }}>
-                Updated: {new Date(profile.updated_at).toLocaleString()}
+  } else {
+    const { user, profile } = state;
+    content = (
+      <section>
+        <h1>Profile</h1>
+        <div style={s.card}>
+          <div style={s.row}>
+            <img
+              src={profile?.avatar_url || '/favicon.svg'}
+              alt="Avatar"
+              width={64}
+              height={64}
+              style={{ borderRadius: 12, background: '#eef3ff' }}
+              loading="lazy"
+              decoding="async"
+            />
+            <div style={{ marginLeft: 12 }}>
+              <div style={{ fontWeight: 700, fontSize: 18 }}>
+                {profile?.display_name || 'Explorer'}
               </div>
-            )}
+              <div style={{ opacity: 0.8 }}>{user.email || 'No email on file'}</div>
+              {profile?.updated_at && (
+                <div style={{ opacity: 0.6, fontSize: 12, marginTop: 4 }}>
+                  Updated: {new Date(profile.updated_at).toLocaleString()}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div style={{ marginTop: 16 }}>
+            <a className="btn" href="/navatar">Create / Update Navatar</a>{' '}
+            <a className="btn" href="/passport">View Passport</a>
           </div>
         </div>
+      </section>
+    );
+  }
 
-        <div style={{ marginTop: 16 }}>
-          <a className="btn" href="/navatar">Create / Update Navatar</a>{' '}
-          <a className="btn" href="/passport">View Passport</a>
-        </div>
-      </div>
-    </section>
-  );
+  return <RequireAuth>{content}</RequireAuth>;
 }
 
 const s: Record<string, React.CSSProperties> = {

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -1,15 +1,23 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { WORLDS } from "../../data/worlds";
 import Meta from "../../components/Meta";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import SmartImg from "../../components/SmartImg";
+import SkeletonGrid from "../../components/SkeletonGrid";
 
 export default function WorldsIndex() {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setReady(true), 250);
+    return () => clearTimeout(t);
+  }, []);
+
   return (
       <div className="page-wrap">
         <Meta title="Worlds — Naturverse" description="Explore the 14 kingdoms." />
         <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Worlds" }]} />
       <p className="muted">Choose a kingdom to explore.</p>
+      {ready ? (
       <div className="cards">
         {WORLDS.map((w) => (
             <a className="card" key={w.slug} href={`/worlds/${w.slug}`}>
@@ -19,6 +27,9 @@ export default function WorldsIndex() {
             </a>
         ))}
       </div>
+      ) : (
+        <SkeletonGrid count={14} />
+      )}
     </div>
   );
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -62,7 +62,6 @@ import Accessibility from './pages/Accessibility';
 import About from './pages/About';
 import NotFound from './pages/NotFound';
 import RootLayout from './layouts/Root';
-import ProtectedRoute from './components/ProtectedRoute';
 
 export const router = createBrowserRouter([
   {
@@ -99,8 +98,8 @@ export const router = createBrowserRouter([
       { path: 'zones/future', element: <FutureZone /> },
       { path: 'marketplace', element: <Marketplace /> },
       { path: 'marketplace/catalog', element: <Catalog /> },
-        { path: 'marketplace/wishlist', element: <ProtectedRoute component={Wishlist} /> },
-        { path: 'marketplace/checkout', element: <ProtectedRoute component={Checkout} /> },
+        { path: 'marketplace/wishlist', element: <Wishlist /> },
+        { path: 'marketplace/checkout', element: <Checkout /> },
       { path: 'naturversity', element: <Naturversity /> },
       { path: 'naturversity/teachers', element: <Teachers /> },
       { path: 'naturversity/partners', element: <Partners /> },
@@ -123,11 +122,11 @@ export const router = createBrowserRouter([
       { path: 'contact', element: <Contact /> },
       { path: 'accessibility', element: <Accessibility /> },
       { path: 'about', element: <About /> },
-        { path: 'navatar', element: <ProtectedRoute component={NavatarPage} /> },
-        { path: 'passport', element: <ProtectedRoute component={Passport} /> },
+        { path: 'navatar', element: <NavatarPage /> },
+        { path: 'passport', element: <Passport /> },
         { path: 'login', element: <LoginPage /> },
         { path: 'turian', element: <Turian /> },
-        { path: 'profile', element: <ProtectedRoute component={ProfilePage} /> },
+        { path: 'profile', element: <ProfilePage /> },
         { path: '*', element: <NotFound /> },
     ],
   },

--- a/src/routes/marketplace/index.tsx
+++ b/src/routes/marketplace/index.tsx
@@ -1,14 +1,25 @@
 import Page from "../../components/Page";
 import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import SkeletonGrid from "../../components/SkeletonGrid";
 
 export default function Marketplace() {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setReady(true), 250);
+    return () => clearTimeout(t);
+  }, []);
   return (
     <Page title="Marketplace" subtitle="Shop creations and merch.">
+      {ready ? (
       <div className="grid gap-4 md:gap-6 sm:grid-cols-2">
         <Card to="/marketplace/catalog" title="Catalog" desc="Browse items." icon="📦" />
         <Card to="/marketplace/wishlist" title="Wishlist" desc="Your favorites." icon="❤️" />
         <Card to="/marketplace/checkout" title="Checkout" desc="Pay & ship." icon="🧾" />
       </div>
+      ) : (
+        <SkeletonGrid count={3} />
+      )}
     </Page>
   );
 }

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -2,6 +2,8 @@ import HubCard from '../../components/HubCard';
 import HubGrid from '../../components/HubGrid';
 import Meta from '../../components/Meta';
 import { breadcrumbs } from '../../lib/jsonld';
+import { useEffect, useState } from 'react';
+import SkeletonGrid from '../../components/SkeletonGrid';
 
 const ZONES = [
   {
@@ -63,6 +65,12 @@ const ZONES = [
 
 
 export default function Zones() {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setReady(true), 250);
+    return () => clearTimeout(t);
+  }, []);
+
   return (
     <div className="container-narrow">
       <Meta title="Zones — Naturverse" description="Pick a zone to start games, music, wellness, and more." />
@@ -71,11 +79,15 @@ export default function Zones() {
         <h1 className="page-title text-brand">Zones</h1>
         <p className="section-lead">Pick a zone to start an activity.</p>
 
+        {ready ? (
         <HubGrid>
           {ZONES.map((z) => (
             <HubCard key={z.title} to={z.to} emoji={z.emoji} title={z.title} sub={z.sub} />
           ))}
         </HubGrid>
+        ) : (
+          <SkeletonGrid count={6} />
+        )}
       </main>
 
       <script

--- a/src/styles/system.css
+++ b/src/styles/system.css
@@ -1,0 +1,12 @@
+.center-pad { display:flex; align-items:center; justify-content:center; padding:40px 0; }
+.spinner {
+  width:28px; height:28px; border:3px solid #e2e8f0; border-top-color:#0ea5e9;
+  border-radius:50%; animation: spin 1s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.card.skeleton { pointer-events:none; }
+.sk-img { width:100%; aspect-ratio: 16/9; background:linear-gradient(90deg,#f1f5f9 25%,#e2e8f0 37%,#f1f5f9 63%); background-size:400% 100%; animation: shimmer 1.2s infinite; border-radius:10px; }
+.sk-line { height:12px; margin-top:10px; border-radius:6px; background:linear-gradient(90deg,#f1f5f9 25%,#e2e8f0 37%,#f1f5f9 63%); background-size:400% 100%; animation: shimmer 1.2s infinite; }
+.sk-line.short { width:60%; }
+@keyframes shimmer { 0%{background-position:100% 0} 100%{background-position:0 0} }


### PR DESCRIPTION
## Summary
- add RequireAuth component for client-side auth redirects
- show skeleton loaders on hub pages while content initializes
- replace 404 page and import system styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS errors in lib/api)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bc75cc508329a935e22329cfa867