### PR TITLE
UI polish: compact sign-out, favicon footer, 24px languages icon

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,40 +1,36 @@
 import React from "react";
-import Img from "./Img";
 
 export default function Footer() {
   return (
-    <footer className="site-footer">
-      <div className="footer-brand" aria-label="A Turian Media Company">
-        <Img
-          src="/Turianmedia-logo-footer.png"
-          alt="A Turian Media Company"
-          width={120}
-          height={28}
-        />
+    <footer className="footer__wrap">
+      <div className="site-footer footer__inner">
+        <span className="footer__brand">
+          <img src="/favicon.ico" alt="Naturverse" />
+          <span>© {new Date().getFullYear()} Naturverse</span>
+        </span>
+        <nav className="footer-social">
+          <a href="https://x.com/turianthedurian" target="_blank" rel="noreferrer">
+            X
+          </a>
+          <a href="https://instagram.com" target="_blank" rel="noreferrer">
+            Instagram
+          </a>
+          <a href="https://youtube.com" target="_blank" rel="noreferrer">
+            YouTube
+          </a>
+          <a href="https://discord.gg" target="_blank" rel="noreferrer">
+            Discord
+          </a>
+          <a href="mailto:info@naturverse.com">info@naturverse.com</a>
+        </nav>
+        <nav className="footer-links">
+          <a href="/terms">Terms</a>
+          <a href="/privacy">Privacy</a>
+          <a href="/contact">Contact</a>
+          <a href="/accessibility">Accessibility</a>
+          <a href="/about">About</a>
+        </nav>
       </div>
-      <nav className="footer-social">
-        <a href="https://x.com/turianthedurian" target="_blank" rel="noreferrer">
-          X
-        </a>
-        <a href="https://instagram.com" target="_blank" rel="noreferrer">
-          Instagram
-        </a>
-        <a href="https://youtube.com" target="_blank" rel="noreferrer">
-          YouTube
-        </a>
-        <a href="https://discord.gg" target="_blank" rel="noreferrer">
-          Discord
-        </a>
-        <a href="mailto:info@naturverse.com">info@naturverse.com</a>
-      </nav>
-      <nav className="footer-links">
-        <span>© 2025 Naturverse</span>
-        <a href="/terms">Terms</a>
-        <a href="/privacy">Privacy</a>
-        <a href="/contact">Contact</a>
-        <a href="/accessibility">Accessibility</a>
-        <a href="/about">About</a>
-      </nav>
     </footer>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import CartButton from './cart/CartButton';
 import Img from './Img';
 import UserMenu from './UserMenu';
+import { signOut } from '../lib/auth';
 
 const LINKS = [
   { href: '/worlds', label: 'Worlds' },
@@ -17,6 +18,11 @@ const LINKS = [
 
 export default function Header() {
   const [open, setOpen] = useState(false);
+
+  async function handleSignOut() {
+    await signOut();
+    window.location.assign('/');
+  }
 
   // close drawer on route change (hash/path)
   useEffect(() => {
@@ -60,6 +66,13 @@ export default function Header() {
 
           <nav className="site-actions" style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <CartButton />
+            <button
+              onClick={handleSignOut}
+              className="btn btn--sm btn--primary"
+              aria-label="Sign out"
+            >
+              Sign out
+            </button>
             <UserMenu />
           </nav>
 

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -37,7 +37,7 @@ export default function NaturversityPage() {
               title: "Languages",
               desc: "Phrasebooks for each kingdom.",
               icon: (
-                <img src="/favicon.svg" alt="" className="nv-languages-icon" />
+                <img src="/favicon.ico" alt="Languages" className="icon--sm" />
               ),
             },
           ]}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -181,3 +181,18 @@ a:focus-visible, button:focus-visible, [role="button"]:focus-visible{
   border-radius:12px;
   z-index:1000;
 }
+
+/* --- UI polish helpers --- */
+.btn { display:inline-flex; align-items:center; gap:.375rem;
+  border-radius:8px; border:0; cursor:pointer;
+  line-height:1; font-weight:600; text-decoration:none; }
+.btn--sm { padding:.35rem .6rem; font-size:.875rem; }
+.btn--primary { background:#3B82F6; color:#fff; }
+.btn--primary:hover { background:#2563EB; }
+
+/* Small icon utility (keeps images from stretching) */
+.icon--sm { width:24px; height:24px; object-fit:contain; }
+
+/* Footer brand: keep favicon tiny and aligned */
+.footer__brand { display:inline-flex; align-items:center; gap:.4rem; }
+.footer__brand img { width:20px; height:20px; object-fit:contain; }


### PR DESCRIPTION
## Summary
- add reusable button/icon utilities
- shrink header Sign out button
- swap footer logo for favicon and dynamically stamp © year
- show a 24px favicon for Naturversity Languages tile

## Testing
- `npm run typecheck` *(fails: TypeScript errors in existing files)*
- `npm run build`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fbfe568c8329a153e1362668965e