### PR TITLE
feat: Languages UI + mobile grid

### DIFF
--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -25,7 +25,6 @@
 .lang-hero,
 .lang-spot {
   width: 100%;
-  max-width: 960px;            /* keep it reasonable on desktop */
   display: block;
   border-radius: 12px;
   background: #f4f6f8;         /* pleasant placeholder behind images */
@@ -34,10 +33,10 @@
 }
 
 /* Tallish hero at top of detail page */
-.lang-hero { aspect-ratio: 16 / 9; }
+.lang-hero { aspect-ratio: 16 / 9; max-width: 960px; }
 
 /* Second image a bit wider and shorter */
-.lang-spot { aspect-ratio: 21 / 9; }
+.lang-spot { aspect-ratio: 21 / 9; max-width: 960px; }
 
 /* Languages card icon (Naturversity landing) */
 .card .lang-icon {
@@ -45,4 +44,22 @@
   height: 28px;
   margin-right: .5rem;
   vertical-align: -6px;
+}
+
+/* Languages grid */
+.cards-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (max-width: 767px) {
+  .cards-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 768px) {
+  .cards-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }


### PR DESCRIPTION
## Summary
- swap Languages card icon to favicon
- constrain language hero and spot images with proper aspect ratios
- add responsive two- and three-column grid for language cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Property 'n' does not exist on type 'IntrinsicAttributes & ImgHTMLAttributes<HTMLImageElement> & { fallbackSrc?: string | undefined; }'.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f5e797f08329a492f280a8d8d502