### PR TITLE
Cap Navatar Character Card image height on desktop

### DIFF
--- a/src/components/NavatarCard.module.css
+++ b/src/components/NavatarCard.module.css
@@ -1,0 +1,24 @@
+.media {
+  width: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #edf1ff;
+  margin: 8px 0;
+}
+
+.mediaImg {
+  width: 100%;
+  height: auto;
+  display: block;
+  object-fit: cover;
+}
+
+@media (min-width: 860px) {
+  .media {
+    max-height: 300px;
+  }
+  .mediaImg {
+    height: 300px;
+    object-fit: cover;
+  }
+}

--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Navatar } from "../types/navatar";
-import Img from "./Img";
+import styles from "./NavatarCard.module.css";
 
 type Props = { navatar: Navatar };
 
@@ -16,9 +16,14 @@ export default function NavatarCard({ navatar }: Props) {
         </div>
       </div>
 
-      <div className="card__media">
+      <div className={styles.media}>
         {navatar.imageDataUrl ? (
-          <Img src={navatar.imageDataUrl} alt={`${navatar.name || navatar.species}`} />
+          <img
+            src={navatar.imageDataUrl}
+            alt={navatar.name || navatar.species}
+            className={styles.mediaImg}
+            loading="lazy"
+          />
         ) : (
           <div className="card__placeholder" aria-label="No photo">No photo</div>
         )}
@@ -40,8 +45,6 @@ export default function NavatarCard({ navatar }: Props) {
         .card__header{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:8px}
         .card__title{font-weight:700}
         .card__meta{opacity:.7;font-size:.9rem}
-        .card__media{display:flex;justify-content:center;align-items:center;background:#fafafa;border-radius:8px;height:220px;overflow:hidden;margin:8px 0}
-        .card__media img{height:100%;object-fit:cover}
         .card__placeholder{color:#aaa}
         .card__section{margin:8px 0}
         .card__backstory{margin:6px 0}


### PR DESCRIPTION
## Summary
- Constrain Navatar card image height on larger screens with new CSS module
- Wrap NavatarCard image in styled container for responsive sizing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68ab473940b4832984a647b379481f9a