### PR TITLE
Align wishlist card layout with marketplace

### DIFF
--- a/src/pages/wishlist.tsx
+++ b/src/pages/wishlist.tsx
@@ -13,7 +13,7 @@ export default function WishlistPage(){
   const { saved, toggleSave } = useCart();
   const ids = Object.keys(saved).filter(k=>saved[k]);
   return (
-    <div className="nvrs-section wishlist">
+    <main id="main" className="nvrs-section wishlist wishlist-page">
       <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Wishlist" }]} />
       <h1>Wishlist</h1>
       {ids.length===0? <p>No saved items yet.</p> :
@@ -22,7 +22,7 @@ export default function WishlistPage(){
             const item = LOOKUP[id];
             if (!item) return null;
             return (
-              <article key={id} className={styles.card}>
+              <article key={id} className={`nv-card ${styles.card}`}>
                 <Link to={item.href} className={styles.imageWrap}>
                   <img src={item.image} alt={item.name} className={styles.img} />
                 </Link>
@@ -32,6 +32,6 @@ export default function WishlistPage(){
             );
           })}
         </div>}
-    </div>
+    </main>
   );
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -405,3 +405,17 @@ main,
 }
 
 /* keep FUTURE as-is: no rule for .nvrs-section.future */
+
+/* ===== Wishlist: align cards with Marketplace ===== */
+.wishlist-page .nv-card,
+.wishlist-page .product-card,
+.wishlist-page .wl-card {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+/* Unify spacing under images */
+.wishlist-page .nv-card h3,
+.wishlist-page .wl-title {
+  margin-top: 16px;
+}


### PR DESCRIPTION
## Summary
- apply `wishlist-page` hook and `nv-card` class to wishlist cards
- center wishlist cards at 640px max width, matching marketplace

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument type 'Omit...' is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68ac870d2d408329a4fe4056fecff034