### PR TITLE
Refresh auth context on sign-in

### DIFF
--- a/lib/supabase-client.ts
+++ b/lib/supabase-client.ts
@@ -1,0 +1,8 @@
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+
+export function createClient() {
+  return createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -1,28 +1,48 @@
 'use client';
 import { createContext, useContext, useEffect, useState } from 'react';
-import { supabase } from './supabaseClient';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/lib/supabase-client';
 
 type AuthState = { loading: boolean; signedIn: boolean; email?: string | null };
 const Ctx = createContext<AuthState>({ loading: true, signedIn: false });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<AuthState>({ loading: true, signedIn: false });
+  const router = useRouter();
+
+  async function loadOnce() {
+    const supabase = createClient();
+    const { data } = await supabase.auth.getSession();
+    const signedIn = !!data.session;
+    setState({ loading: false, signedIn, email: data.session?.user.email ?? null });
+    if (signedIn) router.refresh(); // <- ensure first render shows signed-in UI
+  }
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => {
-      setState({
-        loading: false,
-        signedIn: !!data.session,
-        email: data.session?.user.email ?? null,
-      });
-    });
+    const supabase = createClient();
+    loadOnce(); // initial check
+
     const { data: sub } = supabase.auth.onAuthStateChange((_evt, session) => {
-      setState({ loading: false, signedIn: !!session, email: session?.user.email ?? null });
+      const signedIn = !!session;
+      setState({ loading: false, signedIn, email: session?.user.email ?? null });
+      router.refresh(); // <- flip UI immediately on sign-in/out
     });
+
+    // when coming back from OAuth/magic-link, browsers sometimes cache;
+    // these two listeners help update on tab switch & multi-tab:
+    const onVis = () => loadOnce();
+    const onStorage = (e: StorageEvent) => {
+      if (e.key?.startsWith('sb-')) loadOnce();
+    };
+    document.addEventListener('visibilitychange', onVis);
+    window.addEventListener('storage', onStorage);
+
     return () => {
       sub.subscription.unsubscribe();
+      document.removeEventListener('visibilitychange', onVis);
+      window.removeEventListener('storage', onStorage);
     };
-  }, []);
+  }, [router]);
 
   return <Ctx.Provider value={state}>{children}</Ctx.Provider>;
 }


### PR DESCRIPTION
## Summary
- Update auth-context provider to refresh UI on sign-in/out and sync across tabs
- Add supabase client factory for Next.js

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next/navigation' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abb97527888329a1a452bfacdcd751