### PR TITLE
Site-wide breadcrumbs — Naturversity, Zones, Marketplace, NaturBank, Navatar, Passport, Turian

### DIFF
--- a/src/pages/naturbank.tsx
+++ b/src/pages/naturbank.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { supabase } from "../supabase/client";
+import Breadcrumbs from "../components/Breadcrumbs";
 import type { NaturTxn } from "../types/bank";
 import { setTitle } from "./_meta";
 
@@ -101,7 +102,9 @@ export default function NaturBankPage() {
   if (loading) return <main><h1>NaturBank</h1><p>Loading…</p></main>;
 
   return (
-    <main className="bank">
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "NaturBank" }]} />
+      <main className="bank">
       <h1>NaturBank</h1>
       <p className="muted">{usingLocal ? "Local demo mode." : "Synced to your account."}</p>
 
@@ -157,5 +160,6 @@ export default function NaturBankPage() {
 
       <p className="muted small">Coming soon: real wallet connect, custodial accounts, and redemptions.</p>
     </main>
+    </div>
   );
 }

--- a/src/pages/naturbank/Learn.tsx
+++ b/src/pages/naturbank/Learn.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function Learn() {
   return (
     <main id="main" className="page-wrap">
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/naturbank", label: "NaturBank" }, { label: "Learn" }]} />
       <h1>📘 Learn</h1>
       <ul className="bullet">
         <li><b>Safety:</b> keep keys private, avoid DM links, verify sites.</li>

--- a/src/pages/naturbank/NFTs.tsx
+++ b/src/pages/naturbank/NFTs.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
 
 const items = [
   { id: "card-thai", title: "Navatar — Thailandia", blurb: "Coconuts & Elephants series" },
@@ -9,6 +10,7 @@ const items = [
 export default function NFTs() {
   return (
     <main id="main" className="page-wrap">
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/naturbank", label: "NaturBank" }, { label: "NFTs" }]} />
       <h1>🖼️ NFTs</h1>
       <p>Preview collectibles. Minting connects later.</p>
       <div className="hub-grid">

--- a/src/pages/naturbank/Token.tsx
+++ b/src/pages/naturbank/Token.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
 import { getLedger, addTx, getBalance } from "../../lib/naturbank/store";
 import type { Tx } from "../../lib/naturbank/types";
 
@@ -19,6 +20,7 @@ export default function Token() {
 
   return (
     <main id="main" className="page-wrap">
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/naturbank", label: "NaturBank" }, { label: "Token" }]} />
       <h1>🪙 NATUR Token</h1>
 
       <div className="panel">

--- a/src/pages/naturbank/Wallet.tsx
+++ b/src/pages/naturbank/Wallet.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
 import { createDemoWallet, getWallet, getBalance } from "../../lib/naturbank/store";
 
 export default function Wallet() {
@@ -9,6 +10,7 @@ export default function Wallet() {
 
   return (
     <main id="main" className="page-wrap">
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/naturbank", label: "NaturBank" }, { label: "Wallet" }]} />
       <h1>🪪 Wallet</h1>
       {!w ? (
         <div className="panel">

--- a/src/pages/passport.tsx
+++ b/src/pages/passport.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { supabase } from "../supabase/client";
 import { WORLDS, WorldKey } from "../data/worlds";
 import type { PassportStamp, PassportBadge } from "../types/passport";
+import Breadcrumbs from "../components/Breadcrumbs";
 import { setTitle } from "./_meta";
 
 const LS_STAMPS = "naturverse.passport.stamps.v1";
@@ -106,10 +107,18 @@ export default function PassportPage() {
     grantBadge("first-steps", "First Steps");
   }
 
-  if (loading) return <main><h1>Passport</h1><p>Loading…</p></main>;
+  if (loading)
+    return (
+      <div className="page-wrap">
+        <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "Passport" }]} />
+        <main className="passport"><h1>Passport</h1><p>Loading…</p></main>
+      </div>
+    );
 
   return (
-    <main className="passport">
+    <div className="page-wrap">
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "Passport" }]} />
+      <main className="passport">
       <h1>Passport</h1>
       <p className="muted">{usingLocal ? "Local demo mode." : "Synced to your account."}</p>
 
@@ -171,6 +180,7 @@ export default function PassportPage() {
 
       <p className="muted small">Coming soon: auto-stamps from quizzes, stories, and missions.</p>
     </main>
+    </div>
   );
 }
 

--- a/src/routes/zones/arcade/index.tsx
+++ b/src/routes/zones/arcade/index.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from "react";
+import Breadcrumbs from "../../../components/Breadcrumbs";
 import "../../../styles/zone-widgets.css";
 
 export default function Arcade() {
   return (
     <main className="container">
-      <div className="breadcrumb">Home / Zones / Arcade</div>
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/zones", label: "Zones" }, { label: "Arcade" }]} />
       <h2 className="section-title">Arcade</h2>
       <p className="section-lead">Mini-games, leaderboards &amp; tournaments.</p>
 

--- a/src/routes/zones/creator-lab/index.tsx
+++ b/src/routes/zones/creator-lab/index.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import Breadcrumbs from "../../../components/Breadcrumbs";
 import { CharacterCard, CardData } from "../../../components/CharacterCard";
 import "../../../styles/zone-widgets.css";
 
@@ -66,6 +67,7 @@ export default function CreatorLab() {
 
   return (
     <div>
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/zones", label: "Zones" }, { label: "Creator Lab" }]} />
       <h1>🎨🤖 Creator Lab</h1>
       <p>AI art &amp; character cards (client-only tools for now).</p>
 

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
 import { ZONES } from "../../data/zones";
 import { setTitle } from "../../pages/_meta";
 
@@ -6,6 +7,7 @@ export default function Zones() {
   setTitle("Zones");
   return (
     <div>
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "Zones" }]} />
       <h1>Zones</h1>
       <div className="cards grid-gap">
         {ZONES.map((z) => (

--- a/src/routes/zones/music/index.tsx
+++ b/src/routes/zones/music/index.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import Breadcrumbs from "../../../components/Breadcrumbs";
 import "../../../styles/zone-widgets.css";
 
 export default function Music() {
   return (
     <main className="container">
-      <div className="breadcrumb">Home / Zones / Music</div>
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/zones", label: "Zones" }, { label: "Music" }]} />
       <h2 className="section-title">Music</h2>
       <p className="section-lead">Karaoke, beats &amp; song maker (client-only).</p>
 

--- a/src/routes/zones/wellness/index.tsx
+++ b/src/routes/zones/wellness/index.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from "react";
+import Breadcrumbs from "../../../components/Breadcrumbs";
 import "../../../styles/zone-widgets.css";
 
 export default function Wellness() {
   return (
     <main className="container">
-      <div className="breadcrumb">Home / Zones / Wellness</div>
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/zones", label: "Zones" }, { label: "Wellness" }]} />
       <h2 className="section-title">Wellness</h2>
       <p className="section-lead">Yoga, breathing, stretches, mindful quests (client-only).</p>
 


### PR DESCRIPTION
## Summary
- add breadcrumb trails to zones index and detail pages
- wire breadcrumbs into NaturBank hub and subpages
- include Passport breadcrumbs for site-wide navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68aab628fbb483298b75f16bb1193c71