### PR TITLE
Home: match background to light blue theme

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,7 @@ export default function Home() {
   );
 
   return (
-    <main className="home">
+    <main className="page-wrapper">
       <section className="hero">
         <h1 className="hero__title">Welcome to the Naturverse™</h1>
         <p className="hero__tag">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,12 @@
   --nv-blue-700: #1e4ed8;
   --nv-blue-600: #2563eb;
   --nv-blue-500: #3b82f6;
+  --page-bg: #f8fbff; /* light blue background used across pages */
+}
+
+.page-wrapper {
+  background-color: var(--page-bg);
+  min-height: 100vh;
 }
 
 /* Base */


### PR DESCRIPTION
## Summary
- Add shared `page-wrapper` wrapper to home page to apply themed background
- Define `--page-bg` variable and `page-wrapper` style for light Naturverse blue

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "id" | "created_at" | "updated_at">' is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68ac04b09b6c8329a3b44e07b122b348