### PR TITLE
fix: use favicon for languages card icon

### DIFF
--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -4,7 +4,6 @@ import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
 import SkeletonGrid from "../components/SkeletonGrid";
 import PageHead from "../components/PageHead";
-import LazyImg from "../components/LazyImg";
 
 export default function NaturversityPage() {
   const [ready, setReady] = useState(false);
@@ -38,13 +37,11 @@ export default function NaturversityPage() {
               title: "Languages",
               desc: "Phrasebooks for each kingdom.",
               icon: (
-                  <LazyImg
-                    src="/assets/amerilandia/flag.png"
-                    alt=""
-                    width={24}
-                    height={16}
-                    style={{ borderRadius: 3 }}
-                  />
+                <img
+                  src="/favicon.png"
+                  alt="Languages Icon"
+                  className="w-6 h-6"
+                />
               ),
             },
           ]}


### PR DESCRIPTION
## Summary
- use favicon for Languages card in Naturversity hub

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: several TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9eea4670083299996586a26b50a6c