### PR TITLE
fix/home-auth-buttons-and-footer-color

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,7 +5,9 @@ export default function Footer() {
   return (
     <footer>
       <div className="container" style={{display:"flex",justifyContent:"space-between",alignItems:"center",gap:12}}>
-        <small>© {new Date().getFullYear()} Naturverse™</small>
+        <small style={{ color: "var(--nv-blue-600)" }}>
+          © {new Date().getFullYear()} Naturverse™
+        </small>
         <nav style={{display:"flex",gap:12,flexWrap:"wrap"}}>
           {FOOTER_LINKS.map(l => (
             <a key={l.href} href={l.href} className="muted">{l.label}</a>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,23 @@
 import { useAuth } from '@/lib/auth-context';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { supabase } from '@/lib/supabase-client';
 import styles from '@/styles/home.module.css';
 
 export default function Home() {
-  const { user, signInWithGoogle, signInWithMagicLink } = useAuth();
+  const { user } = useAuth();
   const isAuthed = !!user;
+  const navigate = useNavigate();
+
+  const handleGoogle = async () => {
+    await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
+    });
+  };
+
+  const handleCreate = () => {
+    navigate('/login');
+  };
 
   return (
     <main className={styles.page}>
@@ -15,10 +28,10 @@ export default function Home() {
         </p>
         {!isAuthed && (
           <div className={styles.authRow}>
-            <button className={styles.cta} onClick={signInWithMagicLink}>
+            <button className={styles.cta} onClick={handleCreate}>
               Create account
             </button>
-            <button className={styles.cta} onClick={signInWithGoogle}>
+            <button className={styles.cta} onClick={handleGoogle}>
               Continue with Google
             </button>
           </div>


### PR DESCRIPTION
## Summary
- restore home page auth buttons with programmatic navigation and Supabase OAuth
- make footer copyright text blue

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')*
- `npm test` *(fails: Missing script: "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68ac4e9403608329a64ad50eef30b872