### PR TITLE
feat: add Passport page with stamps and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ Also set the same variables in Netlify → Site settings → Environment variabl
 
 ### Passport
 - Page: `/passport`
-- Works offline via localStorage, and syncs to Supabase when signed in.
-- Run SQL in `supabase/sql/2025-passport.sql` to enable server storage.
+- Stamps per world + badges; demo buttons to add local/server-backed progress.
+- To persist in Supabase: run `supabase/sql/2025-passport.sql`.

--- a/src/data/worlds-data.ts
+++ b/src/data/worlds-data.ts
@@ -1,0 +1,47 @@
+export type World = {
+  slug: string;
+  name: string;
+  map: string;           // public path to map image
+  hero?: string;         // optional hero image
+  blurb: string;
+};
+
+export const WORLD_DATA: World[] = [
+  {
+    slug: "thailandia",
+    name: "Thailandia",
+    map: "/kingdoms/Thailandia/Thailandiamap.jpg",
+    blurb: "Coconuts, elephants, festivals.",
+  },
+  {
+    slug: "amerilandia",
+    name: "Amerilandia",
+    map: "/kingdoms/Amerilandia/Amerilandiamap.png",
+    blurb: "Apples & eagles.",
+  },
+  {
+    slug: "indillandia",
+    name: "Indillandia",
+    map: "/kingdoms/Indillandia/Inlandiamap.png",
+    blurb: "Mangoes & tigers.",
+  },
+  {
+    slug: "brazilandia",
+    name: "Brazilandia",
+    map: "/kingdoms/Brazilandia/Brazilandiamap.png",
+    blurb: "Bananas & parrots.",
+  },
+  {
+    slug: "australandia",
+    name: "Australandia",
+    map: "/kingdoms/Australandia/Australaniamap.png",
+    blurb: "Peaches & kangaroos.",
+  },
+  {
+    slug: "chilandia",
+    name: "Chilandia",
+    map: "/kingdoms/Chilandia/Chilandiamap.jpg",
+    blurb: "Bamboo & pandas.",
+  },
+];
+

--- a/src/data/worlds.ts
+++ b/src/data/worlds.ts
@@ -1,46 +1,19 @@
-export type World = {
-  slug: string;
-  name: string;
-  map: string;           // public path to map image
-  hero?: string;         // optional hero image
-  blurb: string;
-};
+export const WORLDS = [
+  "thailandia",
+  "brazilandia",
+  "indillandia",
+  "amerilandia",
+  "australandia",
+  "chilandia",
+  "japonica",
+  "africana",
+  "europalia",
+  "britannula",
+  "kiwilandia",
+  "madagascaria",
+  "greenlandia",
+  "antarctiland",
+] as const;
 
-export const WORLDS: World[] = [
-  {
-    slug: "thailandia",
-    name: "Thailandia",
-    map: "/kingdoms/Thailandia/Thailandiamap.jpg",
-    blurb: "Coconuts, elephants, festivals."
-  },
-  {
-    slug: "amerilandia",
-    name: "Amerilandia",
-    map: "/kingdoms/Amerilandia/Amerilandiamap.png",
-    blurb: "Apples & eagles."
-  },
-  {
-    slug: "indillandia",
-    name: "Indillandia",
-    map: "/kingdoms/Indillandia/Inlandiamap.png",
-    blurb: "Mangoes & tigers."
-  },
-  {
-    slug: "brazilandia",
-    name: "Brazilandia",
-    map: "/kingdoms/Brazilandia/Brazilandiamap.png",
-    blurb: "Bananas & parrots."
-  },
-  {
-    slug: "australandia",
-    name: "Australandia",
-    map: "/kingdoms/Australandia/Australaniamap.png",
-    blurb: "Peaches & kangaroos."
-  },
-  {
-    slug: "chilandia",
-    name: "Chilandia",
-    map: "/kingdoms/Chilandia/Chilandiamap.jpg",
-    blurb: "Bamboo & pandas."
-  }
-];
+export type WorldKey = typeof WORLDS[number];
+

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { WORLDS } from "../../data/worlds";
+import { WORLD_DATA } from "../../data/worlds-data";
 import Meta from "../../components/Meta";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import SmartImg from "../../components/SmartImg";
@@ -21,7 +21,7 @@ export default function WorldsIndex() {
       <p className="muted">Choose a kingdom to explore.</p>
       {ready ? (
       <div className="cards">
-        {WORLDS.map((w) => (
+        {WORLD_DATA.map((w) => (
             <a className="card" key={w.slug} href={`/worlds/${w.slug}`}>
               <SmartImg src={w.map} alt={`${w.name} map`} ratio="wide" width={800} height={450} />
               <h2>{w.name}</h2>

--- a/src/styles/passport.css
+++ b/src/styles/passport.css
@@ -1,33 +1,33 @@
-.passport { max-width: 1100px; margin: 0 auto; padding: 20px; }
-.muted { color:#6b7280; }
-.small { font-size:12px; }
-
-.panel { border:1px solid #cfe8ff; background:#eff7ff; border-radius:14px; padding:16px; margin:16px 0; }
-.row { display:flex; gap:10px; align-items:flex-end; }
-.row.wrap { flex-wrap:wrap; }
-.field { display:flex; flex-direction:column; gap:6px; }
-.field span { font-size:12px; font-weight:700; color:#475569; }
-.field input, .field select { padding:10px; border:1px solid #cbd5e1; border-radius:10px; }
-.field.grow { flex:1; }
-
+.passport { max-width:1100px; margin:0 auto; padding:20px; }
+.panel{ border:1px solid #cfe8ff; background:#eff7ff; border-radius:14px; padding:16px; margin:16px 0; }
+.muted{ color:#6b7280; }
+.small{ font-size:12px; }
+.row{ display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
 .btn{ padding:10px 12px; border-radius:10px; border:1px solid #0ea5e9; background:#0ea5e9; color:#fff; font-weight:700; }
-.btn.outline{ background:#fff; color:#0ea5e9; }
 .btn.tiny{ padding:6px 10px; font-size:13px; }
+.btn.outline{ background:#fff; color:#0ea5e9; }
 
-.passport-summary {
-  display:grid; grid-template-columns: repeat(auto-fit, minmax(160px,1fr)); gap:12px; margin:16px 0;
-}
-.stamp-box {
-  background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:12px; text-align:center;
-}
-.stamp-box .w { font-weight:800; }
-.stamp-box .c { color:#64748b; font-size:12px; }
+.world-grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap:12px; }
+.world-card{ background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:12px; display:flex; flex-direction:column; gap:6px; }
+.world-name{ font-weight:800; color:#0f172a; }
+.stamp-count{ color:#334155; }
 
-.stamp-list { list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:10px; }
-.stamp-item { display:flex; gap:10px; justify-content:space-between; align-items:flex-start;
-  background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:12px; }
-.stamp-item .top { display:flex; gap:10px; align-items:center; }
-.stamp-item .when { color:#64748b; font-size:12px; }
-.badge { font-weight:700; }
-.note { color:#334155; }
+.stamp-list{ list-style:none; padding:0; margin:0; background:#fff; border:1px solid #e5e7eb; border-radius:12px; overflow:hidden; }
+.stamp-item{ display:grid; grid-template-columns: 160px 1fr 1fr 160px; gap:8px; padding:10px; border-bottom:1px solid #eef2f7; }
+.stamp-item:last-child{ border-bottom:none; }
+.stamp-item .w{ font-weight:700; color:#0f172a; }
+.stamp-item .t{ color:#0f172a; }
+.stamp-item .n{ color:#475569; }
+.stamp-item .d{ color:#64748b; text-align:right; }
+@media (max-width: 720px){
+  .stamp-item{ grid-template-columns: 1fr; }
+  .stamp-item .d{ text-align:left; }
+}
+
+.badge-grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap:12px; }
+.badge{ background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:12px; display:flex; gap:10px; align-items:center; }
+.badge-icon{ font-size:30px; }
+.badge-label{ font-weight:800; color:#0f172a; }
+.badge-code{ font-size:12px; color:#475569; }
+.badge-date{ font-size:12px; color:#64748b; }
 

--- a/src/types/passport.ts
+++ b/src/types/passport.ts
@@ -1,8 +1,16 @@
 export type PassportStamp = {
   id: string;
   user_id: string;
-  world: string;        // e.g., "Thailandia"
-  badge?: string | null; // e.g., "Explorer", "Helper"
+  world: string;        // e.g., "thailandia"
+  title: string;        // e.g., "Temple Explorer"
   note?: string | null;
+  created_at: string | null;
+};
+
+export type PassportBadge = {
+  id: string;
+  user_id: string;
+  code: string;         // e.g., "10-quests", "quiz-master"
+  label: string;        // display name
   created_at: string | null;
 };

--- a/supabase/sql/2025-passport.sql
+++ b/supabase/sql/2025-passport.sql
@@ -2,18 +2,33 @@ create table if not exists public.passport_stamps (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users(id) on delete cascade,
   world text not null,
-  badge text,
+  title text not null,
   note text,
   created_at timestamp with time zone default now()
 );
 
+create table if not exists public.passport_badges (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  code text not null,
+  label text not null,
+  created_at timestamp with time zone default now()
+);
+
 alter table public.passport_stamps enable row level security;
+alter table public.passport_badges enable row level security;
 
 do $$ begin
-  if not exists (select 1 from pg_policies where tablename = 'passport_stamps' and policyname = 'own-stamps') then
+  if not exists (select 1 from pg_policies where tablename='passport_stamps' and policyname='own-stamps') then
     create policy "own-stamps" on public.passport_stamps
+      for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+  end if;
+  if not exists (select 1 from pg_policies where tablename='passport_badges' and policyname='own-badges') then
+    create policy "own-badges" on public.passport_badges
       for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
   end if;
 end $$;
 
-create index if not exists passport_user_idx on public.passport_stamps(user_id, created_at desc);
+create index if not exists stamps_user_idx on public.passport_stamps(user_id, created_at desc);
+create index if not exists badges_user_idx on public.passport_badges(user_id, created_at desc);
+


### PR DESCRIPTION
## Summary
- add PassportStamp and PassportBadge types
- list all worlds and expose WorldKey type
- implement `/passport` page with stamps, badges, and demo progress
- add SQL schema for passport stamps and badges

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Found 8 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9e0b00ca4832982b77c98744326f6