### PR TITLE
feat: hardcode character gallery source

### DIFF
--- a/app/worlds/[slug]/page.tsx
+++ b/app/worlds/[slug]/page.tsx
@@ -9,7 +9,7 @@ export default async function WorldPage({ params }: { params: { slug: string } }
       {/* ... existing world header + map ... */}
 
       <section className="mt-10">
-        <h2 className="text-3xl font-extrabold mb-4">Characters</h2>
+        <h2 className="text-2xl font-bold">Characters</h2>
         <CharacterGallery folder={slugToFolder[params.slug] ?? params.slug} />
       </section>
     </main>

--- a/components/CharacterGallery.tsx
+++ b/components/CharacterGallery.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 type Props = { folder: string }; // e.g., "Thailandia"
 const IMG_RX = /\.(png|jpe?g|webp)$/i;
 const EXCLUDE_RX = /(map|manifest\.json|\.keep)$/i;
+const BASE = "/kingdoms"; // hard lock to /public/kingdoms
 
 export default function CharacterGallery({ folder }: Props) {
   const [files, setFiles] = React.useState<string[] | null>(null);
@@ -14,7 +15,7 @@ export default function CharacterGallery({ folder }: Props) {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(`/kingdoms/${folder}/manifest.json`, { cache: "no-store" });
+        const res = await fetch(`${BASE}/${folder}/manifest.json`, { cache: "no-store" });
         let list: any[] = [];
         if (res.ok) {
           const data = await res.json();
@@ -34,10 +35,13 @@ export default function CharacterGallery({ folder }: Props) {
           })
           .map(String)
           .filter((f) => IMG_RX.test(f) && !EXCLUDE_RX.test(f))
-          .map((f) => {
-            const p = f.startsWith("kingdoms/") || f.startsWith("/kingdoms/") ? `/${f.replace(/^\/?/, "")}` : `/kingdoms/${folder}/${f}`;
-            return encodeURI(p);
-          });
+          .map((f) =>
+            encodeURI(
+              f.startsWith("kingdoms/")
+                ? `/${f.replace(/^kingdoms/, "kingdoms")}`
+                : `${BASE}/${folder}/${f}`
+            )
+          );
         if (!cancelled) setFiles(clean);
       } catch {
         if (!cancelled) setFiles([]);

--- a/lib/kingdoms.ts
+++ b/lib/kingdoms.ts
@@ -6,6 +6,7 @@ export const slugToFolder: Record<string, string> = {
   australandia: "Australandia",
   amerilandia: "Amerilandia",
 };
+export const galleryBase = "/kingdoms"; // explicit source for galleries
 
 export const KINGDOM_FOLDERS = Object.values(slugToFolder) as const;
 export type KingdomFolder = (typeof KINGDOM_FOLDERS)[number];


### PR DESCRIPTION
## Summary
- hard lock character gallery fetching to `/kingdoms`
- export `galleryBase` constant for reuse
- restore Characters header styling on world pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations, among others)*

------
https://chatgpt.com/codex/tasks/task_e_68aaecbbd4388329967298d4ba76328c