### PR TITLE
feat: add naturversity layout and breadcrumbs

### DIFF
--- a/src/layouts/Naturversity.tsx
+++ b/src/layouts/Naturversity.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from "react-router-dom";
+import "../styles/naturversity.css";
+
+export default function NaturversityLayout() {
+  return (
+    <div className="nvrs-naturversity">
+      <Outlet />
+    </div>
+  );
+}

--- a/src/pages/naturversity/Courses.tsx
+++ b/src/pages/naturversity/Courses.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { COURSES } from "../../lib/naturversity/data";
 import { Link } from "react-router-dom";
+import Breadcrumbs from "../../components/Breadcrumbs";
 import { loadEnrollments, toggleEnroll } from "../../lib/naturversity/store";
 
 export default function Courses() {
@@ -17,35 +18,44 @@ export default function Courses() {
   }, [q]);
 
   return (
-    <main id="main" className="page-wrap">
-      <h1>📚 Courses</h1>
-      <div className="edu-toolbar">
-        <input className="input" placeholder="Search courses…" value={q} onChange={e=>setQ(e.target.value)} />
-      </div>
-      <div className="hub-grid">
-        {list.map(c => {
-          const on = enrolled.includes(c.slug);
-          return (
-            <div key={c.slug} className="hub-card">
-              <div className="emoji">{c.emoji ?? "📘"}</div>
-              <div className="title">{c.title}</div>
-              <div className="desc">{c.summary}</div>
-              <div className="row">
-                <span className="badge">{c.track}</span>
-                <div className="spacer" />
-                <button className={"btn tiny outline"+(on?" active":"")}
-                        onClick={()=>setEnrolled(toggleEnroll(c.slug))}
-                        aria-pressed={on}>
-                  {on ? "Enrolled" : "Enroll"}
-                </button>
-                <Link className="btn tiny" to={`/naturversity/course/${c.slug}`}>View Syllabus</Link>
+    <div className="page-wrap">
+      <Breadcrumbs
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Naturversity", href: "/naturversity" },
+          { label: "Courses" },
+        ]}
+      />
+      <main id="main" className="page">
+        <h1>📚 Courses</h1>
+        <div className="edu-toolbar">
+          <input className="input" placeholder="Search courses…" value={q} onChange={e=>setQ(e.target.value)} />
+        </div>
+        <div className="hub-grid">
+          {list.map(c => {
+            const on = enrolled.includes(c.slug);
+            return (
+              <div key={c.slug} className="hub-card">
+                <div className="emoji">{c.emoji ?? "📘"}</div>
+                <div className="title">{c.title}</div>
+                <div className="desc">{c.summary}</div>
+                <div className="row">
+                  <span className="badge">{c.track}</span>
+                  <div className="spacer" />
+                  <button className={"btn tiny outline"+(on?" active":"")}
+                          onClick={()=>setEnrolled(toggleEnroll(c.slug))}
+                          aria-pressed={on}>
+                    {on ? "Enrolled" : "Enroll"}
+                  </button>
+                  <Link className="btn tiny" to={`/naturversity/course/${c.slug}`}>View Syllabus</Link>
+                </div>
               </div>
-            </div>
-          );
-        })}
-      </div>
-      <p className="meta">Coming soon: pacing plans, reminders, and AI tutors.</p>
-    </main>
+            );
+          })}
+        </div>
+        <p className="meta">Coming soon: pacing plans, reminders, and AI tutors.</p>
+      </main>
+    </div>
   );
 }
 

--- a/src/pages/naturversity/Partners.tsx
+++ b/src/pages/naturversity/Partners.tsx
@@ -1,23 +1,33 @@
 import React from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
 import { PARTNERS } from "../../lib/naturversity/data";
 
 export default function Partners() {
   return (
-    <main id="main" className="page-wrap">
-      <h1>🤝 Partners</h1>
-      <div className="edu-list">
-        {PARTNERS.map(p => (
-          <div key={p.id} className="edu-row">
-            <div className="badge">Partner</div>
-            <div className="grow">
-              <div className="title">{p.name}</div>
-              <div className="desc">{p.focus}</div>
+    <div className="page-wrap">
+      <Breadcrumbs
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Naturversity", href: "/naturversity" },
+          { label: "Partners" },
+        ]}
+      />
+      <main id="main" className="page">
+        <h1>🤝 Partners</h1>
+        <div className="edu-list">
+          {PARTNERS.map(p => (
+            <div key={p.id} className="edu-row">
+              <div className="badge">Partner</div>
+              <div className="grow">
+                <div className="title">{p.name}</div>
+                <div className="desc">{p.focus}</div>
+              </div>
+              <button className="btn tiny outline" disabled>Visit (soon)</button>
             </div>
-            <button className="btn tiny outline" disabled>Visit (soon)</button>
-          </div>
-        ))}
-      </div>
-    </main>
+          ))}
+        </div>
+      </main>
+    </div>
   );
 }
 

--- a/src/pages/naturversity/Teachers.tsx
+++ b/src/pages/naturversity/Teachers.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
 import { TEACHERS } from "../../lib/naturversity/data";
 
 export default function Teachers() {
@@ -14,24 +15,33 @@ export default function Teachers() {
   }, [q]);
 
   return (
-    <main id="main" className="page-wrap">
-      <h1>👩‍🏫 Teachers</h1>
-      <div className="edu-toolbar">
-        <input className="input" placeholder="Search mentors…" value={q} onChange={e=>setQ(e.target.value)} />
-      </div>
-      <div className="edu-list">
-        {list.map(t => (
-          <div key={t.id} className="edu-row">
-            <div className="badge">{t.kingdom}</div>
-            <div className="grow">
-              <div className="title">{t.name}</div>
-              <div className="desc">{t.specialty}</div>
+    <div className="page-wrap">
+      <Breadcrumbs
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Naturversity", href: "/naturversity" },
+          { label: "Teachers" },
+        ]}
+      />
+      <main id="main" className="page">
+        <h1>👩‍🏫 Teachers</h1>
+        <div className="edu-toolbar">
+          <input className="input" placeholder="Search mentors…" value={q} onChange={e=>setQ(e.target.value)} />
+        </div>
+        <div className="edu-list">
+          {list.map(t => (
+            <div key={t.id} className="edu-row">
+              <div className="badge">{t.kingdom}</div>
+              <div className="grow">
+                <div className="title">{t.name}</div>
+                <div className="desc">{t.specialty}</div>
+              </div>
+              <button className="btn tiny outline" disabled>Message (soon)</button>
             </div>
-            <button className="btn tiny outline" disabled>Message (soon)</button>
-          </div>
-        ))}
-      </div>
-    </main>
+          ))}
+        </div>
+      </main>
+    </div>
   );
 }
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -27,6 +27,7 @@ import Courses from './pages/naturversity/Courses';
 import CourseDetail from './pages/naturversity/CourseDetail';
 import LanguagesHub from './pages/naturversity/languages';
 import LanguageDetail from './pages/naturversity/languages/[slug]';
+import NaturversityLayout from './layouts/Naturversity';
 import NaturBankPage from './pages/naturbank';
 import BankWallet from './pages/naturbank/Wallet';
 import BankToken from './pages/naturbank/Token';
@@ -74,13 +75,19 @@ export const router = createBrowserRouter([
       },
       { path: 'cart', element: <CartPage /> },
       { path: 'wishlist', element: <WishlistPage /> },
-      { path: 'naturversity', element: <Naturversity /> },
-      { path: 'naturversity/teachers', element: <Teachers /> },
-      { path: 'naturversity/partners', element: <Partners /> },
-      { path: 'naturversity/courses', element: <Courses /> },
-      { path: 'naturversity/course/:slug', element: <CourseDetail /> },
-      { path: 'naturversity/languages', element: <LanguagesHub /> },
-      { path: 'naturversity/languages/:slug', element: <LanguageDetail /> },
+      {
+        path: 'naturversity',
+        element: <NaturversityLayout />,
+        children: [
+          { index: true, element: <Naturversity /> },
+          { path: 'teachers', element: <Teachers /> },
+          { path: 'partners', element: <Partners /> },
+          { path: 'courses', element: <Courses /> },
+          { path: 'course/:slug', element: <CourseDetail /> },
+          { path: 'languages', element: <LanguagesHub /> },
+          { path: 'languages/:slug', element: <LanguageDetail /> },
+        ],
+      },
       { path: 'naturbank', element: <NaturBankPage /> },
       { path: 'naturbank/wallet', element: <BankWallet /> },
       { path: 'naturbank/natur', element: <BankToken /> },

--- a/src/styles/naturversity.css
+++ b/src/styles/naturversity.css
@@ -1,0 +1,55 @@
+/* Naturversity theme */
+.nvrs-naturversity {
+  --nvrs-blue: #2e63ff;
+  --page-bg: var(--nvrs-blue);
+  --card-bg: #ffffff;
+  --card-ring: rgba(255, 255, 255, 0.45);
+  --text-on-bg: #ffffff;
+  min-height: 100%;
+  background: var(--page-bg);
+}
+
+/* page header */
+.nvrs-naturversity .page {
+  color: var(--text-on-bg);
+}
+.nvrs-naturversity .page h1 {
+  color: var(--text-on-bg);
+}
+
+/* breadcrumbs readable on blue */
+.nvrs-naturversity .nv-breadcrumbs a,
+.nvrs-naturversity .nv-breadcrumbs span {
+  color: #e7eeff;
+}
+.nvrs-naturversity .nv-breadcrumbs a:hover {
+  color: #ffffff;
+}
+
+/* cards on Naturversity */
+.nvrs-naturversity .card,
+.nvrs-naturversity .tile,
+.nvrs-naturversity .panel,
+.nvrs-naturversity .hub-card {
+  background: var(--card-bg);
+  border-color: var(--card-ring);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+/* “coming soon” panel */
+.nvrs-naturversity .coming-soon {
+  background: rgba(255, 255, 255, 0.7);
+  border-color: var(--card-ring);
+  color: #244;
+}
+
+/* safety net for common wrappers */
+.nvrs-naturversity main,
+.nvrs-naturversity section {
+  /* let the blue show around content */
+}
+.nvrs-naturversity .box,
+.nvrs-naturversity .list,
+.nvrs-naturversity .item {
+  background: #fff;
+}


### PR DESCRIPTION
## Summary
- theme Naturversity pages with blue background and white cards
- add missing breadcrumbs for Teachers, Partners, and Courses
- wrap Naturversity routes with dedicated layout

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit...' is not assignable to parameter of type 'never[]')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab1c4942648329a3b54dfd3f13ad83