### PR TITLE
Navbar avatar and Turian chat bubble icon

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import Image from "next/image";
+import { useUser } from "@supabase/auth-helpers-react";
+import { useEffect, useState } from "react";
+import { getNavatarUrl } from "@/lib/profile";
+
+export default function Navbar() {
+  const user = useUser();
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      if (user?.id) {
+        const url = await getNavatarUrl(user.id);
+        if (mounted) setAvatarUrl(url);
+      } else {
+        setAvatarUrl(null);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [user?.id]);
+
+  return (
+    <nav className="nv-navbar">
+      <div className="nv-left">
+        {/* existing logo + primary nav */}
+      </div>
+      <div className="nv-right">
+        {user ? (
+          <Link href="/profile" className="nv-profile">
+            {avatarUrl ? (
+              <Image
+                src={avatarUrl}
+                alt="Profile"
+                width={28}
+                height={28}
+                className="nv-profile-img"
+              />
+            ) : (
+              <span className="nv-profile-emoji" aria-label="profile">
+                👤
+              </span>
+            )}
+          </Link>
+        ) : (
+          <Link href="/signin">Sign in</Link>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -1,0 +1,13 @@
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+
+export async function getNavatarUrl(userId: string): Promise<string | null> {
+  const supabase = createClientComponentClient();
+  // assumes table `profiles` with column `navatar_url`
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("navatar_url")
+    .eq("id", userId)
+    .single();
+  if (error || !data?.navatar_url) return null;
+  return data.navatar_url as string;
+}

--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -3,7 +3,6 @@ import Page from "../components/Page";
 import Meta from "../components/Meta";
 import { Img } from "../components";
 import { setTitle } from "./_meta";
-import Favicon from "/favicon-32x32.png";
 
 type Msg = { id: string; role: "user" | "turian"; text: string; ts: number };
 
@@ -36,7 +35,7 @@ const SUGGESTIONS: { section: string; items: string[] }[] = [
 ];
 
 // Use site favicon as Turian's mascot for consistent branding
-const mascotSrc = Favicon;
+const mascotSrc = "/favicon.ico";
 
 function cannedReply(q: string): string {
   // Lightweight, offline “assistant” so we don’t add deps or call APIs.
@@ -122,13 +121,16 @@ export default function TurianPage() {
           {history.map(m => (
             <div key={m.id} className={"msg " + m.role}>
               {m.role === "turian" && (
-                <Img
-                  src={Favicon}
-                  alt="Turian favicon"
-                  width={32}
-                  height={32}
-                  style={{ borderRadius: 6 }}
-                />
+                <div className="turian-avatar">
+                  <Img
+                    src="/favicon.ico"
+                    alt="Turian"
+                    width={28}
+                    height={28}
+                    className="turian-avatar-img"
+                    style={{ borderRadius: 6 }}
+                  />
+                </div>
               )}
               <div className="bubble">
                 {m.text.split("\n").map((ln, i) => <p key={i}>{ln}</p>)}
@@ -137,13 +139,16 @@ export default function TurianPage() {
           ))}
           {!hasHistory && (
             <div className="msg turian">
-              <Img
-                src={Favicon}
-                alt="Turian favicon"
-                width={32}
-                height={32}
-                style={{ borderRadius: 6 }}
-              />
+              <div className="turian-avatar">
+                <Img
+                  src="/favicon.ico"
+                  alt="Turian"
+                  width={28}
+                  height={28}
+                  className="turian-avatar-img"
+                  style={{ borderRadius: 6 }}
+                />
+              </div>
               <div className="bubble">
                 <p>Try a suggestion above or ask something like:</p>
                 <p><em>“Give me 3 eco-quests for Madagas­caria.”</em></p>

--- a/src/styles/turian.css
+++ b/src/styles/turian.css
@@ -83,6 +83,16 @@
   border-radius: 10px;
   padding: 10px;
 }
+.turian-avatar {
+  width: 28px;
+  height: 28px;
+  margin-right: 10px;
+}
+.turian-avatar-img {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+}
 .btn {
   padding: 10px 12px;
   border-radius: 10px;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -30,3 +30,7 @@
   padding: 20px;
   border-radius: 8px;
 }
+
+.nv-profile { display: inline-flex; align-items: center; margin-left: 12px; }
+.nv-profile-img { border-radius: 8px; box-shadow: 0 1px 0 rgba(0,0,0,.08); }
+.nv-profile-emoji { font-size: 22px; line-height: 1; }


### PR DESCRIPTION
## Summary
- Show profile emoji or navatar image in the navbar and link to profile
- Add helper to load navatar URL from Supabase profile table
- Display Turian favicon in chat bubbles with matching styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ab2ec66d20832990730ff93898e2cf