### PR TITLE
Add Naturbank wallet page with balance and history

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -16,6 +16,7 @@
 @import './styles/guard.css';
 @import "./styles/user-menu.css";
 @import "./styles/system.css";
+@import "./styles/naturbank.css";
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/pages/naturbank.tsx
+++ b/src/pages/naturbank.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import { supabase } from "../lib/supabase";
+
+type Tx = {
+  id: string;
+  amount: number;
+  created_at: string;
+};
+
+export default function NaturbankPage() {
+  const [userId, setUserId] = useState<string | null>(null);
+  const [balance, setBalance] = useState<number>(0);
+  const [txs, setTxs] = useState<Tx[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const { data: sessionData } = await supabase.auth.getSession();
+      const session = sessionData.session;
+      if (!session) {
+        setLoading(false);
+        return;
+      }
+      const uid = session.user.id;
+      setUserId(uid);
+
+      const { data } = await supabase
+        .from("xp_ledger")
+        .select("id, amount, created_at")
+        .eq("user_id", uid)
+        .order("created_at", { ascending: false });
+
+      const rows = (data as Tx[]) || [];
+      const total = rows.reduce((acc, r) => acc + (r.amount ?? 0), 0);
+      setBalance(total);
+      setTxs(rows);
+      setLoading(false);
+    })();
+  }, []);
+
+  async function addFunds() {
+    if (!userId) return;
+    const { error } = await supabase
+      .from("xp_ledger")
+      .insert({ user_id: userId, amount: 50 });
+    if (error) return alert(error.message);
+    alert("Added +50 NATUR!");
+    location.reload();
+  }
+
+  if (loading) return <main><h1>Naturbank</h1><p>Loading…</p></main>;
+
+  if (!userId) return (
+    <main>
+      <h1>Naturbank</h1>
+      <p>Please sign in to view your wallet.</p>
+    </main>
+  );
+
+  return (
+    <main className="naturbank-page">
+      <h1>Naturbank</h1>
+      <p>Balance: <strong>{balance} NATUR</strong></p>
+      <button className="btn" onClick={addFunds}>Add Funds (demo)</button>
+
+      <div className="txs">
+        <h2>Transactions</h2>
+        {txs.length === 0 ? (
+          <p>No transactions yet.</p>
+        ) : (
+          <ul>
+            {txs.map((t) => (
+              <li key={t.id}>
+                {t.amount > 0 ? "+" : ""}{t.amount} — {new Date(t.created_at).toLocaleString()}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}
+

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -45,7 +45,7 @@ import IndilandiaLang from './pages/naturversity/languages/IndilandiaLang';
 import BrazilandiaLang from './pages/naturversity/languages/BrazilandiaLang';
 import AustralandiaLang from './pages/naturversity/languages/AustralandiaLang';
 import AmerilandiaLang from './pages/naturversity/languages/AmerilandiaLang';
-import Naturbank from './pages/Naturbank';
+import NaturbankPage from './pages/naturbank';
 import BankWallet from './pages/naturbank/Wallet';
 import BankToken from './pages/naturbank/Token';
 import BankNFTs from './pages/naturbank/NFTs';
@@ -112,7 +112,7 @@ export const router = createBrowserRouter([
       { path: 'naturversity/languages/brazilandia', element: <BrazilandiaLang /> },
       { path: 'naturversity/languages/australandia', element: <AustralandiaLang /> },
       { path: 'naturversity/languages/amerilandia', element: <AmerilandiaLang /> },
-      { path: 'naturbank', element: <Naturbank /> },
+      { path: 'naturbank', element: <NaturbankPage /> },
       { path: 'naturbank/wallet', element: <BankWallet /> },
       { path: 'naturbank/natur', element: <BankToken /> },
       { path: 'naturbank/nfts', element: <BankNFTs /> },

--- a/src/styles/naturbank.css
+++ b/src/styles/naturbank.css
@@ -1,0 +1,4 @@
+.naturbank-page { max-width: 640px; margin: auto; }
+.naturbank-page .btn { margin: 12px 0; }
+.naturbank-page .txs ul { list-style: none; padding: 0; margin: 0; }
+.naturbank-page .txs li { padding: 6px 0; border-bottom: 1px solid #eee; }


### PR DESCRIPTION
## Summary
- add Naturbank page that shows NATUR token balance and recent transactions
- demo "Add Funds" button
- wire page styling and router

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a9cfc7256883298b21894d0f0cc64e