### PR TITLE
Polish pack #2 — lazy-load images, consistent card thumbs, skip-link, and small mobile tweaks (no deps)

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,25 @@
       crossorigin
     />
     <link rel="stylesheet" href="/src/main.css" />
+
+    <!-- a11y: skip to content -->
+    <style>
+      .skip-link{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden}
+      .skip-link:focus{left:12px;top:12px;width:auto;height:auto;background:#0ea5e9;color:#fff;padding:8px 10px;border-radius:8px;z-index:1000}
+    </style>
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to content</a>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+
+    <!-- perf: lazy-enable all imgs that don't opt-out -->
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        document
+          .querySelectorAll('img:not([loading])')
+          .forEach((img) => img.setAttribute('loading', 'lazy'));
+      });
+    </script>
   </body>
 </html>

--- a/public/_headers
+++ b/public/_headers
@@ -3,3 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Cache-Control: public, max-age=600
+
+/assets/*
+  Cache-Control: public, max-age=604800, immutable

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { router } from './router';
 import { CartProvider } from './hooks/useCart';
@@ -7,12 +6,6 @@ import { organizationLd, websiteLd } from './lib/jsonld';
 import ErrorBoundary from './components/ErrorBoundary';
 
 export default function App() {
-  useEffect(() => {
-    // ensure any plain <img> without loading attr is lazy
-    const imgs = document.querySelectorAll('img:not([loading])');
-    imgs.forEach((img) => img.setAttribute('loading', 'lazy'));
-  }, []);
-
   return (
     <>
       <script
@@ -25,9 +18,9 @@ export default function App() {
       />
       <CartProvider>
         <ErrorBoundary>
-          <div id="main">
+          <main id="main">
             <RouterProvider router={router} />
-          </div>
+          </main>
         </ErrorBoundary>
         <CartDrawer />
       </CartProvider>

--- a/src/layouts/Page.tsx
+++ b/src/layouts/Page.tsx
@@ -2,10 +2,8 @@ import React from "react";
 export default function Page({ title, children }:{ title?: string; children: React.ReactNode }) {
   return (
     <div className="page">
-      <main id="main" className="page-wrap">
-        {title ? <h1>{title}</h1> : null}
-        {children}
-      </main>
+      {title ? <h1>{title}</h1> : null}
+      {children}
     </div>
   );
 }

--- a/src/main.css
+++ b/src/main.css
@@ -18,6 +18,7 @@
 @import "./styles/bank.css";
 @import "./styles/polish.css";
 @import "./styles/cards.css";
+@import "./styles/page.css";
 @import './styles/components.css';
 @import "./styles/profile.css";
 

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,22 +1,21 @@
-/* unified card grid */
-.cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px,1fr));
-  gap: 20px;
-  margin-top: 20px;
-}
-.card {
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
-  padding: 16px;
-  text-align: center;
-  transition: transform .2s;
-}
-.card:hover { transform: translateY(-2px); }
-.card img {
-  max-width: 100%;
-  height: 160px;
+/* Consistent card thumbnails and spacing */
+.cards { display:grid; gap:16px; grid-template-columns: repeat(auto-fill,minmax(220px,1fr)); }
+
+/* Any image directly under a .card becomes a 16:9 cover thumb */
+.card > img {
+  width: 100%;
+  aspect-ratio: 16 / 9;
   object-fit: cover;
-  border-radius: 10px;
+  border-radius: 12px;
+  display: block;
 }
+
+/* Slightly tighter card headings across the site */
+.card h2 { margin: 10px 0 6px; font-weight: 800; }
+
+/* Mobile tweaks so long titles don’t overflow */
+@media (max-width:640px){
+  .cards { gap:12px; }
+  .card h2 { font-size: 15px; }
+}
+

--- a/src/styles/nav.css
+++ b/src/styles/nav.css
@@ -5,3 +5,8 @@
   border-bottom: 2px solid #0ea5e9;
   color: #0ea5e9;
 }
+
+/* slightly larger tap area on mobile */
+@media (max-width:640px){
+  .nav-link { padding: 10px 8px; }
+}

--- a/src/styles/page.css
+++ b/src/styles/page.css
@@ -1,0 +1,2 @@
+.page { max-width: 1100px; margin: 0 auto; padding: 16px; }
+


### PR DESCRIPTION
## Summary
- add accessible skip-link and global lazy image loading
- standardize card thumbnail sizing and spacing
- tweak mobile nav padding and cache assets safely

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string | null'. src/auth/AuthContext.tsx(33,51))*

------
https://chatgpt.com/codex/tasks/task_e_68aa785215708329a97eca68e181b6a8