### PR TITLE
feat: lighten naturversity theme background

### DIFF
--- a/src/styles/naturversity.css
+++ b/src/styles/naturversity.css
@@ -1,10 +1,10 @@
 /* Naturversity theme */
 .nvrs-naturversity {
-  --nvrs-blue: #2e63ff;
-  --page-bg: var(--nvrs-blue);
+  /* old: --page-bg: #2e63ff; */
+  --page-bg: #f0f6ff;   /* light Naturverse blue */
   --card-bg: #ffffff;
-  --card-ring: rgba(255, 255, 255, 0.45);
-  --text-on-bg: #ffffff;
+  --card-ring: rgba(0, 0, 0, 0.08);
+  --text-on-bg: #222;   /* dark text on light bg */
   min-height: 100%;
   background: var(--page-bg);
 }


### PR DESCRIPTION
## Summary
- use a light blue background for Naturversity pages
- adjust card ring and text color for better contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab20d584c8832982e00cedf7a9af97