### PR TITLE
Add breadcrumbs to Worlds page

### DIFF
--- a/src/routes/worlds/index.tsx
+++ b/src/routes/worlds/index.tsx
@@ -1,8 +1,11 @@
+import Breadcrumbs from "../../components/Breadcrumbs";
 import { WORLDS } from "../../data/worlds";
 
 export default function WorldsIndex() {
   return (
     <div className="nvrs-section worlds">
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "Worlds" }]} />
+      <h1>Worlds</h1>
       <section className="nv-grid">
         {WORLDS.map(w => (
           <a key={w.slug} href={`/worlds/${w.slug}`} className="nv-card">


### PR DESCRIPTION
## Summary
- add breadcrumb navigation and heading to Worlds index page

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "id" | "created_at" | "updated_at">' is not assignable to parameter of type 'never[]'.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4fd7f3888329b67b28fc059eb4c0