### PR TITLE
Replace email with profile icon in navbar

### DIFF
--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -25,8 +25,20 @@ export default function AuthButton() {
   if (loading) return <span style={{ opacity: 0.6 }}>…</span>;
 
   return user ? (
-    <a href="/profile" title="Profile">
-      {user.user_metadata?.user_name ?? user.email}
+    <a href="/profile" title="Profile" className="profile-icon">
+      {user.user_metadata?.avatar_url ? (
+        <img
+          src={user.user_metadata.avatar_url}
+          alt="Profile"
+          width={24}
+          height={24}
+          style={{ borderRadius: "50%" }}
+        />
+      ) : (
+        <span role="img" aria-label="profile">
+          👤
+        </span>
+      )}
     </a>
   ) : (
     <a href="/login" className="btn sm">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -182,3 +182,17 @@ textarea {
 /* Card media stays square and crops cleanly */
 .nv-card__media { aspect-ratio: 1 / 1; }
 .nv-card__media img { width: 100%; height: 100%; object-fit: cover; }
+
+/* Profile icon in navbar */
+.profile-icon {
+  font-size: 1.5rem;
+  margin-left: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.profile-icon:hover {
+  transform: scale(1.2);
+}


### PR DESCRIPTION
## Summary
- show user avatar or profile emoji in auth button and link to profile
- add styling for profile icon in global stylesheet

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "id" | "created_at" | "updated_at">' is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68ab2cd3837c8329a9eec7b3410aec7a