### PR TITLE
feat: simplify mobile hamburger

### DIFF
--- a/src/components/NavBar.module.css
+++ b/src/components/NavBar.module.css
@@ -12,10 +12,6 @@
 .cartBtn { display: grid; place-items: center; width: 28px; height: 28px; font-size: 18px; text-decoration: none; }
 .profileBtn { display: grid; place-items: center; width: 28px; height: 28px; border-radius: 50%; background: #e6f0ff; font-size: 14px; text-decoration: none; }
 
-/* Hamburger (simple, smaller to match cart) */
-.menuBtn { width: 28px; height: 28px; border-radius: 8px; border: 0; background: #1f4fd8; display: grid; place-items: center; padding: 0 6px; }
-.bar { width: 14px; height: 2px; background: white; display: block; margin: 2px 0; border-radius: 2px; }
-
 /* Mobile drawer */
 .mobile { display: block; position: fixed; inset: 0; background: rgba(0,0,0,.15); opacity: 0; pointer-events: none; transition: opacity .18s ease; }
 .mobile.open { opacity: 1; pointer-events: auto; }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -41,10 +41,14 @@ export default function NavBar() {
             </>
           )}
 
-          <button aria-label="Menu" className={styles.menuBtn} onClick={() => setOpen(!open)}>
-            <span className={styles.bar} />
-            <span className={styles.bar} />
-            <span className={styles.bar} />
+          <button
+            aria-label="Open menu"
+            className={`nv-menu-btn${open ? ' is-open' : ''}`}
+            onClick={() => setOpen(!open)}
+          >
+            <span></span>
+            <span></span>
+            <span></span>
           </button>
         </div>
       </div>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -104,10 +104,14 @@ export default function SiteHeader() {
         <div className="nav-right">
           <AuthButton />
           <CartBadge />
-          <button className="nav-toggle" aria-label="Menu" onClick={() => setOpen((v) => !v)}>
-            <span />
-            <span />
-            <span />
+          <button
+            className={`nv-menu-btn${open ? ' is-open' : ''}`}
+            aria-label="Open menu"
+            onClick={() => setOpen((v) => !v)}
+          >
+            <span></span>
+            <span></span>
+            <span></span>
           </button>
         </div>
       </div>

--- a/src/components/site-header.css
+++ b/src/components/site-header.css
@@ -64,29 +64,7 @@
   order: 2;
 }
 
-.nav-toggle {
-  display: none;
-  border: 0;
-  background: transparent;
-  width: 40px;
-  height: 40px;
-  padding: 6px;
-}
-
-.nav-toggle span {
-  display: block;
-  height: 3px;
-  background: var(--nv-text);
-  border-radius: 3px;
-  margin: 5px 0;
-  transition: 0.2s;
-}
-
-@media (max-width: 820px) {
-  .nav-toggle {
-    display: block;
-  }
-
+@media (max-width: 768px) {
   .nav-links {
     position: fixed;
     inset: 64px 12px auto 12px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,6 +8,7 @@
 @import "./styles/hub.css";
 @import "./styles/crumbs.css";
 @import "./styles/header.css";
+@import "./styles/navbar.css";
 @import "./styles/kingdom.css";
 @import "./styles/brandmark.css";
 @import "./styles/site.css";

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -1,0 +1,65 @@
+/* Mobile hamburger: lines only, no blue pill background */
+.nv-menu-btn {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  /* Remove blue background/box-shadow from any old icon button styles */
+  .nv-icon-button,
+  .btn.nv-icon-button {
+    background: transparent !important;
+    box-shadow: none !important;
+    border: none !important;
+  }
+
+  /* New hamburger */
+  .nv-menu-btn {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 8px;                 /* still gives us a nice 44px tap target with height below */
+    width: 44px;
+    height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;           /* just for focus ring rounding */
+  }
+
+  .nv-menu-btn:focus-visible {
+    outline: 2px solid #1a4d9c;   /* accessible focus */
+    outline-offset: 3px;
+  }
+
+  .nv-menu-btn span {
+    display: block;
+    width: 26px;
+    height: 3px;
+    margin: 3.5px 0;
+    background: #1a4d9c;          /* Naturverse blue lines */
+    border-radius: 3px;
+    transition: transform .2s ease, opacity .2s ease;
+  }
+
+  /* Optional: animate to an “X” when open */
+  .nv-menu-btn.is-open span:nth-child(1) {
+    transform: translateY(6.5px) rotate(45deg);
+  }
+  .nv-menu-btn.is-open span:nth-child(2) {
+    opacity: 0;
+  }
+  .nv-menu-btn.is-open span:nth-child(3) {
+    transform: translateY(-6.5px) rotate(-45deg);
+  }
+
+  /* Nuke any background on an existing SVG-based menu button */
+  .nv-nav .nv-icon-button svg,
+  .nv-nav .nv-icon-button {
+    background: transparent !important;
+    box-shadow: none !important;
+  }
+  .nv-nav .nv-icon-button svg path,
+  .nv-nav .nv-icon-button svg rect {
+    fill: #1a4d9c !important; /* keep the lines blue if the SVG remains */
+  }
+}


### PR DESCRIPTION
## Summary
- replace mobile menu buttons with transparent `nv-menu-btn`
- add global CSS for line-only hamburger with focus styles and open-state animation
- align site header mobile breakpoint with new hamburger

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS errors about missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6006a080832996f62fb3796428df