### PR TITLE
Align marketplace card sizing with Navatar

### DIFF
--- a/src/styles/marketplace.css
+++ b/src/styles/marketplace.css
@@ -30,3 +30,22 @@
   align-items: center;
   justify-content: center;
 }
+/* Fix marketplace cards to match Navatar sizing */
+.marketplace .nv-card {
+  max-width: 280px;
+  margin: 0 auto;
+}
+
+.marketplace .mp-img {
+  width: 100%;
+  height: auto;
+  max-height: 320px;
+  object-fit: contain;
+}
+
+.marketplace .nv-card h1,
+.marketplace .nv-card h2,
+.marketplace .nv-card h3 {
+  font-size: 1.1rem;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- Cap marketplace cards to Navatar dimensions for consistent sizing
- Limit marketplace images to 320px height and avoid vertical stretching
- Center and normalize marketplace card headings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: argument type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac67895a188329ab556811693aa2ff