### PR TITLE
feat(worlds): add character gallery and detail pages

### DIFF
--- a/src/components/CharacterGrid.tsx
+++ b/src/components/CharacterGrid.tsx
@@ -22,11 +22,19 @@ function coerceCharacters(raw: any): Character[] {
   if (Array.isArray(raw.characters)) {
     // { characters: [...] }
     return raw.characters
-      .filter((c: any) => typeof c === "string" || (c && typeof c.image === "string"))
+      .filter(
+        (c: any) =>
+          typeof c === "string" ||
+          (c && (typeof c.image === "string" || typeof c.file === "string")),
+      )
       .map((c: any) =>
         typeof c === "string"
           ? { id: stripExt(c), image: c }
-          : { id: c.id ?? stripExt(c.image), name: c.name, image: c.image },
+          : {
+              id: c.id ?? stripExt(c.image ?? c.file),
+              name: c.name,
+              image: c.image ?? c.file,
+            },
       );
   }
   if (Array.isArray(raw.images)) {
@@ -38,7 +46,7 @@ function coerceCharacters(raw: any): Character[] {
   return [];
 }
 
-export function CharacterGrid({ kingdom }: { kingdom: string }) {
+export function CharacterGrid({ kingdom, slug }: { kingdom: string; slug?: string }) {
   const [chars, setChars] = React.useState<Character[] | null>(null);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -98,7 +106,7 @@ export function CharacterGrid({ kingdom }: { kingdom: string }) {
         <a
           key={c.id}
           className="nv-card"
-          href={`/characters/${encodeURIComponent(c.id)}`}
+          href={slug ? `/worlds/${slug}/characters/${encodeURIComponent(c.id)}` : `/characters/${encodeURIComponent(c.id)}`}
           aria-label={c.name ?? c.id}
         >
           <img

--- a/src/components/WorldLayout.tsx
+++ b/src/components/WorldLayout.tsx
@@ -25,7 +25,7 @@ export default function WorldLayout({ id }: Props) {
       {/* Characters grid */}
       <section className="world-section">
         <h2>Characters</h2>
-        <CharacterGrid kingdom={k.title} />
+        <CharacterGrid kingdom={k.title} slug={id} />
       </section>
     </main>
   );

--- a/src/lib/kingdoms.ts
+++ b/src/lib/kingdoms.ts
@@ -1,0 +1,24 @@
+export type KingdomSlug =
+  | "thailandia"
+  | "chilandia"
+  | "indillandia"
+  | "brazilandia"
+  | "australandia"
+  | "amerilandia";
+
+export const SLUG_TO_FOLDER: Record<KingdomSlug, string> = {
+  thailandia: "Thailandia",
+  chilandia: "Chilandia",
+  indillandia: "Indillandia",
+  brazilandia: "Brazilandia",
+  australandia: "Australandia",
+  amerilandia: "Amerilandia",
+};
+
+export function titleFromSlug(slug: KingdomSlug) {
+  return SLUG_TO_FOLDER[slug];
+}
+
+export type Manifest = {
+  characters: { file: string; name?: string }[];
+};

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter } from 'react-router-dom';
 import Home from './pages/Home';
 import WorldsIndex from './routes/worlds';
 import WorldDetail from './routes/worlds/[slug]';
+import CharacterPage from './routes/worlds/characters/[name]';
 import Zones from './routes/zones';
 import ArcadeZone from './routes/zones/arcade';
 import MusicZone from './routes/zones/music';
@@ -54,6 +55,7 @@ export const router = createBrowserRouter([
       { index: true, element: <Home /> },
       { path: 'worlds', element: <WorldsIndex /> },
       { path: 'worlds/:slug', element: <WorldDetail /> },
+      { path: 'worlds/:slug/characters/:name', element: <CharacterPage /> },
       { path: 'zones', element: <Zones /> },
       { path: 'zones/arcade', element: <ArcadeZone /> },
       { path: 'zones/music', element: <MusicZone /> },

--- a/src/routes/worlds/[slug].tsx
+++ b/src/routes/worlds/[slug].tsx
@@ -2,20 +2,13 @@ import { useParams } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import { CharacterGrid } from "../../components/CharacterGrid";
 import { getWorldBySlug } from "../../data/worlds";
-
-const FOLDER_BY_SLUG: Record<string, string> = {
-  amerilandia: "Amerilandia",
-  australandia: "Australandia",
-  brazilandia: "Brazilandia",
-  chilandia: "Chilandia",
-  indillandia: "Indillandia",
-  thailandia: "Thailandia",
-};
+import { SLUG_TO_FOLDER, type KingdomSlug } from "../../lib/kingdoms";
 
 export default function WorldDetail() {
-  const { slug = "" } = useParams();
+  const { slug } = useParams<{ slug: KingdomSlug }>();
+  if (!slug) return <p>World not found.</p>;
   const world = getWorldBySlug(slug);
-  const folder = FOLDER_BY_SLUG[slug] ?? slug;
+  const folder = SLUG_TO_FOLDER[slug];
   if (!world) return <p>World not found.</p>;
 
   return (
@@ -35,7 +28,7 @@ export default function WorldDetail() {
 
       <section aria-labelledby="characters-heading" style={{ marginTop: 24 }}>
         <h2 id="characters-heading">Characters</h2>
-        <CharacterGrid kingdom={folder} />
+        <CharacterGrid kingdom={folder} slug={slug} />
       </section>
     </article>
   );

--- a/src/routes/worlds/characters/[name].tsx
+++ b/src/routes/worlds/characters/[name].tsx
@@ -1,0 +1,41 @@
+import { Link, useParams } from "react-router-dom";
+import { SLUG_TO_FOLDER, type KingdomSlug } from "../../../lib/kingdoms";
+
+export default function CharacterPage() {
+  const { slug, name } = useParams<{ slug: KingdomSlug; name: string }>();
+  if (!slug || !name) return <p>Character not found.</p>;
+  const folder = SLUG_TO_FOLDER[slug];
+  const fileGuess = decodeURIComponent(name);
+  const candidates = [".png", ".jpg", ".jpeg", ".webp"].map(
+    (ext) => `/kingdoms/${folder}/${fileGuess}${ext}`,
+  );
+
+  return (
+    <div>
+      <nav className="text-sm" aria-label="Breadcrumb">
+        <Link to="/">Home</Link> <span>/</span>{" "}
+        <Link to="/worlds">Worlds</Link> <span>/</span>{" "}
+        <Link to={`/worlds/${slug}`}>{folder}</Link> <span>/</span>{" "}
+        <span className="font-medium">{fileGuess}</span>
+      </nav>
+
+      <h1 className="text-3xl font-extrabold">{fileGuess}</h1>
+
+      <div
+        className="nv-hero-img-wrapper"
+        style={{ maxWidth: 320, margin: "0 auto" }}
+      >
+        {candidates.map((src) => (
+          <img
+            key={src}
+            src={src}
+            alt={fileGuess}
+            style={{ width: "100%", display: "none", objectFit: "contain" }}
+            onLoad={(e) => (e.currentTarget.style.display = "block")}
+            onError={(e) => (e.currentTarget.style.display = "none")}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add centralized kingdom slug mapping
- load characters from public manifests and link to world-specific detail pages
- show character details with breadcrumb and extension fallback

## Testing
- `npm run typecheck` *(fails: Argument of type ... is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68aadec4bde88329a59b1a2734df8b6f