### PR TITLE
UI polish — shared NvCard + NvImg, Languages grid

### DIFF
--- a/src/components/NvCard.tsx
+++ b/src/components/NvCard.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import NvImg from "./NvImg";
+
+type Props = {
+  href: string;
+  title: string;
+  desc?: string;
+  imgSrc?: string;
+  imgAlt?: string;
+  imgW?: number;
+  imgH?: number;
+  badge?: string;
+  onClick?: () => void;
+};
+
+export default function NvCard({
+  href, title, desc, imgSrc, imgAlt = "", imgW = 512, imgH = 512, badge, onClick,
+}: Props) {
+  const Cmp: any = href ? "a" : "div";
+  return (
+    <Cmp href={href} onClick={onClick} className="nvcard">
+      {imgSrc && (
+        <NvImg src={imgSrc} alt={imgAlt} width={imgW} height={imgH} />
+      )}
+      <div className="nvcard-body">
+        <div className="nvcard-title">
+          <span>{title}</span>
+          {badge && <em className="nvcard-badge">{badge}</em>}
+        </div>
+        {desc && <p className="nvcard-desc">{desc}</p>}
+      </div>
+    </Cmp>
+  );
+}
+

--- a/src/components/NvImg.tsx
+++ b/src/components/NvImg.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+type Props = React.ImgHTMLAttributes<HTMLImageElement> & {
+  width: number;   // intrinsic px width
+  height: number;  // intrinsic px height
+};
+
+export default function NvImg({ width, height, style, loading = "lazy", decoding = "async", ...rest }: Props) {
+  const ratio = (height / width) * 100;
+  return (
+    <div className="nvimg" style={{ position: "relative", width: "100%", paddingTop: `${ratio}%` }}>
+      <img
+        {...rest}
+        loading={loading}
+        decoding={decoding}
+        width={width}
+        height={height}
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          objectFit: "cover",
+          borderRadius: 12,
+          ...style,
+        }}
+      />
+    </div>
+  );
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import './styles.css';
 import './styles/shop.css';
 import './styles/edu.css';
 import './main.css';
+import './styles/nvcard.css';
 import SkipToContent from './components/SkipToContent';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/pages/naturversity/languages/[slug].tsx
+++ b/src/pages/naturversity/languages/[slug].tsx
@@ -1,44 +1,110 @@
+import React from "react";
 import { useParams } from "react-router-dom";
-import { LANGUAGES, LangSlug } from "../../../data/languages";
+import NvImg from "../../../components/NvImg";
+
+const meta: Record<string, {title:string; native:string; hero:string; secondary:string; lessons:{hello:string; thanks:string; alphabet:string; numbers:string[];} }> = {
+  thailandia: {
+    title: "Thailandia (Thai)",
+    native: "ไทย",
+    hero: "/Languages/Mangolanguagemainthai.png",
+    secondary: "/Languages/Turianlanguage.png",
+    lessons: {
+      hello: "สวัสดี — sà-wàt-dee",
+      thanks: "ขอบคุณ — khàwp-khun",
+      alphabet: "ก (gor) • ข (khor) • ค (khor) • ง (ngor) • จ (jor)",
+      numbers: ["๑ — nūeng","๒ — sŏng","๓ — sǎam","๔ — sìi","๕ — hâa","๖ — hòk","๗ — jèt","๘ — bpàet","๙ — găo","๑๐ — sìp"],
+    },
+  },
+  chinadia: {
+    title: "Chinadia (Mandarin)",
+    native: "中文",
+    hero: "/Languages/Cranelanguagemainchina.png",
+    secondary: "/Languages/Turianlanguagechina.png",
+    lessons: {
+      hello: "你好 — nǐ hǎo",
+      thanks: "谢谢 — xièxie",
+      alphabet: "Basic pinyin: a o e i u ü; initials: b p m f …",
+      numbers: ["一 yī","二 èr","三 sān","四 sì","五 wǔ","六 liù","七 qī","八 bā","九 jiǔ","十 shí"],
+    },
+  },
+  indillandia: {
+    title: "Indillandia (Hindi)",
+    native: "हिंदी",
+    hero: "/Languages/Genielanguagemainindi.png",
+    secondary: "/Languages/Turianlanguagehindi.png",
+    lessons: {
+      hello: "नमस्ते — namaste",
+      thanks: "धन्यवाद — dhanyavād",
+      alphabet: "अ आ इ ई उ ऊ ए ऐ ओ औ",
+      numbers: ["१ ek","२ do","३ tīn","४ chār","५ pānch","६ chhah","७ sāt","८ āṭh","९ nau","१० das"],
+    },
+  },
+  brazilandia: {
+    title: "Brazilandia (Portuguese)",
+    native: "Português",
+    hero: "/Languages/Birdlanguagemainbrazil.png",
+    secondary: "/Languages/Turianlanguagebrazil.png",
+    lessons: {
+      hello: "Olá",
+      thanks: "Obrigado/Obrigada",
+      alphabet: "A B C Ç D E F G H I J L M N O P Q R S T U V X Z",
+      numbers: ["um","dois","três","quatro","cinco","seis","sete","oito","nove","dez"],
+    },
+  },
+  australandia: {
+    title: "Australandia (English)",
+    native: "English",
+    hero: "/Languages/Koalalanguagemain.png",
+    secondary: "/Languages/Turianlanguageenglish.png",
+    lessons: {
+      hello: "Hello",
+      thanks: "Thank you",
+      alphabet: "A B C D E F G … Z",
+      numbers: ["one","two","three","four","five","six","seven","eight","nine","ten"],
+    },
+  },
+  amerilandia: {
+    title: "Amerilandia (English)",
+    native: "English",
+    hero: "/Languages/Owllanguagemain.png",
+    secondary: "/Languages/Turianlanguageenglish.png",
+    lessons: {
+      hello: "Hello",
+      thanks: "Thank you",
+      alphabet: "A B C D E F G … Z",
+      numbers: ["one","two","three","four","five","six","seven","eight","nine","ten"],
+    },
+  },
+};
 
 export default function LanguageDetail() {
-  const { slug } = useParams<{ slug: LangSlug }>();
-  const data = LANGUAGES[(slug ?? "thailandia") as LangSlug];
+  const { slug = "thailandia" } = useParams();
+  const m = meta[slug] ?? meta.thailandia;
 
   return (
-    <main className="container py-6">
-      <nav className="breadcrumb"><a href="/naturversity">Naturversity</a> / <a href="/naturversity/languages">Languages</a> / {titleFor(slug as LangSlug)}</nav>
-      <h1>{titleFor(slug as LangSlug)} — <span className="muted">{data.nativeName}</span></h1>
-      <img className="lang-hero" src={data.poster} alt="" loading="eager" />
+    <section>
+      <h1>{m.title} — {m.native}</h1>
+      <p>Learn greetings, alphabet basics, and common phrases for {m.title.split(" (")[0]}.</p>
 
-      <section className="stack-md">
+      <div style={{display:"grid", gap:16, maxWidth:980}}>
+        <NvImg src={m.hero} alt={m.title} width={1024} height={768} />
+        <NvImg src={m.secondary} alt={`${m.title} secondary`} width={1024} height={768} />
+      </div>
+
+      <div style={{marginTop:24}}>
         <h3>Starter phrases</h3>
         <ul>
-          <li><strong>Hello:</strong> {data.hello.native} — {data.hello.roman}</li>
-          <li><strong>Thank you:</strong> {data.thankyou.native} — {data.thankyou.roman}</li>
+          <li><strong>Hello:</strong> {m.lessons.hello}</li>
+          <li><strong>Thank you:</strong> {m.lessons.thanks}</li>
         </ul>
 
         <h3>Alphabet basics</h3>
-        <p className="muted">{data.alphabetBasics.join(" · ")}</p>
+        <p>{m.lessons.alphabet}</p>
 
         <h3>Count to ten</h3>
-        <ol className="nums">
-          {data.numbers.map((n, i) => (
-            <li key={i}><strong>{i+1}.</strong> {n.native} — {n.roman}</li>
-          ))}
-        </ol>
-      </section>
-    </main>
+        <ol>{m.lessons.numbers.map((n) => <li key={n}>{n}</li>)}</ol>
+      </div>
+    </section>
   );
 }
 
-function titleFor(slug: LangSlug) {
-  return {
-    thailandia: "Thailandia (Thai)",
-    chilandia: "Chilandia (Mandarin)",
-    indillandia: "Indillandia (Hindi)",
-    brazilandia: "Brazilandia (Portuguese)",
-    australandia: "Australandia (English)",
-    amerilandia: "Amerilandia (English)",
-  }[slug];
-}

--- a/src/pages/naturversity/languages/index.tsx
+++ b/src/pages/naturversity/languages/index.tsx
@@ -1,20 +1,65 @@
 import React from "react";
-import { LANGUAGE_WORLDS } from "../../../data/languages";
-import ImageSafe from "../../../components/ImageSafe";
+import NvCard from "../../../components/NvCard";
 
-export default function LanguagesIndex() {
+const langs = [
+  {
+    slug: "thailandia",
+    title: "Thailandia (Thai)",
+    native: "ไทย",
+    img: "/Languages/Mangolanguagemainthai.png",
+  },
+  {
+    slug: "chinadia",
+    title: "Chinadia (Mandarin)",
+    native: "中文",
+    img: "/Languages/Cranelanguagemainchina.png",
+  },
+  {
+    slug: "indillandia",
+    title: "Indillandia (Hindi)",
+    native: "हिंदी",
+    img: "/Languages/Genielanguagemainindi.png",
+  },
+  {
+    slug: "brazilandia",
+    title: "Brazilandia (Portuguese)",
+    native: "Português",
+    img: "/Languages/Birdlanguagemainbrazil.png",
+  },
+  {
+    slug: "australandia",
+    title: "Australandia (English)",
+    native: "English",
+    img: "/Languages/Koalalanguagemain.png",
+  },
+  {
+    slug: "amerilandia",
+    title: "Amerilandia (English)",
+    native: "English",
+    img: "/Languages/Owllanguagemain.png",
+  },
+];
+
+export default function LanguagesPage() {
   return (
-    <div>
+    <section>
       <h1>Languages</h1>
-      <div className="cards grid-gap">
-        {LANGUAGE_WORLDS.map((it) => (
-          <a key={it.slug} className="card" href={`/naturversity/languages/${it.slug}`}>
-            {it.thumb && <ImageSafe src={it.thumb} alt={it.name} />}
-            <h2>{it.name}</h2>
-            <p>Basics, numbers, greetings.</p>
-          </a>
+      <p>Phrasebooks for each kingdom.</p>
+      <div className="nvgrid" style={{ marginTop: 16 }}>
+        {langs.map((l) => (
+          <NvCard
+            key={l.slug}
+            href={`/naturversity/languages/${l.slug}`}
+            title={l.title}
+            desc={`Native: ${l.native}`}
+            imgSrc={l.img}
+            imgAlt={l.title}
+            imgW={512}
+            imgH={512}
+          />
         ))}
       </div>
-    </div>
+    </section>
   );
 }
+

--- a/src/styles/nvcard.css
+++ b/src/styles/nvcard.css
@@ -1,0 +1,26 @@
+.nvgrid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.nvcard {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  text-decoration: none;
+  color: inherit;
+  background: #fff;
+  transition: box-shadow .15s ease, transform .05s ease;
+}
+.nvcard:where(:hover,:focus-visible){ box-shadow: 0 4px 24px rgba(2,8,23,.08); transform: translateY(-1px); }
+
+.nvcard-body { display: grid; gap: 6px; }
+.nvcard-title { font-weight: 800; display: flex; align-items: center; gap: 8px; }
+.nvcard-badge { font-style: normal; font-size: 12px; padding: 2px 6px; border-radius: 999px; background: #eef2ff; color:#3730a3; }
+.nvcard-desc { margin: 0; color: #475569; font-size: 14px; }
+
+.nvimg img{ display:block; }
+


### PR DESCRIPTION
## Summary
- add reusable NvImg component for fixed-ratio lazy images
- build NvCard component and nvcard.css styling
- refactor Naturversity languages pages to use NvCard grid with responsive images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: type errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8a2324e083299eb58f91710235f9