### PR TITLE
Align home tiles and flow

### DIFF
--- a/src/pages/home.module.css
+++ b/src/pages/home.module.css
@@ -1,5 +1,5 @@
-/* --- TOP TILES (center the whole group) --- */
-.features {
+/* -------- TOP TILES: Play / Learn / Earn (centered) -------- */
+.tilesCenter {
   max-width: 1100px;
   margin: 1.25rem auto 1.75rem;
   display: grid;
@@ -11,14 +11,22 @@
   width: 100%;
   max-width: 360px;
 }
-
-/* --- FLOW (left align) --- */
-.flow {
-  max-width: 1100px;
-  margin: 1.25rem auto 2rem;
+.tilesCenter :global(.home-tile__title),
+.tilesCenter :global(.home-tile__body) {
+  text-align: center;
 }
-.flowList {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+
+/* -------- BOTTOM FLOW: Create / Pick / Play·Learn·Earn (left-aligned) -------- */
+.flowLeft {
+  max-width: 1100px;
+  margin: 1.25rem 0 2rem;
+  display: grid;
+  gap: 0.875rem;
+}
+.flowLeft :global(.flow-card__title),
+.flowLeft :global(.flow-card__body),
+.flowLeft :global(a) {
+  text-align: left;
+  margin-left: 0;
+  margin-right: auto;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,8 +26,8 @@ export default function Home() {
         )}
       </section>
 
-      {/* Top feature tiles: CENTER the group */}
-      <section className={styles.features}>
+      {/* TOP: Play / Learn / Earn (centered) */}
+      <section className={styles.tilesCenter}>
         <div className={styles.tileWrap}>
           <FeatureTile
             title="Play"
@@ -51,30 +51,28 @@ export default function Home() {
         </div>
       </section>
 
-      {/* How it works flow: LEFT aligned */}
-      <section className={styles.flow}>
-        <div className={styles.flowList}>
-          <FlowStep title="1) Create">
-            Create a free account ·{' '}
-            <a href={authed ? '/navatar' : '/auth/magic'}>create your Navatar</a>
-          </FlowStep>
-          <FlowStep title="2) Pick a hub">
-            <a href="/worlds">
-              <b>Worlds</b>
-            </a>{' '}
-            ·{' '}
-            <a href="/zones">
-              <b>Zones</b>
-            </a>{' '}
-            ·{' '}
-            <a href="/marketplace">
-              <b>Marketplace</b>
-            </a>
-          </FlowStep>
-          <FlowStep title="3) Play · Learn · Earn">
-            Explore, meet characters, earn badges <em>(Natur Coin — coming soon)</em>
-          </FlowStep>
-        </div>
+      {/* BOTTOM: Create flow (left-aligned) */}
+      <section className={styles.flowLeft}>
+        <FlowStep title="1) Create">
+          Create a free account ·{' '}
+          <a href={authed ? '/navatar' : '/auth/magic'}>create your Navatar</a>
+        </FlowStep>
+        <FlowStep title="2) Pick a hub">
+          <a href="/worlds">
+            <b>Worlds</b>
+          </a>{' '}
+          ·{' '}
+          <a href="/zones">
+            <b>Zones</b>
+          </a>{' '}
+          ·{' '}
+          <a href="/marketplace">
+            <b>Marketplace</b>
+          </a>
+        </FlowStep>
+        <FlowStep title="3) Play · Learn · Earn">
+          Explore, meet characters, earn badges <em>(Natur Coin — coming soon)</em>
+        </FlowStep>
       </section>
     </main>
   );


### PR DESCRIPTION
## Summary
- center the Play/Learn/Earn tiles
- left-align Create/Pick/Play-Learn-Earn flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0f4bdebc8329951259dc6c923e7b