### PR TITLE
feat: add passport page with local and supabase stamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ Also set the same variables in Netlify → Site settings → Environment variabl
 - Works without servers (localStorage) OR with Supabase tables if present.
 - Page: `/naturbank`
 - To enable server sync, run SQL in `supabase/sql/2025-setup-naturbank.sql`.
+
+### Passport
+- Page: `/passport`
+- Works offline via localStorage, and syncs to Supabase when signed in.
+- Run SQL in `supabase/sql/2025-passport.sql` to enable server storage.

--- a/src/styles/passport.css
+++ b/src/styles/passport.css
@@ -1,13 +1,33 @@
-.passport { max-width: 960px; margin: 0 auto; padding: 20px; }
-.stamp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 12px; }
-.stamp { border: 1px solid #cfe8ff; background: #eff7ff; border-radius: 12px; padding: 12px; display: flex; flex-direction: column; gap: 8px; }
-.stamp.earned { background: #e9fce9; border-color: #b9e5b9; }
-.stamp.locked { opacity: 0.95; }
-.stamp-title { font-weight: 800; }
-.stamp-mark { font-size: 28px; }
-.stamp-list ul { list-style: none; padding: 0; }
-.stamp-list li { padding: 6px 0; border-bottom: 1px solid #eee; }
-.btn.tiny { padding: 6px 10px; font-size: 13px; border-radius: 8px; }
-.btn.outline { background: #fff; color: #0ea5e9; border: 1px solid #0ea5e9; }
-.muted { color: #6b7280; }
+.passport { max-width: 1100px; margin: 0 auto; padding: 20px; }
+.muted { color:#6b7280; }
+.small { font-size:12px; }
+
+.panel { border:1px solid #cfe8ff; background:#eff7ff; border-radius:14px; padding:16px; margin:16px 0; }
+.row { display:flex; gap:10px; align-items:flex-end; }
+.row.wrap { flex-wrap:wrap; }
+.field { display:flex; flex-direction:column; gap:6px; }
+.field span { font-size:12px; font-weight:700; color:#475569; }
+.field input, .field select { padding:10px; border:1px solid #cbd5e1; border-radius:10px; }
+.field.grow { flex:1; }
+
+.btn{ padding:10px 12px; border-radius:10px; border:1px solid #0ea5e9; background:#0ea5e9; color:#fff; font-weight:700; }
+.btn.outline{ background:#fff; color:#0ea5e9; }
+.btn.tiny{ padding:6px 10px; font-size:13px; }
+
+.passport-summary {
+  display:grid; grid-template-columns: repeat(auto-fit, minmax(160px,1fr)); gap:12px; margin:16px 0;
+}
+.stamp-box {
+  background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:12px; text-align:center;
+}
+.stamp-box .w { font-weight:800; }
+.stamp-box .c { color:#64748b; font-size:12px; }
+
+.stamp-list { list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:10px; }
+.stamp-item { display:flex; gap:10px; justify-content:space-between; align-items:flex-start;
+  background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:12px; }
+.stamp-item .top { display:flex; gap:10px; align-items:center; }
+.stamp-item .when { color:#64748b; font-size:12px; }
+.badge { font-weight:700; }
+.note { color:#334155; }
 

--- a/src/types/passport.ts
+++ b/src/types/passport.ts
@@ -1,0 +1,8 @@
+export type PassportStamp = {
+  id: string;
+  user_id: string;
+  world: string;        // e.g., "Thailandia"
+  badge?: string | null; // e.g., "Explorer", "Helper"
+  note?: string | null;
+  created_at: string | null;
+};

--- a/supabase/sql/2025-passport.sql
+++ b/supabase/sql/2025-passport.sql
@@ -1,0 +1,19 @@
+create table if not exists public.passport_stamps (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  world text not null,
+  badge text,
+  note text,
+  created_at timestamp with time zone default now()
+);
+
+alter table public.passport_stamps enable row level security;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where tablename = 'passport_stamps' and policyname = 'own-stamps') then
+    create policy "own-stamps" on public.passport_stamps
+      for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+  end if;
+end $$;
+
+create index if not exists passport_user_idx on public.passport_stamps(user_id, created_at desc);


### PR DESCRIPTION
## Summary
- add PassportStamp type and Supabase SQL schema
- build Passport page with localStorage fallback and remote sync
- style passport UI and document setup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: existing TS errors in api modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a9da3ea53c832992792a31250ded04