### PR TITLE
feat: add character gallery and detail pages

### DIFF
--- a/components/CharacterGallery.tsx
+++ b/components/CharacterGallery.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import Image from "next/image";
+
+interface Character {
+  name: string;
+  image: string;
+  slug: string;
+}
+
+export default function CharacterGallery({ world, characters }: { world: string; characters: Character[] }) {
+  if (!characters || characters.length === 0) {
+    return <p className="text-center text-gray-500">Characters coming soon.</p>;
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {characters.map((char) => (
+        <Link key={char.slug} href={`/characters/${char.slug}`} className="block text-center">
+          <div className="border rounded-lg p-2 bg-white shadow hover:shadow-md">
+            <Image
+              src={char.image}
+              alt={char.name}
+              width={200}
+              height={200}
+              className="mx-auto object-contain"
+            />
+            <p className="mt-2 font-semibold">{char.name}</p>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/pages/characters/[slug].tsx
+++ b/pages/characters/[slug].tsx
@@ -1,0 +1,36 @@
+import { useRouter } from "next/router";
+import Image from "next/image";
+import fs from "fs";
+import path from "path";
+
+export default function CharacterPage() {
+  const router = useRouter();
+  const { slug } = router.query;
+
+  let character = null;
+  try {
+    const filePath = path.join(process.cwd(), "public", "characters", `${slug}.json`);
+    const fileData = fs.readFileSync(filePath, "utf-8");
+    character = JSON.parse(fileData);
+  } catch (err) {
+    character = null;
+  }
+
+  if (!character) {
+    return <p className="p-6 text-center text-gray-500">Character not found.</p>;
+  }
+
+  return (
+    <div className="p-6 text-center">
+      <h1 className="text-3xl font-bold mb-4">{character.name}</h1>
+      <Image
+        src={character.image}
+        alt={character.name}
+        width={400}
+        height={400}
+        className="mx-auto object-contain"
+      />
+      <p className="mt-4 text-lg text-gray-700">More about {character.name} coming soon.</p>
+    </div>
+  );
+}

--- a/pages/worlds/[world].tsx
+++ b/pages/worlds/[world].tsx
@@ -1,0 +1,35 @@
+import { useRouter } from "next/router";
+import Image from "next/image";
+import fs from "fs";
+import path from "path";
+import CharacterGallery from "../../components/CharacterGallery";
+
+export default function WorldPage() {
+  const router = useRouter();
+  const { world } = router.query;
+
+  let characters = [];
+  try {
+    const filePath = path.join(process.cwd(), "public", "kingdoms", `${world}`, "manifest.json");
+    const fileData = fs.readFileSync(filePath, "utf-8");
+    characters = JSON.parse(fileData);
+  } catch (err) {
+    characters = [];
+  }
+
+  return (
+    <div className="p-6">
+      <h1 className="text-3xl font-bold mb-4 capitalize">{world}</h1>
+      <div className="mb-6">
+        <Image
+          src={`/MapsMain/${world}mapmain.png`}
+          alt={`${world} map`}
+          width={600}
+          height={400}
+          className="mx-auto object-contain"
+        />
+      </div>
+      <CharacterGallery world={world as string} characters={characters} />
+    </div>
+  );
+}

--- a/public/characters/mangosteen-monk.json
+++ b/public/characters/mangosteen-monk.json
@@ -1,0 +1,4 @@
+{
+  "name": "Mangosteen Monk",
+  "image": "/kingdoms/thailandia/mangosteen.png"
+}

--- a/public/characters/turian.json
+++ b/public/characters/turian.json
@@ -1,0 +1,4 @@
+{
+  "name": "Turian the Durian",
+  "image": "/kingdoms/thailandia/turian.png"
+}

--- a/public/kingdoms/thailandia/manifest.json
+++ b/public/kingdoms/thailandia/manifest.json
@@ -1,0 +1,4 @@
+[
+  { "name": "Turian the Durian", "image": "/kingdoms/thailandia/turian.png", "slug": "turian" },
+  { "name": "Mangosteen Monk", "image": "/kingdoms/thailandia/mangosteen.png", "slug": "mangosteen-monk" }
+]


### PR DESCRIPTION
## Summary
- add reusable character gallery component
- render characters and map on world pages
- show individual character detail pages with images

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run typecheck` *(fails: No overload matches this call)*

------
https://chatgpt.com/codex/tasks/task_e_68aad9395cd0832985c2c963e27efd3f