### PR TITLE
Refactor auth context and connect navbar to it

### DIFF
--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -1,39 +1,50 @@
 'use client';
+
 import { createContext, useContext, useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { createClient } from '@/lib/supabase-client';
 
-type AuthState = { loading: boolean; signedIn: boolean; email?: string | null };
+type AuthState = {
+  loading: boolean;
+  signedIn: boolean;
+  email?: string | null;
+};
+
 const Ctx = createContext<AuthState>({ loading: true, signedIn: false });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<AuthState>({ loading: true, signedIn: false });
-  const router = useRouter();
 
   async function loadOnce() {
     const supabase = createClient();
     const { data } = await supabase.auth.getSession();
-    const signedIn = !!data.session;
-    setState({ loading: false, signedIn, email: data.session?.user.email ?? null });
-    if (signedIn) router.refresh(); // <- ensure first render shows signed-in UI
+    setState({
+      loading: false,
+      signedIn: !!data.session,
+      email: data.session?.user.email ?? null,
+    });
   }
 
   useEffect(() => {
     const supabase = createClient();
-    loadOnce(); // initial check
 
+    // Initial check (covers coming back from OAuth/magic link)
+    loadOnce();
+
+    // Live updates for sign-in / sign-out
     const { data: sub } = supabase.auth.onAuthStateChange((_evt, session) => {
-      const signedIn = !!session;
-      setState({ loading: false, signedIn, email: session?.user.email ?? null });
-      router.refresh(); // <- flip UI immediately on sign-in/out
+      setState({
+        loading: false,
+        signedIn: !!session,
+        email: session?.user.email ?? null,
+      });
     });
 
-    // when coming back from OAuth/magic-link, browsers sometimes cache;
-    // these two listeners help update on tab switch & multi-tab:
+    // Also update when tab becomes visible or another tab signs in/out
     const onVis = () => loadOnce();
     const onStorage = (e: StorageEvent) => {
       if (e.key?.startsWith('sb-')) loadOnce();
     };
+
     document.addEventListener('visibilitychange', onVis);
     window.addEventListener('storage', onStorage);
 
@@ -42,7 +53,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       document.removeEventListener('visibilitychange', onVis);
       window.removeEventListener('storage', onStorage);
     };
-  }, [router]);
+  }, []);
 
   return <Ctx.Provider value={state}>{children}</Ctx.Provider>;
 }


### PR DESCRIPTION
## Summary
- replace auth context to remove Next.js router dependency and refresh session on visibility/storage events
- use auth context in Next.js navbar to show cart and profile only when signed in

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "id" | "created_at" | "updated_at">' is not assignable to parameter of type 'never[]'.)*

------
https://chatgpt.com/codex/tasks/task_e_68abbdaacaac832984bf43016218c2c5