### PR TITLE
feat: allow header navigation to wrap

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -31,76 +31,78 @@ export default function SiteHeader() {
   return (
     <header className={`site-header ${open ? 'open' : ''}`}>
       <div className="container">
-        <Link to="/" className="brand" onClick={() => setOpen(false)}>
-          <Img src="/favicon-32x32.png" width="28" height="28" alt="Naturverse" />
-          <span>Naturverse</span>
-        </Link>
-        <nav className="nav">
-          <NavLink
-            to="/worlds"
-            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-            onClick={() => setOpen(false)}
-          >
-            Worlds
-          </NavLink>
-          <NavLink
-            to="/zones"
-            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-            onClick={() => setOpen(false)}
-          >
-            Zones
-          </NavLink>
-          <NavLink
-            to="/marketplace"
-            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-            onClick={() => setOpen(false)}
-          >
-            Marketplace
-          </NavLink>
-          <NavLink
-            to="/wishlist"
-            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-            onClick={() => setOpen(false)}
-          >
-            Wishlist
-          </NavLink>
-          <NavLink
-            to="/naturversity"
-            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-            onClick={() => setOpen(false)}
-          >
-            Naturversity
-          </NavLink>
-          <NavLink
-            to="/naturbank"
-            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-            onClick={() => setOpen(false)}
-          >
-            NaturBank
-          </NavLink>
-          <NavLink
-            to="/navatar"
-            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-            onClick={() => setOpen(false)}
-          >
-            Navatar
-          </NavLink>
-          <NavLink
-            to="/passport"
-            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-            onClick={() => setOpen(false)}
-          >
-            Passport
-          </NavLink>
-          <NavLink
-            to="/turian"
-            className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-            onClick={() => setOpen(false)}
-          >
-            Turian
-          </NavLink>
-        </nav>
-        <div style={{ marginLeft: 'auto', display: 'flex', gap: 12, alignItems: 'center' }}>
+        <div className="nav-left">
+          <Link to="/" className="brand" onClick={() => setOpen(false)}>
+            <Img src="/favicon-32x32.png" width="28" height="28" alt="Naturverse" />
+            <span>Naturverse</span>
+          </Link>
+          <nav className="nav nav-links">
+            <NavLink
+              to="/worlds"
+              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+              onClick={() => setOpen(false)}
+            >
+              Worlds
+            </NavLink>
+            <NavLink
+              to="/zones"
+              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+              onClick={() => setOpen(false)}
+            >
+              Zones
+            </NavLink>
+            <NavLink
+              to="/marketplace"
+              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+              onClick={() => setOpen(false)}
+            >
+              Marketplace
+            </NavLink>
+            <NavLink
+              to="/wishlist"
+              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+              onClick={() => setOpen(false)}
+            >
+              Wishlist
+            </NavLink>
+            <NavLink
+              to="/naturversity"
+              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+              onClick={() => setOpen(false)}
+            >
+              Naturversity
+            </NavLink>
+            <NavLink
+              to="/naturbank"
+              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+              onClick={() => setOpen(false)}
+            >
+              NaturBank
+            </NavLink>
+            <NavLink
+              to="/navatar"
+              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+              onClick={() => setOpen(false)}
+            >
+              Navatar
+            </NavLink>
+            <NavLink
+              to="/passport"
+              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+              onClick={() => setOpen(false)}
+            >
+              Passport
+            </NavLink>
+            <NavLink
+              to="/turian"
+              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+              onClick={() => setOpen(false)}
+            >
+              Turian
+            </NavLink>
+          </nav>
+        </div>
+        <div className="nav-right">
           <AuthButton />
           <CartBadge />
           <button className="nav-toggle" aria-label="Menu" onClick={() => setOpen((v) => !v)}>

--- a/src/components/site-header.css
+++ b/src/components/site-header.css
@@ -2,15 +2,27 @@
   position: sticky;
   top: 0;
   z-index: 50;
+  width: 100%;
   background: #fff;
-  border-bottom: 1px solid var(--nv-border);
+  border-bottom: 1px solid #e5e7eb;
 }
+
 .site-header .container {
   display: flex;
   align-items: center;
-  gap: 16px;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  row-gap: 8px;
   padding: 0.75rem 0;
 }
+
+.nav-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
 .site-header .brand {
   display: flex;
   align-items: center;
@@ -19,19 +31,32 @@
   color: var(--ink);
   text-decoration: none;
 }
-.site-header .nav {
+
+.nav-links {
   display: flex;
-  gap: 18px;
+  flex-wrap: wrap;
+  gap: 12px;
   align-items: center;
 }
-.site-header .nav a {
+
+.nav-links a {
   color: var(--nv-blue-700);
   text-decoration: none;
   font-weight: 600;
   opacity: 0.9;
 }
-.site-header .nav a.active {
+
+.nav-links a.active {
   color: var(--nv-blue-700);
+}
+
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+  margin-left: auto;
+  order: 2;
 }
 
 .nav-toggle {
@@ -42,6 +67,7 @@
   height: 40px;
   padding: 6px;
 }
+
 .nav-toggle span {
   display: block;
   height: 3px;
@@ -55,7 +81,8 @@
   .nav-toggle {
     display: block;
   }
-  .site-header .nav {
+
+  .nav-links {
     position: fixed;
     inset: 64px 12px auto 12px;
     display: flex;
@@ -71,9 +98,11 @@
     pointer-events: none;
     transition: 0.15s ease;
   }
-  .site-header.open .nav {
+
+  .site-header.open .nav-links {
     transform: translateY(0);
     opacity: 1;
     pointer-events: auto;
   }
 }
+

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,7 @@ html,
 body {
   background: var(--nv-bg);
   color: var(--nv-text);
+  overflow-x: hidden;
 }
 a {
   color: var(--nv-blue-600);


### PR DESCRIPTION
## Summary
- allow header navigation to wrap onto a second row on narrow screens
- add classes for left and right nav sections
- hide horizontal overflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TS errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68abe34d21b8832993748a77847d60da