### PR TITLE
Fix Naturversity → Languages (favicon tile, grid list, correct lessons, image sizing)

### DIFF
--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -1,56 +1,66 @@
-import React, { useEffect, useState } from "react";
-import { HubGrid } from "../components/HubGrid";
-import Meta from "../components/Meta";
-import Breadcrumbs from "../components/Breadcrumbs";
-import SkeletonGrid from "../components/SkeletonGrid";
-import PageHead from "../components/PageHead";
+import { Link } from "react-router-dom";
+import "../styles/cards-unify.css";
 
 export default function NaturversityPage() {
-  const [ready, setReady] = useState(false);
-  useEffect(() => {
-    const t = setTimeout(() => setReady(true), 250);
-    return () => clearTimeout(t);
-  }, []);
   return (
-      <>
-        <PageHead title="Naturverse — Naturversity" description="Teachers, partners, and courses." />
-        <div className="page-wrap">
-          <Meta title="Naturversity — Naturverse" description="Teachers, partners, and courses." />
-          <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Naturversity" }]} />
-          <main id="main">
-          <h1>Naturversity</h1>
-          <p className="muted">Teachers, partners, and courses.</p>
+    <main className="page">
+      <h1>Naturversity</h1>
+      <p>Teachers, partners, and courses.</p>
 
-        {ready ? (
-        <HubGrid
-          items={[
-            { to: "/naturversity/teachers", title: "Teachers", desc: "Mentors across the 14 kingdoms.", icon: "🎓" },
-            { to: "/naturversity/partners", title: "Partners", desc: "Brands & orgs supporting missions.", icon: "🤝" },
-            {
-              to: "/naturversity/courses",
-              title: "Courses",
-              desc: "Nature, art, music, wellness, crypto basics.",
-              icon: "📚",
-            },
-            {
-              to: "/naturversity/languages",
-              title: "Languages",
-              desc: "Phrasebooks for each kingdom.",
-              icon: (
-                <img src="/favicon.ico" alt="Languages" className="icon--sm" />
-              ),
-            },
-          ]}
-        />
-        ) : (
-          <SkeletonGrid count={4} />
-        )}
+      <div className="grid-tiles">
+        {/* Teachers */}
+        <Link to="/naturversity/teachers" className="tile">
+          <div className="tile__icon" aria-hidden>
+            <span role="img" aria-label="mortarboard">🎓</span>
+          </div>
+          <div className="tile__body">
+            <h2 className="tile__title">Teachers</h2>
+            <p className="tile__subtitle">Mentors across the 14 kingdoms.</p>
+          </div>
+        </Link>
 
-        <p className="muted" style={{ marginTop: 12 }}>
-          Coming soon: AI tutors and step-by-step lessons.
-        </p>
-          </main>
-        </div>
-      </>
+        {/* Partners */}
+        <Link to="/naturversity/partners" className="tile">
+          <div className="tile__icon" aria-hidden>
+            <span role="img" aria-label="heart-hands">🫶</span>
+          </div>
+          <div className="tile__body">
+            <h2 className="tile__title">Partners</h2>
+            <p className="tile__subtitle">Brands & orgs supporting missions.</p>
+          </div>
+        </Link>
+
+        {/* Languages (now uses favicon, sized like the others) */}
+        <Link to="/naturversity/languages" className="tile">
+          <div className="tile__icon" aria-hidden>
+            <img
+              src="/favicon.svg"
+              alt=""
+              width={28}
+              height={28}
+              style={{ display: "block" }}
+            />
+          </div>
+          <div className="tile__body">
+            <h2 className="tile__title">Languages</h2>
+            <p className="tile__subtitle">Phrasebooks for each kingdom.</p>
+          </div>
+        </Link>
+
+        {/* Courses */}
+        <Link to="/naturversity/courses" className="tile">
+          <div className="tile__icon" aria-hidden>
+            <span role="img" aria-label="books">📚</span>
+          </div>
+          <div className="tile__body">
+            <h2 className="tile__title">Courses</h2>
+            <p className="tile__subtitle">Nature, art, music, wellness, crypto basics…</p>
+          </div>
+        </Link>
+      </div>
+
+      <p className="coming-soon">Coming soon: AI tutors and step-by-step lessons.</p>
+    </main>
   );
 }
+

--- a/src/pages/naturversity/languages/[slug].tsx
+++ b/src/pages/naturversity/languages/[slug].tsx
@@ -1,67 +1,102 @@
 import { Link, useParams } from "react-router-dom";
-import { getLanguage } from "../../../data/languages";
+import "../../../styles/cards-unify.css";
+import { LANGUAGES } from "./index";
+
+type Lesson = {
+  hello: string;
+  thanks: string;
+  alphabet: string[];
+  numbers: string[];
+};
+
+const LESSONS: Record<string, Lesson> = {
+  thailandia: {
+    hello: "สวัสดี — sà-wàt-dee",
+    thanks: "ขอบคุณ — khàwp-khun",
+    alphabet: ["ก (gor)", "ข (khor)", "ค (khor)", "ง (ngor)", "จ (jor)"],
+    numbers: ["๑ nûeng", "๒ sŏng", "๓ săam", "๔ sìi", "๕ hâa", "๖ hòk", "๗ jèt", "๘ bpàet", "๙ găo", "๑๐ sìp"]
+  },
+  chinadia: {
+    hello: "你好 — nǐ hǎo",
+    thanks: "谢谢 — xièxie",
+    alphabet: ["(Pinyin) a", "o", "e", "i", "u", "ü"],
+    numbers: ["一 yī", "二 èr", "三 sān", "四 sì", "五 wǔ", "六 liù", "七 qī", "八 bā", "九 jiǔ", "十 shí"]
+  },
+  indillandia: {
+    hello: "नमस्ते — namaste",
+    thanks: "धन्यवाद — dhanyavād",
+    alphabet: ["अ a", "आ ā", "इ i", "ई ī", "उ u"],
+    numbers: ["१ ek", "२ do", "३ tīn", "४ chār", "५ pāñch", "६ chhah", "७ sāt", "८ āṭh", "९ nau", "१० das"]
+  },
+  brazilandia: {
+    hello: "Olá",
+    thanks: "Obrigado / Obrigada",
+    alphabet: ["a", "e", "i", "o", "u"],
+    numbers: ["um", "dois", "três", "quatro", "cinco", "seis", "sete", "oito", "nove", "dez"]
+  },
+  australandia: {
+    hello: "Hello",
+    thanks: "Thank you",
+    alphabet: ["a", "e", "i", "o", "u"],
+    numbers: ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"]
+  },
+};
 
 export default function LanguageDetail() {
   const { slug } = useParams();
-  const data = getLanguage(slug!);
+  const lang = LANGUAGES.find((l) => l.slug === slug);
+  const lesson = LESSONS[slug ?? ""];
 
-  if (!data) {
+  if (!lang) {
     return (
-      <main className="wrap">
-        <p>Language not found.</p>
+      <main className="page">
+        <h1>Language not found</h1>
+        <p>Try another language from the list.</p>
       </main>
     );
   }
 
   return (
-    <main className="wrap">
-      <nav className="kicker">
-        <Link to="/naturversity">Naturversity</Link> / <Link to="/naturversity/languages">Languages</Link> / {data.name}
+    <main className="page">
+      <nav className="crumbs">
+        <Link to="/naturversity">Naturversity</Link> / <Link to="/naturversity/languages">Languages</Link> / {lang.name}
       </nav>
-      <h1>
-        {data.name} — <span className="kicker">{data.nativeName}</span>
-      </h1>
-      <p className="kicker">
-        Learn greetings, alphabet basics, and common phrases for {data.region}.
-      </p>
 
-      <img
-        src={`/Languages/${data.heroImg}`}
-        alt={`${data.name} welcome board`}
-        className="img-hero"
-      />
-      <img
-        src={`/Languages/${data.secondaryImg}`}
-        alt={`${data.name} classroom`}
-        className="img-hero"
-      />
+      <h1>{lang.name} — <span className="native">{lang.native}</span></h1>
+      <p>Learn greetings, alphabet basics, and common phrases for {lang.name.split(" ")[0]}.</p>
 
-      <section>
-        <h2>Starter phrases</h2>
-        <ul>
-          {data.starter.map((p) => (
-            <li key={p.en}>
-              <strong>{p.en}:</strong> {p.native} — <em>{p.romanized}</em>
-            </li>
-          ))}
-        </ul>
-      </section>
+      <figure className="hero">
+        <img src={lang.hero} alt="" className="hero__img" loading="eager" />
+      </figure>
 
-      <section>
-        <h2>Alphabet basics</h2>
-        <p className="kicker">{data.alphabet.note}</p>
-      </section>
+      {lesson && (
+        <>
+          <section className="lesson">
+            <h2>Starter phrases</h2>
+            <ul>
+              <li><strong>Hello:</strong> {lesson.hello}</li>
+              <li><strong>Thank you:</strong> {lesson.thanks}</li>
+            </ul>
+          </section>
 
-      <section>
-        <h2>Count to ten</h2>
-        <ol>
-          {data.count.slice(0, 10).map((n) => (
-            <li key={n.num}>
-              <strong>{n.num}.</strong> {n.native} — <em>{n.romanized}</em>
-            </li>
-          ))}
-        </ol>
-      </section>
+          <section className="lesson">
+            <h2>Alphabet basics</h2>
+            <p>{lesson.alphabet.join(" · ")}</p>
+          </section>
+
+          <section className="lesson">
+            <h2>Count to ten</h2>
+            <ol>
+              {lesson.numbers.map((n, i) => <li key={i}>{n}</li>)}
+            </ol>
+          </section>
+        </>
+      )}
+
+      <figure className="secondary">
+        <img src={lang.secondary} alt="" className="secondary__img" loading="lazy" />
+      </figure>
     </main>
   );
 }
+

--- a/src/pages/naturversity/languages/index.tsx
+++ b/src/pages/naturversity/languages/index.tsx
@@ -1,35 +1,85 @@
 import { Link } from "react-router-dom";
-import { LANGUAGES } from "../../../data/languages";
+import "../../../styles/cards-unify.css";
 
-export default function LanguagesList() {
-  const langs = LANGUAGES.map((l) => ({
-    slug: l.slug,
-    name: l.name,
-    nativeName: l.nativeName,
-    img: l.heroImg,
-  }));
+/** Shared map → ensures correct images + copy per language */
+export const LANGUAGES = [
+  {
+    slug: "thailandia",
+    name: "Thailandia (Thai)",
+    native: "ไทย",
+    thumb: "/Languages/Mangolanguagemainthai.png",
+    hero: "/Languages/Mangolanguagemainthai.png",
+    secondary: "/Languages/Turianlanguagehindi.png" // Turian secondary per your note
+  },
+  {
+    slug: "chinadia",
+    name: "Chinadia (Mandarin)",
+    native: "中文",
+    thumb: "/Languages/Cranelanguagemainchina.png",
+    hero: "/Languages/Cranelanguagemainchina.png",
+    secondary: "/Languages/Turianlanguagechina.png"
+  },
+  {
+    slug: "indillandia",
+    name: "Indillandia (Hindi)",
+    native: "हिंदी",
+    thumb: "/Languages/Genielanguagemainindi.png",
+    hero: "/Languages/Genielanguagemainindi.png",
+    secondary: "/Languages/Turianlanguagehindi.png"
+  },
+  {
+    slug: "brazilandia",
+    name: "Brazilandia (Portuguese)",
+    native: "Português",
+    thumb: "/Languages/Birdlanguagemainbrazil.png",
+    hero: "/Languages/Birdlanguagemainbrazil.png",
+    secondary: "/Languages/Turianlanguagebrazil.png"
+  },
+  {
+    slug: "australandia",
+    name: "Australandia (English)",
+    native: "English",
+    thumb: "/Languages/Koalalanguagemain.png",
+    hero: "/Languages/Koalalanguagemain.png",
+    secondary: "/Languages/Turianlanguageenglish.png"
+  },
+  // You can enable this when you want Amerilandia as a distinct English variant:
+  // {
+  //   slug: "amerilandia",
+  //   name: "Amerilandia (English)",
+  //   native: "English",
+  //   thumb: "/Languages/Owllanguagemain.png",
+  //   hero: "/Languages/Owllanguagemain.png",
+  //   secondary: "/Languages/Turianlanguageenglish.png"
+  // },
+];
 
+export default function LanguagesIndex() {
   return (
-    <main className="wrap">
+    <main className="page">
       <h1>Languages</h1>
-      <p className="kicker">Phrasebooks for each kingdom.</p>
+      <p>Phrasebooks for each kingdom.</p>
 
-      {langs.map((l) => (
-        <div key={l.slug} className="grid-stack">
-          <img
-            src={`/Languages/${l.img}`}
-            alt={`${l.name} cover`}
-            width={96}
-            height={96}
-            loading="lazy"
-            className="img-thumb"
-          />
-          <div>
-            <Link to={`/naturversity/languages/${l.slug}`}><strong>{l.name}</strong></Link>
-            <div className="kicker">Native: {l.nativeName}</div>
-          </div>
-        </div>
-      ))}
+      <section className="grid-langs" data-testid="langs-grid">
+        {LANGUAGES.map((l) => (
+          <Link to={`/naturversity/languages/${l.slug}`} className="lang-card" key={l.slug}>
+            <img
+              className="lang-thumb"
+              src={l.thumb}
+              alt=""
+              width={96}
+              height={96}
+              loading="lazy"
+              decoding="async"
+            />
+            <div className="lang-meta">
+              <h3 className="lang-name">{l.name}</h3>
+              <div className="lang-native">Native: <span>{l.native}</span></div>
+            </div>
+          </Link>
+        ))}
+      </section>
     </main>
   );
 }
+

--- a/src/styles/cards-unify.css
+++ b/src/styles/cards-unify.css
@@ -44,3 +44,68 @@
   );
   border-radius: 8px;
 }
+
+/* ---- Naturversity / Languages ------------------------------------------ */
+.grid-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+  margin-block: 16px 24px;
+}
+
+.tile {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  gap: 12px;
+  align-items: start;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 14px 16px;
+  background: #fff;
+  text-decoration: none;
+}
+
+.tile__icon { width: 28px; height: 28px; display: grid; place-items: center; }
+.tile__title { margin: 0; font-size: 20px; line-height: 1.2; }
+.tile__subtitle { margin: 4px 0 0; color: #6b7280; }
+
+.grid-langs {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.lang-card {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  text-decoration: none;
+}
+
+.lang-thumb {
+  width: 96px;
+  height: 96px;
+  object-fit: cover;
+  border-radius: 14px;
+  box-shadow: 0 1px 0 rgba(0,0,0,.06);
+}
+
+.lang-name { margin: 0 0 4px; font-size: 18px; }
+.lang-native { color: #6b7280; }
+
+.hero__img, .secondary__img {
+  width: 100%;
+  max-width: 980px;
+  height: auto;
+  display: block;
+  border-radius: 12px;
+  margin: 12px 0;
+}
+
+.lesson { margin: 18px 0; }
+.lesson h2 { margin: 0 0 8px; }


### PR DESCRIPTION
## Summary
- refresh Naturversity hub with favicon tile and compact grid layout
- list language cards in a responsive grid with proper thumbnails
- restore per-language lessons with distinct phrases and images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Type 'HTMLElement' is missing...)*

------
https://chatgpt.com/codex/tasks/task_e_68aa04c12dd483299be2a37cfc217dc1