### PR TITLE
Refresh Home and simplify sign-in

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import AuthButtons from '@/components/auth/AuthButtons';
+
+export default function Home() {
+  return (
+    <main className="page narrow">
+      <section className="hero">
+        <h1>Welcome to the Naturverse™</h1>
+        <p>A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.</p>
+        <div className="hero-ctas">
+          <Link className="btn" href="/worlds">Explore Worlds</Link>
+          <Link className="btn ghost" href="/zones">Play Games</Link>
+        </div>
+      </section>
+
+      <section className="grid grid-3">
+        <Link href="/zones" className="card hover">
+          <h3>🎮 Play</h3>
+          <p>Mini-games, leaderboards, and tournaments.</p>
+        </Link>
+
+        <Link href="/naturversity" className="card hover">
+          <h3>📘 Learn</h3>
+          <p>Teachers, languages, and courses across the 14 kingdoms.</p>
+        </Link>
+
+        <Link href="/naturbank" className="card hover">
+          <h3>💰 Earn</h3>
+          <p>Quests and rewards that build real-life skills.</p>
+        </Link>
+      </section>
+
+      <section className="grid gap-lg">
+        <AuthButtons />
+      </section>
+    </main>
+  );
+}
+

--- a/components/auth/AuthButtons.tsx
+++ b/components/auth/AuthButtons.tsx
@@ -1,0 +1,62 @@
+'use client';
+import { useState } from 'react';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
+
+export default function AuthButtons() {
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function sendMagicLink(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email) return;
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: `${location.origin}/auth/callback` }
+    });
+    setLoading(false);
+    if (!error) setSent(true);
+    else alert(error.message);
+  }
+
+  async function signInGoogle() {
+    await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: `${location.origin}/auth/callback` }
+    });
+  }
+
+  return (
+    <div className="card" style={{ maxWidth: 560 }}>
+      <h3>Sign in or create an account</h3>
+
+      <form onSubmit={sendMagicLink} style={{ display: 'grid', gap: 12 }}>
+        <label className="sr-only" htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <button className="btn" type="submit" disabled={loading || sent}>
+          {sent ? 'Check your email ✉️' : loading ? 'Sending…' : 'Send magic link'}
+        </button>
+      </form>
+
+      <div style={{ display: 'grid', gap: 8, marginTop: 12 }}>
+        <button className="btn" onClick={signInGoogle}>Continue with Google</button>
+        <a className="link" href="/worlds">Continue as guest</a>
+        <small>By continuing you agree to our <a href="/terms">Terms</a> and <a href="/privacy">Privacy</a>.</small>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -51,12 +51,12 @@ export default function LoginForm() {
     }
   }
 
-  async function signInWith(provider: 'google' | 'apple') {
+  async function signInWithGoogle() {
     setStatus('sending');
     setMessage(null);
     try {
       const { error } = await supabase.auth.signInWithOAuth({
-        provider,
+        provider: 'google',
         options: { redirectTo: window.location.origin },
       });
       if (error) throw error;
@@ -103,11 +103,8 @@ export default function LoginForm() {
       </form>
 
       <div style={{ display: 'flex', gap: 8 }}>
-        <button onClick={() => signInWith('google')} aria-label="Sign in with Google">
+        <button onClick={signInWithGoogle} aria-label="Sign in with Google">
           Continue with Google
-        </button>
-        <button onClick={() => signInWith('apple')} aria-label="Sign in with Apple">
-          Continue with Apple
         </button>
       </div>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,3 +35,20 @@
 .nv-profile { display: inline-flex; align-items: center; margin-left: 12px; }
 .nv-profile-img { border-radius: 8px; box-shadow: 0 1px 0 rgba(0,0,0,.08); }
 .nv-profile-emoji { font-size: 22px; line-height: 1; }
+
+/* Layout helpers */
+.page.narrow { max-width: 1040px; margin: 0 auto; padding: 1rem; }
+.hero { background: #eef4ff; border-radius: 16px; padding: 24px; margin-bottom: 20px; }
+.hero-ctas { display: flex; gap: 12px; flex-wrap: wrap; }
+
+.grid { display: grid; gap: 16px; }
+.grid-3 { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+.gap-lg { gap: 24px; }
+
+.card.hover { transition: transform .08s ease, box-shadow .12s ease; }
+.card.hover:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(0,0,0,.06); }
+
+/* Form bits for AuthButtons */
+.card input[type="email"] { height: 44px; padding: 0 12px; }
+.btn.ghost { background: transparent; border: 2px solid var(--brand); }
+.link { text-align: center; }


### PR DESCRIPTION
## Summary
- add `AuthButtons` component with magic-link email and Google login
- redesign home page hero and sections for Play/Learn/Earn
- drop Apple OAuth support and add layout/form styles

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next')*


------
https://chatgpt.com/codex/tasks/task_e_68ab4cac07c48329979dd760e65e9ccf