### PR TITLE
sitewide/overrides – blue body text + mobile hamburger transparent

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -40,3 +40,5 @@ document.addEventListener('DOMContentLoaded', () => {
     .querySelectorAll<HTMLImageElement>('img:not([loading])')
     .forEach((img) => (img.loading = 'lazy'));
 });
+
+import './styles/overrides.css';

--- a/src/styles/overrides.css
+++ b/src/styles/overrides.css
@@ -1,0 +1,39 @@
+/* === load LAST: global overrides === */
+:root{
+  --nv-blue: #1E40AF;            /* brand blue */
+}
+
+/* 1) Make all secondary/tertiary text blue site-wide */
+html, body { color: var(--nv-blue); }
+
+p, small, li, dd, dt, figcaption, label,
+.breadcrumbs, .breadcrumbs a, .nv-breadcrumbs, .nv-breadcrumbs a,
+.nv-card p, .nv-tile p, .nv-desc, .nv-note, .nv-help,
+.section p, .panel p, .muted, .subtext, .copy,
+input::placeholder, textarea::placeholder {
+  color: var(--nv-blue) !important;
+}
+
+/* keep buttons readable */
+button, .btn, .nv-btn, [role="button"] { color:#fff !important; }
+
+/* 2) Nuke mobile nav box; keep only the three lines */
+header .nav-toggle,
+header [aria-label*="menu"],
+button.hamburger, .hamburger, .menu-button {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  border-radius: 0 !important;
+  padding: 6px !important;
+}
+
+/* make the icon the brand blue */
+header .nav-toggle svg,
+header [aria-label*="menu"] svg,
+button.hamburger svg, .hamburger svg, .menu-button svg {
+  color: var(--nv-blue) !important;
+  fill: none !important;
+  stroke: currentColor !important;
+  stroke-width: 2.5;
+}


### PR DESCRIPTION
## Summary
- add sitewide override stylesheet applying brand blue text and transparent hamburger button
- load overrides last via main entry import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; ... }' is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68ac72a8592883298f3e6a1a7fad56ce