### PR TITLE
Add passport page with stamps grid

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -17,7 +17,13 @@ export default function NavBar() {
       <a href="/naturversity" className={path.startsWith('/naturversity') ? 'active' : undefined} aria-current={path.startsWith('/naturversity') ? 'page' : undefined}>Naturversity</a>
       <a href="/naturbank" className={path.startsWith('/naturbank') ? 'active' : undefined} aria-current={path.startsWith('/naturbank') ? 'page' : undefined}>Naturbank</a>
       <a href="/navatar" className={path.startsWith('/navatar') ? 'active' : undefined} aria-current={path.startsWith('/navatar') ? 'page' : undefined}>Navatar</a>
-      <a href="/passport" className={path.startsWith('/passport') ? 'active' : undefined} aria-current={path.startsWith('/passport') ? 'page' : undefined}>Passport</a>
+      <a
+        href="/passport"
+        className={`nav-link${path.startsWith('/passport') ? ' active' : ''}`}
+        aria-current={path.startsWith('/passport') ? 'page' : undefined}
+      >
+        Passport
+      </a>
       <a href="/turian" className={path.startsWith('/turian') ? 'active' : undefined} aria-current={path.startsWith('/turian') ? 'page' : undefined}>Turian</a>
       <a href="/profile" className={path.startsWith('/profile') ? 'active' : undefined} aria-current={path.startsWith('/profile') ? 'page' : undefined}>Profile</a>
     </nav>

--- a/src/main.css
+++ b/src/main.css
@@ -17,6 +17,7 @@
 @import "./styles/user-menu.css";
 @import "./styles/system.css";
 @import "./styles/naturbank.css";
+@import "./styles/passport.css";
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -51,7 +51,7 @@ import BankToken from './pages/naturbank/Token';
 import BankNFTs from './pages/naturbank/NFTs';
 import BankLearn from './pages/naturbank/Learn';
 import NavatarPage from './pages/Navatar';
-import Passport from './pages/passport';
+import PassportPage from './pages/passport';
 import LoginPage from './pages/Login';
 import Turian from './routes/turian';
 import ProfilePage from './pages/profile';
@@ -123,7 +123,7 @@ export const router = createBrowserRouter([
       { path: 'accessibility', element: <Accessibility /> },
       { path: 'about', element: <About /> },
         { path: 'navatar', element: <NavatarPage /> },
-        { path: 'passport', element: <Passport /> },
+        { path: 'passport', element: <PassportPage /> },
         { path: 'login', element: <LoginPage /> },
         { path: 'turian', element: <Turian /> },
         { path: 'profile', element: <ProfilePage /> },

--- a/src/styles/passport.css
+++ b/src/styles/passport.css
@@ -1,6 +1,13 @@
-.passport-page { max-width: 640px; margin: auto; }
-.passport-page .btn { margin: 12px 0; }
-.stamps { margin-top: 16px; display: grid; gap: 12px; }
-.stamp { padding: 12px; border: 1px solid #ddd; border-radius: 8px; }
-.stamp h3 { margin: 0; }
-.stamp span { opacity: .6; font-size: 12px; }
+.passport { max-width: 960px; margin: 0 auto; padding: 20px; }
+.stamp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 12px; }
+.stamp { border: 1px solid #cfe8ff; background: #eff7ff; border-radius: 12px; padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+.stamp.earned { background: #e9fce9; border-color: #b9e5b9; }
+.stamp.locked { opacity: 0.95; }
+.stamp-title { font-weight: 800; }
+.stamp-mark { font-size: 28px; }
+.stamp-list ul { list-style: none; padding: 0; }
+.stamp-list li { padding: 6px 0; border-bottom: 1px solid #eee; }
+.btn.tiny { padding: 6px 10px; font-size: 13px; border-radius: 8px; }
+.btn.outline { background: #fff; color: #0ea5e9; border: 1px solid #0ea5e9; }
+.muted { color: #6b7280; }
+


### PR DESCRIPTION
## Summary
- add passport page that fetches and lists earned stamps, with demo stamp insertion
- style passport stamps grid and import styles
- wire up /passport route and navbar link

## Testing
- `npm test` (fails: missing script)
- `npm run typecheck` (fails: TS errors in existing files)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9d4460d708329af41ecd3ae4abe57