### PR TITLE
Breadcrumbs pass + Marketplace images (no deps, safe)

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,16 +1,73 @@
-import React from "react";
-export default function Breadcrumbs({ items, className = "" }: { items: { href?: string; label: string }[]; className?: string; }) {
-  if (!items?.length) return null;
+import { Link, useLocation } from "react-router-dom";
+import * as React from "react";
+
+type Crumb = { label: string; href?: string };
+
+const LABELS: Record<string, string> = {
+  "": "Home",
+  worlds: "Worlds",
+  naturversity: "Naturversity",
+  languages: "Languages",
+  zones: "Zones",
+  marketplace: "Marketplace",
+  naturbank: "NaturBank",
+  navatar: "Navatar",
+  passport: "Passport",
+  turian: "Turian",
+  profile: "Profile",
+  "arcade": "Arcade",
+  "music": "Music",
+  "wellness": "Wellness",
+  "creator-lab": "Creator Lab",
+  community: "Community",
+  culture: "Culture",
+  future: "Future",
+  observations: "Observations",
+  quizzes: "Quizzes",
+  stories: "Stories",
+};
+
+export function Breadcrumbs(props: { items?: Crumb[] }) {
+  const location = useLocation();
+
+  // Allow explicit items to override auto mode when needed
+  const items: Crumb[] = React.useMemo(() => {
+    if (props.items?.length) return props.items;
+
+    const parts = location.pathname.replace(/^\/+|\/+$/g, "").split("/");
+    const acc: Crumb[] = [];
+    let path = "";
+
+    // Always include Home
+    acc.push({ label: "Home", href: "/" });
+
+    parts.forEach((seg, i) => {
+      if (!seg) return;
+      path += `/${seg}`;
+      const label = LABELS[seg.toLowerCase()] ?? seg.replace(/-/g, " ");
+      const isLast = i === parts.length - 1;
+      acc.push({ label, href: isLast ? undefined : path });
+    });
+
+    return acc;
+  }, [location.pathname, props.items]);
+
+  if (items.length <= 1) return null;
+
   return (
-    <nav aria-label="Breadcrumb" className={`crumbs ${className}`}>
+    <nav aria-label="Breadcrumb" className="nv-breadcrumbs">
       <ol>
-        {items.map((it, i) => (
-          <li key={i} className="crumb">
-            {it.href ? <a href={it.href}>{it.label}</a> : <span>{it.label}</span>}
-            {i < items.length - 1 && <span className="sep"> / </span>}
-          </li>
-        ))}
+        {items.map((c, i) => {
+          const isLast = i === items.length - 1;
+          return (
+            <li key={`${c.label}-${i}`} aria-current={isLast ? "page" : undefined}>
+              {c.href && !isLast ? <Link to={c.href}>{c.label}</Link> : <span>{c.label}</span>}
+              {!isLast && <span className="sep"> / </span>}
+            </li>
+          );
+        })}
       </ol>
     </nav>
   );
 }
+export default Breadcrumbs;

--- a/src/data/marketplace.ts
+++ b/src/data/marketplace.ts
@@ -1,0 +1,31 @@
+export type Product = {
+  id: string;
+  name: string;
+  price: number;
+  imageSrc?: string;
+  imageAlt?: string;
+};
+
+export const PRODUCTS: Product[] = [
+  {
+    id: "turian-plush",
+    name: "Turian Plush",
+    price: 24.0,
+    imageSrc: "/Marketplace/Turianplushie.png",
+    imageAlt: "Turian plush toy mockup",
+  },
+  {
+    id: "navatar-tee",
+    name: "Navatar Tee",
+    price: 18.0,
+    imageSrc: "/Marketplace/Turiantshirt.png",
+    imageAlt: "T-shirt with Navatar graphic",
+  },
+  {
+    id: "sticker-pack",
+    name: "Sticker Pack",
+    price: 6.0,
+    imageSrc: "/Marketplace/Stickerpack.png",
+    imageAlt: "Naturverse sticker pack",
+  },
+];

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -1,6 +1,0 @@
-export type Product = { id: string; name: string; price: number; img?: string };
-export const PRODUCTS: Product[] = [
-  { id: "plush-turian", name: "Turian Plush", price: 24.0, img: "/assets/market/plush-turian.png" },
-  { id: "tee-navatar",  name: "Navatar Tee",  price: 18.0, img: "/assets/market/tee-navatar.png"  },
-  { id: "sticker-pack", name: "Sticker Pack", price: 6.0,  img: "/assets/market/stickers.png"     },
-];

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -4,8 +4,7 @@ import Meta from "../components/Meta";
 import { breadcrumbs } from "../lib/jsonld";
 import Breadcrumbs from "../components/Breadcrumbs";
 import PageHead from "../components/PageHead";
-import { PRODUCTS } from "../data/products";
-import ImageSafe from "../components/ImageSafe";
+import { PRODUCTS } from "../data/marketplace";
 import { setTitle } from "./_meta";
 
 const labels = { '/marketplace': 'Marketplace' };
@@ -34,7 +33,14 @@ export default function MarketplacePage() {
           <div className="cards grid-gap" style={{ marginTop: 20 }}>
             {PRODUCTS.map((p) => (
               <a key={p.id} className="card" href={`/marketplace/${p.id}`}>
-                {p.img && <ImageSafe src={p.img} alt={p.name} />}
+                {p.imageSrc && (
+                  <img
+                    src={p.imageSrc}
+                    alt={p.imageAlt ?? p.name}
+                    loading="lazy"
+                    style={{ width: "100%", height: "auto", borderRadius: "0.5rem" }}
+                  />
+                )}
                 <h2>{p.name}</h2>
                 <p>${p.price.toFixed(2)}</p>
               </a>

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -7,7 +7,7 @@ export default function NaturversityPage() {
   setTitle("Naturversity");
   return (
     <div className="page-wrap">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "Naturversity" }]} />
+      <Breadcrumbs />
       <main className="page">
         <h1>Naturversity</h1>
         <p>Teachers, partners, and courses.</p>

--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -84,7 +84,7 @@ export default function TurianPage() {
 
   return (
     <>
-        <Page title="Turian the Durian" subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet." crumbs={[{ href:"/", label:"Home" }, { label:"Turian" }]}> 
+        <Page title="Turian the Durian" subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet." >
       <Meta title="Turian — Naturverse" description="Offline AI assistant demo." />
 
       <div className="nv-card" style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 12 }}>

--- a/src/pages/Worlds.tsx
+++ b/src/pages/Worlds.tsx
@@ -1,11 +1,12 @@
 import CardGrid, { Card } from "../components/CardGrid";
 import KingdomImage from "../components/KingdomImage";
 import { KINGDOMS } from "../content/kingdoms";
+import Breadcrumbs from "../components/Breadcrumbs";
 
 export default function Worlds() {
   return (
     <main id="main" className="container">
-      <div className="breadcrumb">Home / Worlds</div>
+      <Breadcrumbs />
       <h2 className="section-title">Worlds</h2>
       <p className="section-lead">Explore the 14 kingdoms.</p>
 

--- a/src/pages/naturbank.tsx
+++ b/src/pages/naturbank.tsx
@@ -103,7 +103,7 @@ export default function NaturBankPage() {
 
   return (
     <div className="page-wrap">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "NaturBank" }]} />
+      <Breadcrumbs />
       <main className="bank">
       <h1>NaturBank</h1>
       <p className="muted">{usingLocal ? "Local demo mode." : "Synced to your account."}</p>

--- a/src/pages/passport.tsx
+++ b/src/pages/passport.tsx
@@ -110,14 +110,14 @@ export default function PassportPage() {
   if (loading)
     return (
       <div className="page-wrap">
-        <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "Passport" }]} />
+        <Breadcrumbs />
         <main className="passport"><h1>Passport</h1><p>Loading…</p></main>
       </div>
     );
 
   return (
     <div className="page-wrap">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "Passport" }]} />
+      <Breadcrumbs />
       <main className="passport">
       <h1>Passport</h1>
       <p className="muted">{usingLocal ? "Local demo mode." : "Synced to your account."}</p>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -5,6 +5,7 @@ import XPPanel from "../components/profile/XPPanel";
 import { useCloudProfile } from "../hooks/useCloudProfile";
 import type { LocalProfile } from "../types/profile";
 import { setTitle } from "./_meta";
+import Breadcrumbs from "../components/Breadcrumbs";
 
 const K = {
   profile: "naturverse.profile.v1",
@@ -102,6 +103,7 @@ export default function ProfilePage() {
 
   return (
     <main className="container profile-page">
+      <Breadcrumbs />
       <h1>Profile</h1>
       <form
         className="card"

--- a/src/pages/zones/Community.tsx
+++ b/src/pages/zones/Community.tsx
@@ -131,7 +131,7 @@ export default function Community() {
 
   return (
     <div className="page-wrap">
-      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Community" }]} />
+      <Breadcrumbs />
       <main id="main">
       <h1>🗳️🌍 Community</h1>
       <p>Vote for new lands & characters, and join local volunteer events.</p>

--- a/src/pages/zones/Culture.tsx
+++ b/src/pages/zones/Culture.tsx
@@ -15,7 +15,6 @@ export default function Culture() {
       <Page
         title="Culture"
         subtitle="Beliefs, holidays, and ceremonies across the 14 kingdoms."
-        crumbs={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Culture" }]}
       >
       <div className="culture-grid grid gap-4 md:gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {kingdoms.map((k) => (

--- a/src/pages/zones/Future.tsx
+++ b/src/pages/zones/Future.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 export default function FutureZone() {
   return (
       <div className="page-wrap">
-        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Future" }]} />
+        <Breadcrumbs />
         <main id="main" className="page">
 
         <h1>🔮 Future Zone</h1>

--- a/src/pages/zones/Observations.tsx
+++ b/src/pages/zones/Observations.tsx
@@ -146,7 +146,7 @@ export default function Observations() {
 
   return (
     <div className="page-wrap">
-      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Observations" }]} />
+      <Breadcrumbs />
       <main id="main">
       <h1>📷🌿 Observations</h1>
       <p>Upload nature pics; tag, learn, earn. (Local & offline; data stays in your browser.)</p>

--- a/src/pages/zones/Quizzes.tsx
+++ b/src/pages/zones/Quizzes.tsx
@@ -65,7 +65,7 @@ export default function Quizzes() {
 
   return (
     <div className="page-wrap">
-      <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Quizzes" }]} />
+      <Breadcrumbs />
       <main id="main">
       <h1>🎯 Quizzes</h1>
       <p>Solo & party quiz play with scoring (client-only; no backend).</p>

--- a/src/pages/zones/Stories.tsx
+++ b/src/pages/zones/Stories.tsx
@@ -86,7 +86,7 @@ export default function Stories() {
 
   return (
       <div className="page-wrap">
-        <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/zones", label:"Zones" }, { label:"Stories" }]} />
+        <Breadcrumbs />
         <main id="main">
         <h1>📚✨ Stories</h1>
       <p>AI story paths set in all 14 kingdoms (local, no-backend version).</p>

--- a/src/routes/worlds/[slug].tsx
+++ b/src/routes/worlds/[slug].tsx
@@ -9,7 +9,7 @@ export default function WorldDetail() {
 
   return (
     <article>
-      <Breadcrumbs items={[{ href: "/worlds", label: "Worlds" }, { label: world.title }]} />
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/worlds", label: "Worlds" }, { label: world.title }]} />
       <h1>{world.title}</h1>
       <p>Zoom into landmarks, routes, and regions.</p>
 

--- a/src/routes/zones/arcade/index.tsx
+++ b/src/routes/zones/arcade/index.tsx
@@ -5,7 +5,7 @@ import "../../../styles/zone-widgets.css";
 export default function Arcade() {
   return (
     <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/zones", label: "Zones" }, { label: "Arcade" }]} />
+      <Breadcrumbs />
       <h2 className="section-title">Arcade</h2>
       <p className="section-lead">Mini-games, leaderboards &amp; tournaments.</p>
 

--- a/src/routes/zones/creator-lab/index.tsx
+++ b/src/routes/zones/creator-lab/index.tsx
@@ -67,7 +67,7 @@ export default function CreatorLab() {
 
   return (
     <div>
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/zones", label: "Zones" }, { label: "Creator Lab" }]} />
+      <Breadcrumbs />
       <h1>🎨🤖 Creator Lab</h1>
       <p>AI art &amp; character cards (client-only tools for now).</p>
 

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -7,7 +7,7 @@ export default function Zones() {
   setTitle("Zones");
   return (
     <div>
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "Zones" }]} />
+      <Breadcrumbs />
       <h1>Zones</h1>
       <div className="cards grid-gap">
         {ZONES.map((z) => (

--- a/src/routes/zones/music/index.tsx
+++ b/src/routes/zones/music/index.tsx
@@ -5,7 +5,7 @@ import "../../../styles/zone-widgets.css";
 export default function Music() {
   return (
     <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/zones", label: "Zones" }, { label: "Music" }]} />
+      <Breadcrumbs />
       <h2 className="section-title">Music</h2>
       <p className="section-lead">Karaoke, beats &amp; song maker (client-only).</p>
 

--- a/src/routes/zones/wellness/index.tsx
+++ b/src/routes/zones/wellness/index.tsx
@@ -5,7 +5,7 @@ import "../../../styles/zone-widgets.css";
 export default function Wellness() {
   return (
     <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/zones", label: "Zones" }, { label: "Wellness" }]} />
+      <Breadcrumbs />
       <h2 className="section-title">Wellness</h2>
       <p className="section-lead">Yoga, breathing, stretches, mindful quests (client-only).</p>
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -17,3 +17,11 @@
 
 /* --- Minor typography ----------------------------------------------------- */
 .kicker { color:#6b7280; font:500 13px/1.2 system-ui; }
+
+/* --- Breadcrumbs --------------------------------------------------------- */
+.nv-breadcrumbs { margin: 0 0 0.75rem; }
+.nv-breadcrumbs ol { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; }
+.nv-breadcrumbs li { font-size: .9rem; }
+.nv-breadcrumbs .sep { opacity:.5; margin: 0 .25rem; }
+.nv-breadcrumbs a { text-decoration: none; }
+.nv-breadcrumbs a:hover { text-decoration: underline; }


### PR DESCRIPTION
## Summary
- replace manual trails with new `<Breadcrumbs />` component that auto-builds paths yet accepts overrides
- apply breadcrumb navigation to Worlds, Naturversity, Zones, and profile pages
- source Marketplace product images from `/public/Marketplace`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')*


------
https://chatgpt.com/codex/tasks/task_e_68aab9990874832987c8318b9d0030cf