### PR TITLE
Fix Navatar enable, unify Home tiles styles & spacing

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/lib/auth-context';
 
 export default function NavBar() {
   const { ready, user } = useAuth();
+  const authed = Boolean(user);
   const headEmoji =
     (user?.user_metadata?.navatarEmoji as string) ??
     (user?.user_metadata?.avatar_emoji as string) ??
@@ -16,15 +17,26 @@ export default function NavBar() {
         <Link className="nv-brand" href="/">Naturverse</Link>
 
         <nav className="nv-links">
-          <Link href="/worlds">Worlds</Link>
-          <Link href="/zones">Zones</Link>
-          <Link href="/marketplace">Marketplace</Link>
-          <Link href="/wishlist">Wishlist</Link>
-          <Link href="/naturversity">Naturversity</Link>
-          <Link href="/naturbank">NaturBank</Link>
-          <Link href="/navatar">Navatar</Link>
-          <Link href="/passport">Passport</Link>
-          <Link href="/turian">Turian</Link>
+          <Link className="nv-link" href="/worlds">Worlds</Link>
+          <Link className="nv-link" href="/zones">Zones</Link>
+          <Link className="nv-link" href="/marketplace">Marketplace</Link>
+          <Link className="nv-link" href="/wishlist">Wishlist</Link>
+          <Link className="nv-link" href="/naturversity">Naturversity</Link>
+          <Link className="nv-link" href="/naturbank">NaturBank</Link>
+          {authed ? (
+            <Link className="nv-link" href="/navatar">Navatar</Link>
+          ) : (
+            <a
+              href="#"
+              aria-disabled
+              className="nv-link is-disabled"
+              onClick={(e) => e.preventDefault()}
+            >
+              Navatar
+            </a>
+          )}
+          <Link className="nv-link" href="/passport">Passport</Link>
+          <Link className="nv-link" href="/turian">Turian</Link>
           {ready && user ? (
             <>
               <Link className="nv-cart" href="/cart" aria-label="Cart">

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,4 @@
+# send auth routes to index for SPA routing
+/auth/*   /index.html   200
 /*  /index.html  200
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,67 +1,104 @@
-import { Link } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
-import styles from '../styles/home.module.css'
+import { useAuth } from '@/lib/auth-context';
 
 export default function Home() {
-  const { user, loading } = useAuth()
+  const { user } = useAuth();
+  const authed = !!user;
 
-  const SignedOutCTAs = (
-    <div className="welcome-buttons">
-      <Link className={styles.btn} to="/auth">Create account</Link>
-      <Link className={styles.btnSecondary} to="/auth/google">Continue with Google</Link>
-    </div>
-  )
+  const Tile = ({
+    title,
+    body,
+    href,
+  }: {
+    title: string;
+    body: string;
+    href: string;
+  }) => (
+    <a
+      href={authed ? href : '#'}
+      onClick={(e) => {
+        if (!authed) e.preventDefault();
+      }}
+      aria-disabled={!authed}
+      className={`home-tile ${authed ? '' : 'is-disabled'}`}
+    >
+      <div className="home-tile__title">{title}</div>
+      <div className="home-tile__body">{body}</div>
+    </a>
+  );
 
   return (
-    <main className={styles.wrap}>
-      <section className={styles.hero}>
-        <h1>Welcome to the Naturverse™</h1>
-        <p className="welcome-subtitle">A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.</p>
+    <main className="home">
+      <section className="hero">
+        <h1 className="hero__title">Welcome to the Naturverse™</h1>
+        <p className="hero__tag">
+          A playful world of kingdoms, characters, and quests that teach wellness, creativity,
+          and kindness.
+        </p>
 
-        {!loading && !user && SignedOutCTAs}
-      </section>
-
-      <section className={styles.pills}>
-        <div className={`tile ${styles.pill}`}>
-          <h3>🎮 Play</h3>
-          <p className="tile-subtitle">Mini-games, stories, and map adventures across 14 kingdoms.</p>
-        </div>
-        <div className={`tile ${styles.pill}`}>
-          <h3>📚 Learn</h3>
-          <p className="tile-subtitle">Naturversity lessons in languages, art, music, wellness, and more.</p>
-        </div>
-        <div className={`tile ${styles.pill}`}>
-          <h3>🪙 Earn</h3>
-          <p className="tile-subtitle">Collect badges, save favorites, and build your Navatar card.<br/><em>Natur Coin — coming soon</em></p>
+        <div className="hero__cta">
+          <a href="/auth/magic" className="btn btn-primary">
+            Create account
+          </a>
+          <a href="/auth/google" className="btn btn-secondary">
+            Continue with Google
+          </a>
         </div>
       </section>
 
-      <section className={styles.flow}>
-        <div className="step-box">
-          <strong>1) Create</strong>
-          <p>Create a free account / create your Navatar</p>
-        </div>
-        <div className={styles.arrow}>↓</div>
-        <div className="step-box">
-          <strong>2) Pick a hub</strong>
-          <p>
-            <Link to="/worlds">Worlds</Link> • <Link to="/zones">Zones</Link> • <Link to="/marketplace">Marketplace</Link>
-          </p>
-        </div>
-        <div className={styles.arrow}>↓</div>
-        <div className="step-box">
-          <strong>3) Play · Learn · Earn</strong>
-          <p>Explore, meet characters, earn badges</p>
-          <small>(Natur Coin — coming soon)</small>
-        </div>
+      <section className="home-tiles">
+        <Tile
+          title="Play"
+          body="Mini-games, stories, and map adventures across 14 kingdoms."
+          href="/worlds"
+        />
+        <Tile
+          title="Learn"
+          body="Naturversity lessons in languages, art, music, wellness, and more."
+          href="/naturversity"
+        />
+        <Tile
+          title="Earn"
+          body="Collect badges, save favorites, and build your Navatar card. Natur Coin — coming soon"
+          href="/naturbank"
+        />
+      </section>
 
-        {!loading && !user && (
-          <div className="welcome-buttons">
-            <Link className={styles.btn} to="/auth">Get started</Link>
-            <Link className={styles.btnSecondary} to="/auth/google">Continue with Google</Link>
+      <section className="home-flow">
+        <div className="flow-card">
+          <div className="flow-card__title">1) Create</div>
+          <div className="flow-card__body">
+            Create a free account ·{' '}
+            <a href={authed ? '/navatar' : '/auth/magic'}>create your Navatar</a>
           </div>
-        )}
+        </div>
+        <div className="flow-arrow">↓</div>
+
+        <div className="flow-card">
+          <div className="flow-card__title">2) Pick a hub</div>
+          <div className="flow-card__body flow-links">
+            <a href="/worlds">
+              <b>Worlds</b>
+            </a>{' '}
+            ·{' '}
+            <a href="/zones">
+              <b>Zones</b>
+            </a>{' '}
+            ·{' '}
+            <a href="/marketplace">
+              <b>Marketplace</b>
+            </a>
+          </div>
+        </div>
+        <div className="flow-arrow">↓</div>
+
+        <div className="flow-card">
+          <div className="flow-card__title">3) Play · Learn · Earn</div>
+          <div className="flow-card__body">
+            Explore, meet characters, earn badges <em>(Natur Coin — coming soon)</em>
+          </div>
+        </div>
       </section>
     </main>
-  )
+  );
 }
+

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,86 +1,62 @@
-.home { padding: 16px 0 48px; }
-.hero { margin-top: 12px; text-align: center; }
-.homeTitle { margin: 12px 0 8px; }
-.homeSubtitle { margin: 0 auto 18px; max-width: 900px; color: var(--nv-blue-700); }
+/* spacing under the navbar site-wide (small but consistent) */
+main, .page {
+  --top-gap: clamp(8px, 1.5vh, 18px);
+  margin-top: var(--top-gap);
+}
 
+/* hero */
+.hero { text-align: center; max-width: 980px; margin: 0 auto 2.25rem; }
+.hero__title { color: #2763DA; font-weight: 800; font-size: clamp(28px, 4.2vw, 44px); }
+.hero__tag { color: #4c6280; margin: .5rem 0 1.25rem; }
+.hero__cta { display:flex; gap:.8rem; justify-content:center; flex-wrap:wrap; }
 
-/* Hero spacing & centering */
-.ctaRow { display: flex; gap: 16px; justify-content: center; margin: 10px 0 20px; }
-
-/* Tile grid */
-.tiles {
+/* tiles */
+.home-tiles {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 20px;
-  align-items: stretch;
-  margin: 18px auto 8px;
+  gap: 16px;
   max-width: 1080px;
+  margin: 0 auto 2.25rem;
+  padding: 0 .5rem;
 }
-
-/* Clickable wrapper */
-.tileLink { text-decoration: none; display: block; }
-
-/* Tile card */
-.tile {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 10px;
-  padding: 22px;
-  border: 2px solid var(--nv-blue-200);
+@media (max-width: 860px) {
+  .home-tiles { grid-template-columns: 1fr; }
+}
+.home-tile {
+  border: 2px solid #9fb9f3;
   border-radius: 16px;
-  background: var(--nv-card);
-  min-height: 136px;
+  padding: 16px 18px;
+  background: #f7fbff;
+  text-decoration: none;
+  display: block;
+  transition: transform .12s ease, box-shadow .12s ease;
+}
+.home-tile__title {
+  color: #1f53c3; font-weight: 800; font-size: 20px; margin-bottom: 6px;
   text-align: left;
 }
+.home-tile__body { color: #1f53c3; opacity: .95; }
+.home-tile:hover { transform: translateY(-2px); box-shadow: 0 6px 18px rgba(39,99,218,.12); }
+.home-tile.is-disabled { pointer-events: none; opacity: .55; }
 
-/* Prevent weird line stacking */
-.tile * { margin: 0; }
-.tileTitle {
-  font-weight: 800;
-  font-size: 22px;
-  line-height: 1.2;
-  color: var(--nv-blue-700);
-  letter-spacing: .1px;
-  white-space: normal;
-  word-break: keep-all;
+/* flow */
+.home-flow {
+  max-width: 980px; margin: 0 auto 56px; padding: 18px; border-radius: 16px;
+  background: linear-gradient(180deg, rgba(153,187,255,.12), rgba(153,187,255,.06));
+  border: 2px dashed rgba(39,99,218,.25);
 }
-.tileDesc {
-  color: var(--nv-blue-700);
-  line-height: 1.35;
+.flow-card {
+  border: 2px solid #9fb9f3; border-radius: 14px; padding: 14px 16px; margin: 0 auto 10px;
+  background: #fff;
 }
-.tileFoot {
-  color: var(--nv-muted);
-  font-size: 13px;
-}
+.flow-card__title { color:#1f53c3; font-weight:800; text-align:center; margin-bottom:4px; }
+.flow-card__body  { color:#1f53c3; text-align:center; }
+.flow-links a { text-decoration:none; }
+.flow-links a b { color:#1f53c3; }
+.flow-arrow { text-align:center; color:#1f53c3; font-size:20px; margin: 2px 0 10px; }
 
-.tileDisabled { opacity: .55; pointer-events: none; cursor: default; }
+/* buttons */
+.btn { border-radius: 10px; padding: 10px 16px; font-weight: 700; }
+.btn-primary { background:#2763DA; color:#fff; }
+.btn-secondary { background:#1E66F5; color:#fff; }
 
-/* Steps box polish to match tiles */
-.flow {
-  margin: 28px auto 0;
-  max-width: 1080px;
-  background: var(--nv-surface);
-  border-radius: 18px;
-  padding: 20px;
-  border: 2px dashed var(--nv-blue-200);
-}
-.step {
-  margin: 14px auto;
-  padding: 14px 18px;
-  border: 2px solid var(--nv-blue-200);
-  border-radius: 14px;
-  background: var(--nv-card);
-}
-.stepTitle { text-align: center; font-weight: 800; color: var(--nv-blue-700); }
-.stepDesc  { text-align: center; color: var(--nv-blue-700); }
-.muted { color: var(--nv-muted); }
-
-/* universal top spacing under navbar */
-.pageRoot { padding-top: 14px; }
-
-/* Responsive: stack tiles on small screens */
-@media (max-width: 900px) {
-  .tiles { grid-template-columns: 1fr; }
-  .tile  { min-height: 120px; text-align: left; }
-}

--- a/src/styles/nav.css
+++ b/src/styles/nav.css
@@ -10,3 +10,9 @@
 @media (max-width:640px){
   .nav-link { padding: 10px 8px; }
 }
+
+.nv-link.is-disabled {
+  opacity: .45;
+  pointer-events: none;
+  cursor: default;
+}

--- a/styles/nav.css
+++ b/styles/nav.css
@@ -6,3 +6,9 @@
 .nv-links a:hover { text-decoration:underline; }
 .nv-cart { font-size:18px; line-height:1; }
 .nv-profile { display:inline-flex; }
+
+.nv-link.is-disabled {
+  opacity: .45;
+  pointer-events: none;
+  cursor: default;
+}


### PR DESCRIPTION
## Summary
- disable Navatar link when signed out and show profile/cart only when authed
- restyle Home page tiles and flow section with consistent blue theme and auth gating
- redirect `/auth/*` to index for Netlify previews

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type ... not assignable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac01e7bf908329a67f72226a746be4