### PR TITLE
fix: standardize card dimensions

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -222,6 +222,22 @@ textarea {
 .nv-card__media { aspect-ratio: 1 / 1; }
 .nv-card__media img { width: 100%; height: 100%; object-fit: cover; }
 
+/* Ensure all product/character cards stay consistent */
+.nv-card,
+.mp-card,
+.wishlist-card {
+  max-width: 280px;
+  margin: 0 auto;
+}
+
+.nv-card img,
+.mp-card img,
+.wishlist-card img {
+  max-width: 100%;
+  max-height: 280px;
+  object-fit: contain;
+}
+
 /* Profile icon in navbar */
 .profile-icon {
   font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- cap marketplace, navatar, and wishlist cards to consistent width and image height

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type ... is not assignable to parameter of type 'never')*


------
https://chatgpt.com/codex/tasks/task_e_68ac63d6ab1083298b8398c9da8c9d65