### PR TITLE
Align mobile menu icon with cart

### DIFF
--- a/src/components/NavBar.module.css
+++ b/src/components/NavBar.module.css
@@ -8,5 +8,5 @@
 @media (max-width:768px){
   .userPill{display:none}
   .iconDesktop{display:none}
-  .iconMobile{display:inline;font-size:22px;background:none;color:#2563eb;padding:0;border-radius:0}
+  .iconMobile{display:inline;font-size:18px/* closer to cart size */;background:none;color:#2563eb;padding:0;border-radius:0;vertical-align:middle}
 }


### PR DESCRIPTION
## Summary
- Adjust mobile menu icon size and alignment to match cart icon

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type Omit<...> is not assignable to parameter of type 'never[]')*


------
https://chatgpt.com/codex/tasks/task_e_68ab3fd3f6c883299731c1d7a8302c7e