### PR TITLE
Resilience & SEO pack — 404 page, error boundary, OG meta, sitemap/robots, SPA fallback (no deps)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,22 +8,24 @@
     <!-- SEO base -->
     <meta
       name="description"
-      content="Naturverse — learn & earn across kid-friendly worlds: games, music, wellness, language, crypto basics, and more."
+      content="Naturverse — playful learning across worlds: games, music, wellness, languages, marketplace, and more."
     />
     <meta property="og:title" content="Naturverse" />
     <meta
       property="og:description"
-      content="Explore 14 magical kingdoms, create your Navatar, and learn by playing."
+      content="Play, learn, and explore kingdoms with your Navatar."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/favicon-192.png" />
+    <meta property="og:url" content="https://naturverse.netlify.app/" />
+    <meta property="og:image" content="/favicon-512.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Naturverse" />
     <meta
       name="twitter:description"
-      content="Explore 14 magical kingdoms, create your Navatar, and learn by playing."
+      content="Play, learn, and explore kingdoms with your Navatar."
     />
-    <meta name="twitter:image" content="/favicon-192.png" />
+    <meta name="twitter:image" content="/favicon-512.png" />
+    <link rel="canonical" href="https://naturverse.netlify.app/" />
 
     <!-- PWA-ish icons -->
     <link rel="icon" href="/favicon.ico" />

--- a/public/_headers
+++ b/public/_headers
@@ -6,3 +6,12 @@
 
 /assets/*
   Cache-Control: public, max-age=604800, immutable
+
+/favicon-*.png
+  Cache-Control: public, max-age=604800, immutable
+
+/sitemap.xml
+  Content-Type: application/xml; charset=utf-8
+
+/robots.txt
+  Content-Type: text/plain; charset=utf-8

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://YOUR_DOMAIN/sitemap.xml
+Sitemap: https://naturverse.netlify.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,13 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://YOUR_DOMAIN/</loc></url>
-  <url><loc>https://YOUR_DOMAIN/worlds</loc></url>
-  <url><loc>https://YOUR_DOMAIN/zones</loc></url>
-  <url><loc>https://YOUR_DOMAIN/marketplace</loc></url>
-  <url><loc>https://YOUR_DOMAIN/naturversity</loc></url>
-  <url><loc>https://YOUR_DOMAIN/naturbank</loc></url>
-  <url><loc>https://YOUR_DOMAIN/navatar</loc></url>
-  <url><loc>https://YOUR_DOMAIN/passport</loc></url>
-  <url><loc>https://YOUR_DOMAIN/turian</loc></url>
-  <url><loc>https://YOUR_DOMAIN/profile</loc></url>
+  <!-- core hubs -->
+  <url><loc>https://naturverse.netlify.app/</loc></url>
+  <url><loc>https://naturverse.netlify.app/worlds</loc></url>
+  <url><loc>https://naturverse.netlify.app/zones</loc></url>
+  <url><loc>https://naturverse.netlify.app/marketplace</loc></url>
+  <url><loc>https://naturverse.netlify.app/naturversity</loc></url>
+  <url><loc>https://naturverse.netlify.app/naturbank</loc></url>
+  <url><loc>https://naturverse.netlify.app/navatar</loc></url>
+  <url><loc>https://naturverse.netlify.app/passport</loc></url>
+  <url><loc>https://naturverse.netlify.app/turian</loc></url>
+  <url><loc>https://naturverse.netlify.app/profile</loc></url>
+  <url><loc>https://naturverse.netlify.app/future</loc></url>
+
+  <!-- worlds detail routes (adjust if you use different slugs) -->
+  <url><loc>https://naturverse.netlify.app/worlds/thailandia</loc></url>
+  <url><loc>https://naturverse.netlify.app/worlds/chinadia</loc></url>
+  <url><loc>https://naturverse.netlify.app/worlds/indilandia</loc></url>
+  <url><loc>https://naturverse.netlify.app/worlds/brazilandia</loc></url>
+  <url><loc>https://naturverse.netlify.app/worlds/australandia</loc></url>
+  <url><loc>https://naturverse.netlify.app/worlds/amerilandia</loc></url>
 </urlset>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,26 +1,25 @@
 import React from "react";
 
-type State = { hasError: boolean };
+type State = { hasError: boolean; err?: unknown };
 
 export default class ErrorBoundary extends React.Component<
-  React.PropsWithChildren,
+  React.PropsWithChildren<{}>,
   State
 > {
   state: State = { hasError: false };
-  static getDerivedStateFromError() {
-    return { hasError: true };
+  static getDerivedStateFromError(err: unknown): State {
+    return { hasError: true, err };
   }
-  componentDidCatch() {
-    /* no-op */
+  componentDidCatch(err: unknown, info: unknown) {
+    // optional: console to surface during dev
+    console.error("ErrorBoundary", err, info);
   }
   render() {
     if (this.state.hasError) {
       return (
-        <div style={{ maxWidth: 900, margin: "24px auto", padding: "16px" }}>
+        <div className="page" style={{ padding: 24 }}>
           <h1>Something went wrong.</h1>
-          <p className="muted">
-            Please try going <a href="/">home</a> and reopening the page.
-          </p>
+          <p className="muted">Please refresh or go back to the <a href="/">home page</a>.</p>
         </div>
       );
     }

--- a/src/main.css
+++ b/src/main.css
@@ -21,6 +21,8 @@
 @import "./styles/page.css";
 @import './styles/components.css';
 @import "./styles/profile.css";
+@import "./styles/util-a11y.css";
+@import "./styles/notfound.css";
 
 body {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -2,10 +2,10 @@ import React from "react";
 
 export default function NotFound() {
   return (
-    <div style={{maxWidth:900,margin:"24px auto",padding:"16px"}}>
-      <h1>Page not found</h1>
+    <div className="page notfound" style={{ padding: 24 }}>
+      <h1>404 — Page not found</h1>
       <p className="muted">The page you’re looking for doesn’t exist.</p>
-      <a className="btn" href="/">Back to Home</a>
+      <p><a className="btn" href="/">Back to Home</a></p>
     </div>
   );
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -117,7 +117,7 @@ export const router = createBrowserRouter([
         { path: 'login', element: <LoginPage /> },
         { path: 'turian', element: <Turian /> },
         { path: 'profile', element: <ProfilePage /> },
-        { path: 'not-found', element: <NotFound /> },
+        { path: '404', element: <NotFound /> },
         { path: '*', element: <NotFound /> },
     ],
   },

--- a/src/styles/notfound.css
+++ b/src/styles/notfound.css
@@ -1,0 +1,2 @@
+.notfound h1{font-size:28px;margin-bottom:8px}
+.notfound .btn{display:inline-block;margin-top:10px}

--- a/src/styles/util-a11y.css
+++ b/src/styles/util-a11y.css
@@ -1,0 +1,5 @@
+/* focus ring for keyboard users */
+:focus-visible {
+  outline: 3px solid #0ea5e9;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- add reusable `ErrorBoundary` with friendly fallback page
- provide dedicated `NotFound` page and 404 catch‑all route
- enhance SEO & sharing metadata and add robots, sitemap and headers for deployment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string | null'.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7a800ae883298b7d4e6ebdbbaa73