### PR TITLE
Fix Marketplace card sizing to match Wishlist/Navatar

### DIFF
--- a/src/styles/marketplace.css
+++ b/src/styles/marketplace.css
@@ -30,10 +30,22 @@
   align-items: center;
   justify-content: center;
 }
-/* Fix marketplace cards to match Navatar sizing */
-.marketplace .nv-card {
-  max-width: 280px;
+/* Fix Marketplace card sizing to match Wishlist/Navatar */
+.marketplace .nv-card,
+.marketplace .nv-card .mp-hero img {
+  max-width: 220px;   /* Same cap as Wishlist/Navatar */
+  width: 100%;
+  height: auto;
+  object-fit: contain;
   margin: 0 auto;
+}
+
+.marketplace .nv-card {
+  flex: 0 1 220px;    /* Prevents stretching */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
 .marketplace .mp-img {


### PR DESCRIPTION
## Summary
- cap Marketplace cards at 220px like Wishlist/Navatar
- prevent Marketplace cards from stretching and keep content centered

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS2345, TS2339 and related type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6dd60e648329848b56cf904614db