### PR TITLE
Refactor Navatar card markup and styling

### DIFF
--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -5,47 +5,36 @@ type Props = { navatar: Navatar };
 
 export default function NavatarCard({ navatar }: Props) {
   return (
-    <article className="card navatar-card nv-card character-card">
-      <div className="card-hero">
-        {navatar.imageDataUrl ? (
-          <img
-            src={navatar.imageDataUrl}
-            alt={navatar.name || navatar.species}
-            loading="lazy"
-          />
-        ) : (
-          <div className="card__placeholder" aria-label="No photo">No photo</div>
-        )}
-      </div>
-
-      <div className="card__header">
-        <div className="card__title">
-          <span role="img" aria-label="leaf">🌿</span> {navatar.name || navatar.species}
+    <div className="character-card">
+      <article className="ccard">
+        <div className="ccard-hero">
+          {navatar.imageDataUrl ? (
+            <img
+              src={navatar.imageDataUrl}
+              alt={navatar.name || navatar.species}
+              loading="lazy"
+            />
+          ) : (
+            <div className="card__placeholder" aria-label="No photo">No photo</div>
+          )}
         </div>
-        <div className="card__meta">
-          {navatar.base} • {new Date(navatar.createdAt).toLocaleDateString()}
+
+        <div className="ccard-head">
+          <div className="left">
+            <span className="sprout" aria-hidden="true">🌿</span>
+            <strong className="name">{navatar.name || navatar.species}</strong>
+          </div>
+          <div className="right">
+            {navatar.base} • {new Date(navatar.createdAt).toLocaleDateString()}
+          </div>
         </div>
-      </div>
 
-      <div className="card__section">
-        <strong>Species:</strong> {navatar.species}
-      </div>
-      <div className="card__section">
-        <strong>Powers:</strong> {navatar.powers.join(" · ")}
-      </div>
-      <div className="card__section">
-        <strong>Backstory:</strong>
-        <p className="card__backstory">{navatar.backstory}</p>
-      </div>
-
-      <style>{`
-        .card__header{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:8px}
-        .card__title{font-weight:700}
-        .card__meta{opacity:.7;font-size:.9rem}
-        .card__placeholder{color:#aaa}
-        .card__section{margin:8px 0}
-        .card__backstory{margin:6px 0}
-      `}</style>
-    </article>
+        <p><span className="label">Species:</span> {navatar.species}</p>
+        <p><span className="label">Powers:</span> {navatar.powers.join(" · ")}</p>
+        <p>
+          <span className="label">Backstory:</span> {navatar.backstory}
+        </p>
+      </article>
+    </div>
   );
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -49,41 +49,67 @@
 .nv-breadcrumbs a:hover { text-decoration: underline; }
 
 /* NAVATAR Character Card */
-[data-page="navatar"] .navatar-card-wrap {
+.nvrs-section.navatar .navatar-card-wrap {
   display: flex;
   justify-content: center;
+  max-width: 840px;
+  margin: 0 auto;
 }
-[data-page="navatar"] .navatar-card {
-  max-width: 360px;     /* bump from ~300 → 360px */
-  width: 100%;
-  margin: 0 auto 24px;
-  padding: 16px;
+
+.nvrs-section.navatar .character-card {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+@media (min-width: 1024px) {
+  .nvrs-section.navatar .character-card { max-width: 840px; }
+}
+
+.nvrs-section.navatar .ccard {
+  padding: 18px 20px 22px;
   border-radius: 18px;
 }
 
-/* Image area exactly like product cards */
-[data-page="navatar"] .navatar-card .card-hero {
+/* Big hero image, same feel as Marketplace */
+.nvrs-section.navatar .ccard-hero {
   width: 100%;
   aspect-ratio: 4 / 3;
-  max-height: 280px;    /* taller image space */
   border-radius: 14px;
   overflow: hidden;
+  background: var(--panel-img, #f1f5f9);
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f1f5f9;
+  margin: 6px 0 12px;
 }
-
-[data-page="navatar"] .navatar-card .card-hero img {
+.nvrs-section.navatar .ccard-hero img {
   width: 100%;
   height: 100%;
   object-fit: contain;
 }
 
-/* Prevent long text from stretching */
-[data-page="navatar"] .navatar-card h3,
-[data-page="navatar"] .navatar-card p,
-[data-page="navatar"] .navatar-card ul {
-  max-width: 100%;
-  word-break: break-word;
+/* Header row: Name on left, meta on right */
+.nvrs-section.navatar .ccard-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 6px 0 10px;
 }
+.nvrs-section.navatar .ccard-head .left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+}
+.nvrs-section.navatar .ccard-head .right {
+  font-weight: 600;
+  opacity: 0.9;
+  white-space: nowrap;
+}
+
+/* Keep the rest of the details readable but compact */
+.nvrs-section.navatar .ccard p,
+.nvrs-section.navatar .ccard li { line-height: 1.35; }
+.nvrs-section.navatar .ccard .label { font-weight: 700; }
+.nvrs-section.navatar .ccard .card__placeholder { color: #aaa; }


### PR DESCRIPTION
## Summary
- restructure NavatarCard with hero image then header for cleaner markup
- apply new global CSS for Navatar character card layout and sizing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac9af2fd388329a93505b13afde0a0