### PR TITLE
feat: improve profile save and home styles

### DIFF
--- a/db/policies_profiles_and_storage.sql
+++ b/db/policies_profiles_and_storage.sql
@@ -32,7 +32,9 @@ for insert to authenticated with check (auth.uid() = id);
 
 drop policy if exists "profiles update own" on natur.profiles;
 create policy "profiles update own" on natur.profiles
-for update to authenticated using (auth.uid() = id);
+for update to authenticated
+using (auth.uid() = id)
+with check (auth.uid() = id);
 
 -- Storage bucket
 insert into storage.buckets (id, name, public)
@@ -52,4 +54,5 @@ with check (bucket_id='avatars' and (storage.foldername(name))[1]=auth.uid()::te
 drop policy if exists "avatars owner update" on storage.objects;
 create policy "avatars owner update" on storage.objects
 for update to authenticated
-using (bucket_id='avatars' and (storage.foldername(name))[1]=auth.uid()::text);
+using (bucket_id='avatars' and (storage.foldername(name))[1]=auth.uid()::text)
+with check (bucket_id='avatars' and (storage.foldername(name))[1]=auth.uid()::text);

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -1,64 +1,74 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import { useAuth } from '../auth/AuthContext';
+import { saveProfile } from '../lib/saveProfile';
 
 export default function ProfileForm() {
   const { user } = useAuth();
-  const [username, setUsername] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [file, setFile] = useState<File | undefined>();
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!user) return;
-    (async () => {
-      const { data } = await supabase
-        .from('profiles')
-        .select('username')
-        .eq('id', user.id)
-        .single();
-      if (data?.username) setUsername(data.username);
-    })();
-  }, [user]);
+      (async () => {
+        const { data } = await supabase
+          .from('profiles')
+          .select('display_name')
+          .eq('id', user.id)
+          .single();
+        if (data?.display_name) setDisplayName(data.display_name);
+      })();
+    }, [user]);
 
-  async function save(e: React.FormEvent) {
-    e.preventDefault();
-    if (!user) return;
-    setLoading(true);
-    const { error } = await supabase
-      .from('profiles')
-      .update({ username, updated_at: new Date().toISOString() })
-      .eq('id', user.id);
-    setLoading(false);
-    if (error) alert(error.message);
-    else alert('✅ Saved!');
-  }
+    async function save(e: React.FormEvent) {
+      e.preventDefault();
+      if (!user) return;
+      try {
+        setLoading(true);
+        await saveProfile(supabase, user, displayName, file);
+        alert('Profile saved!');
+      } catch (e: any) {
+        alert(`Save failed: ${e.message ?? 'Unknown error'}`);
+      } finally {
+        setLoading(false);
+      }
+    }
 
   if (!user) return null;
 
-  return (
-    <form onSubmit={save} style={{ maxWidth: 400, margin: '1rem auto' }}>
-      <h2>Profile</h2>
-      <label style={{ display: 'block', margin: '8px 0 4px' }}>Username</label>
-      <input
-        value={username}
-        onChange={(e) => setUsername(e.target.value)}
-        placeholder='Your name'
-        style={{ width: '100%', padding: 8, borderRadius: 8, border: '1px solid #ccc' }}
-      />
-      <button
-        type='submit'
-        disabled={loading}
-        style={{
-          marginTop: 12,
-          padding: '8px 14px',
-          borderRadius: 8,
-          border: 0,
-          background: '#2f7ae5',
-          color: '#fff',
-          fontWeight: 700,
-        }}
-      >
-        {loading ? 'Saving...' : 'Save'}
-      </button>
-    </form>
-  );
+    return (
+      <form onSubmit={save} style={{ maxWidth: 400, margin: '1rem auto' }}>
+        <h2>Profile</h2>
+        <label style={{ display: 'block', margin: '8px 0 4px' }}>Display name</label>
+        <input
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          placeholder='Your name'
+          style={{ width: '100%', padding: 8, borderRadius: 8, border: '1px solid #ccc' }}
+        />
+        <label style={{ display: 'block', margin: '8px 0 4px' }}>Avatar</label>
+        <input
+          type='file'
+          accept='image/*'
+          onChange={(e) => setFile(e.target.files?.[0])}
+          style={{ display: 'block', marginBottom: 12 }}
+        />
+        <button
+          type='submit'
+          disabled={loading}
+          style={{
+            marginTop: 12,
+            padding: '8px 14px',
+            borderRadius: 8,
+            border: 0,
+            background: '#2f7ae5',
+            color: '#fff',
+            fontWeight: 700,
+          }}
+        >
+          {loading ? 'Saving...' : 'Save'}
+        </button>
+      </form>
+    );
 }

--- a/src/lib/saveProfile.ts
+++ b/src/lib/saveProfile.ts
@@ -1,0 +1,36 @@
+import { createClient } from '@supabase/supabase-js';
+
+export async function saveProfile(
+  supabase: ReturnType<typeof createClient>,
+  user: { id: string; email?: string },
+  displayName: string,
+  file?: File
+) {
+  let avatar_url: string | null = null;
+
+  if (file) {
+    const path = `${user.id}/avatar-${Date.now()}.png`;
+    const { error: uploadErr } = await supabase.storage
+      .from('avatars')
+      .upload(path, file, { upsert: true, contentType: file.type });
+
+    if (uploadErr) throw new Error(`upload: ${uploadErr.message}`);
+
+    const { data: publicUrl } = supabase.storage.from('avatars').getPublicUrl(path);
+    avatar_url = publicUrl?.publicUrl ?? null;
+  }
+
+  const { error: upsertErr } = await supabase
+    .from('profiles')
+    .upsert(
+      {
+        id: user.id,
+        display_name: displayName || null,
+        avatar_url,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' }
+    );
+
+  if (upsertErr) throw new Error(`upsert: ${upsertErr.message}`);
+}

--- a/src/pages/home.css
+++ b/src/pages/home.css
@@ -1,3 +1,25 @@
+:root {
+  --nv-primary: #2563eb;
+  --nv-primary-ink: #ffffff;
+}
+
+.button-primary {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-height:44px;
+  padding:12px 16px;
+  border-radius:12px;
+  background: var(--nv-primary);
+  color: var(--nv-primary-ink) !important;
+  font-weight: 700;
+  letter-spacing:.2px;
+  text-decoration:none;
+  border:0;
+}
+.button-primary:disabled { opacity:.55; }
+.button-primary:focus-visible { outline: 3px solid #93c5fd; outline-offset:2px; }
+
 .home {
   max-width: 980px;
   margin: 0 auto;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,10 +33,10 @@ export default function Home() {
         <p className="subtitle">
           A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.
         </p>
-        <div className="hero-cta">
-          <a className="btn btn-primary" href="/signup">Create account</a>
-          <a className="btn btn-outline" href="/worlds">Explore Worlds</a>
-        </div>
+          <div className="hero-cta">
+            <a className="button-primary" href="/signup">Create account</a>
+            <a className="button-primary" href="/worlds">Explore Worlds</a>
+          </div>
       </section>
 
       {/* About / Mission */}
@@ -106,13 +106,13 @@ export default function Home() {
       </section>
 
       {/* CTA */}
-      <section className="home-cta">
-        <h2>Ready to join the journey?</h2>
-        <div className="hero-cta">
-          <Link className="btn btn-primary" to="/signup">Sign up free</Link>
-          <Link className="btn" to="/signin">Sign in</Link>
-        </div>
-      </section>
+        <section className="home-cta">
+          <h2>Ready to join the journey?</h2>
+          <div className="hero-cta">
+            <Link className="button-primary" to="/signup">Sign up free</Link>
+            <Link className="button-primary" to="/signin">Sign in</Link>
+          </div>
+        </section>
     </main>
     </>
   );

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -21,22 +21,16 @@
   box-shadow: 0 0 0 2px var(--nv-blue-200);
 }
 
-/* Languages: responsive image frames */
-.lang-hero,
-.lang-spot {
-  width: 100%;
-  display: block;
-  border-radius: 12px;
-  background: #f4f6f8;         /* pleasant placeholder behind images */
-  object-fit: cover;           /* crop to frame instead of stretching */
-  overflow: hidden;
+/* Languages: detail hero image */
+.lang-hero {
+  width:100%;
+  max-width: 720px;
+  border-radius:16px;
+  display:block;
+  margin: 0 auto 1rem auto;
 }
 
-/* Tallish hero at top of detail page */
-.lang-hero { aspect-ratio: 16 / 9; max-width: 960px; }
-
-/* Second image a bit wider and shorter */
-.lang-spot { aspect-ratio: 21 / 9; max-width: 960px; }
+@media (max-width: 640px){ .lang-hero{ max-width: 100%; } }
 
 /* Languages card icon (Naturversity landing) */
 .card .lang-icon {
@@ -122,18 +116,6 @@
   gap: 24px;
 }
 @media (max-width: 860px) { .lang-page { grid-template-columns: 1fr; } }
-
-.lang-hero, .lang-secondary {
-  width: 100%;
-  max-width: 420px;
-  border-radius: 14px;
-  display: block;
-  object-fit: cover;
-  box-shadow: 0 2px 6px rgba(0,0,0,.06);
-}
-
-.lang-hero { aspect-ratio: 1 / 1; }
-.lang-secondary { aspect-ratio: 16 / 10; margin-top: 12px; }
 
 /* Ensure text content is never hidden by images */
 .lang-content h3 { margin-top: 16px; }


### PR DESCRIPTION
## Summary
- add stricter RLS policies for profiles table and avatar storage
- implement robust profile save helper with avatar upload and error handling
- standardize home page buttons and refine language hero image styling

## Testing
- `npm run typecheck` *(fails: Argument of type ... is not assignable to parameter of type 'never')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa65c756ac83299defb77b656e8600