### PR TITLE
Global Layout Polish: Centered Hero + Unified Naturverse Blue Styling

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -49,14 +49,14 @@ export default function Home() {
           </div>
         </div>
 
-        <div className="card" style={{ marginTop: "10px" }}>
+        <div className="card">
           <div className="nv-stepTitle">2) Pick a hub</div>
           <div className="nv-stepBody">
             <strong>Worlds</strong> · <strong>Zones</strong> · <strong>Marketplace</strong>
           </div>
         </div>
 
-        <div className="card" style={{ marginTop: "10px" }}>
+        <div className="card">
           <div className="nv-stepTitle">3) Play · Learn · Earn</div>
           <div className="nv-stepBody">
             Explore, meet characters, earn badges

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -207,7 +207,8 @@ textarea {
 /* Global page spacing */
 main,
 .nv-page {
-  padding-top: 1.25rem; /* space under navbar */
+  padding-top: 1.5rem; /* space under navbar */
+  text-align: center; /* Centered everything */
 }
 
 /* Shared “hero” centering */
@@ -229,21 +230,16 @@ main,
 .nv-ctaRow {
   display: flex;
   justify-content: center;
-  gap: .75rem;
-  margin-bottom: 1.25rem;
+  gap: 1rem;
+  margin-bottom: 2rem;
 }
 
 /* Tile row on home */
 .nv-tiles {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 1rem;
   justify-items: center;
-}
-@media (max-width: 900px) {
-  .nv-tiles {
-    grid-template-columns: 1fr;
-  }
 }
 
 /* Make the blue title + copy consistent inside tiles */
@@ -261,11 +257,14 @@ main,
 .nv-flow {
   margin: 1.25rem auto 0;
   max-width: 64rem;
+  display: grid;
+  gap: .625rem;
 }
 .nv-flow .nv-stepTitle {
   color: var(--nv-blue-700);
   font-weight: 700;
   text-align: center;
+  margin-bottom: .25rem;
 }
 .nv-flow .nv-stepBody {
   color: var(--nv-blue-600);


### PR DESCRIPTION
## Summary
- center all main content and add top padding under navbar
- standardize hero, CTA rows, and tile grid for responsive spacing
- simplify home step flow markup and rely on global blue styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: Cannot find module 'next/link' and 24 other errors)


------
https://chatgpt.com/codex/tasks/task_e_68abf170721083299e705413264239fb