### PR TITLE
Resize Language Lesson Header Images

### DIFF
--- a/src/pages/naturversity/languages/[slug].tsx
+++ b/src/pages/naturversity/languages/[slug].tsx
@@ -1,5 +1,4 @@
 import { useParams } from "react-router-dom";
-import "../../../components/card.css";
 import Breadcrumbs from "../../../components/Breadcrumbs";
 
 type Content = {
@@ -84,7 +83,9 @@ export default function LanguageDetail() {
         <h1 style={{ marginBottom: 4 }}>{titleFor(slug)}</h1>
         <p>Learn greetings, alphabet basics, and common phrases for {titleFor(slug, true)}.</p>
 
-        <img className="lang-hero" src={d.hero} alt="" />
+        <div className="language-lesson-header">
+          <img src={d.hero} alt={`${titleFor(slug, true)} language`} />
+        </div>
         <section style={{ marginTop: 20 }}>
           <h3>Starter phrases</h3>
         <ul>
@@ -105,7 +106,9 @@ export default function LanguageDetail() {
         </ol>
       </section>
 
-      <img className="lang-hero" src={d.secondary} alt="" style={{ marginTop: 16 }} />
+      <div className="language-lesson-header" style={{ marginTop: 16 }}>
+        <img src={d.secondary} alt="" />
+      </div>
       </main>
     </div>
   );

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -139,6 +139,16 @@ textarea {
   margin: 1rem 0 1.25rem;
 }
 
+/* Language lesson header images */
+.language-lesson-header img {
+  max-width: 250px;
+  height: auto;
+  display: block;
+  margin: 0 auto 1rem auto;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+
 /* Buttons */
 .btn {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- Constrain language lesson header images to a centered 250px max width with rounded, shadowed styling.
- Wrap lesson images in a dedicated container so they align consistently with overview card thumbnails.

## Testing
- ⚠️ `npm test` (missing script: "test")
- ⚠️ `npm run typecheck` (cannot find Next.js modules)


------
https://chatgpt.com/codex/tasks/task_e_68ab2b9d86848329936c382c3c9caf78