### PR TITLE
Stack hamburger menu lines vertically

### DIFF
--- a/src/styles/overrides.css
+++ b/src/styles/overrides.css
@@ -37,3 +37,23 @@ button.hamburger svg, .hamburger svg, .menu-button svg {
   stroke: currentColor !important;
   stroke-width: 2.5;
 }
+
+/* Hamburger menu lines stacked vertically */
+header .nav-toggle svg,
+header [aria-label*="menu"] svg,
+button.hamburger svg, .hamburger svg, .menu-button svg {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 4px !important;   /* spacing between bars */
+  width: 22px;           /* bar width */
+  height: auto;
+}
+
+header .nav-toggle svg rect,
+header [aria-label*="menu"] svg rect,
+button.hamburger svg rect, .hamburger svg rect, .menu-button svg rect {
+  width: 100% !important;
+  height: 3px !important;
+  rx: 2px;                 /* rounded corners */
+  fill: currentColor !important;
+}


### PR DESCRIPTION
## Summary
- Force hamburger icon `svg` elements into a vertical flex layout
- Style the `rect` bars for consistent width, height, and color

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ac751ccf38832999186dc52360b123