### PR TITLE
Update Home page classes and styles

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -27,71 +27,69 @@ export default function Home() {
   return (
     <main className="home">
       {/* HERO */}
-      <section className="hero">
-        <div className="wrap">
-          <h1>Welcome to the Naturverse™</h1>
-          <p className="lead">
-            A playful world of kingdoms, characters, and quests that teach
-            wellness, creativity, and kindness.
-          </p>
+      <section className="home-hero">
+        <h1>Welcome to the Naturverse™</h1>
+        <p className="lead">
+          A playful world of kingdoms, characters, and quests that teach
+          wellness, creativity, and kindness.
+        </p>
 
-          {showAuthButtons && (
-            <AuthButtons cta="Create account" className="mt-4" />
-          )}
-        </div>
+        {showAuthButtons && (
+          <AuthButtons cta="Create account" className="mt-4" />
+        )}
       </section>
 
       {/* === Top tiles === */}
-      <section className="tiles">
-        <MaybeLink to="/zones" enabled={canClick} className="tile clickable">
-          <h3>Play</h3>
-          <p>Mini-games, stories, and map adventures across 14 kingdoms.</p>
+      <section className="home-tiles">
+        <MaybeLink to="/zones" enabled={canClick} className="tile card">
+          <h3 className="tile-title">Play</h3>
+          <p className="tile-sub">Mini-games, stories, and map adventures across 14 kingdoms.</p>
         </MaybeLink>
 
-        <MaybeLink to="/naturversity" enabled={canClick} className="tile clickable">
-          <h3>Learn</h3>
-          <p>Naturversity lessons in languages, art, music, wellness, and more.</p>
+        <MaybeLink to="/naturversity" enabled={canClick} className="tile card">
+          <h3 className="tile-title">Learn</h3>
+          <p className="tile-sub">Naturversity lessons in languages, art, music, wellness, and more.</p>
         </MaybeLink>
 
-        <MaybeLink to="/naturbank" enabled={canClick} className="tile clickable">
-          <h3>Earn</h3>
-          <p>Collect badges, save favorites, and build your Navatar card.</p>
-          <small>Natur Coin — coming soon</small>
+        <MaybeLink to="/naturbank" enabled={canClick} className="tile card">
+          <h3 className="tile-title">Earn</h3>
+          <p className="tile-sub">Collect badges, save favorites, and build your Navatar card.</p>
+          <small className="muted">Natur Coin — coming soon</small>
         </MaybeLink>
       </section>
 
       {/* === Flow === */}
-      <section className="flow">
+      <section className="home-flow">
         {/* 1) Create → /navatar */}
-        <MaybeLink to="/navatar" enabled={canClick} className="flowRow clickable">
-          <div className="flowTitle">1) Create</div>
-          <div className="flowDesc">Create a free account · create your Navatar</div>
+        <MaybeLink to="/navatar" enabled={canClick} className="flow-row card flow-click">
+          <div className="flow-title">1) Create</div>
+          <div className="flow-desc">Create a free account · create your Navatar</div>
         </MaybeLink>
 
         {/* Arrow */}
-        <div className="flowArrow">↓</div>
+        <div className="flow-arrow">↓</div>
 
         {/* 2) Pick a hub — keep three links, but bold style */}
-        <div className="flowRow">
-          <div className="flowTitle">2) Pick a hub</div>
-          <div className="flowDesc">
-            <a href="/worlds" className="hubLink">
+        <div className="flow-row card">
+          <div className="flow-title">2) Pick a hub</div>
+          <div className="flow-desc">
+            <a href="/worlds" className="hub-link">
               Worlds
             </a>{" "}
-            · <a href="/zones" className="hubLink">Zones</a> ·{" "}
-            <a href="/marketplace" className="hubLink">Marketplace</a>
+            · <a href="/zones" className="hub-link">Zones</a> ·{" "}
+            <a href="/marketplace" className="hub-link">Marketplace</a>
           </div>
         </div>
 
         {/* Arrow */}
-        <div className="flowArrow">↓</div>
+        <div className="flow-arrow">↓</div>
 
         {/* 3) Play · Learn · Earn → /worlds (left label clickable) */}
-        <MaybeLink to="/worlds" enabled={canClick} className="flowRow clickable">
-          <div className="flowTitle">3) Play · Learn · Earn</div>
-          <div className="flowDesc">
+        <MaybeLink to="/worlds" enabled={canClick} className="flow-row card flow-click">
+          <div className="flow-title">3) Play · Learn · Earn</div>
+          <div className="flow-desc">
             Explore, meet characters, earn badges <br />
-            <small>(Natur Coin — coming soon)</small>
+            <small className="muted">(Natur Coin — coming soon)</small>
           </div>
         </MaybeLink>
       </section>

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,47 +1,89 @@
-/* Section wrappers */
-.home .hero {
-  background: linear-gradient(180deg, #F3F7FF 0%, #FFFFFF 100%);
-  padding: 48px 0 28px;
-  border-bottom: 1px solid rgba(36,85,255,0.08);
+:root{
+  --nv-blue:#1f4fd7;      /* Naturverse blue */
+  --nv-ink:#10223d;
+  --nv-ink-2:#34445f;
+  --nv-stroke:#BFD1FF;
+  --nv-soft:#F3F7FF;
+  --nv-round:16px;
 }
-.home .wrap { max-width: 980px; margin: 0 auto; padding: 0 16px; }
 
-.home h1 { font-size: clamp(32px, 4.2vw, 44px); line-height: 1.1; margin: 0 0 8px; }
-.home .lead { font-size: clamp(16px, 2.2vw, 18px); color: #3b3f47; max-width: 820px; }
-
-/* Tiles */
-.home .tiles {
-  max-width: 980px; margin: 28px auto; padding: 0 16px;
-  display: grid; gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px,1fr));
-}
-.home .tile {
-  border:1px solid #BFD1FF;
-  border-radius:16px;
-  padding:16px;
-  text-decoration:none;
-  color:#1b2b4b;
+/* Shared card look */
+.card{
+  border:1px solid var(--nv-stroke);
+  border-radius:var(--nv-round);
   background:#fff;
+  box-shadow:0 1px 0 rgba(10,18,40,.03);
 }
-.home .tile h3 { margin:0 0 6px; }
 
-.home .clickable { transition: transform .08s ease; }
-.home .clickable:hover { transform: translateY(-1px); }
-
-/* Flow */
-.home .flow {
-  max-width: 980px; margin: 28px auto 56px; padding: 0 16px;
-  display:flex; flex-direction:column; gap:16px;
+/* ===== Tiles ===== */
+.home-tiles{
+  max-width:1100px;
+  margin:24px auto 8px;
+  display:grid;
+  grid-template-columns:repeat(3, minmax(0, 1fr));
+  gap:20px;
+  padding:0 16px;
 }
-.home .flowRow {
-  display:flex; justify-content:space-between; gap:16px;
-  border:1px solid #E4EBFF; border-radius:12px;
-  padding:12px 16px; background:#fff;
+.tile{
+  text-decoration:none;
+  padding:18px 20px;
+  transition:transform .08s ease, box-shadow .08s ease, border-color .08s ease;
+  color:var(--nv-ink);
 }
-.home .flowTitle { font-weight:800; color:#1b2b4b; }
-.home .flowDesc { color:#334155; }
-.home .flowArrow { align-self:center; color:#2455FF; text-align:center; }
+.tile:hover{ transform:translateY(-1px); border-color:#8fb0ff; box-shadow:0 4px 14px rgba(31,79,215,.08); }
+.tile-title{ margin:0 0 6px; font-weight:800; color:var(--nv-blue); }
+.tile-sub{ margin:0; color:var(--nv-ink-2); line-height:1.45; }
+.muted{ color:#6b7a96; }
 
-/* Hub links */
-.home .hubLink { font-weight:800; color:#1b2b4b; text-decoration:none; }
-.home .hubLink:hover { text-decoration:underline; }
+/* Responsive: stack 2 / 1 */
+@media (max-width: 980px){ .home-tiles{ grid-template-columns:repeat(2, minmax(0,1fr)); } }
+@media (max-width: 620px){ .home-tiles{ grid-template-columns:1fr; } }
+
+/* ===== Flow ===== */
+.home-flow{
+  max-width:980px;
+  margin:22px auto 40px;
+  padding:18px 16px;
+  border-radius:20px;
+  background:linear-gradient(180deg, var(--nv-soft), #fff);
+  border:1px dashed #d7e3ff;
+}
+.flow-row{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:16px;
+  padding:12px 16px;
+  margin:10px auto;
+}
+.flow-title{ font-weight:800; color:var(--nv-blue); }
+.flow-desc{ color:var(--nv-ink-2); }
+.flow-click{ cursor:pointer; }
+.flow-click:hover{ border-color:#8fb0ff; box-shadow:0 3px 12px rgba(31,79,215,.08); }
+.flow-arrow{
+  text-align:center;
+  color:#7d93c7;
+  font-size:20px;
+  margin:6px 0;
+}
+
+/* Make “hub” links bold, not default blue */
+.hub-link{
+  font-weight:800;
+  color:var(--nv-blue);
+  text-decoration:none;
+  padding:0 2px;
+}
+.hub-link:hover{ text-decoration:underline; }
+
+/* Mobile flow stacking */
+@media (max-width:700px){
+  .flow-row{ flex-direction:column; align-items:flex-start; }
+}
+
+/* Optional: soften the hero band so tiles feel centered under it */
+.home-hero{ 
+  max-width:1100px; margin:0 auto; padding:24px 16px;
+  background:linear-gradient(180deg,#f6f9ff 0%, #ffffff 100%);
+  border-radius:20px;
+}


### PR DESCRIPTION
## Summary
- revamp Home page markup with new tile and flow class hooks
- implement card styling, CSS variables, and responsive flow/tiles

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit...' etc)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68abd76a2fb883299ff3400cf97ef229