### PR TITLE
Normalize hero image sizing for Navatar cards

### DIFF
--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -5,7 +5,7 @@ type Props = { navatar: Navatar };
 
 export default function NavatarCard({ navatar }: Props) {
   return (
-    <div className="card navatar-card">
+    <div className="card navatar-card nv-card character-card">
       <div className="card__header">
         <div className="card__title">
           <span role="img" aria-label="leaf">🌿</span> {navatar.name || navatar.species}
@@ -15,9 +15,10 @@ export default function NavatarCard({ navatar }: Props) {
         </div>
       </div>
 
-      <div className="card-media">
+      <div className="card-media cc-hero">
         {navatar.imageDataUrl ? (
           <img
+            className="cc-img"
             src={navatar.imageDataUrl}
             alt={navatar.name || navatar.species}
             loading="lazy"

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,3 +1,37 @@
+/* --- Hero image sizing ---------------------------------------------------- */
+:root {
+  --hero-max-width: 320px;   /* match Marketplace card feel */
+  --hero-aspect: 3 / 4;      /* portrait-ish like your art */
+}
+
+.mp-hero img,
+.mp-img {
+  width: 100%;
+  height: auto;
+  max-width: var(--hero-max-width);
+  aspect-ratio: var(--hero-aspect);
+  object-fit: contain;
+  display: block;
+  margin-inline: auto;
+}
+
+.cc-hero img,
+.cc-img {
+  width: 100%;
+  height: auto;
+  max-width: var(--hero-max-width);
+  aspect-ratio: var(--hero-aspect);
+  object-fit: contain;
+  display: block;
+  margin-inline: auto;
+}
+
+.character-card,
+.nv-card.character,
+.navatar-card {
+  max-width: calc(var(--hero-max-width) + 2rem);
+}
+
 /* --- Buttons -------------------------------------------------------------- */
 .btn { display:inline-flex; align-items:center; gap:.375rem;
   border:1px solid var(--border, #cdd6e1); background:var(--surface,#fff);
@@ -25,27 +59,6 @@
 .nv-breadcrumbs .sep { opacity:.5; margin: 0 .25rem; }
 .nv-breadcrumbs a { text-decoration: none; }
 .nv-breadcrumbs a:hover { text-decoration: underline; }
-
-/* Navatar card sizing */
-.navatar-card {
-  max-width: 340px;
-  width: 100%;
-}
-
-.navatar-card .card-media {
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  overflow: hidden;
-  border-radius: 12px;
-}
-
-.navatar-card .card-media img,
-.navatar-card .card-media canvas {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
 
 /* Center card on wide screens */
 .navatar-card-wrap {

--- a/src/styles/marketplace.css
+++ b/src/styles/marketplace.css
@@ -17,12 +17,6 @@
   justify-content: center;
 }
 
-.mp-img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;       /* no cropping, just fit */
-}
-
 /* Larger, consistent image on the product detail page */
 .mp-hero {
   width: 100%;


### PR DESCRIPTION
## Summary
- unify hero image sizing across Marketplace and Navatar cards
- remove stretching rules from Marketplace images
- update Navatar preview card to use shared hero styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...> is not assignable to parameter of type 'never[]'...)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5a845e348329a9e9dc16dee17bf2