### PR TITLE
Show profile link when logged in

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,17 +1,22 @@
 import styles from './NavBar.module.css';
+import { useAuth } from '../auth/AuthContext';
 
 function CartIcon() {
   return <span aria-hidden>🛒</span>;
 }
 
 export default function NavBar() {
-  const user = null as { email?: string } | null;
+  const { session } = useAuth();
   return (
     <header className={styles.wrap}>
       <a href="/" className={styles.brand}>Naturverse</a>
       <nav className={styles.tools}>
-        {user?.email && <span className={styles.userPill}>{user.email}</span>}
         <a href="/cart" aria-label="Cart"><CartIcon /></a>
+        {session && (
+          <a href="/profile" aria-label="Profile" className="profile-icon">
+            <span aria-hidden>👤</span>
+          </a>
+        )}
         <button className={styles.menuBtn} aria-label="Menu">
           <span className={styles.iconDesktop} aria-hidden>≡</span>
           <span className={styles.iconMobile} aria-hidden>🍃</span>


### PR DESCRIPTION
## Summary
- Always show cart icon in navbar
- Show profile link only when a user session exists

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68abad5deb7483298cae0be2d1aa5263