### PR TITLE
style: refine mobile nav icon appearance

### DIFF
--- a/src/components/NavBar.module.css
+++ b/src/components/NavBar.module.css
@@ -8,5 +8,5 @@
 @media (max-width:768px){
   .userPill{display:none}
   .iconDesktop{display:none}
-  .iconMobile{display:inline;font-size:18px/* closer to cart size */;background:none;color:#2563eb;padding:0;border-radius:0;vertical-align:middle}
+  .iconMobile{display:inline-flex;font-size:18px/* match cart height */;background:none/* remove blue box */;color:#2563eb;padding:0;margin:0 4px;border:none;box-shadow:none;vertical-align:middle}
 }


### PR DESCRIPTION
## Summary
- remove mobile menu's blue background and shadow
- align mobile nav icon size with cart icon using inline-flex layout

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ab41c1f1508329bcef5c20db2f0100