### PR TITLE
Reduce mobile menu icon size; show full images on Wishlist

### DIFF
--- a/src/components/NavBar.module.css
+++ b/src/components/NavBar.module.css
@@ -8,5 +8,5 @@
 @media (max-width:768px){
   .userPill{display:none}
   .iconDesktop{display:none}
-  .iconMobile{display:inline-flex;font-size:18px/* match cart height */;background:none/* remove blue box */;color:#2563eb;padding:0;margin:0 4px;border:none;box-shadow:none;vertical-align:middle}
+  .iconMobile{display:inline-flex;align-items:center;justify-content:center;font-size:18px;background:none;color:#2563eb;padding:0;margin:0 4px;border:none;box-shadow:none;vertical-align:middle;line-height:1;height:20px;width:20px}
 }

--- a/src/pages/Wishlist.module.css
+++ b/src/pages/Wishlist.module.css
@@ -1,0 +1,27 @@
+.card {
+  border-radius: 18px;
+  border: 1px solid var(--nv-border);
+  background: white;
+  padding: 14px;
+}
+
+/* Show full product image (like Languages cards) */
+.imageWrap {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #f1f5f9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.img {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain; /* show full image */
+  display: block;
+}

--- a/src/pages/wishlist.tsx
+++ b/src/pages/wishlist.tsx
@@ -1,6 +1,7 @@
 import { useCart } from "../lib/cart";
 import { Link } from "react-router-dom";
 import Breadcrumbs from "../components/Breadcrumbs";
+import styles from "./Wishlist.module.css";
 
 const LOOKUP: Record<string,{name:string; image:string; href:string}> = {
   "turian-plush": { name:"Turian Plush", image:"/Marketplace/Turianplushie.png", href:"/marketplace/turian-plush" },
@@ -18,11 +19,14 @@ export default function WishlistPage(){
       {ids.length===0? <p>No saved items yet.</p> :
         <div className="nv-grid">
           {ids.map(id=>{
-            const p = LOOKUP[id]; if (!p) return null;
+            const item = LOOKUP[id];
+            if (!item) return null;
             return (
-              <article key={id} className="nv-card">
-                <Link to={p.href} className="nv-imgbox"><img src={p.image} alt="" /></Link>
-                <h3><Link to={p.href}>{p.name}</Link></h3>
+              <article key={id} className={styles.card}>
+                <Link to={item.href} className={styles.imageWrap}>
+                  <img src={item.image} alt={item.name} className={styles.img} />
+                </Link>
+                <h3><Link to={item.href}>{item.name}</Link></h3>
                 <button className="btn-danger" onClick={()=>toggleSave(id)}>Remove</button>
               </article>
             );


### PR DESCRIPTION
## Summary
- shrink and center mobile menu icon, removing blue box
- show full images on wishlist cards with new styles
- apply wishlist image styles on component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab43200f608329b0e974b99d86a5b0