### PR TITLE
Profile ↔ Supabase sync (load/save cloud profile, no new deps)

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -14,6 +14,7 @@ export default function NavBar() {
         <ActiveLink href="/navatar" className="nav-link">Navatar</ActiveLink>
         <ActiveLink href="/passport" className="nav-link">Passport</ActiveLink>
         <ActiveLink href="/turian" className="nav-link">Turian</ActiveLink>
+        <ActiveLink href="/profile" className="nav-link">Profile</ActiveLink>
       </nav>
     </header>
   );

--- a/src/hooks/useCloudProfile.ts
+++ b/src/hooks/useCloudProfile.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from "react";
+import { supabase } from "../lib/supabaseClient";
+import { getUserId } from "../lib/session";
+import type { CloudProfile, LocalProfile } from "../types/profile";
+
+export function useCloudProfile() {
+  const [userId, setUserId] = useState<string | null>(null);
+  const [cloud, setCloud] = useState<CloudProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const id = await getUserId();
+      setUserId(id);
+      if (!id) { setCloud(null); setLoading(false); return; }
+      const { data, error } = await supabase.from("profiles").select("*").eq("id", id).single();
+      if (!error) setCloud(data as CloudProfile);
+      setLoading(false);
+    })();
+  }, []);
+
+  const saveFromLocal = useCallback(
+    async (local: LocalProfile, avatar_url?: string | null) => {
+      const id = userId ?? (await getUserId());
+      if (!id) return { error: "no-user" } as const;
+      const payload: Partial<CloudProfile> = {
+        id,
+        display_name: local.displayName || null,
+        email: local.email || null,
+        kid_safe_chat: !!local.kidSafeChat,
+        theme: local.theme,
+        newsletter: !!local.newsletter,
+        avatar_url: avatar_url ?? null,
+        updated_at: new Date().toISOString(),
+      };
+      const { data, error } = await supabase.from("profiles").upsert(payload, { onConflict: "id" }).select().single();
+      if (!error) setCloud(data as CloudProfile);
+      return { data, error } as const;
+    },
+    [userId]
+  );
+
+  return { userId, cloud, loading, saveFromLocal };
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,6 @@
+import { supabase } from "./supabaseClient";
+
+export async function getUserId(): Promise<string | null> {
+  const { data } = await supabase.auth.getUser();
+  return data.user?.id ?? null;
+}

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,18 @@
+export type LocalProfile = {
+  displayName: string;
+  email: string;
+  kidSafeChat: boolean;
+  theme: "system" | "light" | "dark";
+  newsletter: boolean;
+};
+
+export type CloudProfile = {
+  id: string;
+  display_name: string | null;
+  email: string | null;
+  kid_safe_chat: boolean | null;
+  theme: "system" | "light" | "dark" | null;
+  newsletter: boolean | null;
+  avatar_url: string | null;
+  updated_at?: string | null;
+};


### PR DESCRIPTION
## Summary
- add session helper and profile types for Supabase
- implement `useCloudProfile` hook and cloud-sync UI on profile page
- expose Profile link in top navigation

## Testing
- `npm run typecheck` *(fails: Argument of type 'Partial<...>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68aa74e35b2883298d600965e7c7f950