### PR TITLE
Center top tiles; left-align flow tiles on homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -45,7 +45,8 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="home-tiles">
+      {/* Top feature tiles: centered */}
+      <section className="home-tiles tiles-centered">
         <Tile
           title="Play"
           body="Mini-games, stories, and map adventures across 14 kingdoms."
@@ -63,7 +64,8 @@ export default function Home() {
         />
       </section>
 
-      <section className="home-flow">
+      {/* Bottom flow tiles: left-aligned with margin-left */}
+      <section className="home-flow flow-left">
         <div className="flow-card">
           <div className="flow-card__title">1) Create</div>
           <div className="flow-card__body">

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -13,14 +13,24 @@ main, .page {
 /* tiles */
 .home-tiles {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 22rem));
   gap: 16px;
-  max-width: 1080px;
-  margin: 0 auto 2.25rem;
-  padding: 0 .5rem;
 }
-@media (max-width: 860px) {
-  .home-tiles { grid-template-columns: 1fr; }
+
+/* Center the whole block horizontally */
+.tiles-centered {
+  justify-content: center;
+  margin-inline: auto;
+  max-width: 72rem;
+}
+
+@media (max-width: 900px) {
+  .home-tiles {
+    grid-template-columns: 1fr;
+    max-width: 34rem;
+  }
+  .tiles-centered { padding-inline: .5rem; }
+  .flow-left { margin-left: .5rem; }
 }
 .home-tile {
   border: 2px solid #9fb9f3;
@@ -41,9 +51,21 @@ main, .page {
 
 /* flow */
 .home-flow {
-  max-width: 980px; margin: 0 auto 56px; padding: 18px; border-radius: 16px;
-  background: linear-gradient(180deg, rgba(153,187,255,.12), rgba(153,187,255,.06));
   border: 2px dashed rgba(39,99,218,.25);
+  background: linear-gradient(180deg, rgba(153,187,255,.12), rgba(153,187,255,.06));
+  border-radius: 16px;
+  padding: 18px;
+  display: grid;
+  gap: .75rem;
+  max-width: 72rem;
+  margin-bottom: 56px;
+}
+
+/* Left-align the flow block and give it a small left margin */
+.flow-left {
+  justify-content: start;
+  margin-left: clamp(0rem, 3vw, 1.25rem);
+  margin-right: 0;
 }
 .flow-card {
   border: 2px solid #9fb9f3; border-radius: 14px; padding: 14px 16px; margin: 0 auto 10px;


### PR DESCRIPTION
## Summary
- center the Play/Learn/Earn tile block for a balanced layout
- left-align the three-step flow cards with a slight left margin

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac07bea1048329a21e7bc6a0d421a9