### PR TITLE
style: scope secondary blue on remaining pages

### DIFF
--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -67,7 +67,7 @@ export default function NavatarPage() {
   }
 
   return (
-    <div className="nvrs-section navatar page-wrap">
+    <div className="nvrs-section navatar page-wrap nv-secondary-scope">
       <PageHead title="Naturverse — Navatar Creator" description="Design your character and save cards." />
       <Meta title="Navatar Creator — Naturverse" description="Design your character and save cards." />
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Navatar" }]} />

--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -83,7 +83,7 @@ export default function TurianPage() {
   const groupedSuggestions = useMemo(() => SUGGESTIONS, []);
 
   return (
-    <div className="nvrs-section turian">
+    <div className="nvrs-section turian nv-secondary-scope">
         <Page title="Turian the Durian" subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet." >
       <Meta title="Turian — Naturverse" description="Offline AI assistant demo." />
 

--- a/src/pages/marketplace/[slug].tsx
+++ b/src/pages/marketplace/[slug].tsx
@@ -15,7 +15,7 @@ export default function ProductPage(){
   const p = MAP[slug];
   if (!p) return null;
   return (
-    <div className="nvrs-section marketplace">
+    <div className="nvrs-section marketplace nv-secondary-scope">
       <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Marketplace", href: "/marketplace" }, { label: p.name }]} />
       <article className="nv-card">
         <div className="mp-hero">

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -12,7 +12,7 @@ const PRODUCTS = [
 
 export default function MarketplacePage(){
   return (
-    <div className="nvrs-section marketplace">
+    <div className="nvrs-section marketplace nv-secondary-scope">
       <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Marketplace" }]} />
       <h1>Marketplace</h1>
       <div className="nv-grid">

--- a/src/pages/naturbank.tsx
+++ b/src/pages/naturbank.tsx
@@ -102,7 +102,7 @@ export default function NaturBankPage() {
   if (loading) return <main><h1>NaturBank</h1><p>Loading…</p></main>;
 
   return (
-    <div className="nvrs-section naturbank page-wrap">
+    <div className="nvrs-section naturbank page-wrap nv-secondary-scope">
       <Breadcrumbs />
       <main className="bank">
       <h1>NaturBank</h1>

--- a/src/pages/passport.tsx
+++ b/src/pages/passport.tsx
@@ -109,14 +109,14 @@ export default function PassportPage() {
 
   if (loading)
     return (
-      <div className="nvrs-section passport page-wrap">
+      <div className="nvrs-section passport page-wrap nv-secondary-scope">
         <Breadcrumbs />
         <main className="passport"><h1>Passport</h1><p>Loading…</p></main>
       </div>
     );
 
   return (
-    <div className="nvrs-section passport page-wrap">
+    <div className="nvrs-section passport page-wrap nv-secondary-scope">
       <Breadcrumbs />
       <main className="passport">
       <h1>Passport</h1>

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,6 +16,7 @@
 @import "./styles/nv-images.css";
 @import "./styles/marketplace.css";
 @import "./styles/home.css";
+@import "./styles/theme.css";
 @import "../app/styles/global-sections.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; }
 *{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,27 @@
+:root{
+  /* existing tokens... */
+  --nv-blue-700: #2D5CFF; /* our brand blue */
+}
+
+/* Scope helper: everything *except* big headings inherits secondary blue */
+.nv-secondary-scope {
+  /* nothing here – color is applied to child types */
+}
+.nv-secondary-scope p,
+.nv-secondary-scope small,
+.nv-secondary-scope .desc,
+.nv-secondary-scope .meta,
+.nv-secondary-scope .helper,
+.nv-secondary-scope li,
+.nv-secondary-scope label,
+.nv-secondary-scope .subtitle,
+.nv-secondary-scope .breadcrumb,
+.nv-secondary-scope .price {
+  color: var(--nv-blue-700);
+}
+/* Keep major headings and primary links on their existing colors/weights */
+.nv-secondary-scope h1,
+.nv-secondary-scope h2,
+.nv-secondary-scope h3 {
+  color: inherit;
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -8,7 +8,7 @@
   --nv-blue-400: #7eacff;
   --nv-blue-500: #3b82f6; /* primary */
   --nv-blue-600: #2463EB; /* existing brand blue (keep in sync) */
-  --nv-blue-700: #1e4ed8; /* active/focus ring */
+  --nv-blue-700: #2D5CFF; /* active/focus ring */
   --nv-blue-800: #1e479e;
   --nv-blue-900: #173878;
 


### PR DESCRIPTION
## Summary
- introduce nv-secondary-scope helper and update brand blue
- apply secondary text scope to Turian, Passport, Navatar, NaturBank, and Marketplace

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS2307 cannot find module 'next/link', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6c2bfbb08329a22f0d36272bf828