### PR TITLE
Polish homepage CTA logic & styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,37 +1,77 @@
-import Link from 'next/link';
-import AuthButtons from '@/components/auth/AuthButtons';
+'use client';
+
+import { useUser } from '@supabase/auth-helpers-react';
+import styles from '@/styles/Home.module.css';
 
 export default function Home() {
+  const user = useUser();
+
+  const SignedOutCTA = () => (
+    <div className={styles.ctaRow}>
+      <a className="btn btn-primary" href="/auth">Create account</a>
+      <a className="btn btn-secondary" href="/auth/google">Continue with Google</a>
+    </div>
+  );
+
   return (
-    <main className="page narrow">
-      <section className="hero">
+    <main className={styles.home}>
+      <section className={styles.hero}>
         <h1>Welcome to the Naturverse™</h1>
         <p>A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.</p>
-        <div className="hero-ctas">
-          <Link className="btn" href="/worlds">Explore Worlds</Link>
-          <Link className="btn ghost" href="/zones">Play Games</Link>
+        {!user && <SignedOutCTA />}
+      </section>
+
+      {/* Play / Learn / Earn */}
+      <section className={styles.tiles3}>
+        <a className={styles.infoCard} href="/zones/arcade">
+          <h3>Play</h3>
+          <p>Mini-games, stories, and map adventures across 14 kingdoms.</p>
+        </a>
+        <a className={styles.infoCard} href="/naturversity">
+          <h3>Learn</h3>
+          <p>Naturversity lessons in languages, art, music, wellness, and more.</p>
+        </a>
+        <a className={styles.infoCard} href="/passport">
+          <h3>Earn</h3>
+          <p>Collect badges, save favorites, build your Navatar card.<br/><em>Natur Coin — coming soon</em></p>
+        </a>
+      </section>
+
+      {/* How it works flow (vertical) */}
+      <section className={styles.flowWrap}>
+        <div className={styles.flowCard}>
+          <div className={styles.flowStep}>1) Create</div>
+          <div className={styles.flowText}>
+            Create a free account{!user && ' or '}
+            {!user && <a href="/navatar">create your Navatar</a>}.
+          </div>
         </div>
-      </section>
 
-      <section className="grid grid-3">
-        <Link href="/zones" className="card hover">
-          <h3>🎮 Play</h3>
-          <p>Mini-games, leaderboards, and tournaments.</p>
-        </Link>
+        <div className={styles.flowArrow}>↓</div>
 
-        <Link href="/naturversity" className="card hover">
-          <h3>📘 Learn</h3>
-          <p>Teachers, languages, and courses across the 14 kingdoms.</p>
-        </Link>
+        <div className={styles.flowCard}>
+          <div className={styles.flowStep}>2) Pick a hub</div>
+          <div className={styles.flowText}>
+            <a href="/worlds">Worlds</a> • <a href="/zones">Zones</a> • <a href="/marketplace">Marketplace</a>
+          </div>
+        </div>
 
-        <Link href="/naturbank" className="card hover">
-          <h3>💰 Earn</h3>
-          <p>Quests and rewards that build real-life skills.</p>
-        </Link>
-      </section>
+        <div className={styles.flowArrow}>↓</div>
 
-      <section className="grid gap-lg">
-        <AuthButtons />
+        <div className={styles.flowCard}>
+          <div className={styles.flowStep}>3) Play · Learn · Earn</div>
+          <div className={styles.flowText}>
+            Explore, meet characters, earn badges<br/>
+            <small>(Natur Coin — coming soon)</small>
+          </div>
+        </div>
+
+        {!user && (
+          <div className={styles.ctaRowBottom}>
+            <a className="btn btn-primary" href="/auth">Get started</a>
+            <a className="btn btn-secondary" href="/auth/google">Continue with Google</a>
+          </div>
+        )}
       </section>
     </main>
   );

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.28.0",
-    "@supabase/supabase-js": "^2.45.4"
+    "@supabase/supabase-js": "^2.45.4",
+    "@supabase/auth-helpers-react": "^0.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,0 +1,67 @@
+.home { --nv-blue:#2563eb; --nv-blue-200:#dbeafe; --nv-blue-300:#bfdbfe; --nv-blue-400:#60a5fa; }
+
+.hero {
+  background: linear-gradient(180deg, var(--nv-blue-200) 0%, transparent 80%);
+  padding: 2rem 1rem;
+  border-radius: 12px;
+  margin-bottom: 1.5rem;
+}
+
+.ctaRow,
+.ctaRowBottom {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+/* Top tiles (already present, keep) */
+.tiles3 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px,1fr));
+  gap: 1rem;
+  margin: 1.25rem 0 2rem;
+}
+
+.infoCard {
+  background: #fff;
+  border: 2px solid var(--nv-blue-400);
+  border-radius: 16px;
+  padding: 1rem 1.1rem;
+  box-shadow: 0 2px 0 rgba(37,99,235,0.15);
+  text-decoration: none;
+  color: inherit;
+}
+
+/* How it works (make them match infoCard) */
+.flowWrap {
+  background: linear-gradient(180deg, #f8fbff 0%, #f6faff 100%);
+  padding: 1.25rem;
+  border-radius: 16px;
+  margin-bottom: 2rem;
+}
+
+.flowCard {
+  background: #fff;
+  border: 2px solid var(--nv-blue-400);
+  border-radius: 16px;
+  padding: 0.9rem 1.1rem;
+  box-shadow: 0 2px 0 rgba(37,99,235,0.15);
+}
+
+.flowStep { font-weight: 700; color: var(--nv-blue); margin-bottom: 0.25rem; }
+.flowText { color: #374151; }
+
+.flowArrow {
+  text-align: center;
+  color: var(--nv-blue);
+  margin: 0.5rem 0;
+  font-size: 1.25rem;
+}
+
+/* Button polish */
+.btn { /* if you have global btn classes, this can be omitted */ }
+@media (min-width: 768px) {
+  .ctaRowBottom { justify-content: center; }
+}
+


### PR DESCRIPTION
## Summary
- Hide sign-up CTAs when authenticated and add bottom CTA for guests
- Style "How it works" flow cards to match Play/Learn/Earn cards and center bottom buttons
- Include `@supabase/auth-helpers-react` for user detection

## Testing
- ⚠️ `npm test` (missing script)
- ⚠️ `npm run typecheck` (Cannot find modules: `next`, `@supabase/auth-helpers-react`, etc.)
- ⚠️ `npm install` (403 Forbidden fetching `@supabase/auth-helpers-react`)


------
https://chatgpt.com/codex/tasks/task_e_68ab6019b16c8329b10de9c8cfc3cd9b