### PR TITLE
Add lazy fade-in animations for Languages images

### DIFF
--- a/src/components/useFadeInOnIntersect.ts
+++ b/src/components/useFadeInOnIntersect.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+
+export function useFadeInOnIntersect<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    // If already complete (e.g., cached image), show immediately
+    const tryShow = () => el.classList.add("is-visible");
+
+    // Observe visibility
+    const io = new IntersectionObserver(
+      entries => entries.forEach(e => {
+        if (e.isIntersecting) {
+          // If it's an <img>, wait for load; else reveal immediately
+          if ((el as HTMLImageElement).tagName === "IMG") {
+            const img = el as HTMLImageElement;
+            if (img.complete) tryShow();
+            else img.addEventListener("load", tryShow, { once: true });
+          } else {
+            tryShow();
+          }
+          io.disconnect();
+        }
+      }),
+      { rootMargin: "64px" } // start a bit before it scrolls in
+    );
+
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return ref;
+}
+

--- a/src/pages/naturversity/languages/[slug].tsx
+++ b/src/pages/naturversity/languages/[slug].tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useParams } from "react-router-dom";
+import { useFadeInOnIntersect } from "../../../components/useFadeInOnIntersect";
 
 const IMAGES: Record<string, { hero: string; spot: string; title: string; native: string }> = {
   thailandia: {
@@ -46,6 +47,9 @@ export default function LanguageDetail() {
 
   if (!data) return <p>Language not found.</p>;
 
+  const heroRef = useFadeInOnIntersect<HTMLImageElement>();
+  const spotRef = useFadeInOnIntersect<HTMLImageElement>();
+
   return (
     <article>
       <nav className="breadcrumb">
@@ -59,10 +63,11 @@ export default function LanguageDetail() {
       <p>Learn greetings, alphabet basics, and common phrases for {data.title.split(' ')[0]}.</p>
 
       <img
+        ref={heroRef}
+        className="lang-hero fade-in"
         src={data.hero}
         alt=""
-        className="lang-hero"
-        loading="eager"
+        loading="lazy"
         decoding="async"
       />
 
@@ -75,9 +80,10 @@ export default function LanguageDetail() {
       </section>
 
       <img
+        ref={spotRef}
+        className="lang-spot fade-in"
         src={data.spot}
         alt=""
-        className="lang-spot"
         loading="lazy"
         decoding="async"
       />

--- a/src/pages/naturversity/languages/index.tsx
+++ b/src/pages/naturversity/languages/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useFadeInOnIntersect } from "../../../components/useFadeInOnIntersect";
 
 const LANG_CARDS = [
   {
@@ -46,21 +47,25 @@ export default function LanguagesIndex() {
       <p>Phrasebooks for each kingdom.</p>
 
       <div className="cards-grid">
-        {LANG_CARDS.map((k) => (
-          <a key={k.slug} className="card" href={`/naturversity/languages/${k.slug}`}>
-          <img
-            src={k.cover}
-            alt=""
-            className="lang-hero"
-            loading="lazy"
-            decoding="async"
-          />
-            <div className="card-body">
-              <h3>{k.title}</h3>
-              <small>Native: {k.native}</small>
-            </div>
-          </a>
-        ))}
+        {LANG_CARDS.map((k) => {
+          const imgRef = useFadeInOnIntersect<HTMLImageElement>();
+          return (
+            <a key={k.slug} className="card" href={`/naturversity/languages/${k.slug}`}>
+              <img
+                ref={imgRef}
+                className="lang-hero fade-in"
+                src={k.cover}
+                alt=""
+                loading="lazy"
+                decoding="async"
+              />
+              <div className="card-body">
+                <h3>{k.title}</h3>
+                <small>Native: {k.native}</small>
+              </div>
+            </a>
+          );
+        })}
       </div>
     </section>
   );

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -63,3 +63,27 @@
     grid-template-columns: repeat(3, 1fr);
   }
 }
+
+/* ---------- Lazy-fade helpers ---------- */
+.fade-in {
+  opacity: 0;
+  transform: translateY(8px);
+  will-change: opacity, transform;
+  transition:
+    opacity 280ms ease-out,
+    transform 280ms ease-out;
+}
+
+.fade-in.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Reduce/disable motion for those who prefer it */
+@media (prefers-reduced-motion: reduce) {
+  .fade-in {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `useFadeInOnIntersect` hook
- fade in language images once intersecting the viewport
- append CSS helpers for lazy-fade animations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument type errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f74b700083298bbbdf18f23d4d79