### PR TITLE
feat: add lazy images and unified card grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,21 +6,38 @@
     <title>Naturverse</title>
 
     <!-- SEO base -->
-    <meta name="description" content="The Naturverse — kid-friendly worlds, quests, learning, and play." />
-    <meta property="og:title" content="Naturverse" />
-    <meta property="og:description" content="Explore 14 magical kingdoms, create your Navatar, learn & earn NATUR." />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="/" />
-    <meta property="og:image" content="/favicon-192.png" />
+    <meta
+      name="description"
+      content="The Naturverse — a magical world of learning with characters, games, and adventures."
+    />
+    <meta property="og:title" content="The Naturverse" />
+    <meta
+      property="og:description"
+      content="A magical world of learning with characters, games, and adventures."
+    />
+    <meta property="og:image" content="/favicon-512.png" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="The Naturverse" />
+    <meta
+      name="twitter:description"
+      content="A magical world of learning with characters, games, and adventures."
+    />
+    <meta name="twitter:image" content="/favicon-512.png" />
 
     <!-- PWA-ish icons -->
     <link rel="icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/favicon-192.png" />
 
-    <!-- Preload main CSS for faster paint -->
-    <link rel="preload" as="style" href="/src/main.css" onload="this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="/src/main.css"></noscript>
+    <!-- Preload assets -->
+    <link rel="preload" as="style" href="/src/main.css" />
+    <link
+      rel="preload"
+      as="font"
+      href="/fonts/your-main-font.woff2"
+      type="font/woff2"
+      crossorigin
+    />
+    <link rel="stylesheet" href="/src/main.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/_headers
+++ b/public/_headers
@@ -1,12 +1,6 @@
 /*
-  X-Content-Type-Options: nosniff
-  X-Frame-Options: SAMEORIGIN
-  Referrer-Policy: strict-origin-when-cross-origin
-  Permissions-Policy: geolocation=(), microphone=(), camera=()
-  Cache-Control: public, max-age=600
-
-/index.html
-  Cache-Control: no-cache
-
-/assets/*
   Cache-Control: public, max-age=31536000, immutable
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-/*  /index.html  200
+/*    /index.html   200
 

--- a/src/components/AuthMenu.tsx
+++ b/src/components/AuthMenu.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import { supabase } from "../lib/supabase";
+import LazyImg from "./LazyImg";
 import "../styles/auth-menu.css";
 
 type MiniUser = { id: string; email: string | null; avatar_url?: string | null };
@@ -71,13 +72,12 @@ export default function AuthMenu() {
   return (
     <div className="auth-menu" ref={menuRef}>
       {user.avatar_url ? (
-        <img
+        <LazyImg
           className="auth-avatar"
           src={user.avatar_url}
           alt="Avatar"
           width={28}
           height={28}
-          loading="lazy"
           decoding="async"
         />
       ) : (

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -27,5 +27,5 @@ export function Card({ href, title, subtitle, image }: CardProps) {
 }
 
 export default function CardGrid({ children }: { children: React.ReactNode }) {
-  return <div className="grid">{children}</div>;
+  return <div className="cards">{children}</div>;
 }

--- a/src/components/HubGrid.tsx
+++ b/src/components/HubGrid.tsx
@@ -11,10 +11,10 @@ type Item = {
 export function HubGrid({ items, children }: { items?: Item[]; children?: React.ReactNode }) {
   if (items) {
     return (
-      <div className="hub-grid">
+      <div className="cards">
         {items.map((it, i) =>
           it.to ? (
-            <Link key={i} to={it.to} className="hub-card card">
+            <Link key={i} to={it.to} className="card">
               <strong className="hub-card-title card-title">
                 {it.icon && (
                   <span className="hub-ico emoji" aria-hidden>
@@ -26,7 +26,7 @@ export function HubGrid({ items, children }: { items?: Item[]; children?: React.
               {it.desc && <span className="hub-card-desc">{it.desc}</span>}
             </Link>
           ) : (
-            <div key={i} className="hub-card card">
+            <div key={i} className="card">
               <strong className="hub-card-title card-title">
                 {it.icon && (
                   <span className="hub-ico emoji" aria-hidden>
@@ -43,7 +43,7 @@ export function HubGrid({ items, children }: { items?: Item[]; children?: React.
     );
   }
 
-  return <div className="hub-grid">{children}</div>;
+  return <div className="cards">{children}</div>;
 }
 
 export default HubGrid;

--- a/src/components/LazyImg.tsx
+++ b/src/components/LazyImg.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+type Props = React.ImgHTMLAttributes<HTMLImageElement> & { alt: string };
+
+export default function LazyImg(props: Props) {
+  return <img loading="lazy" {...props} />;
+}

--- a/src/components/UserChip.tsx
+++ b/src/components/UserChip.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { supabase } from '../lib/supabaseClient';
+import LazyImg from './LazyImg';
 
 export default function UserChip({ email }: { email?: string | null }) {
   const [open, setOpen] = useState(false);
@@ -21,7 +22,7 @@ export default function UserChip({ email }: { email?: string | null }) {
         className="btn"
         style={{ display: 'inline-flex', alignItems: 'center', gap: 8, paddingInline: 10 }}
       >
-        <img
+        <LazyImg
           src="/favicon.svg"
           alt="Avatar"
           width={20}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { supabase } from "../lib/supabaseClient";
+import LazyImg from "./LazyImg";
 
 type SessionUser = {
   email?: string | null;
@@ -63,12 +64,12 @@ export default function UserMenu() {
   return (
     <div className="usermenu" ref={ref}>
       <button className="avatar-btn" onClick={() => setOpen(v => !v)} aria-expanded={open}>
-        {pic ? <img src={pic} alt={name} /> : <span>{initials(name, user.email)}</span>}
+        {pic ? <LazyImg src={pic} alt={name} /> : <span>{initials(name, user.email)}</span>}
       </button>
       {open && (
         <div className="menu">
           <div className="who">
-            {pic ? <img src={pic} alt={name} /> : <span className="circle">{initials(name, user.email)}</span>}
+            {pic ? <LazyImg src={pic} alt={name} /> : <span className="circle">{initials(name, user.email)}</span>}
             <div className="meta">
               <strong>{name}</strong>
               <small>{user.email}</small>

--- a/src/main.css
+++ b/src/main.css
@@ -3,8 +3,6 @@
 @import './styles/cart.css';
 @import './styles/footer.css';
 @import './styles/home.css';
-@import './styles/cards-unify.css';
-@import './styles/cards.css';
 @import './styles/auth-menu.css';
 @import './styles/buttons.css';
 @import './styles/languages.css';
@@ -20,6 +18,7 @@
 @import "./styles/passport.css";
 @import "./styles/bank.css";
 @import "./styles/polish.css";
+@import "./styles/cards.css";
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -4,6 +4,7 @@ import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
 import SkeletonGrid from "../components/SkeletonGrid";
 import PageHead from "../components/PageHead";
+import LazyImg from "../components/LazyImg";
 
 export default function NaturversityPage() {
   const [ready, setReady] = useState(false);
@@ -37,12 +38,11 @@ export default function NaturversityPage() {
               title: "Languages",
               desc: "Phrasebooks for each kingdom.",
               icon: (
-                  <img
+                  <LazyImg
                     src="/assets/amerilandia/flag.png"
                     alt=""
                     width={24}
                     height={16}
-                    loading="lazy"
                     style={{ borderRadius: 3 }}
                   />
               ),

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import { supabase } from "../lib/supabaseClient";
+import LazyImg from "../components/LazyImg";
 
 type Profile = {
   id: string;
@@ -135,7 +136,7 @@ export default function ProfilePage() {
             <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
               <input ref={fileRef} type="file" accept="image/*" />
               {profile?.photo_url ? (
-                <img
+                <LazyImg
                   src={profile.photo_url}
                   alt="Avatar preview"
                   width={56}

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,8 +1,22 @@
-.cards .card img {
-  width: 100%;
-  height: auto;
-  display: block;
-  aspect-ratio: 16/9;
+/* unified card grid */
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px,1fr));
+  gap: 20px;
+  margin-top: 20px;
+}
+.card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+  padding: 16px;
+  text-align: center;
+  transition: transform .2s;
+}
+.card:hover { transform: translateY(-2px); }
+.card img {
+  max-width: 100%;
+  height: 160px;
   object-fit: cover;
   border-radius: 10px;
 }


### PR DESCRIPTION
## Summary
- add preload links and sharing metadata to index.html
- implement `LazyImg` component and use it for avatars and Naturversity flag
- unify card grid styling and classes across grids
- configure Netlify headers and SPA redirects

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Property 'n' does not exist on type ...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9e4adbd588329ba7e82df27a6f779