### PR TITLE
Home — space auth buttons and hide after login

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -35,14 +35,16 @@ export default function Home() {
           and kindness.
         </p>
 
-        <div className="hero__cta">
-          <a href="/auth/magic" className="btn btn-primary">
-            Create account
-          </a>
-          <a href="/auth/google" className="btn btn-secondary">
-            Continue with Google
-          </a>
-        </div>
+        {!authed && (
+          <div className="hero__cta">
+            <a href="/auth/magic" className="btn btn-primary">
+              Create account
+            </a>
+            <a href="/auth/google" className="btn btn-secondary">
+              Continue with Google
+            </a>
+          </div>
+        )}
       </section>
 
       {/* Top feature tiles: centered */}

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -8,7 +8,13 @@ main, .page {
 .hero { text-align: center; max-width: 980px; margin: 0 auto 2.25rem; }
 .hero__title { color: #2763DA; font-weight: 800; font-size: clamp(28px, 4.2vw, 44px); }
 .hero__tag { color: #4c6280; margin: .5rem 0 1.25rem; }
-.hero__cta { display:flex; gap:.8rem; justify-content:center; flex-wrap:wrap; }
+.hero__cta {
+  display:flex;
+  gap:.875rem;
+  flex-wrap:wrap;
+  justify-content:center;
+  margin:.25rem 0 1.25rem;
+}
 
 /* tiles */
 .home-tiles {


### PR DESCRIPTION
## Summary
- hide homepage auth buttons once user session is present
- add flex layout for auth button row with consistent spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS2307: Cannot find module 'next' or its corresponding type declarations., TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string | null', and more)*

------
https://chatgpt.com/codex/tasks/task_e_68ac09362238832981940d2db6a659d8