### PR TITLE
feat: center layout with reusable container

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,8 +15,10 @@ export default function App() {
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
         />
-        <main id="main" className="container-nv">
-          <RouterProvider router={router} />
+        <main id="main">
+          <div className="container">
+            <RouterProvider router={router} />
+          </div>
         </main>
       </>
     </CartProvider>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,13 +3,15 @@ import { FOOTER_LINKS } from "../data/footer";
 
 export default function Footer() {
   return (
-    <footer className="container-nv" style={{display:"flex",justifyContent:"space-between",alignItems:"center",gap:12}}>
-      <small>© {new Date().getFullYear()} Naturverse™</small>
-      <nav style={{display:"flex",gap:12,flexWrap:"wrap"}}>
-        {FOOTER_LINKS.map(l => (
-          <a key={l.href} href={l.href} className="muted">{l.label}</a>
-        ))}
-      </nav>
+    <footer>
+      <div className="container" style={{display:"flex",justifyContent:"space-between",alignItems:"center",gap:12}}>
+        <small>© {new Date().getFullYear()} Naturverse™</small>
+        <nav style={{display:"flex",gap:12,flexWrap:"wrap"}}>
+          {FOOTER_LINKS.map(l => (
+            <a key={l.href} href={l.href} className="muted">{l.label}</a>
+          ))}
+        </nav>
+      </div>
     </footer>
   );
 }

--- a/src/components/NavBar.module.css
+++ b/src/components/NavBar.module.css
@@ -1,5 +1,5 @@
 .header { position: sticky; top: 0; background: #fff; z-index: 40; }
-.inner { display: flex; align-items: center; gap: 12px; padding: 10px 16px; }
+.inner { display: flex; align-items: center; gap: 12px; padding: 10px 0; }
 .brand { font-weight: 800; font-size: 20px; text-decoration: none; color: #1f4fd8; }
 
 .links { display: none; gap: 14px; margin-left: 8px; }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -12,7 +12,7 @@ export default function NavBar() {
 
   return (
     <header className={styles.header}>
-      <div className={styles.inner}>
+      <div className={`container ${styles.inner}`}>
         <Link to="/" className={styles.brand}>
           Naturverse
         </Link>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -30,7 +30,7 @@ export default function SiteHeader() {
 
   return (
     <header className={`site-header ${open ? 'open' : ''}`}>
-      <div className="wrap">
+      <div className="container">
         <Link to="/" className="brand" onClick={() => setOpen(false)}>
           <Img src="/favicon-32x32.png" width="28" height="28" alt="Naturverse" />
           <span>Naturverse</span>

--- a/src/components/site-header.css
+++ b/src/components/site-header.css
@@ -5,13 +5,11 @@
   background: #fff;
   border-bottom: 1px solid var(--nv-border);
 }
-.site-header .wrap {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 0.75rem 1rem;
+.site-header .container {
   display: flex;
   align-items: center;
   gap: 16px;
+  padding: 0.75rem 0;
 }
 .site-header .brand {
   display: flex;

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -71,7 +71,7 @@ export default function NavatarPage() {
       <PageHead title="Naturverse — Navatar Creator" description="Design your character and save cards." />
       <Meta title="Navatar Creator — Naturverse" description="Design your character and save cards." />
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Navatar" }]} />
-      <main id="main" className="wrap">
+      <main id="main" className="container">
         <h1>Navatar Creator</h1>
         <p>Choose a base type, customize details, and save your character card.</p>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -166,7 +166,7 @@ textarea {
 .btn-small { padding: .45rem .7rem; border-radius: 10px; font-size: .9rem; }
 
 /* Utilities */
-.container { max-width: 1024px; margin: 0 auto; padding: 0 16px; }
+.container { max-width: 1200px; margin: 0 auto; padding: 0 1rem; }
 .stack-md > *+* { margin-top: .75rem; }
 .muted { color: #6b7280; }
 

--- a/src/styles/util.css
+++ b/src/styles/util.css
@@ -2,6 +2,5 @@
   color: var(--nv-text-muted);
 }
 
-.container-nv { max-width: 1100px; margin: 0 auto; padding: 10px; }
 .grid-gap { gap: 12px; }
 img[loading="lazy"] { color: transparent; }


### PR DESCRIPTION
## Summary
- add global `.container` utility and apply it across site header, footer, and main app
- update nav components to wrap content in the shared container
- convert remaining pages to use container for consistent centering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next', TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abe05a28048329827cca4411d6162d