### PR TITLE
Replace world maps with new uniform set + manifest; consistent sizing (no deps)

### DIFF
--- a/src/components/WorldLayout.tsx
+++ b/src/components/WorldLayout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { KINGDOMS, KingdomId, imgUrl } from "../data/kingdoms";
+import { mapFor } from "../data/maps";
 import "../styles/worlds.css";
 import SmartImg from "./SmartImg";
 
@@ -14,17 +15,13 @@ export default function WorldLayout({ id }: Props) {
       <h1 className="world-title">{k.title}</h1>
 
       {/* Map hero */}
-      <section className="world-hero card">
-        <figure className="hero-figure">
-          <SmartImg
-            src={imgUrl(folder, k.mapFile)}
-            alt={`${k.title} map`}
-            ratio="wide"
-            width={1280}
-            height={720}
-            loading="eager"
-          />
-        </figure>
+      <section className="world-hero-wrap card">
+        <img
+          src={mapFor(id)}
+          alt={`${k.title} map`}
+          className="world-hero"
+          loading="eager"
+        />
         <div className="hero-meta">
           <h2>World Map</h2>
           <p>Zoom into landmarks, routes, and regions.</p>

--- a/src/components/WorldPage.tsx
+++ b/src/components/WorldPage.tsx
@@ -12,10 +12,11 @@ export default function WorldPage({ title, intro, mapSrc }: Props) {
 
   return (
     <div className="world-page">
-      <figure className="world-hero">
+      <figure className="world-hero-wrap">
         <Img
           src={mapSrc}
           alt={`${title} map`}
+          className="world-hero"
           onError={(e) => ((e.currentTarget.src = fallback))}        />
         <figcaption className="sr-only">{title} map</figcaption>
       </figure>

--- a/src/components/worlds/WorldGallery.tsx
+++ b/src/components/worlds/WorldGallery.tsx
@@ -14,8 +14,8 @@ export default function WorldGallery({
 }) {
   return (
     <>
-      <figure className="world-hero">
-        <Img src={mapSrc} alt={alt} />
+      <figure className="world-hero-wrap">
+        <Img src={mapSrc} alt={alt} className="world-hero" />
       </figure>
 
       <section aria-labelledby="gallery" className="world-section">

--- a/src/data/kingdoms.ts
+++ b/src/data/kingdoms.ts
@@ -9,7 +9,6 @@ export type KingdomId =
 export type KingdomData = {
   id: KingdomId;
   title: string;
-  mapFile: string; // exact filename in /public/kingdoms/<TitleCase>/
   characters: string[]; // image filenames for that kingdom (PNG/WEBP/JPG)
 };
 
@@ -21,7 +20,6 @@ export const KINGDOMS: Record<KingdomId, KingdomData> = {
   thailandia: {
     id: "thailandia",
     title: "Thailandia",
-    mapFile: "Thailandiamap.jpg", // per your folder
     characters: [
       "2kay.png",
       "Blu Butterfly.png",
@@ -50,7 +48,6 @@ export const KINGDOMS: Record<KingdomId, KingdomData> = {
   brazilandia: {
     id: "brazilandia",
     title: "Brazilandia",
-    mapFile: "Brazilandiamap.png",
     characters: [
       "Amzonicaspirit.png",
       "Ariamacaw.png",
@@ -63,7 +60,6 @@ export const KINGDOMS: Record<KingdomId, KingdomData> = {
   australandia: {
     id: "australandia",
     title: "Australandia",
-    mapFile: "Australaniamap.png",
     characters: [
       "Bird.png",
       "Groupof four.png",
@@ -81,7 +77,6 @@ export const KINGDOMS: Record<KingdomId, KingdomData> = {
   chilandia: {
     id: "chilandia",
     title: "Chilandia",
-    mapFile: "Chilandiamap.jpg",
     characters: [
       "Baobaopandaandlongweidragon.png",
       "Bodrummer.png",
@@ -96,7 +91,6 @@ export const KINGDOMS: Record<KingdomId, KingdomData> = {
   indillandia: {
     id: "indillandia",
     title: "Indillandia",
-    mapFile: "Inlandiamap.png",
     characters: [
       "Geniebaba.png",
       "Gurucow.png",
@@ -109,7 +103,6 @@ export const KINGDOMS: Record<KingdomId, KingdomData> = {
   amerilandia: {
     id: "amerilandia",
     title: "Amerilandia",
-    mapFile: "Amerilandiamap.png",
     characters: [
       "Aligatorsport.png",
       "Baldeagle.png",

--- a/src/data/maps.ts
+++ b/src/data/maps.ts
@@ -1,0 +1,12 @@
+// Central map manifest. Keys are world slugs.
+const V = "v1"; // bump when you replace images
+export const MAPS: Record<string, string> = {
+  thailandia:   `/Mapsmain/Thailandiamapmain.png?${V}`,
+  chinadia:     `/Mapsmain/Chilandiamapmain.png?${V}`,
+  indillandia:  `/Mapsmain/Indilandiamapmain.png?${V}`,
+  brazilandia:  `/Mapsmain/Brazilandiamapmain.png?${V}`,
+  australandia: `/Mapsmain/Australandiamapmain.png?${V}`,
+  amerilandia:  `/Mapsmain/Amerilandiamapmain.png?${V}`,
+};
+
+export const mapFor = (slug: string) => MAPS[slug] ?? MAPS.thailandia;

--- a/src/data/worlds.ts
+++ b/src/data/worlds.ts
@@ -2,16 +2,15 @@ export type World = {
   slug: string;
   title: string;
   blurb: string;
-  hero?: string; // optional image path
 };
 
 export const WORLDS: World[] = [
-  { slug: "thailandia",   title: "Thailandia",   blurb: "Coconuts, elephants, festivals.",   hero: "/assets/thailandia/Thailandiamap.jpg" },
-  { slug: "brazilandia",  title: "Brazilandia",  blurb: "Rainforests, parrots, beaches.",    hero: "/assets/brazilandia/Brazilandiamap.png" },
-  { slug: "indilandia",   title: "Indilandia",   blurb: "Mangoes, tigers, temples.",         hero: "/assets/indilandia/Indilandiamap.png" },
-  { slug: "amerilandia",  title: "Amerilandia",  blurb: "Apples, eagles, canyons.",          hero: "/assets/amerilandia/Amerilandiamap.png" },
-  { slug: "australandia", title: "Australandia", blurb: "Peaches, kangaroos, reefs.",        hero: "/assets/australandia/Australandiamap.png" },
-  { slug: "chilandia",    title: "Chilandia",    blurb: "Bamboo, pandas, lanterns.",         hero: "/assets/chilandia/Chilandiamap.png" },
+  { slug: "thailandia",   title: "Thailandia",   blurb: "Coconuts, elephants, festivals." },
+  { slug: "brazilandia",  title: "Brazilandia",  blurb: "Rainforests, parrots, beaches." },
+  { slug: "indilandia",   title: "Indilandia",   blurb: "Mangoes, tigers, temples." },
+  { slug: "amerilandia",  title: "Amerilandia",  blurb: "Apples, eagles, canyons." },
+  { slug: "australandia", title: "Australandia", blurb: "Peaches, kangaroos, reefs." },
+  { slug: "chilandia",    title: "Chilandia",    blurb: "Bamboo, pandas, lanterns." },
   // add more later
 ];
 

--- a/src/pages/worlds/index.tsx
+++ b/src/pages/worlds/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { WORLDS } from "../../data/worlds";
 import ImageSafe from "../../components/ImageSafe";
+import { mapFor } from "../../data/maps";
 import Meta from "../../components/Meta";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import PageHead from "../../components/PageHead";
@@ -18,7 +19,7 @@ export default function WorldsIndex() {
       <div className="cards grid-gap">
         {WORLDS.map((w) => (
           <a key={w.slug} className="card" href={`/worlds/${w.slug}`}>
-            {w.hero && <ImageSafe src={w.hero} alt={w.title} />}
+            <ImageSafe src={mapFor(w.slug)} alt={w.title} />
             <h2>{w.title}</h2>
             <p>{w.blurb}</p>
           </a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -159,3 +159,16 @@ textarea {
 .container { max-width: 1024px; margin: 0 auto; padding: 0 16px; }
 .stack-md > *+* { margin-top: .75rem; }
 .muted { color: #6b7280; }
+
+/* World map heroes scale nicely and never overflow */
+.world-hero {
+  width: 100%;
+  max-height: 520px;
+  object-fit: contain;
+  border-radius: 14px;
+  display: block;
+}
+
+/* Card media stays square and crops cleanly */
+.nv-card__media { aspect-ratio: 1 / 1; }
+.nv-card__media img { width: 100%; height: 100%; object-fit: cover; }

--- a/src/styles/worlds.css
+++ b/src/styles/worlds.css
@@ -12,25 +12,12 @@
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 14px;
 }
-.world-hero {
+.world-hero-wrap {
   display: grid;
   gap: 1rem;
   grid-template-columns: minmax(0, 1fr);
   padding: 0.75rem;
   margin-bottom: 1.25rem;
-}
-.hero-figure {
-  position: relative;
-  border-radius: 10px;
-  overflow: hidden;
-  aspect-ratio: 16 / 9;
-  background: #eef3f6;
-}
-.hero-figure img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
 }
 .hero-meta {
   padding: 0 0.25rem 0.25rem;
@@ -93,7 +80,7 @@
 }
 
 @media (min-width: 900px) {
-  .world-hero {
+  .world-hero-wrap {
     grid-template-columns: 2fr 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- centralize world map paths via new `mapFor` manifest
- swap worlds grid and layouts to load maps through `mapFor`
- add CSS to keep map heroes and card media consistently sized

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string | null'.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aa99d4fec08329a52a26a628ebeb68