### PR TITLE
Wire up Shopping Cart — new /cart page + header link (breadcrumbs included)

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,6 +8,7 @@ const PAGES = [
   '/worlds',
   '/zones',
   '/marketplace',
+  '/cart',
   '/naturversity',
   '/naturbank',
   '/navatar',

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -73,10 +73,10 @@ export default function SiteHeader() {
           <NavLink
             to="/cart"
             aria-label="Cart"
-            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link') + ' icon'}
+            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link') + ' icon nav-cart'}
             onClick={() => setOpen(false)}
           >
-            🛒
+            <span aria-hidden="true">🛒</span>
           </NavLink>
         </nav>
         <div style={{ marginLeft: 'auto', display: 'flex', gap: 12, alignItems: 'center' }}>

--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import Breadcrumbs from "../components/Breadcrumbs";
+
+export default function CartPage() {
+  return (
+    <main id="main" className="page-wrap">
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/marketplace", label: "Marketplace" }, { label: "Cart" }]} />
+      <h1>Cart</h1>
+      <p className="sub">Review items and checkout.</p>
+
+      <section className="card empty">
+        <div className="icon">
+          <img src="/favicon-32x32.png" alt="Naturverse" width={48} height={48} />
+        </div>
+        <h2>Your cart is empty</h2>
+        <p>When you add something, it will show up here.</p>
+        <Link className="btn" to="/marketplace">Continue shopping</Link>
+      </section>
+
+      <style>{`
+        .page-wrap { max-width: 960px; margin: 0 auto; padding: 1rem; }
+        .sub { color: #475569; margin-bottom: 1rem; }
+        .card.empty {
+          border: 2px solid #c7d2fe; border-radius: 14px; padding: 1.25rem;
+          display: grid; gap: .5rem; justify-items: start; background: #fff;
+        }
+        .icon { border: 2px solid #e2e8f0; border-radius: 12px; padding: .5rem; background: #f8fafc; }
+        .btn {
+          display: inline-block; padding: .6rem 1rem; border-radius: 12px;
+          background: #2563eb; color: #fff; text-decoration: none; box-shadow: 0 4px 0 #1e40af;
+        }
+        .btn:active { transform: translateY(1px); box-shadow: 0 3px 0 #1e40af; }
+      `}</style>
+    </main>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -19,6 +19,7 @@ import Marketplace from './pages/Marketplace';
 import Catalog from './pages/marketplace/Catalog';
 import Wishlist from './pages/marketplace/Wishlist';
 import Checkout from './pages/marketplace/Checkout';
+import CartPage from './pages/cart';
 import Naturversity from './pages/Naturversity';
 import Teachers from './pages/naturversity/Teachers';
 import Partners from './pages/naturversity/Partners';
@@ -67,6 +68,7 @@ export const router = createBrowserRouter([
       { path: 'marketplace/catalog', element: <Catalog /> },
         { path: 'marketplace/wishlist', element: <Wishlist /> },
         { path: 'marketplace/checkout', element: <Checkout /> },
+      { path: 'cart', element: <CartPage /> },
       { path: 'naturversity', element: <Naturversity /> },
       { path: 'naturversity/teachers', element: <Teachers /> },
       { path: 'naturversity/partners', element: <Partners /> },


### PR DESCRIPTION
## Summary
- add `/cart` page with breadcrumbs and empty state
- link header cart icon to the new page
- register `/cart` in router and sitemap

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS2345 etc. in existing files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aabd72a278832999c4297635343bc2