### PR TITLE
Unify homepage styling across devices

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
   const user = useUser();
 
   const SignedOutCTA = () => (
-    <div className={styles.ctaRow}>
+    <div className="welcome-buttons">
       <a className="btn btn-primary" href="/auth">Create account</a>
       <a className="btn btn-secondary" href="/auth/google">Continue with Google</a>
     </div>
@@ -17,57 +17,57 @@ export default function Home() {
     <main className={styles.home}>
       <section className={styles.hero}>
         <h1>Welcome to the Naturverse™</h1>
-        <p>A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.</p>
+        <p className="welcome-subtitle">A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.</p>
         {!user && <SignedOutCTA />}
       </section>
 
       {/* Play / Learn / Earn */}
       <section className={styles.tiles3}>
-        <a className={styles.infoCard} href="/zones/arcade">
+        <a className={`tile ${styles.infoCard}`} href="/zones/arcade">
           <h3>Play</h3>
-          <p>Mini-games, stories, and map adventures across 14 kingdoms.</p>
+          <p className="tile-subtitle">Mini-games, stories, and map adventures across 14 kingdoms.</p>
         </a>
-        <a className={styles.infoCard} href="/naturversity">
+        <a className={`tile ${styles.infoCard}`} href="/naturversity">
           <h3>Learn</h3>
-          <p>Naturversity lessons in languages, art, music, wellness, and more.</p>
+          <p className="tile-subtitle">Naturversity lessons in languages, art, music, wellness, and more.</p>
         </a>
-        <a className={styles.infoCard} href="/passport">
+        <a className={`tile ${styles.infoCard}`} href="/passport">
           <h3>Earn</h3>
-          <p>Collect badges, save favorites, build your Navatar card.<br/><em>Natur Coin — coming soon</em></p>
+          <p className="tile-subtitle">Collect badges, save favorites, build your Navatar card.<br/><em>Natur Coin — coming soon</em></p>
         </a>
       </section>
 
       {/* How it works flow (vertical) */}
       <section className={styles.flowWrap}>
-        <div className={styles.flowCard}>
-          <div className={styles.flowStep}>1) Create</div>
-          <div className={styles.flowText}>
+        <div className="step-box">
+          <strong>1) Create</strong>
+          <p>
             Create a free account{!user && ' or '}
             {!user && <a href="/navatar">create your Navatar</a>}.
-          </div>
+          </p>
         </div>
 
         <div className={styles.flowArrow}>↓</div>
 
-        <div className={styles.flowCard}>
-          <div className={styles.flowStep}>2) Pick a hub</div>
-          <div className={styles.flowText}>
+        <div className="step-box">
+          <strong>2) Pick a hub</strong>
+          <p>
             <a href="/worlds">Worlds</a> • <a href="/zones">Zones</a> • <a href="/marketplace">Marketplace</a>
-          </div>
+          </p>
         </div>
 
         <div className={styles.flowArrow}>↓</div>
 
-        <div className={styles.flowCard}>
-          <div className={styles.flowStep}>3) Play · Learn · Earn</div>
-          <div className={styles.flowText}>
+        <div className="step-box">
+          <strong>3) Play · Learn · Earn</strong>
+          <p>
             Explore, meet characters, earn badges<br/>
             <small>(Natur Coin — coming soon)</small>
-          </div>
+          </p>
         </div>
 
         {!user && (
-          <div className={styles.ctaRowBottom}>
+          <div className="welcome-buttons">
             <a className="btn btn-primary" href="/auth">Get started</a>
             <a className="btn btn-secondary" href="/auth/google">Continue with Google</a>
           </div>

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -109,3 +109,64 @@ a:focus-visible, button:focus-visible, [role="button"]:focus-visible{
   border-radius:12px;
   z-index:1000;
 }
+
+/* === Auth Buttons === */
+.welcome-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin: 20px auto;
+  flex-wrap: wrap;
+}
+
+/* === Subtitle Texts (under Welcome + Steps + Tiles) === */
+.welcome-subtitle,
+.step-box p,
+.step-box a,
+.tile-subtitle {
+  color: #2563eb;
+  font-weight: 600;
+  text-align: center;
+  margin: 10px 0;
+}
+
+/* === Tiles (Play, Learn, Earn) === */
+.tile {
+  text-align: center;
+  margin: 10px;
+}
+
+.tile h3 {
+  color: #2563eb;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+/* === Steps Section === */
+.step-box {
+  text-align: center;
+  margin: 15px auto;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
+  max-width: 600px;
+}
+
+/* === Responsive Wrapping (for TV, mobile, tablets) === */
+@media (max-width: 768px) {
+  .welcome-buttons {
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+  }
+  .tile {
+    margin: 12px auto;
+  }
+}
+
+@media (min-width: 1600px) {
+  .container {
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,7 @@ export default function Home() {
   const { user, loading } = useAuth()
 
   const SignedOutCTAs = (
-    <div className={styles.ctaRow}>
+    <div className="welcome-buttons">
       <Link className={styles.btn} to="/auth">Create account</Link>
       <Link className={styles.btnSecondary} to="/auth/google">Continue with Google</Link>
     </div>
@@ -16,47 +16,47 @@ export default function Home() {
     <main className={styles.wrap}>
       <section className={styles.hero}>
         <h1>Welcome to the Naturverse™</h1>
-        <p>A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.</p>
+        <p className="welcome-subtitle">A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.</p>
 
         {!loading && !user && SignedOutCTAs}
       </section>
 
       <section className={styles.pills}>
-        <div className={styles.pill}>
+        <div className={`tile ${styles.pill}`}>
           <h3>🎮 Play</h3>
-          <p>Mini-games, stories, and map adventures across 14 kingdoms.</p>
+          <p className="tile-subtitle">Mini-games, stories, and map adventures across 14 kingdoms.</p>
         </div>
-        <div className={styles.pill}>
+        <div className={`tile ${styles.pill}`}>
           <h3>📚 Learn</h3>
-          <p>Naturversity lessons in languages, art, music, wellness, and more.</p>
+          <p className="tile-subtitle">Naturversity lessons in languages, art, music, wellness, and more.</p>
         </div>
-        <div className={styles.pill}>
+        <div className={`tile ${styles.pill}`}>
           <h3>🪙 Earn</h3>
-          <p>Collect badges, save favorites, and build your Navatar card.<br/><em>Natur Coin — coming soon</em></p>
+          <p className="tile-subtitle">Collect badges, save favorites, and build your Navatar card.<br/><em>Natur Coin — coming soon</em></p>
         </div>
       </section>
 
       <section className={styles.flow}>
-        <div className={styles.flowCard}>
+        <div className="step-box">
           <strong>1) Create</strong>
-          <span>Create a free account / create your Navatar</span>
+          <p>Create a free account / create your Navatar</p>
         </div>
         <div className={styles.arrow}>↓</div>
-        <div className={styles.flowCard}>
+        <div className="step-box">
           <strong>2) Pick a hub</strong>
-          <span>
+          <p>
             <Link to="/worlds">Worlds</Link> • <Link to="/zones">Zones</Link> • <Link to="/marketplace">Marketplace</Link>
-          </span>
+          </p>
         </div>
         <div className={styles.arrow}>↓</div>
-        <div className={styles.flowCard}>
+        <div className="step-box">
           <strong>3) Play · Learn · Earn</strong>
-          <span>Explore, meet characters, earn badges</span>
+          <p>Explore, meet characters, earn badges</p>
           <small>(Natur Coin — coming soon)</small>
         </div>
 
         {!loading && !user && (
-          <div className={styles.bottomCtas}>
+          <div className="welcome-buttons">
             <Link className={styles.btn} to="/auth">Get started</Link>
             <Link className={styles.btnSecondary} to="/auth/google">Continue with Google</Link>
           </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -197,3 +197,64 @@ textarea {
 .profile-icon:hover {
   transform: scale(1.2);
 }
+
+/* === Auth Buttons === */
+.welcome-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin: 20px auto;
+  flex-wrap: wrap;
+}
+
+/* === Subtitle Texts (under Welcome + Steps + Tiles) === */
+.welcome-subtitle,
+.step-box p,
+.step-box a,
+.tile-subtitle {
+  color: #2563eb;
+  font-weight: 600;
+  text-align: center;
+  margin: 10px 0;
+}
+
+/* === Tiles (Play, Learn, Earn) === */
+.tile {
+  text-align: center;
+  margin: 10px;
+}
+
+.tile h3 {
+  color: #2563eb;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+/* === Steps Section === */
+.step-box {
+  text-align: center;
+  margin: 15px auto;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
+  max-width: 600px;
+}
+
+/* === Responsive Wrapping (for TV, mobile, tablets) === */
+@media (max-width: 768px) {
+  .welcome-buttons {
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+  }
+  .tile {
+    margin: 12px auto;
+  }
+}
+
+@media (min-width: 1600px) {
+  .container {
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+}

--- a/src/styles/home.module.css
+++ b/src/styles/home.module.css
@@ -1,6 +1,5 @@
 .wrap { padding: 1.25rem 1rem 3rem; }
 .hero { background: linear-gradient(#eef5ff, #ffffff); border-radius: 12px; padding: 1.25rem; margin-bottom: 1rem; position: relative; z-index: 1; }
-.ctaRow, .bottomCtas { display: flex; gap: .75rem; flex-wrap: wrap; margin-top: .75rem; }
 .btn { padding: .6rem 1rem; border-radius: 10px; background: #2b6ee7; color: #fff; box-shadow: 0 6px 0 #1d4fb1; }
 .btnSecondary { padding: .6rem 1rem; border-radius: 10px; background: #3a7cf0; color: #fff; box-shadow: 0 6px 0 #285ec7; }
 
@@ -8,7 +7,6 @@
 .pill { border: 2px solid #9bb9ff; border-radius: 14px; padding: 1rem; background: #fff; }
 
 .flow { background: #f3f7ff; border-radius: 14px; padding: 1rem; }
-.flowCard { background: #fff; border: 1px solid #dbe6ff; border-radius: 12px; padding: .9rem 1rem; margin: .75rem auto; max-width: 560px; text-align: center; }
 .flow small { color: #6b7280; }
 .arrow { text-align: center; font-size: 1.4rem; color: #5c7de7; }
 

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -7,15 +7,8 @@
   margin-bottom: 1.5rem;
 }
 
-.ctaRow,
-.ctaRowBottom {
-  display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  margin-top: 1rem;
-}
 
-/* Top tiles (already present, keep) */
+/* Top tiles (layout wrapper) */
 .tiles3 {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px,1fr));
@@ -23,17 +16,7 @@
   margin: 1.25rem 0 2rem;
 }
 
-.infoCard {
-  background: #fff;
-  border: 2px solid var(--nv-blue-400);
-  border-radius: 16px;
-  padding: 1rem 1.1rem;
-  box-shadow: 0 2px 0 rgba(37,99,235,0.15);
-  text-decoration: none;
-  color: inherit;
-}
-
-/* How it works (make them match infoCard) */
+/* How it works wrapper */
 .flowWrap {
   background: linear-gradient(180deg, #f8fbff 0%, #f6faff 100%);
   padding: 1.25rem;
@@ -41,27 +24,11 @@
   margin-bottom: 2rem;
 }
 
-.flowCard {
-  background: #fff;
-  border: 2px solid var(--nv-blue-400);
-  border-radius: 16px;
-  padding: 0.9rem 1.1rem;
-  box-shadow: 0 2px 0 rgba(37,99,235,0.15);
-}
-
-.flowStep { font-weight: 700; color: var(--nv-blue); margin-bottom: 0.25rem; }
-.flowText { color: #374151; }
 
 .flowArrow {
   text-align: center;
   color: var(--nv-blue);
   margin: 0.5rem 0;
   font-size: 1.25rem;
-}
-
-/* Button polish */
-.btn { /* if you have global btn classes, this can be omitted */ }
-@media (min-width: 768px) {
-  .ctaRowBottom { justify-content: center; }
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -52,3 +52,64 @@
 .card input[type="email"] { height: 44px; padding: 0 12px; }
 .btn.ghost { background: transparent; border: 2px solid var(--brand); }
 .link { text-align: center; }
+
+/* === Auth Buttons === */
+.welcome-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  margin: 20px auto;
+  flex-wrap: wrap;
+}
+
+/* === Subtitle Texts (under Welcome + Steps + Tiles) === */
+.welcome-subtitle,
+.step-box p,
+.step-box a,
+.tile-subtitle {
+  color: #2563eb;
+  font-weight: 600;
+  text-align: center;
+  margin: 10px 0;
+}
+
+/* === Tiles (Play, Learn, Earn) === */
+.tile {
+  text-align: center;
+  margin: 10px;
+}
+
+.tile h3 {
+  color: #2563eb;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+/* === Steps Section === */
+.step-box {
+  text-align: center;
+  margin: 15px auto;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
+  max-width: 600px;
+}
+
+/* === Responsive Wrapping (for TV, mobile, tablets) === */
+@media (max-width: 768px) {
+  .welcome-buttons {
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+  }
+  .tile {
+    margin: 12px auto;
+  }
+}
+
+@media (min-width: 1600px) {
+  .container {
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+}


### PR DESCRIPTION
## Summary
- add global auth button, subtitle, tile, and step box styles for consistent layout on desktop, mobile, and TV
- update home pages to use unified classes and remove redundant module styles

## Testing
- `npm run typecheck` *(fails: Argument of type ... is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68abe57bb1b08329b7b1ae37a030c1a6