### PR TITLE
feat: theme zones pages with Naturverse blue background

### DIFF
--- a/app/styles/zones.css
+++ b/app/styles/zones.css
@@ -1,0 +1,8 @@
+.nvrs-zones {
+  --page-bg: #f0f6ff;   /* light Naturverse blue */
+  --card-bg: #ffffff;
+  --card-ring: rgba(0,0,0,.08);
+  --text-on-bg: #222;
+  min-height: 100%;
+  background: var(--page-bg);
+}

--- a/src/layouts/Zones.tsx
+++ b/src/layouts/Zones.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from "react-router-dom";
+import "../../app/styles/zones.css";
+
+export default function ZonesLayout() {
+  return (
+    <div className="nvrs-zones">
+      <Outlet />
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -45,6 +45,7 @@ import Accessibility from './pages/Accessibility';
 import About from './pages/About';
 import NotFound from './routes/NotFound';
 import RootLayout from './layouts/Root';
+import ZonesLayout from './layouts/Zones';
 
 export const router = createBrowserRouter([
   {
@@ -55,17 +56,23 @@ export const router = createBrowserRouter([
       { path: 'worlds', element: <WorldsIndex /> },
       { path: 'worlds/:slug', element: <WorldDetail /> },
       { path: 'worlds/:slug/characters/:name', element: <CharacterPage /> },
-      { path: 'zones', element: <Zones /> },
-      { path: 'zones/arcade', element: <ArcadeZone /> },
-      { path: 'zones/music', element: <MusicZone /> },
-      { path: 'zones/wellness', element: <WellnessZone /> },
-      { path: 'zones/creator-lab', element: <CreatorLabPage /> },
-      { path: 'zones/stories', element: <Stories /> },
-      { path: 'zones/quizzes', element: <Quizzes /> },
-      { path: 'zones/observations', element: <Observations /> },
-      { path: 'zones/culture', element: <Culture /> },
-      { path: 'zones/community', element: <Community /> },
-      { path: 'zones/future', element: <FutureZone /> },
+      {
+        path: 'zones',
+        element: <ZonesLayout />,
+        children: [
+          { index: true, element: <Zones /> },
+          { path: 'arcade', element: <ArcadeZone /> },
+          { path: 'music', element: <MusicZone /> },
+          { path: 'wellness', element: <WellnessZone /> },
+          { path: 'creator-lab', element: <CreatorLabPage /> },
+          { path: 'stories', element: <Stories /> },
+          { path: 'quizzes', element: <Quizzes /> },
+          { path: 'observations', element: <Observations /> },
+          { path: 'culture', element: <Culture /> },
+          { path: 'community', element: <Community /> },
+          { path: 'future', element: <FutureZone /> },
+        ],
+      },
       {
         path: 'marketplace',
         children: [


### PR DESCRIPTION
## Summary
- style zones with light Naturverse blue background and surface variables
- wrap zones routes in new layout applying theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TS errors for api type mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68ab229eb69c832998ad793fad6c5e15