### PR TITLE
style: add soft blue background to kingdom pages

### DIFF
--- a/src/pages/worlds/amerilandia.tsx
+++ b/src/pages/worlds/amerilandia.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function AmerilandiaPage() {
   return (
-    <div className="page-wrap">
+    <div className="page-wrap kingdom-detail">
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Amerilandia" }]} />
       <WorldLayout id="amerilandia" />
     </div>

--- a/src/pages/worlds/australandia.tsx
+++ b/src/pages/worlds/australandia.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function AustralandiaPage() {
   return (
-    <div className="page-wrap">
+    <div className="page-wrap kingdom-detail">
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Australandia" }]} />
       <WorldLayout id="australandia" />
     </div>

--- a/src/pages/worlds/brazilandia.tsx
+++ b/src/pages/worlds/brazilandia.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function BrazilandiaPage() {
   return (
-    <div className="page-wrap">
+    <div className="page-wrap kingdom-detail">
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Brazilandia" }]} />
       <WorldLayout id="brazilandia" />
     </div>

--- a/src/pages/worlds/chilandia.tsx
+++ b/src/pages/worlds/chilandia.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function ChilandiaPage() {
   return (
-    <div className="page-wrap">
+    <div className="page-wrap kingdom-detail">
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Chilandia" }]} />
       <WorldLayout id="chilandia" />
     </div>

--- a/src/pages/worlds/indillandia.tsx
+++ b/src/pages/worlds/indillandia.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function IndillandiaPage() {
   return (
-    <div className="page-wrap">
+    <div className="page-wrap kingdom-detail">
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Indillandia" }]} />
       <WorldLayout id="indillandia" />
     </div>

--- a/src/pages/worlds/thailandia.tsx
+++ b/src/pages/worlds/thailandia.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function ThailandiaPage() {
   return (
-    <div className="page-wrap">
+    <div className="page-wrap kingdom-detail">
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { href:"/worlds", label:"Worlds" }, { label:"Thailandia" }]} />
       <WorldLayout id="thailandia" />
     </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,3 +22,11 @@
 .naturverse-subtitle {
   @apply text-blue-100 text-lg mb-6;
 }
+
+/* Light blue background for the 6 main kingdoms */
+.kingdom-detail {
+  background-color: #f0f8ff; /* soft blue */
+  min-height: 100vh;
+  padding: 20px;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- add `.kingdom-detail` style for soft blue background
- apply `kingdom-detail` class to Thailandia, Chilandia, Indillandia, Brazilandia, Australandia and Amerilandia pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "id" | "created_at" | "updated_at">' is not assignable to parameter of type 'never[]'. ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab28be1ecc8329b6d80b6a60980f4f