### PR TITLE
Scope Navatar card styles

### DIFF
--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -5,20 +5,10 @@ type Props = { navatar: Navatar };
 
 export default function NavatarCard({ navatar }: Props) {
   return (
-    <div className="card navatar-card nv-card character-card">
-      <div className="card__header">
-        <div className="card__title">
-          <span role="img" aria-label="leaf">🌿</span> {navatar.name || navatar.species}
-        </div>
-        <div className="card__meta">
-          {navatar.base} • {new Date(navatar.createdAt).toLocaleDateString()}
-        </div>
-      </div>
-
-      <div className="card-media cc-hero">
+    <article className="card navatar-card nv-card character-card">
+      <div className="card-hero">
         {navatar.imageDataUrl ? (
           <img
-            className="cc-img"
             src={navatar.imageDataUrl}
             alt={navatar.name || navatar.species}
             loading="lazy"
@@ -26,6 +16,15 @@ export default function NavatarCard({ navatar }: Props) {
         ) : (
           <div className="card__placeholder" aria-label="No photo">No photo</div>
         )}
+      </div>
+
+      <div className="card__header">
+        <div className="card__title">
+          <span role="img" aria-label="leaf">🌿</span> {navatar.name || navatar.species}
+        </div>
+        <div className="card__meta">
+          {navatar.base} • {new Date(navatar.createdAt).toLocaleDateString()}
+        </div>
       </div>
 
       <div className="card__section">
@@ -47,6 +46,6 @@ export default function NavatarCard({ navatar }: Props) {
         .card__section{margin:8px 0}
         .card__backstory{margin:6px 0}
       `}</style>
-    </div>
+    </article>
   );
 }

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -71,7 +71,7 @@ export default function NavatarPage() {
       <PageHead title="Naturverse — Navatar Creator" description="Design your character and save cards." />
       <Meta title="Navatar Creator — Naturverse" description="Design your character and save cards." />
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Navatar" }]} />
-      <main id="main" className="container">
+      <main id="main" data-page="navatar" className="page container">
         <h1>Navatar Creator</h1>
         <p>Choose a base type, customize details, and save your character card.</p>
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -15,20 +15,8 @@
   margin-inline: auto;
 }
 
-.cc-hero img,
-.cc-img {
-  width: 100%;
-  height: auto;
-  max-width: var(--hero-max-width);
-  aspect-ratio: var(--hero-aspect);
-  object-fit: contain;
-  display: block;
-  margin-inline: auto;
-}
-
 .character-card,
-.nv-card.character,
-.navatar-card {
+.nv-card.character {
   max-width: calc(var(--hero-max-width) + 2rem);
 }
 
@@ -60,8 +48,44 @@
 .nv-breadcrumbs a { text-decoration: none; }
 .nv-breadcrumbs a:hover { text-decoration: underline; }
 
-/* Center card on wide screens */
-.navatar-card-wrap {
+/* ===== NAVATAR PAGE ONLY ===== */
+[data-page="navatar"] .navatar-card-wrap {
   display: flex;
   justify-content: center;
+}
+
+/* Match the compact Marketplace/Wishlist card sizing */
+[data-page="navatar"] .navatar-card {
+  max-width: 280px;
+  width: 100%;
+  margin: 0 auto 22px;
+  padding: 14px;
+  border-radius: 18px;
+}
+
+/* Image area behaves like the product cards */
+[data-page="navatar"] .navatar-card .card-hero {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  max-height: 220px;
+  border-radius: 14px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f1f5f9;
+}
+
+[data-page="navatar"] .navatar-card .card-hero img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+/* (optional) keep text from stretching the card */
+[data-page="navatar"] .navatar-card h3,
+[data-page="navatar"] .navatar-card p,
+[data-page="navatar"] .navatar-card ul {
+  max-width: 100%;
+  word-break: break-word;
 }


### PR DESCRIPTION
## Summary
- scope Navatar page with `data-page="navatar"`
- refactor NavatarCard markup to use `.card-hero`
- add Navatar-only CSS matching compact Marketplace/Wishlist card sizing

## Testing
- ❌ `npm run typecheck` (fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "id" | "created_at" | "updated_at">' is not assignable to parameter of type 'never[]'.)


------
https://chatgpt.com/codex/tasks/task_e_68ac8f84b1108329a7899f0b71f29a27