### PR TITLE
Remove mobile NavBar icon background

### DIFF
--- a/src/components/NavBar.module.css
+++ b/src/components/NavBar.module.css
@@ -8,5 +8,5 @@
 @media (max-width:768px){
   .userPill{display:none}
   .iconDesktop{display:none}
-  .iconMobile{display:inline;font-size:22px}
+  .iconMobile{display:inline;font-size:22px;background:none;color:#2563eb;padding:0;border-radius:0}
 }


### PR DESCRIPTION
## Summary
- remove blue background and padding from mobile NavBar icon, reverting to plain button text style

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: Argument of type ... is not assignable to parameter of type 'never')

------
https://chatgpt.com/codex/tasks/task_e_68ab3e663744832988f52af29b760788