### PR TITLE
fix: run kingdom gallery builder without ts-node

### DIFF
--- a/lib/kingdoms.js
+++ b/lib/kingdoms.js
@@ -1,0 +1,11 @@
+export const slugToFolder = {
+  thailandia: "Thailandia",
+  chilandia: "Chilandia",
+  indillandia: "Indillandia",
+  brazilandia: "Brazilandia",
+  australandia: "Australandia",
+  amerilandia: "Amerilandia",
+};
+export const galleryBase = "/kingdoms"; // explicit source for galleries
+
+export const KINGDOM_FOLDERS = Object.values(slugToFolder);

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm install && node -r ts-node/register scripts/build-kingdom-gallery.ts && npm run build"
+  command = "npm install && npm run build"
   publish = "dist"
 
 [functions]

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
+    "build:gallery": "node scripts/build-kingdom-gallery.js",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --port 5173",
     "typecheck": "tsc --noEmit",
-    "prebuild": "node -r ts-node/register scripts/build-kingdom-gallery.ts"
+    "prebuild": "npm run build:gallery"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/scripts/build-kingdom-gallery.js
+++ b/scripts/build-kingdom-gallery.js
@@ -4,7 +4,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { KINGDOM_FOLDERS } from "@/lib/kingdoms";
+import { KINGDOM_FOLDERS } from "../lib/kingdoms.js";
 
 const ROOT = process.cwd();
 const PUB = path.join(ROOT, "public");
@@ -13,14 +13,14 @@ const KINGDOMS_DIR = path.join(PUB, "kingdoms");
 const IMG_RE = /\.(png|jpg|jpeg|webp)$/i;
 const EXCLUDE = /(map|\.keep|manifest\.json)/i;
 
-function listImages(dir: string) {
+function listImages(dir) {
   return fs
     .readdirSync(dir)
     .filter((f) => IMG_RE.test(f) && !EXCLUDE.test(f))
     .map((f) => path.posix.join("kingdoms", path.basename(dir), f));
 }
 
-const manifest: Record<string, string[]> = {};
+const manifest = {};
 for (const folder of KINGDOM_FOLDERS) {
   const d = path.join(KINGDOMS_DIR, folder);
   manifest[folder] = fs.existsSync(d) ? listImages(d) : [];


### PR DESCRIPTION
## Summary
- build kingdom gallery manifest with plain Node.js instead of ts-node
- move kingdom data to a reusable JavaScript module
- simplify Netlify build command

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' and related type errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaf0c9bab883298a46ca0407b0fa87