### PR TITLE
feat: unify section backgrounds with light Naturverse blue

### DIFF
--- a/app/styles/global-sections.css
+++ b/app/styles/global-sections.css
@@ -1,0 +1,9 @@
+/* Shared background style for all major sections */
+.nvrs-section {
+  --page-bg: #f0f6ff;   /* light Naturverse blue */
+  --card-bg: #ffffff;
+  --card-ring: rgba(0,0,0,.08);
+  --text-on-bg: #222;
+  min-height: 100%;
+  background: var(--page-bg);
+}

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -67,7 +67,7 @@ export default function NavatarPage() {
   }
 
   return (
-    <div className="page-wrap">
+    <div className="nvrs-section navatar page-wrap">
       <PageHead title="Naturverse — Navatar Creator" description="Design your character and save cards." />
       <Meta title="Navatar Creator — Naturverse" description="Design your character and save cards." />
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Navatar" }]} />

--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -84,7 +84,7 @@ export default function TurianPage() {
   const groupedSuggestions = useMemo(() => SUGGESTIONS, []);
 
   return (
-    <>
+    <div className="nvrs-section turian">
         <Page title="Turian the Durian" subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet." >
       <Meta title="Turian — Naturverse" description="Offline AI assistant demo." />
 
@@ -173,7 +173,7 @@ export default function TurianPage() {
 
       <p className="meta">Coming soon: real AI tutor connected across Worlds, Zones, Marketplace, and Naturbank; context-aware hints; quest generation; and Supabase history.</p>
       </Page>
-    </>
+    </div>
   );
 }
 

--- a/src/pages/Worlds.tsx
+++ b/src/pages/Worlds.tsx
@@ -5,22 +5,24 @@ import Breadcrumbs from "../components/Breadcrumbs";
 
 export default function Worlds() {
   return (
-    <main id="main" className="container">
-      <Breadcrumbs />
-      <h2 className="section-title">Worlds</h2>
-      <p className="section-lead">Explore the 14 kingdoms.</p>
+    <div className="nvrs-section worlds">
+      <main id="main" className="container">
+        <Breadcrumbs />
+        <h2 className="section-title">Worlds</h2>
+        <p className="section-lead">Explore the 14 kingdoms.</p>
 
-      <CardGrid>
-        {KINGDOMS.map(k => (
-          <Card
-            key={k.key}
-            href={`/worlds/${k.key.toLowerCase()}`}
-            title={k.title}
-            subtitle={k.subtitle}
-            image={<KingdomImage kingdom={k.key} kind="card" />}
-          />
-        ))}
-      </CardGrid>
-    </main>
+        <CardGrid>
+          {KINGDOMS.map(k => (
+            <Card
+              key={k.key}
+              href={`/worlds/${k.key.toLowerCase()}`}
+              title={k.title}
+              subtitle={k.subtitle}
+              image={<KingdomImage kingdom={k.key} kind="card" />}
+            />
+          ))}
+        </CardGrid>
+      </main>
+    </div>
   );
 }

--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../components/Breadcrumbs";
 export default function CartPage(){
   const { items, inc, dec, remove, subtotal } = useCart();
   return (
-    <>
+    <div className="nvrs-section cart">
       <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Cart" }]} />
       <h1>Cart</h1>
       {items.length===0 ? <p>Your cart is empty.</p> :
@@ -32,6 +32,6 @@ export default function CartPage(){
           <button className="btn-primary w-full" style={{marginTop:"1rem"}}>Checkout (stub)</button>
         </div>
       }
-    </>
+    </div>
   );
 }

--- a/src/pages/marketplace/[slug].tsx
+++ b/src/pages/marketplace/[slug].tsx
@@ -15,7 +15,7 @@ export default function ProductPage(){
   const p = MAP[slug];
   if (!p) return null;
   return (
-    <>
+    <div className="nvrs-section marketplace">
       <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Marketplace", href: "/marketplace" }, { label: p.name }]} />
       <article className="nv-card">
         <div className="mp-hero">
@@ -29,6 +29,6 @@ export default function ProductPage(){
           <SaveButton id={p.id}/>
         </div>
       </article>
-    </>
+    </div>
   );
 }

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -12,7 +12,7 @@ const PRODUCTS = [
 
 export default function MarketplacePage(){
   return (
-    <>
+    <div className="nvrs-section marketplace">
       <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Marketplace" }]} />
       <h1>Marketplace</h1>
       <div className="nv-grid">
@@ -30,6 +30,6 @@ export default function MarketplacePage(){
           </article>
         ))}
       </div>
-    </>
+    </div>
   );
 }

--- a/src/pages/naturbank.tsx
+++ b/src/pages/naturbank.tsx
@@ -102,7 +102,7 @@ export default function NaturBankPage() {
   if (loading) return <main><h1>NaturBank</h1><p>Loading…</p></main>;
 
   return (
-    <div className="page-wrap">
+    <div className="nvrs-section naturbank page-wrap">
       <Breadcrumbs />
       <main className="bank">
       <h1>NaturBank</h1>

--- a/src/pages/naturbank/Learn.tsx
+++ b/src/pages/naturbank/Learn.tsx
@@ -3,7 +3,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function Learn() {
   return (
-    <main id="main" className="page-wrap">
+    <main id="main" className="nvrs-section naturbank page-wrap">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/naturbank", label: "NaturBank" }, { label: "Learn" }]} />
       <h1>📘 Learn</h1>
       <ul className="bullet">

--- a/src/pages/naturbank/NFTs.tsx
+++ b/src/pages/naturbank/NFTs.tsx
@@ -9,7 +9,7 @@ const items = [
 
 export default function NFTs() {
   return (
-    <main id="main" className="page-wrap">
+    <main id="main" className="nvrs-section naturbank page-wrap">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/naturbank", label: "NaturBank" }, { label: "NFTs" }]} />
       <h1>🖼️ NFTs</h1>
       <p>Preview collectibles. Minting connects later.</p>

--- a/src/pages/naturbank/Token.tsx
+++ b/src/pages/naturbank/Token.tsx
@@ -19,7 +19,7 @@ export default function Token() {
   };
 
   return (
-    <main id="main" className="page-wrap">
+    <main id="main" className="nvrs-section naturbank page-wrap">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/naturbank", label: "NaturBank" }, { label: "Token" }]} />
       <h1>🪙 NATUR Token</h1>
 

--- a/src/pages/naturbank/Wallet.tsx
+++ b/src/pages/naturbank/Wallet.tsx
@@ -9,7 +9,7 @@ export default function Wallet() {
   const create = () => { const nw = createDemoWallet(); setW(nw); setBal(getBalance()); };
 
   return (
-    <main id="main" className="page-wrap">
+    <main id="main" className="nvrs-section naturbank page-wrap">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/naturbank", label: "NaturBank" }, { label: "Wallet" }]} />
       <h1>🪪 Wallet</h1>
       {!w ? (

--- a/src/pages/passport.tsx
+++ b/src/pages/passport.tsx
@@ -109,14 +109,14 @@ export default function PassportPage() {
 
   if (loading)
     return (
-      <div className="page-wrap">
+      <div className="nvrs-section passport page-wrap">
         <Breadcrumbs />
         <main className="passport"><h1>Passport</h1><p>Loading…</p></main>
       </div>
     );
 
   return (
-    <div className="page-wrap">
+    <div className="nvrs-section passport page-wrap">
       <Breadcrumbs />
       <main className="passport">
       <h1>Passport</h1>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -102,10 +102,11 @@ export default function ProfilePage() {
   };
 
   return (
-    <main className="container profile-page">
-      <Breadcrumbs />
-      <h1>Profile</h1>
-      <form
+    <div className="nvrs-section profile">
+      <main className="container profile-page">
+        <Breadcrumbs />
+        <h1>Profile</h1>
+        <form
         className="card"
         onSubmit={(e) => {
           e.preventDefault();
@@ -189,8 +190,9 @@ export default function ProfilePage() {
         <p className="muted">Signed-in data will sync with Supabase as features roll in.</p>
       </section>
 
-      <WalletPanel />
-      <XPPanel />
-    </main>
+        <WalletPanel />
+        <XPPanel />
+      </main>
+    </div>
   );
 }

--- a/src/pages/wishlist.tsx
+++ b/src/pages/wishlist.tsx
@@ -12,7 +12,7 @@ export default function WishlistPage(){
   const { saved, toggleSave } = useCart();
   const ids = Object.keys(saved).filter(k=>saved[k]);
   return (
-    <>
+    <div className="nvrs-section wishlist">
       <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Wishlist" }]} />
       <h1>Wishlist</h1>
       {ids.length===0? <p>No saved items yet.</p> :
@@ -28,6 +28,6 @@ export default function WishlistPage(){
             );
           })}
         </div>}
-    </>
+    </div>
   );
 }

--- a/src/routes/worlds/index.tsx
+++ b/src/routes/worlds/index.tsx
@@ -2,21 +2,23 @@ import { WORLDS } from "../../data/worlds";
 
 export default function WorldsIndex() {
   return (
-    <section className="nv-grid">
-      {WORLDS.map(w => (
-        <a key={w.slug} href={`/worlds/${w.slug}`} className="nv-card">
-          <div className="nv-card-img-wrapper">
-            <img
-              src={w.imgSrc}
-              alt={w.imgAlt}
-              loading="lazy"
-              className="nv-card-img"
-            />
-          </div>
-          <h3 className="nv-card-title">{w.title}</h3>
-          <p className="nv-card-sub">{w.subtitle}</p>
-        </a>
-      ))}
-    </section>
+    <div className="nvrs-section worlds">
+      <section className="nv-grid">
+        {WORLDS.map(w => (
+          <a key={w.slug} href={`/worlds/${w.slug}`} className="nv-card">
+            <div className="nv-card-img-wrapper">
+              <img
+                src={w.imgSrc}
+                alt={w.imgAlt}
+                loading="lazy"
+                className="nv-card-img"
+              />
+            </div>
+            <h3 className="nv-card-title">{w.title}</h3>
+            <p className="nv-card-sub">{w.subtitle}</p>
+          </a>
+        ))}
+      </section>
+    </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -15,6 +15,7 @@
 @import "./styles/naturverse-blue.css";
 @import "./styles/nv-images.css";
 @import "./styles/marketplace.css";
+@import "../app/styles/global-sections.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}


### PR DESCRIPTION
## Summary
- add shared `nvrs-section` style for light Naturverse blue backgrounds
- apply `nvrs-section` class to worlds, marketplace, wishlist, naturbank, navatar, passport, turian, profile, and cart sections
- import global section styles into app

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TS2345 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab23bf08c48329a5f7ed4f787f387f