### PR TITLE
feat(home): refresh homepage and unlock Navatar

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -24,11 +24,7 @@ export default function NavBar() {
           <Link to="/wishlist">Wishlist</Link>
           <Link to="/naturversity">Naturversity</Link>
           <Link to="/naturbank">NaturBank</Link>
-          {user ? (
-            <Link to="/navatar">Navatar</Link>
-          ) : (
-            <span className={styles.disabledLink} aria-disabled="true">Navatar</span>
-          )}
+          <Link to="/navatar">Navatar</Link>
           <Link to="/passport">Passport</Link>
           <Link to="/turian">Turian</Link>
         </nav>
@@ -39,21 +35,13 @@ export default function NavBar() {
               <Link to="/cart" aria-label="Cart" className={styles.cartBtn}>
                 🛒
               </Link>
-              <Link
-                to="/profile"
-                aria-label="Profile"
-                className={styles.profileBtn}
-              >
+              <Link to="/profile" aria-label="Profile" className={styles.profileBtn}>
                 {emoji}
               </Link>
             </>
           )}
 
-          <button
-            aria-label="Menu"
-            className={styles.menuBtn}
-            onClick={() => setOpen(!open)}
-          >
+          <button aria-label="Menu" className={styles.menuBtn} onClick={() => setOpen(!open)}>
             <span className={styles.bar} />
             <span className={styles.bar} />
             <span className={styles.bar} />
@@ -61,14 +49,8 @@ export default function NavBar() {
         </div>
       </div>
 
-      <div
-        className={`${styles.mobile} ${open ? styles.open : ''}`}
-        onClick={() => setOpen(false)}
-      >
-        <div
-          className={styles.sheet}
-          onClick={(e) => e.stopPropagation()}
-        >
+      <div className={`${styles.mobile} ${open ? styles.open : ''}`} onClick={() => setOpen(false)}>
+        <div className={styles.sheet} onClick={(e) => e.stopPropagation()}>
           {ready && user && (
             <Link to="/profile" className={styles.mobileProfile}>
               <span className={styles.mobileEmoji}>{emoji}</span>
@@ -81,11 +63,7 @@ export default function NavBar() {
           <Link to="/wishlist">Wishlist</Link>
           <Link to="/naturversity">Naturversity</Link>
           <Link to="/naturbank">NaturBank</Link>
-          {user ? (
-            <Link to="/navatar">Navatar</Link>
-          ) : (
-            <span className={styles.disabledLink} aria-disabled="true">Navatar</span>
-          )}
+          <Link to="/navatar">Navatar</Link>
           <Link to="/passport">Passport</Link>
           <Link to="/turian">Turian</Link>
         </div>
@@ -93,4 +71,3 @@ export default function NavBar() {
     </header>
   );
 }
-

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -1,0 +1,118 @@
+.page {
+  /* same light-blue you liked elsewhere */
+  background: var(--nv-page-bg, #f5f8ff);
+  min-height: 100%;
+  padding: 24px 0 64px;
+}
+
+.hero {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 0 20px 16px;
+  text-align: center;
+}
+
+.title {
+  margin: 0 0 8px;
+  font-size: clamp(28px, 3.6vw, 44px);
+  color: var(--nv-blue-700, #1f4ed8);
+  font-weight: 800;
+  letter-spacing: 0.2px;
+}
+
+.subtitle {
+  margin: 0 auto 20px;
+  max-width: 960px;
+  color: var(--nv-text-600, #3a4a66);
+}
+
+.ctaRow {
+  display: inline-flex;
+  gap: 16px;
+  margin-top: 8px;
+}
+
+.cta {
+  display: inline-block;
+  padding: 12px 18px;
+  border-radius: 14px;
+  background: var(--nv-blue-600, #2563eb);
+  color: #fff;
+  font-weight: 700;
+  box-shadow: 0 6px 0 rgba(0, 0, 0, 0.12);
+  text-decoration: none;
+}
+
+.featureGrid {
+  max-width: 1040px;
+  margin: 28px auto 8px;
+  padding: 0 20px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+@media (min-width: 880px) {
+  .featureGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.featureCard {
+  background: var(--nv-surface, #fff);
+  border: 2px solid rgba(37, 99, 235, 0.25);
+  border-radius: 18px;
+  padding: 18px 20px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.cardTitleCenter {
+  margin: 0 0 6px;
+  text-align: center;
+  color: var(--nv-blue-700, #1f4ed8);
+  font-weight: 800;
+}
+
+.cardTextCenter {
+  text-align: center;
+}
+
+.flowWrap {
+  max-width: 1040px;
+  margin: 28px auto 0;
+  padding: 18px 20px;
+  border-radius: 18px;
+  border: 2px dashed rgba(37, 99, 235, 0.25);
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.flowStep {
+  background: var(--nv-surface, #fff);
+  border: 2px solid rgba(37, 99, 235, 0.25);
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin: 0 0 14px;
+}
+
+.flowHead {
+  color: var(--nv-blue-700, #1f4ed8);
+  font-weight: 800;
+  margin-bottom: 4px;
+  text-align: left;
+}
+
+.flowBody {
+  color: var(--nv-text-700, #2b3b55);
+  text-align: left;
+}
+
+.flowLink {
+  font-weight: 800;
+  color: var(--nv-blue-700, #1f4ed8);
+  text-decoration: none;
+}
+
+.flowLink:hover {
+  text-decoration: underline;
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,66 +1,85 @@
+import styles from './Home.module.css';
+import { Link } from 'react-router-dom';
 import { useAuth } from '@/lib/auth-context';
-import type React from 'react';
-import { signInWithGoogle } from '../lib/auth';
 
 export default function Home() {
   const { user } = useAuth();
-  const authed = !!user;
 
   return (
-    <main className="home">
-      <section className="hero">
-        <h1 className="homeTitle">Welcome to the Naturverse™</h1>
-        <p className="homeSubtitle">A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.</p>
-
-        {!authed && (
-          <div className="ctaRow">
-            <button className="btn-primary" onClick={() => document.getElementById('open-signup')?.click()}>
+    <main className={styles.page}>
+      <section className={styles.hero}>
+        <h1 className={styles.title}>Welcome to the Naturverse™</h1>
+        <p className={styles.subtitle}>
+          A playful world of kingdoms, characters, and quests that teach wellness, creativity, and
+          kindness.
+        </p>
+        {!user && (
+          <div className={styles.ctaRow}>
+            <Link to="/auth/signup" className={styles.cta}>
               Create account
-            </button>
-            <button className="btn-primary" onClick={signInWithGoogle}>
+            </Link>
+            <Link to="/auth/google" className={styles.cta}>
               Continue with Google
-            </button>
+            </Link>
           </div>
         )}
+      </section>
 
-        <div className="tiles">
-          <Tile title="Play" desc="Mini-games, stories, and map adventures across 14 kingdoms."
-                to={authed ? '/zones' : undefined} disabled={!authed} />
-          <Tile title="Learn" desc="Naturversity lessons in languages, art, music, wellness, and more."
-                to={authed ? '/naturversity' : undefined} disabled={!authed} />
-          <Tile title="Earn" desc="Collect badges, save favorites, and build your Navatar card."
-                foot="Natur Coin — coming soon"
-                to={authed ? '/naturbank' : undefined} disabled={!authed} />
+      {/* Top feature tiles — text centered */}
+      <section className={styles.featureGrid}>
+        <Link to={user ? '/worlds' : '#'} className={styles.featureCard} tabIndex={0}>
+          <h3 className={styles.cardTitleCenter}>Play</h3>
+          <p className={styles.cardTextCenter}>
+            Mini-games, stories, and map adventures across 14 kingdoms.
+          </p>
+        </Link>
+        <Link to={user ? '/naturversity' : '#'} className={styles.featureCard} tabIndex={0}>
+          <h3 className={styles.cardTitleCenter}>Learn</h3>
+          <p className={styles.cardTextCenter}>
+            Naturversity lessons in languages, art, music, wellness, and more.
+          </p>
+        </Link>
+        <Link to={user ? '/naturbank' : '#'} className={styles.featureCard} tabIndex={0}>
+          <h3 className={styles.cardTitleCenter}>Earn</h3>
+          <p className={styles.cardTextCenter}>
+            Collect badges, save favorites, and build your Navatar card.
+            <br />
+            <em>Natur Coin — coming soon</em>
+          </p>
+        </Link>
+      </section>
+
+      {/* Bottom flow — text left-aligned */}
+      <section className={styles.flowWrap}>
+        <div className={styles.flowStep}>
+          <div className={styles.flowHead}>1) Create</div>
+          <div className={styles.flowBody}>
+            Create a free account · <Link to="/navatar">create your Navatar</Link>
+          </div>
+        </div>
+        <div className={styles.flowStep}>
+          <div className={styles.flowHead}>2) Pick a hub</div>
+          <div className={styles.flowBody}>
+            <Link to="/worlds" className={styles.flowLink}>
+              Worlds
+            </Link>{' '}
+            ·{' '}
+            <Link to="/zones" className={styles.flowLink}>
+              Zones
+            </Link>{' '}
+            ·{' '}
+            <Link to="/marketplace" className={styles.flowLink}>
+              Marketplace
+            </Link>
+          </div>
+        </div>
+        <div className={styles.flowStep}>
+          <div className={styles.flowHead}>3) Play · Learn · Earn</div>
+          <div className={styles.flowBody}>
+            Explore, meet characters, earn badges <em>(Natur Coin — coming soon)</em>
+          </div>
         </div>
       </section>
-
-      <section className="flow">
-        <Step title="1) Create" desc={<span>Create a free account · <a href="#" onClick={(e)=>{e.preventDefault(); document.getElementById('open-signup')?.click();}}>create your Navatar</a></span>} />
-        <Step title="2) Pick a hub" desc={<span><b>Worlds</b> · <b>Zones</b> · <b>Marketplace</b></span>} />
-        <Step title="3) Play · Learn · Earn" desc={<span>Explore, meet characters, earn badges <small className="muted">(Natur Coin — coming soon)</small></span>} />
-      </section>
     </main>
-  );
-}
-
-function Tile({ title, desc, foot, to, disabled }:{
-  title:string; desc:string; foot?:string; to?:string; disabled?:boolean
-}) {
-  const core = (
-    <div className={`tile ${disabled ? 'tileDisabled' : ''}`} aria-disabled={disabled}>
-      <h3 className="tileTitle">{title}</h3>
-      <p className="tileDesc">{desc}</p>
-      {foot && <p className="tileFoot">{foot}</p>}
-    </div>
-  );
-  return disabled || !to ? core : <a className="tileLink" href={to}>{core}</a>;
-}
-
-function Step({ title, desc }:{title:string; desc:React.ReactNode}) {
-  return (
-    <div className="step">
-      <div className="stepTitle">{title}</div>
-      <div className="stepDesc">{desc}</div>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
- unlock Navatar link in main navigation
- redesign homepage layout and spacing with centered tiles and left-aligned flow
- add homepage styles and buttons that hide after login

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1e53612c83299ff7f906b15d5ab3