### PR TITLE
Hide navbar and profile icon when signed out

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -24,6 +24,11 @@ export default function Navbar() {
     };
   }, [user?.id]);
 
+  if (!user) {
+    // Signed out: don't render navbar
+    return null;
+  }
+
   return (
     <nav className="nv-navbar">
       <div className="nv-left">
@@ -38,25 +43,21 @@ export default function Navbar() {
         🍃
       </button>
       <div className="nv-right">
-        {user ? (
-          <Link href="/profile" className="nv-profile">
-            {avatarUrl ? (
-              <Image
-                src={avatarUrl}
-                alt="Profile"
-                width={28}
-                height={28}
-                className="nv-profile-img"
-              />
-            ) : (
-              <span className="nv-profile-emoji" aria-label="profile">
-                👤
-              </span>
-            )}
-          </Link>
-        ) : (
-          <Link href="/signin">Sign in</Link>
-        )}
+        <Link href="/profile" className="nv-profile">
+          {avatarUrl ? (
+            <Image
+              src={avatarUrl}
+              alt="Profile"
+              width={28}
+              height={28}
+              className="nv-profile-img"
+            />
+          ) : (
+            <span className="nv-profile-emoji" aria-label="profile">
+              👤
+            </span>
+          )}
+        </Link>
       </div>
     </nav>
   );

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -23,8 +23,9 @@ export default function AuthButton() {
   }, []);
 
   if (loading) return <span style={{ opacity: 0.6 }}>…</span>;
+  if (!user) return null;
 
-  return user ? (
+  return (
     <a href="/profile" title="Profile" className="profile-icon">
       {user.user_metadata?.avatar_url ? (
         <img
@@ -39,10 +40,6 @@ export default function AuthButton() {
           👤
         </span>
       )}
-    </a>
-  ) : (
-    <a href="/login" className="btn sm">
-      Sign in
     </a>
   );
 }

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,12 +1,33 @@
 import { Link, NavLink } from 'react-router-dom';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
 import './site-header.css';
 import Img from './Img';
 import AuthButton from './AuthButton';
 import CartBadge from './CartBadge';
+import { supabase } from '../lib/supabaseClient';
 
 export default function SiteHeader() {
   const [open, setOpen] = useState(false);
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    supabase.auth.getSession().then(({ data }) => {
+      if (!mounted) return;
+      setUser(data.session?.user ?? null);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
+      setUser(session?.user ?? null);
+    });
+    return () => {
+      mounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  if (!user) return null;
+
   return (
     <header className={`site-header ${open ? 'open' : ''}`}>
       <div className="wrap">


### PR DESCRIPTION
## Summary
- Only render the navbar after authentication
- Show profile icon exclusively for signed-in users
- Drop sign-in placeholder from header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS errors in navatar, passport, profile, saveProfile)*

------
https://chatgpt.com/codex/tasks/task_e_68ab58cb12408329a9dc070d2b35691c