### PR TITLE
Restore character galleries from public manifests

### DIFF
--- a/src/components/WorldLayout.tsx
+++ b/src/components/WorldLayout.tsx
@@ -25,7 +25,7 @@ export default function WorldLayout({ id }: Props) {
       {/* Characters grid */}
       <section className="world-section">
         <h2>Characters</h2>
-        <CharacterGrid world={k.title} />
+        <CharacterGrid kingdom={k.title} />
       </section>
     </main>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,11 @@ import './styles/edu.css';
 import './main.css';
 import './styles/nvcard.css';
 import SkipToContent from './components/SkipToContent';
+import { characterGridStyles } from './components/CharacterGrid';
+
+const style = document.createElement('style');
+style.innerHTML = characterGridStyles;
+document.head.appendChild(style);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/routes/worlds/[slug].tsx
+++ b/src/routes/worlds/[slug].tsx
@@ -1,10 +1,21 @@
 import { useParams } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
+import { CharacterGrid } from "../../components/CharacterGrid";
 import { getWorldBySlug } from "../../data/worlds";
+
+const FOLDER_BY_SLUG: Record<string, string> = {
+  amerilandia: "Amerilandia",
+  australandia: "Australandia",
+  brazilandia: "Brazilandia",
+  chilandia: "Chilandia",
+  indillandia: "Indillandia",
+  thailandia: "Thailandia",
+};
 
 export default function WorldDetail() {
   const { slug = "" } = useParams();
   const world = getWorldBySlug(slug);
+  const folder = FOLDER_BY_SLUG[slug] ?? slug;
   if (!world) return <p>World not found.</p>;
 
   return (
@@ -22,7 +33,10 @@ export default function WorldDetail() {
         />
       </div>
 
-      {/* …characters, sections, etc… */}
+      <section aria-labelledby="characters-heading" style={{ marginTop: 24 }}>
+        <h2 id="characters-heading">Characters</h2>
+        <CharacterGrid kingdom={folder} />
+      </section>
     </article>
   );
 }


### PR DESCRIPTION
## Summary
- Implement manifest-based `CharacterGrid` component with skeletons and graceful fallback
- Inject grid styles globally for use across the app
- Render character galleries on world detail pages using folder mapping

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: existing TypeScript errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aad38390a08329a0b7817f40c0ef97