### PR TITLE
fix Netlify build by adding ts-node dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.7.1",
+    "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
     "vite": "^5.4.2"
   },


### PR DESCRIPTION
## Summary
- fix Netlify build by ensuring ts-node is installed as a dev dependency

## Testing
- `npm run typecheck`
- `npm test` (fails: Missing script: "test")
- `npm install --no-package-lock` (fails: 403 Forbidden - GET https://registry.npmjs.org/ts-node)
- `npm run build` (fails: Cannot find module 'ts-node/register')

------
https://chatgpt.com/codex/tasks/task_e_68aaeef9a2208329a3de7feb2a4d3346