### PR TITLE
Fix: add Vite alias and Supabase client for Netlify build

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 import { upsertProfile } from '../lib/upsertProfile';
 
 type AuthCtx = {

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "@/lib/supabase-client";
 import type { User } from "@supabase/supabase-js";
 
 export default function AuthButton() {

--- a/src/components/AuthButtons.tsx
+++ b/src/components/AuthButtons.tsx
@@ -1,10 +1,5 @@
 import { useState } from "react";
-import { createClient } from "@supabase/supabase-js";
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL!,
-  import.meta.env.VITE_SUPABASE_ANON_KEY!
-);
+import { supabase } from '@/lib/supabase-client';
 
 type Props = {
   cta?: string;           // e.g., "Create account"
@@ -67,4 +62,3 @@ export default function AuthButtons({ cta = "Create account", variant="solid", s
     </div>
   );
 }
-

--- a/src/components/AuthMenu.tsx
+++ b/src/components/AuthMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from "react";
-import { supabase } from "../lib/supabase";
+import { supabase } from "@/lib/supabase-client";
 import LazyImg from "./LazyImg";
 import "../styles/auth-menu.css";
 

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 type Status = 'idle' | 'sending' | 'sent' | 'error';
 

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 import { useAuth } from '../auth/AuthContext';
 import { saveProfile } from '../lib/saveProfile';
 

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { ComponentType, useEffect, useState } from 'react';
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 type Props = { component: ComponentType<any> };
 

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect, useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "@/lib/supabase-client";
 
 export default function RequireAuth({ children }: { children: ReactNode }) {
   const [ready, setReady] = useState(false);

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -5,7 +5,7 @@ import './site-header.css';
 import Img from './Img';
 import AuthButton from './AuthButton';
 import CartBadge from './CartBadge';
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 export default function SiteHeader() {
   const [open, setOpen] = useState(false);

--- a/src/components/UserChip.tsx
+++ b/src/components/UserChip.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 import LazyImg from './LazyImg';
 
 export default function UserChip({ email }: { email?: string | null }) {

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "@/lib/supabase-client";
 import LazyImg from "./LazyImg";
 
 type SessionUser = {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
-import { supabase } from '../lib/supabase'
+import { supabase } from '@/lib/supabase-client'
 
 export function useAuth() {
   const [user, setUser] = useState<User | null>(null)

--- a/src/hooks/useCloudProfile.ts
+++ b/src/hooks/useCloudProfile.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "@/lib/supabase-client";
 import { getUserId } from "../lib/session";
 import type { CloudProfile, LocalProfile } from "../types/profile";
 

--- a/src/hooks/useLanguages.ts
+++ b/src/hooks/useLanguages.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "@/lib/supabase-client";
 
 export function useLanguages() {
   const [languages, setLanguages] = useState<any[]>([]);

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "@/lib/supabase-client";
 
 type Wallet = { balance: number };
 

--- a/src/hooks/useXP.ts
+++ b/src/hooks/useXP.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "@/lib/supabase-client";
 
 export function useXP() {
   const [xp, setXp] = useState(0);

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext, useEffect, useState } from 'react';
-import { createClient } from '@/lib/supabase-client';
+import { supabase } from '@/lib/supabase-client';
 
 type AuthState = {
   loading: boolean;
@@ -15,7 +15,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<AuthState>({ loading: true, signedIn: false });
 
   async function loadOnce() {
-    const supabase = createClient();
     const { data } = await supabase.auth.getSession();
     setState({
       loading: false,
@@ -25,8 +24,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   useEffect(() => {
-    const supabase = createClient();
-
     // Initial check (covers coming back from OAuth/magic link)
     loadOnce();
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,5 @@
 // Thin wrappers around supabase-js so pages/components don't touch the client directly
-import { supabase } from './supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 
 /**

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 /** Submit general app/lesson feedback */
 export async function submitFeedback(input: {

--- a/src/lib/getProfile.ts
+++ b/src/lib/getProfile.ts
@@ -1,5 +1,5 @@
 // Tiny helper to load the current user and their profile row
-import { supabase } from './supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 export type NaturProfile = {
   id: string;

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 // --------------------
 // Profiles

--- a/src/lib/quizzes.ts
+++ b/src/lib/quizzes.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 /** Create a quiz shell (title/metadata); questions inserted separately */
 export async function createQuiz(payload: {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,4 +1,4 @@
-import { supabase } from "./supabaseClient";
+import { supabase } from "@/lib/supabase-client";
 
 export async function getUserId(): Promise<string | null> {
   const { data } = await supabase.auth.getUser();

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 function sanitizeFilename(name: string) {
   return name.toLowerCase().replace(/[^a-z0-9\.\-_]/g, '_');

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,0 @@
-import { createClient } from '@supabase/supabase-js'
-
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL!,
-  import.meta.env.VITE_SUPABASE_ANON_KEY!
-)

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,0 @@
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL!;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY!;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/upsertProfile.ts
+++ b/src/lib/upsertProfile.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 export async function upsertProfile(userId: string, email: string | null) {
   const { error } = await supabase.from('profiles').upsert(

--- a/src/lib/use-profile-emoji.ts
+++ b/src/lib/use-profile-emoji.ts
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { supabase } from './supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 export function useProfileEmoji() {
   const [emoji, setEmoji] = useState('🙂');

--- a/src/lib/useAuthUser.ts
+++ b/src/lib/useAuthUser.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from './supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 export function useAuthUser() {
   const [user, setUser] = useState<null | { id: string; email?: string | null }>(null);

--- a/src/lib/xp.ts
+++ b/src/lib/xp.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 // --------------------
 // XP Ledger

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import LoginForm from '../components/LoginForm';
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from '@/lib/supabase-client';
 
 function redirectAfterLogin() {
   try {

--- a/src/pages/auth/callback.tsx
+++ b/src/pages/auth/callback.tsx
@@ -1,10 +1,5 @@
 import { useEffect } from "react";
-import { createClient } from "@supabase/supabase-js";
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL!,
-  import.meta.env.VITE_SUPABASE_ANON_KEY!
-);
+import { supabase } from '@/lib/supabase-client';
 
 export default function Callback() {
   useEffect(() => {

--- a/src/pages/naturbank.tsx
+++ b/src/pages/naturbank.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { supabase } from "../supabase/client";
+import { supabase } from "@/lib/supabase-client";
 import Breadcrumbs from "../components/Breadcrumbs";
 import type { NaturTxn } from "../types/bank";
 import { setTitle } from "./_meta";

--- a/src/pages/passport.tsx
+++ b/src/pages/passport.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { supabase } from "../supabase/client";
+import { supabase } from "@/lib/supabase-client";
 import { WORLDS, WorldKey } from "../data/worlds";
 import type { PassportStamp, PassportBadge } from "../types/passport";
 import Breadcrumbs from "../components/Breadcrumbs";

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "@/lib/supabase-client";
 import WalletPanel from "../components/profile/WalletPanel";
 import XPPanel from "../components/profile/XPPanel";
 import { useCloudProfile } from "../hooks/useCloudProfile";

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,5 @@
 // Single entrypoint for all backend helpers
-export * from '../lib/supabaseClient';
+export * from '@/lib/supabase-client';
 export * from '../lib/types';
 export * from '../lib/mappers';
 export * from '../lib/storage';

--- a/src/supabase/client.ts
+++ b/src/supabase/client.ts
@@ -1,1 +1,0 @@
-export { supabase } from "../lib/supabase";

--- a/supabase/seed_lessons.ts
+++ b/supabase/seed_lessons.ts
@@ -1,4 +1,6 @@
-import { supabase } from "../src/lib/supabase";
+import { createClient } from "../lib/supabase-client";
+
+const supabase = createClient();
 
 const lessons = [
   {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "types": ["node"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["*"]
+      "@/*": ["src/*"]
     }
   },
   "include": ["app", "components", "lib", "scripts", "src"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,19 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import path from "path";
 
 export default defineConfig({
   plugins: [react()],
   envPrefix: ["VITE_", "NEXT_PUBLIC_"],
-  build: { outDir: "dist" }
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  build: {
+    outDir: "dist",
+    rollupOptions: {
+      external: [],
+    },
+  }
 });


### PR DESCRIPTION
## Summary
- add Supabase client helper and Vite `@` alias
- update TypeScript paths and fix imports to use the new alias
- clean up old Supabase client files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abc032d82c83299fd6a22232fa1196