### PR TITLE
fix: remove nav toggle background

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -43,7 +43,7 @@ export default function NavBar() {
 
           {/* Mobile hamburger (no blue background) */}
           <button
-            className="nv-hamburger"
+            className="nv-hamburger nav-toggle"
             aria-label="Open menu"
             onClick={() => setOpen(true)}
           >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -45,9 +45,25 @@
     width: 24px;
     height: 2px;
     margin: 5px 0;
-    background: var(--nv-blue-700);
+    background: #1E40AF;
     border-radius: 1px;
   }
+}
+
+/* Remove blue background box on mobile nav (hamburger menu) */
+.nav-toggle,
+.nav-toggle button,
+.nav-toggle svg {
+  background: none !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+/* Make sure only the lines show */
+.nav-toggle svg {
+  fill: #1E40AF; /* blue lines, match site branding */
+  width: 28px;
+  height: 28px;
 }
 
 /* Keep titles/links as-is (don’t inherit the rule above) */


### PR DESCRIPTION
## Summary
- ensure nav toggle renders only three blue lines without pill background
- update global styles for nav toggle transparency and branding

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TS2345 & TS2339: Argument of type 'Partial<...>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6ecaeb30832992d7970f1d1588cc