### PR TITLE
Hide signup CTAs when logged in + prevent cached signed-out homepage

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,6 +4,9 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Cache-Control: public, max-age=600
 
+/
+  Cache-Control: no-store, max-age=0
+
 /assets/*
   Cache-Control: public, max-age=604800, immutable
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,16 @@
+import { useEffect, useState } from "react";
 import AuthButtons from "../components/AuthButtons";
 import { useAuthUser } from "../lib/useAuthUser";
 import "../styles/home.css";
 
 export default function Home() {
-  const { user } = useAuthUser();
+  const { user, loading } = useAuthUser();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  const showAuthButtons = mounted && !loading && !user;
+
   return (
     <main className="home">
       {/* HERO */}
@@ -15,7 +22,9 @@ export default function Home() {
             wellness, creativity, and kindness.
           </p>
 
-          {!user && <AuthButtons cta="Create account" className="mt-4" />}
+          {showAuthButtons && (
+            <AuthButtons cta="Create account" className="mt-4" />
+          )}
         </div>
       </section>
 
@@ -50,7 +59,10 @@ export default function Home() {
         <div className="panel flow-vertical">
           <div className="flow-step">
             <h4>1) Create</h4>
-            <p>Create a free account.</p>
+            <p>
+              Create a free account <span className="dot">•</span> create your
+              Navatar
+            </p>
           </div>
           <div className="flow-arrow-down" aria-hidden>↓</div>
           <div className="flow-step">
@@ -70,7 +82,7 @@ export default function Home() {
           </div>
         </div>
 
-        {!user && (
+        {showAuthButtons && (
           <AuthButtons
             cta="Get started"
             variant="outline"

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -77,6 +77,12 @@
   width: max-content;
 }
 
+/* Inline dot separator */
+.home .dot {
+  opacity: .4;
+  margin: 0 6px;
+}
+
 /* Muted note for Natur Coin */
 .home .muted {
   color: #667085;


### PR DESCRIPTION
## Summary
- Gate home page signup CTAs behind a mounted, authenticated check to avoid flashing for logged-in users
- Add "create your Navatar" copy in step one of the flow with inline dot styling
- Disable caching for `/` via Netlify headers to prevent stale signed-out homepages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...> is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68aba56e75488329bdc4e1b7e3e9f338