### PR TITLE
Frontend hooks & panels — wallet, XP, languages (no deps)

### DIFF
--- a/src/components/profile/WalletPanel.tsx
+++ b/src/components/profile/WalletPanel.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { useWallet } from "../../hooks/useWallet";
+
+export default function WalletPanel() {
+  const { wallet, loading, earn, spend } = useWallet();
+  return (
+    <section className="panel">
+      <h2>NATUR Wallet</h2>
+      <p className="big">{loading ? "…" : `${wallet?.balance ?? 0} NATUR`}</p>
+      <div className="row">
+        <button className="btn tiny" onClick={() => earn(5, { reason: "demo" })}>+5</button>
+        <button className="btn tiny" onClick={() => spend(2, { reason: "demo" })}>−2</button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/profile/XPPanel.tsx
+++ b/src/components/profile/XPPanel.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { useXP } from "../../hooks/useXP";
+
+export default function XPPanel() {
+  const { xp, loading, addXP } = useXP();
+  return (
+    <section className="panel">
+      <h2>Experience (XP)</h2>
+      <p className="big">{loading ? "…" : `${xp} XP`}</p>
+      <div className="row">
+        <button className="btn tiny" onClick={() => addXP(10, "demo")}>+10 XP</button>
+      </div>
+    </section>
+  );
+}

--- a/src/hooks/useLanguages.ts
+++ b/src/hooks/useLanguages.ts
@@ -6,22 +6,20 @@ export function useLanguages() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    async function fetchLanguages() {
-      const { data, error } = await supabase.from("languages").select("*");
-      if (error) console.error(error);
-      setLanguages(data || []);
+    (async () => {
+      const { data, error } = await supabase.from("languages").select("*").order("name");
+      if (!error) setLanguages(data || []);
       setLoading(false);
-    }
-    fetchLanguages();
+    })();
   }, []);
 
   async function getLessons(languageId: string) {
     const { data, error } = await supabase
       .from("language_lessons")
       .select("*, language_lesson_items(*)")
-      .eq("language_id", languageId);
-
-    if (error) console.error(error);
+      .eq("language_id", languageId)
+      .order("order_index", { ascending: true });
+    if (error) return [];
     return data || [];
   }
 

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,37 +1,32 @@
 import { useEffect, useState } from "react";
 import { supabase } from "../lib/supabaseClient";
 
+type Wallet = { balance: number };
+
 export function useWallet() {
-  const [wallet, setWallet] = useState<{ balance: number } | null>(null);
+  const [wallet, setWallet] = useState<Wallet | null>(null);
   const [loading, setLoading] = useState(true);
 
+  async function refresh() {
+    const { data } = await supabase.from("v_my_wallet").select("*").single();
+    setWallet((data as Wallet) || { balance: 0 });
+    return data;
+  }
+
   useEffect(() => {
-    async function fetchWallet() {
-      const { data, error } = await supabase
-        .from("v_my_wallet")
-        .select("*")
-        .single();
-      if (error) console.error(error);
-      setWallet(data);
-      setLoading(false);
-    }
-    fetchWallet();
+    (async () => {
+      try { await refresh(); } finally { setLoading(false); }
+    })();
   }, []);
 
   async function earn(amount: number, meta: object = {}) {
     await supabase.rpc("earn_spend_natur", { p_kind: "earn", p_amount: amount, p_meta: meta });
-    return await refresh();
+    return refresh();
   }
 
   async function spend(amount: number, meta: object = {}) {
     await supabase.rpc("earn_spend_natur", { p_kind: "spend", p_amount: amount, p_meta: meta });
-    return await refresh();
-  }
-
-  async function refresh() {
-    const { data } = await supabase.from("v_my_wallet").select("*").single();
-    setWallet(data);
-    return data;
+    return refresh();
   }
 
   return { wallet, loading, earn, spend, refresh };

--- a/src/main.css
+++ b/src/main.css
@@ -19,6 +19,7 @@
 @import "./styles/polish.css";
 @import "./styles/cards.css";
 @import './styles/components.css';
+@import "./styles/profile.css";
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "../lib/supabase";
-import { useWallet } from "../hooks/useWallet";
-import { useXP } from "../hooks/useXP";
+import WalletPanel from "../components/profile/WalletPanel";
+import XPPanel from "../components/profile/XPPanel";
 
 type ProfileRow = {
   id: string;
@@ -19,8 +19,6 @@ export default function ProfilePage() {
   const [avatarUrl, setAvatarUrl] = useState("");
   const [saving, setSaving] = useState(false);
   const [lastUpdated, setLastUpdated] = useState("—");
-  const { wallet, earn, spend } = useWallet();
-  const { xp, addXP } = useXP();
 
   useEffect(() => {
     (async () => {
@@ -91,12 +89,6 @@ export default function ProfilePage() {
   return (
     <main className="container">
       <h1>Profile</h1>
-      <p>XP: {xp}</p>
-      <button onClick={() => addXP(10, "test")}>+10 XP</button>
-
-      <p>Wallet: {wallet?.balance ?? 0} NATUR</p>
-      <button onClick={() => earn(5, { reason: "test earn" })}>+5 NATUR</button>
-      <button onClick={() => spend(2, { reason: "test spend" })}>-2 NATUR</button>
       <form
         className="card"
         onSubmit={(e) => { e.preventDefault(); void handleSave(); }}
@@ -131,6 +123,14 @@ export default function ProfilePage() {
           Sign out
         </button>
       </form>
+
+      <section className="panel">
+        <h2>Account & App Data</h2>
+        <p className="muted">Signed-in data will sync with Supabase as features roll in.</p>
+      </section>
+
+      <WalletPanel />
+      <XPPanel />
     </main>
   );
 }

--- a/src/styles/profile.css
+++ b/src/styles/profile.css
@@ -1,5 +1,5 @@
 .panel {
-  border: 1px solid var(--nv-border);
+  border:1px solid #e5e7eb;
   background: #fff;
   border-radius: 14px;
   padding: 14px;
@@ -14,7 +14,7 @@
 .select span {
   font-size: 12px;
   font-weight: 700;
-  color: var(--nv-text-muted);
+  color:#6b7280;
   display: block;
   margin-bottom: 6px;
 }
@@ -69,14 +69,14 @@
 .btn {
   padding: 10px 12px;
   border-radius: 10px;
-  border: 1px solid var(--nv-blue-600);
-  background: var(--nv-blue-600);
+  border:1px solid #0ea5e9;
+  background:#0ea5e9;
   color: #fff;
   font-weight: 700;
 }
 .btn.outline {
   background: #fff;
-  color: var(--nv-blue-600);
+  color:#0ea5e9;
 }
 .row {
   display: flex;
@@ -94,7 +94,7 @@
   font-size: 13px;
 }
 .muted {
-  color: var(--nv-text-muted);
+  color:#6b7280;
 }
 .profile-page .row { display: grid; gap: 6px; margin: 12px 0; }
 .profile-page label { font-weight: 600; }


### PR DESCRIPTION
## Summary
- add Supabase-based hooks for wallet balance, experience, and languages
- add wallet and XP panels and surface them on the profile page
- style new panels and wire CSS into the main bundle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa7339ddac8329955a2f5e127a76d8