### PR TITLE
Add icons to home feature cards

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -22,16 +22,26 @@ export default function Home() {
       {/* 3-UP: Play / Learn / Earn */}
       <section className="triptych">
         <div className="card">
-          <h3>Play</h3>
+          <h3 className="bubble-title">
+            <span className="bubble-emoji" aria-hidden>🎮</span> Play
+          </h3>
           <p>Mini-games, stories, and map adventures across 14 kingdoms.</p>
         </div>
         <div className="card">
-          <h3>Learn</h3>
+          <h3 className="bubble-title">
+            <span className="bubble-emoji" aria-hidden>📚</span> Learn
+          </h3>
           <p>Naturversity lessons in languages, art, music, wellness, and more.</p>
         </div>
         <div className="card">
-          <h3>Earn</h3>
-          <p>Collect badges, save favorites, and build your Navatar card.</p>
+          <h3 className="bubble-title">
+            <span className="bubble-emoji" aria-hidden>🪙</span> Earn
+          </h3>
+          <p>
+            Collect badges, save favorites, and build your Navatar card.
+            <br />
+            <em>Natur Coin — coming soon</em>
+          </p>
         </div>
       </section>
 

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -88,3 +88,15 @@
   text-decoration: underline;
   text-underline-offset: 2px;
 }
+
+/* Icons for Play / Learn / Earn titles */
+.bubble-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bubble-emoji {
+  line-height: 1;
+  transform: translateY(1px); /* subtle optical alignment */
+}


### PR DESCRIPTION
## Summary
- add playful emoji icons for Play, Learn, and Earn cards on the home page
- include "Natur Coin — coming soon" note in the Earn card
- add spacing styles to align icons with titles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type ... is not assignable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5cffa0088329873ad4b9637481f7