### PR TITLE
Scope wishlist card styles to wishlist page

### DIFF
--- a/src/pages/wishlist.tsx
+++ b/src/pages/wishlist.tsx
@@ -9,29 +9,45 @@ const LOOKUP: Record<string,{name:string; image:string; href:string}> = {
   "stickers":     { name:"Sticker Pack", image:"/Marketplace/Stickerpack.png", href:"/marketplace/stickers" },
 };
 
-export default function WishlistPage(){
+export default function WishlistPage() {
   const { saved, toggleSave } = useCart();
-  const ids = Object.keys(saved).filter(k=>saved[k]);
+  const ids = Object.keys(saved).filter((k) => saved[k]);
   return (
-    <main id="main" className="nvrs-section wishlist wishlist-page">
-      <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Wishlist" }]} />
+    <main id="main" data-page="wishlist" className="nvrs-section wishlist page">
+      <Breadcrumbs
+        items={[{ label: "Home", href: "/" }, { label: "Wishlist" }]}
+      />
       <h1>Wishlist</h1>
-      {ids.length===0? <p>No saved items yet.</p> :
+      {ids.length === 0 ? (
+        <p>No saved items yet.</p>
+      ) : (
         <div className="nv-grid">
-          {ids.map(id=>{
+          {ids.map((id) => {
             const item = LOOKUP[id];
             if (!item) return null;
             return (
-              <article key={id} className={`nv-card ${styles.card}`}>
-                <Link to={item.href} className={styles.imageWrap}>
-                  <img src={item.image} alt={item.name} className={styles.img} />
+              <article key={id} className={`nv-card wl-card ${styles.card}`}>
+                <Link
+                  to={item.href}
+                  className={`${styles.imageWrap} imageWrap`}
+                >
+                  <img
+                    src={item.image}
+                    alt={item.name}
+                    className={styles.img}
+                  />
                 </Link>
-                <h3><Link to={item.href}>{item.name}</Link></h3>
-                <button className="btn-danger" onClick={()=>toggleSave(id)}>Remove</button>
+                <h3>
+                  <Link to={item.href}>{item.name}</Link>
+                </h3>
+                <button className="btn-danger" onClick={() => toggleSave(id)}>
+                  Remove
+                </button>
               </article>
             );
           })}
-        </div>}
+        </div>
+      )}
     </main>
   );
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -406,29 +406,31 @@ main,
 
 /* keep FUTURE as-is: no rule for .nvrs-section.future */
 
-/* ===== Wishlist: align cards with Marketplace ===== */
-.wishlist-page .nv-card,
-.wishlist-page .product-card,
+/* ===== WISHLIST ONLY ===== */
+[data-page="wishlist"] .wl-card,
 .wishlist-page .wl-card {
-  max-width: 300px;
-  margin: 0 auto;
+  max-width: 280px; /* matches Marketplace card width */
+  margin: 0 auto 22px;
   padding: 12px;
 }
 
-/* Unify spacing under images */
-.wishlist-page .nv-card h3,
-.wishlist-page .wl-title {
-  margin-top: 16px;
-}
-
-/* Wishlist image sizing to match Marketplace */
-.wishlist-page .imageWrap {
+/* image wrapper inside the card */
+[data-page="wishlist"] .wl-card .imageWrap,
+.wishlist-page .wl-card .imageWrap {
   aspect-ratio: 4 / 3;
   width: 100%;
-  max-height: 220px;
+  max-height: 220px; /* same visual height as Marketplace */
   border-radius: 14px;
   overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+/* image itself */
+[data-page="wishlist"] .wl-card img,
+.wishlist-page .wl-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }


### PR DESCRIPTION
## Summary
- scope wishlist page with `data-page="wishlist"` and `wl-card` markup
- add wishlist-only CSS rules and remove global card styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8e0ce7148329989bccce50e49ef7