### PR TITLE
Marketplace — uniform image sizing

### DIFF
--- a/src/pages/marketplace/[slug].tsx
+++ b/src/pages/marketplace/[slug].tsx
@@ -18,7 +18,9 @@ export default function ProductPage(){
     <>
       <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Marketplace", href: "/marketplace" }, { label: p.name }]} />
       <article className="nv-card">
-        <div className="nv-imgbox"><img src={p.image} alt="" /></div>
+        <div className="mp-hero">
+          <img className="mp-img" src={p.image} alt={p.name} />
+        </div>
         <h1>{p.name}</h1>
         <div>${p.price.toFixed(2)}</div>
         <p>{p.blurb}</p>

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -1,5 +1,7 @@
 import Breadcrumbs from "../../components/Breadcrumbs";
-import ProductCard from "../../components/ProductCard";
+import AddToCartButton from "../../components/AddToCartButton";
+import SaveButton from "../../components/SaveButton";
+import { Link } from "react-router-dom";
 import "./../../styles/marketplace.css";
 
 const PRODUCTS = [
@@ -14,7 +16,19 @@ export default function MarketplacePage(){
       <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Marketplace" }]} />
       <h1>Marketplace</h1>
       <div className="nv-grid">
-        {PRODUCTS.map(p => <ProductCard key={p.id} p={p}/>)}
+        {PRODUCTS.map(p => (
+          <article key={p.id} className="nv-card">
+            <Link to={p.href} className="mp-thumb" aria-label={p.name}>
+              <img className="mp-img" src={p.image} alt={p.name} loading="lazy" />
+            </Link>
+            <h3><Link to={p.href}>{p.name}</Link></h3>
+            <div>${p.price.toFixed(2)}</div>
+            <div className="nv-cta">
+              <AddToCartButton id={p.id} name={p.name} price={p.price} image={p.image}/>
+              <SaveButton id={p.id}/>
+            </div>
+          </article>
+        ))}
       </div>
     </>
   );

--- a/src/styles/marketplace.css
+++ b/src/styles/marketplace.css
@@ -4,3 +4,35 @@
 .nv-imgbox{ aspect-ratio: 4/3; border:1px solid #e5efff; border-radius:.8rem; display:grid; place-items:center; overflow:hidden; }
 .nv-imgbox img{ width:100%; height:100%; object-fit:contain; }
 .nv-cta{ display:flex; gap:.5rem; margin-top:.5rem; }
+
+/* Uniform product thumbnails */
+.mp-thumb {
+  width: 100%;
+  aspect-ratio: 4 / 3;      /* adjust to 1 / 1 if you want squares */
+  border-radius: 14px;
+  overflow: hidden;
+  background: #f6f8ff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mp-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;       /* no cropping, just fit */
+}
+
+/* Larger, consistent image on the product detail page */
+.mp-hero {
+  width: 100%;
+  max-width: 560px;
+  aspect-ratio: 4 / 3;
+  margin: 0 auto;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #f6f8ff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary
- add flexible thumb and hero styles so marketplace images scale to fit
- render marketplace cards and product hero with new image containers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0d2e4c7483299acdd3c269645a42