### PR TITLE
Align wishlist card sizing with marketplace

### DIFF
--- a/src/pages/Wishlist.module.css
+++ b/src/pages/Wishlist.module.css
@@ -2,13 +2,14 @@
   border-radius: 18px;
   border: 1px solid var(--nv-border);
   background: white;
-  padding: 14px;
+  padding: 12px;
 }
 
 /* Show full product image (like Languages cards) */
 .imageWrap {
   width: 100%;
   aspect-ratio: 4 / 3;
+  max-height: 220px;
   border-radius: 14px;
   overflow: hidden;
   background: #f1f5f9;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -410,12 +410,25 @@ main,
 .wishlist-page .nv-card,
 .wishlist-page .product-card,
 .wishlist-page .wl-card {
-  max-width: 640px;
+  max-width: 300px;
   margin: 0 auto;
+  padding: 12px;
 }
 
 /* Unify spacing under images */
 .wishlist-page .nv-card h3,
 .wishlist-page .wl-title {
   margin-top: 16px;
+}
+
+/* Wishlist image sizing to match Marketplace */
+.wishlist-page .imageWrap {
+  aspect-ratio: 4 / 3;
+  width: 100%;
+  max-height: 220px;
+  border-radius: 14px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }


### PR DESCRIPTION
## Summary
- shrink wishlist cards to 300px width with tighter padding
- cap wishlist images to a 4:3 aspect ratio and max 220px height

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit<...> is not assignable to parameter of type 'never[]')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac8a20e31c8329a33007c9c69bf2f9