### PR TITLE
Align Navatar card styling with character cards

### DIFF
--- a/components/NavatarCard.tsx
+++ b/components/NavatarCard.tsx
@@ -1,0 +1,24 @@
+import Image from "next/image";
+
+export default function NavatarCard({ navatar }: { navatar: any }) {
+  return (
+    <div className="character-card">
+      <h3 className="card-title">Your Navatar</h3>
+      <div className="card-image-container">
+        <Image
+          src={navatar.image_url}
+          alt={navatar.name || "Navatar"}
+          width={400}
+          height={240}
+          className="card-image"
+        />
+      </div>
+      <div className="card-body">
+        <p><strong>Name:</strong> {navatar.name}</p>
+        <p><strong>Category:</strong> {navatar.category}</p>
+        <p><strong>Created:</strong> {new Date(navatar.created_at).toLocaleDateString()}</p>
+      </div>
+    </div>
+  );
+}
+

--- a/styles/cards.css
+++ b/styles/cards.css
@@ -1,0 +1,33 @@
+.character-card {
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  padding: 12px;
+  background: #fff;
+  margin-bottom: 20px;
+  max-width: 420px;
+}
+
+.card-title {
+  font-weight: bold;
+  margin-bottom: 8px;
+  color: #1e40af; /* blue like headers */
+}
+
+.card-image-container {
+  width: 100%;
+  height: 240px;
+  overflow: hidden;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #f9f9f9;
+}
+
+.card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;   /* ensures consistent scaling like Character Card */
+}
+

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,4 @@
+@import "./cards.css";
 /* Primary button used across Naturversity */
 .btn-primary {
   @apply bg-blue-600 text-white font-extrabold uppercase tracking-wide


### PR DESCRIPTION
## Summary
- Add `NavatarCard` component using shared card layout
- Introduce `cards.css` with reusable card styling and import globally

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next/image' and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3035c1048329ad94ce44f8456636