### PR TITLE
Add global error boundary, 404 page, and per-page metadata

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,29 +1,35 @@
 import React from "react";
 
-type State = { hasError: boolean; err?: unknown };
+type State = { hasError: boolean; message?: string };
 
 export default class ErrorBoundary extends React.Component<React.PropsWithChildren, State> {
   state: State = { hasError: false };
 
-  static getDerivedStateFromError(err: unknown) {
-    return { hasError: true, err };
+  static getDerivedStateFromError(err: unknown): State {
+    return { hasError: true, message: err instanceof Error ? err.message : String(err) };
   }
 
-  componentDidCatch(error: unknown, info: unknown) {
-    // no-op; could log to Supabase later
-    void error; void info;
+  componentDidCatch(err: unknown, info: unknown) {
+    // optional: console log so we don't white screen silently
+    console.error("App crashed:", err, info);
   }
 
   render() {
     if (this.state.hasError) {
       return (
-        <div className="page-wrap" style={{ paddingTop: 24 }}>
+        <div id="main" className="page" style={{ maxWidth: 900, margin: "24px auto" }}>
           <h1>Something went wrong</h1>
-          <p className="muted">Try refreshing, or head back home.</p>
-          <a className="btn" href="/">Back to Home</a>
+          <p className="muted">Please try again or go back to the homepage.</p>
+          {this.state.message && (
+            <pre style={{ background:"#fff", border:"1px solid #e5e7eb", padding:12, borderRadius:12, overflow:"auto" }}>
+              {this.state.message}
+            </pre>
+          )}
+          <a className="btn" href="/">← Back to Home</a>
         </div>
       );
     }
     return this.props.children;
   }
 }
+

--- a/src/components/PageHead.tsx
+++ b/src/components/PageHead.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+/** Tiny helper to set document title + description without any deps. */
+export default function PageHead({ title, description }: { title: string; description?: string }) {
+  useEffect(() => {
+    document.title = title;
+    if (description) {
+      let m = document.querySelector('meta[name="description"]') as HTMLMetaElement | null;
+      if (!m) {
+        m = document.createElement("meta");
+        m.name = "description";
+        document.head.appendChild(m);
+      }
+      m.content = description;
+    }
+  }, [title, description]);
+  return null;
+}
+

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -3,12 +3,14 @@ import { HubGrid } from "../components/HubGrid";
 import Meta from "../components/Meta";
 import { breadcrumbs } from "../lib/jsonld";
 import Breadcrumbs from "../components/Breadcrumbs";
+import PageHead from "../components/PageHead";
 
 const labels = { '/marketplace': 'Marketplace' };
 
 export default function MarketplacePage() {
     return (
       <>
+        <PageHead title="Naturverse — Marketplace" description="Shop Naturverse creations, merch, and bundles." />
         <Meta title="Marketplace — Naturverse" description="Shop Naturverse creations, merch, and bundles." />
         <div className="page-wrap">
           <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Marketplace" }]} />

--- a/src/pages/Naturbank.tsx
+++ b/src/pages/Naturbank.tsx
@@ -3,14 +3,17 @@ import { HubGrid } from "../components/HubGrid";
 import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
 import RequireAuth from "../components/RequireAuth";
+import PageHead from "../components/PageHead";
 
 export default function NaturbankPage() {
   return (
     <RequireAuth>
-      <div className="page-wrap">
-        <Meta title="Naturbank — Naturverse" description="Wallets, token, and collectibles." />
-        <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Naturbank" }]} />
-        <main id="main">
+      <>
+        <PageHead title="Naturverse — Naturbank" description="Wallets, token, and collectibles." />
+        <div className="page-wrap">
+          <Meta title="Naturbank — Naturverse" description="Wallets, token, and collectibles." />
+          <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Naturbank" }]} />
+          <main id="main">
         <h1>Naturbank</h1>
         <p className="muted">Wallets, token, and collectibles.</p>
 
@@ -23,11 +26,12 @@ export default function NaturbankPage() {
         ]}
       />
 
-      <p className="muted" style={{ marginTop: 12 }}>
-        Coming soon: live wallets, on-chain mints, and payouts.
-      </p>
-        </main>
-      </div>
+        <p className="muted" style={{ marginTop: 12 }}>
+          Coming soon: live wallets, on-chain mints, and payouts.
+        </p>
+          </main>
+        </div>
+      </>
     </RequireAuth>
   );
 }

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -3,6 +3,7 @@ import { HubGrid } from "../components/HubGrid";
 import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
 import SkeletonGrid from "../components/SkeletonGrid";
+import PageHead from "../components/PageHead";
 
 export default function NaturversityPage() {
   const [ready, setReady] = useState(false);
@@ -12,6 +13,7 @@ export default function NaturversityPage() {
   }, []);
   return (
       <>
+        <PageHead title="Naturverse — Naturversity" description="Teachers, partners, and courses." />
         <div className="page-wrap">
           <Meta title="Naturversity — Naturverse" description="Teachers, partners, and courses." />
           <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Naturversity" }]} />

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -5,6 +5,7 @@ import { loadActive, saveActive, loadLibrary, saveLibrary } from "../lib/localSt
 import NavatarCard from "../components/NavatarCard";
 import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
+import PageHead from "../components/PageHead";
 
 const BASES: NavatarBase[] = ["Animal", "Fruit", "Insect", "Spirit"];
 
@@ -65,6 +66,7 @@ export default function NavatarPage() {
 
   return (
     <div className="page-wrap">
+      <PageHead title="Naturverse — Navatar Creator" description="Design your character and save cards." />
       <Meta title="Navatar Creator — Naturverse" description="Design your character and save cards." />
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Navatar" }]} />
       <main id="main" className="wrap">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,9 +1,17 @@
+import React, { useEffect } from "react";
+
 export default function NotFound() {
+  useEffect(() => {
+    document.title = "Naturverse — Page not found";
+    const m = document.querySelector('meta[name="description"]');
+    if (m) m.setAttribute("content", "This page could not be found.");
+  }, []);
+
   return (
-    <div className="page">
-      <h1>404 — Lost in the Naturverse</h1>
-      <p className="muted">That page doesn’t exist (yet).</p>
-      <a className="btn" href="/">Back to Home</a>
+    <div id="main" className="page" style={{ maxWidth: 900, margin: "24px auto" }}>
+      <h1>404 — Not found</h1>
+      <p className="muted">Looks like this trail doesn’t exist yet.</p>
+      <a className="btn" href="/">← Back to Home</a>
     </div>
   );
 }

--- a/src/pages/Passport.tsx
+++ b/src/pages/Passport.tsx
@@ -6,6 +6,7 @@ import Page from "../components/Page";
 import Meta from "../components/Meta";
 import { Img } from "../components";
 import RequireAuth from "../components/RequireAuth";
+import PageHead from "../components/PageHead";
 
 const KINGDOMS = [
   "Thailandia","Brazilandia","Indillandia","Amerilandia",
@@ -34,7 +35,8 @@ export default function PassportPage() {
 
     return (
       <RequireAuth>
-      <Page title="Passport" subtitle="Badges, stamps, XP, and NATUR coin." crumbs={[{ href:"/", label:"Home" }, { label:"Passport" }]}> 
+      <Page title="Passport" subtitle="Badges, stamps, XP, and NATUR coin." crumbs={[{ href:"/", label:"Home" }, { label:"Passport" }]}>
+      <PageHead title="Naturverse — Passport" description="Track stamps, badges, XP, and NATUR coin." />
       <Meta title="Passport — Naturverse" description="Track stamps, badges, XP, and NATUR." />
       {/* Identity / Navatar */}
       <div className="passport-id">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,10 +2,15 @@ import React from "react";
 import { Link } from "react-router-dom";
 import Meta from "../components/Meta";
 import { Img } from "../components";
+import PageHead from "../components/PageHead";
 
 export default function Home() {
   return (
     <>
+      <PageHead
+        title="Naturverse — Learn & Play Across 14 Magical Kingdoms"
+        description="Explore worlds, play games, create your Navatar, and learn with Naturversity."
+      />
       <Meta
         title="Naturverse — Learn & Play Across 14 Magical Kingdoms"
         description="Explore worlds, play games, create your Navatar, and learn with Naturversity."

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import { getCurrentUserAndProfile, NaturProfile } from '../lib/getProfile';
 import RequireAuth from '../components/RequireAuth';
+import PageHead from '../components/PageHead';
 
 type ViewState =
   | { kind: 'loading' }
@@ -120,7 +121,10 @@ export default function ProfilePage() {
   }
   return (
     <RequireAuth>
-      <main id="main" className="page-wrap">{content}</main>
+      <>
+        <PageHead title="Naturverse — Profile" description="View your profile and account settings." />
+        <main id="main" className="page-wrap">{content}</main>
+      </>
     </RequireAuth>
   );
 }

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -4,6 +4,7 @@ import Meta from "../../components/Meta";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import SmartImg from "../../components/SmartImg";
 import SkeletonGrid from "../../components/SkeletonGrid";
+import PageHead from "../../components/PageHead";
 
 export default function WorldsIndex() {
   const [ready, setReady] = useState(false);
@@ -14,6 +15,7 @@ export default function WorldsIndex() {
 
   return (
       <div id="main" className="page-wrap">
+        <PageHead title="Naturverse — Worlds" description="Explore the 14 kingdoms." />
         <Meta title="Worlds — Naturverse" description="Explore the 14 kingdoms." />
         <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Worlds" }]} />
       <p className="muted">Choose a kingdom to explore.</p>

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -4,6 +4,7 @@ import Meta from '../../components/Meta';
 import { breadcrumbs } from '../../lib/jsonld';
 import { useEffect, useState } from 'react';
 import SkeletonGrid from '../../components/SkeletonGrid';
+import PageHead from '../../components/PageHead';
 
 const ZONES = [
   {
@@ -73,6 +74,7 @@ export default function Zones() {
 
   return (
     <div className="container-narrow">
+      <PageHead title="Naturverse — Zones" description="Pick a zone to start games, music, wellness, and more." />
       <Meta title="Zones — Naturverse" description="Pick a zone to start games, music, wellness, and more." />
       <main id="main" className="container">
         <div className="breadcrumb">Home / Zones</div>


### PR DESCRIPTION
## Summary
- replace error boundary to show error message and link home
- add 404 NotFound page and catch-all titles/meta helper
- set document titles & descriptions per page via new `PageHead`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string | null', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c04007b0832999866dc124efc26f