### PR TITLE
style: global fixes for buttons, tiles, and nav across all devices

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,0 +1,60 @@
+/* ===== Naturverse Global Fixes ===== */
+
+/* Center and space homepage buttons */
+.auth-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 1rem; /* space between Create + Google */
+  margin-bottom: 1.5rem;
+}
+
+/* Center Play / Learn / Earn tiles */
+.tiles {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin: 2rem auto;
+  flex-wrap: wrap;
+  text-align: center;
+}
+
+.tiles .tile h3 {
+  color: #1d4ed8; /* Naturverse blue */
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+/* Center step flow + make text Naturverse blue */
+.steps {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+.steps h3,
+.steps strong,
+.steps a {
+  color: #1d4ed8; /* Naturverse blue */
+  font-weight: bold;
+  text-decoration: none;
+}
+
+/* Responsive fixes for all devices */
+@media (max-width: 768px) {
+  .tiles {
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .auth-buttons {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+}
+
+@media (min-width: 1600px) {
+  .nav-bar {
+    justify-content: space-between;
+    padding: 0 4rem; /* prevent cutoff on TVs */
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import './styles/shop.css';
 import './styles/edu.css';
 import './main.css';
 import './styles/nvcard.css';
+import './app.css';
 import SkipToContent from './components/SkipToContent';
 import { supabase } from '@/lib/supabase-client';
 


### PR DESCRIPTION
## Summary
- center auth buttons and tiles for consistent homepage layout
- style step flow text in Naturverse blue and bold
- tweak responsive nav spacing for small and large screens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: Cannot find module 'next' or its corresponding type declarations, and other type errors)


------
https://chatgpt.com/codex/tasks/task_e_68abe6ffeb908329b922225a3deba86b