### PR TITLE
feat: add Naturverse theme

### DIFF
--- a/app/naturversity/page.tsx
+++ b/app/naturversity/page.tsx
@@ -1,59 +1,40 @@
 import Link from "next/link";
-import { Card, CardHeader, CardDescription } from "@/components/ui/card";
 import Breadcrumbs from "@/components/breadcrumbs";
 import ComingSoonBanner from "@/components/coming-soon-banner";
 
 export default function Naturversity() {
   return (
-    <main className="container mx-auto px-4 md:px-6">
-      <Breadcrumbs items={[{ href: '/', label: 'Home' }, { label: 'Naturversity' }]} />
-      <h1 className="page-title">Naturversity</h1>
-      <p className="mt-2 text-muted-foreground">Teachers, partners, and courses.</p>
+    <main className="naturverse-bg min-h-screen py-12">
+      <div className="container mx-auto px-4 md:px-6">
+        <Breadcrumbs items={[{ href: '/', label: 'Home' }, { label: 'Naturversity' }]} />
+        <h1 className="naturverse-title">Naturversity</h1>
+        <p className="naturverse-subtitle">Teachers, partners, and courses.</p>
 
-      <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {/* Teachers */}
-        <Card>
-          <CardHeader>
-            <CardDescription>Mentors across the 14 kingdoms.</CardDescription>
-          </CardHeader>
-          <div className="px-6 pb-6">
-            <Link href="/naturversity/teachers" className="btn-primary btn-block">Teachers</Link>
+        <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="naturverse-card">
+            <Link href="/naturversity/teachers" className="font-bold text-blue-700">Teachers</Link>
+            <p className="text-gray-600">Mentors across the 14 kingdoms.</p>
           </div>
-        </Card>
 
-        {/* Partners */}
-        <Card>
-          <CardHeader>
-            <CardDescription>Brands & orgs supporting missions.</CardDescription>
-          </CardHeader>
-          <div className="px-6 pb-6">
-            <Link href="/naturversity/partners" className="btn-primary btn-block">Partners</Link>
+          <div className="naturverse-card">
+            <Link href="/naturversity/partners" className="font-bold text-blue-700">Partners</Link>
+            <p className="text-gray-600">Brands & orgs supporting missions.</p>
           </div>
-        </Card>
 
-        {/* Languages */}
-        <Card>
-          <CardHeader>
-            <CardDescription>Phrasebooks for each kingdom.</CardDescription>
-          </CardHeader>
-          <div className="px-6 pb-6">
-            <Link href="/naturversity/languages" className="btn-primary btn-block">Languages</Link>
+          <div className="naturverse-card">
+            <Link href="/naturversity/languages" className="font-bold text-blue-700">Languages</Link>
+            <p className="text-gray-600">Phrasebooks for each kingdom.</p>
           </div>
-        </Card>
 
-        {/* Courses */}
-        <Card className="sm:col-span-2 lg:col-span-1">
-          <CardHeader>
-            <CardDescription>Nature, art, music, wellness, crypto basics…</CardDescription>
-          </CardHeader>
-          <div className="px-6 pb-6">
-            <Link href="/naturversity/courses" className="btn-primary btn-block">Courses</Link>
+          <div className="naturverse-card sm:col-span-2 lg:col-span-1">
+            <Link href="/naturversity/courses" className="font-bold text-blue-700">Courses</Link>
+            <p className="text-gray-600">Nature, art, music, wellness, crypto basics…</p>
           </div>
-        </Card>
-      </div>
+        </div>
 
-      <div className="mt-10">
-        <ComingSoonBanner text="Coming soon: AI tutors and step-by-step lessons." />
+        <div className="mt-10">
+          <ComingSoonBanner text="Coming soon: AI tutors and step-by-step lessons." />
+        </div>
       </div>
     </main>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,3 +8,17 @@
 
 /* Full-width helper when needed */
 .btn-block { @apply w-full; }
+
+/* Naturverse theme */
+.naturverse-bg {
+  background-color: #1d4ed8; /* Tailwind blue-700 */
+}
+.naturverse-card {
+  @apply bg-white rounded-xl shadow-md p-6 transition hover:shadow-lg;
+}
+.naturverse-title {
+  @apply text-white font-extrabold text-3xl;
+}
+.naturverse-subtitle {
+  @apply text-blue-100 text-lg mb-6;
+}


### PR DESCRIPTION
## Summary
- introduce Naturverse theme utility classes for background, cards, and typography
- refresh Naturversity page to use bold blue background and white cards

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ab18a19d40832992cbab79ecdf664f