### PR TITLE
Fix navbar auth state & z-index; always show profile/cart when signed-in

### DIFF
--- a/src/components/NavBar.module.css
+++ b/src/components/NavBar.module.css
@@ -1,12 +1,6 @@
-.wrap{display:flex;align-items:center;justify-content:space-between;padding:12px 16px}
+.wrap{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;position:sticky;top:0;z-index:60}
 .brand{font-weight:800;font-size:24px;color:var(--ink-strong);text-decoration:none}
-.tools{display:flex;gap:12px;align-items:center}
-.userPill{background:var(--surface-2);padding:6px 10px;border-radius:999px;font-size:14px;color:var(--ink)}
+.icons{display:flex;gap:.5rem;align-items:center}
+.iconBtn{font-size:20px;line-height:1}
+.avatarEmoji{font-size:20px;display:inline-block}
 .menuBtn{background:#1e5fff;color:#fff;border:none;border-radius:12px;padding:10px 12px;line-height:1;font-size:22px;box-shadow:0 2px 0 rgba(0,0,0,.1);cursor:pointer;display:inline-flex;align-items:center;justify-content:center}
-.iconDesktop{display:inline}
-.iconMobile{display:none}
-@media (max-width:768px){
-  .userPill{display:none}
-  .iconDesktop{display:none}
-  .iconMobile{display:inline-flex;align-items:center;justify-content:center;font-size:18px;background:none;color:#2563eb;padding:0;margin:0 4px;border:none;box-shadow:none;vertical-align:middle;line-height:1;height:20px;width:20px}
-}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,26 +1,26 @@
+'use client';
+import { Link } from 'react-router-dom';
 import styles from './NavBar.module.css';
-import { useAuth } from '../auth/AuthContext';
-
-function CartIcon() {
-  return <span aria-hidden>🛒</span>;
-}
+import { useAuthState } from '../lib/auth-context';
+import { useProfileEmoji } from '../lib/use-profile-emoji';
 
 export default function NavBar() {
-  const { session } = useAuth();
+  const { loading, signedIn } = useAuthState();
+  const emoji = useProfileEmoji();
+
   return (
     <header className={styles.wrap}>
-      <a href="/" className={styles.brand}>Naturverse</a>
-      <nav className={styles.tools}>
-        <a href="/cart" aria-label="Cart"><CartIcon /></a>
-        {session && (
-          <a href="/profile" aria-label="Profile" className="profile-icon">
-            <span aria-hidden>👤</span>
-          </a>
+      <Link to="/" className={styles.brand}>🌿 Naturverse</Link>
+      <nav className={styles.icons}>
+        {signedIn && !loading && (
+          <>
+            <Link to="/cart" aria-label="Cart" className={styles.iconBtn}>🛒</Link>
+            <Link to="/profile" aria-label="Profile" className={styles.iconBtn}>
+              <span className={styles.avatarEmoji}>{emoji}</span>
+            </Link>
+          </>
         )}
-        <button className={styles.menuBtn} aria-label="Menu">
-          <span className={styles.iconDesktop} aria-hidden>≡</span>
-          <span className={styles.iconMobile} aria-hidden>🍃</span>
-        </button>
+        <button className={styles.menuBtn} aria-label="Menu">≡</button>
       </nav>
     </header>
   );

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { supabase } from './supabaseClient';
+
+type AuthState = { loading: boolean; signedIn: boolean; email?: string | null };
+const Ctx = createContext<AuthState>({ loading: true, signedIn: false });
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AuthState>({ loading: true, signedIn: false });
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setState({
+        loading: false,
+        signedIn: !!data.session,
+        email: data.session?.user.email ?? null,
+      });
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_evt, session) => {
+      setState({ loading: false, signedIn: !!session, email: session?.user.email ?? null });
+    });
+    return () => {
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  return <Ctx.Provider value={state}>{children}</Ctx.Provider>;
+}
+
+export const useAuthState = () => useContext(Ctx);

--- a/src/lib/use-profile-emoji.ts
+++ b/src/lib/use-profile-emoji.ts
@@ -1,0 +1,19 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { supabase } from './supabaseClient';
+
+export function useProfileEmoji() {
+  const [emoji, setEmoji] = useState('🙂');
+  useEffect(() => {
+    const fetchEmoji = async () => {
+      const { data } = await supabase
+        .from('profiles')
+        .select('navatar_emoji, avatar')
+        .single();
+      if (data?.navatar_emoji) setEmoji(data.navatar_emoji);
+      else if (data?.avatar) setEmoji('🧑‍🎨');
+    };
+    fetchEmoji();
+  }, []);
+  return emoji;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { AuthProvider } from './auth/AuthContext';
+import { AuthProvider as BaseAuthProvider } from './auth/AuthContext';
+import { AuthProvider } from './lib/auth-context';
 import ErrorBoundary from './components/ErrorBoundary';
 import './styles.css';
 import './styles/shop.css';
@@ -14,9 +15,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <SkipToContent />
     <ErrorBoundary>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      <BaseAuthProvider>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </BaseAuthProvider>
     </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/src/styles/home.module.css
+++ b/src/styles/home.module.css
@@ -1,5 +1,5 @@
 .wrap { padding: 1.25rem 1rem 3rem; }
-.hero { background: linear-gradient(#eef5ff, #ffffff); border-radius: 12px; padding: 1.25rem; margin-bottom: 1rem; }
+.hero { background: linear-gradient(#eef5ff, #ffffff); border-radius: 12px; padding: 1.25rem; margin-bottom: 1rem; position: relative; z-index: 1; }
 .ctaRow, .bottomCtas { display: flex; gap: .75rem; flex-wrap: wrap; margin-top: .75rem; }
 .btn { padding: .6rem 1rem; border-radius: 10px; background: #2b6ee7; color: #fff; box-shadow: 0 6px 0 #1d4fb1; }
 .btnSecondary { padding: .6rem 1rem; border-radius: 10px; background: #3a7cf0; color: #fff; box-shadow: 0 6px 0 #285ec7; }
@@ -11,6 +11,8 @@
 .flowCard { background: #fff; border: 1px solid #dbe6ff; border-radius: 12px; padding: .9rem 1rem; margin: .75rem auto; max-width: 560px; text-align: center; }
 .flow small { color: #6b7280; }
 .arrow { text-align: center; font-size: 1.4rem; color: #5c7de7; }
+
+.heroOverlay { pointer-events: none; }
 
 @media (max-width: 768px) {
   .pills { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- add lightweight auth context to track sign-in state and email
- display cart and profile icons only when signed in and ensure navbar overlays hero
- prevent hero section from blocking clicks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68abb67df5d88329bed25084362e5a85