### PR TITLE
Fix marketplace image paths

### DIFF
--- a/src/pages/marketplace/[slug].tsx
+++ b/src/pages/marketplace/[slug].tsx
@@ -5,9 +5,9 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import "./../../styles/marketplace.css";
 
 const MAP:any = {
-  "turian-plush": { id:"turian-plush", name:"Turian Plush", price:24, image:"/public/Marketplace/Turianplushie.png", blurb:"Cuddly plush of Turian." },
-  "navatar-tee":  { id:"navatar-tee",  name:"Navatar Tee",  price:18, image:"/public/Marketplace/Turiantshirt.png",  blurb:"Soft tee with Navatar." },
-  "stickers":     { id:"stickers",     name:"Sticker Pack", price:6,  image:"/public/Marketplace/Stickerpack.png", blurb:"Six vinyl stickers." },
+  "turian-plush": { id:"turian-plush", name:"Turian Plush", price:24, image:"/Marketplace/Turianplushie.png", blurb:"Cuddly plush of Turian." },
+  "navatar-tee":  { id:"navatar-tee",  name:"Navatar Tee",  price:18, image:"/Marketplace/Turiantshirt.png",  blurb:"Soft tee with Navatar." },
+  "stickers":     { id:"stickers",     name:"Sticker Pack", price:6,  image:"/Marketplace/Stickerpack.png", blurb:"Six vinyl stickers." },
 };
 
 export default function ProductPage(){

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -3,9 +3,9 @@ import ProductCard from "../../components/ProductCard";
 import "./../../styles/marketplace.css";
 
 const PRODUCTS = [
-  { id:"turian-plush", name:"Turian Plush", price:24, image:"/public/Marketplace/Turianplushie.png", href:"/marketplace/turian-plush" },
-  { id:"navatar-tee",  name:"Navatar Tee",  price:18, image:"/public/Marketplace/Turiantshirt.png",  href:"/marketplace/navatar-tee" },
-  { id:"stickers",     name:"Sticker Pack", price:6,  image:"/public/Marketplace/Stickerpack.png", href:"/marketplace/stickers" },
+  { id:"turian-plush", name:"Turian Plush", price:24, image:"/Marketplace/Turianplushie.png", href:"/marketplace/turian-plush" },
+  { id:"navatar-tee",  name:"Navatar Tee",  price:18, image:"/Marketplace/Turiantshirt.png",  href:"/marketplace/navatar-tee" },
+  { id:"stickers",     name:"Sticker Pack", price:6,  image:"/Marketplace/Stickerpack.png", href:"/marketplace/stickers" },
 ];
 
 export default function MarketplacePage(){

--- a/src/pages/wishlist.tsx
+++ b/src/pages/wishlist.tsx
@@ -3,9 +3,9 @@ import { Link } from "react-router-dom";
 import Breadcrumbs from "../components/Breadcrumbs";
 
 const LOOKUP: Record<string,{name:string; image:string; href:string}> = {
-  "turian-plush": { name:"Turian Plush", image:"/public/Marketplace/Turianplushie.png", href:"/marketplace/turian-plush" },
-  "navatar-tee":  { name:"Navatar Tee",  image:"/public/Marketplace/Turiantshirt.png",  href:"/marketplace/navatar-tee" },
-  "stickers":     { name:"Sticker Pack", image:"/public/Marketplace/Stickerpack.png", href:"/marketplace/stickers" },
+  "turian-plush": { name:"Turian Plush", image:"/Marketplace/Turianplushie.png", href:"/marketplace/turian-plush" },
+  "navatar-tee":  { name:"Navatar Tee",  image:"/Marketplace/Turiantshirt.png",  href:"/marketplace/navatar-tee" },
+  "stickers":     { name:"Sticker Pack", image:"/Marketplace/Stickerpack.png", href:"/marketplace/stickers" },
 };
 
 export default function WishlistPage(){


### PR DESCRIPTION
## Summary
- point marketplace product images to root paths
- update product detail and wishlist pages to match

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck` (fails: Argument of type 'Omit<...> is not assignable to parameter of type 'never[]')

------
https://chatgpt.com/codex/tasks/task_e_68ab0a88f5588329a36c6807c369b333