### PR TITLE
feat: restore navatar character card layout

### DIFF
--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -5,36 +5,40 @@ type Props = { navatar: Navatar };
 
 export default function NavatarCard({ navatar }: Props) {
   return (
-    <div className="character-card">
-      <article className="ccard">
-        <div className="ccard-hero">
-          {navatar.imageDataUrl ? (
-            <img
-              src={navatar.imageDataUrl}
-              alt={navatar.name || navatar.species}
-              loading="lazy"
-            />
-          ) : (
-            <div className="card__placeholder" aria-label="No photo">No photo</div>
-          )}
-        </div>
+    <article id="navatar-card" className="nv-card">
+      <header className="cc-head">
+        <span className="cc-name">{navatar.name || navatar.species}</span>
+        <span className="cc-meta">
+          {navatar.base} • {new Date(navatar.createdAt).toLocaleDateString()}
+        </span>
+      </header>
 
-        <div className="ccard-head">
-          <div className="left">
-            <span className="sprout" aria-hidden="true">🌿</span>
-            <strong className="name">{navatar.name || navatar.species}</strong>
-          </div>
-          <div className="right">
-            {navatar.base} • {new Date(navatar.createdAt).toLocaleDateString()}
-          </div>
-        </div>
+      <div className="cc-hero">
+        {navatar.imageDataUrl ? (
+          <img
+            src={navatar.imageDataUrl}
+            alt={navatar.name || navatar.species}
+            loading="lazy"
+          />
+        ) : (
+          <div className="card__placeholder" aria-label="No photo">No photo</div>
+        )}
+      </div>
 
-        <p><span className="label">Species:</span> {navatar.species}</p>
-        <p><span className="label">Powers:</span> {navatar.powers.join(" · ")}</p>
-        <p>
-          <span className="label">Backstory:</span> {navatar.backstory}
-        </p>
-      </article>
-    </div>
+      <dl className="cc-fields">
+        <div>
+          <dt>Species</dt>
+          <dd>{navatar.species}</dd>
+        </div>
+        <div>
+          <dt>Powers</dt>
+          <dd>{navatar.powers.join(" · ")}</dd>
+        </div>
+        <div>
+          <dt>Backstory</dt>
+          <dd>{navatar.backstory}</dd>
+        </div>
+      </dl>
+    </article>
   );
 }

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -167,6 +167,58 @@ export default function NavatarPage() {
         .lib li{margin:4px 0}
         .linklike{background:none;border:none;padding:0;color:#0b62d6;cursor:pointer}
         .note{opacity:.75;margin-top:24px}
+
+        /* === Navatar Character Card reset (scoped) === */
+        #navatar-card{
+          max-width:560px;
+          margin:0 auto;
+          padding:16px 18px 20px;
+          border-radius:24px;
+        }
+
+        /* header row: name left, meta right */
+        #navatar-card .cc-head{
+          display:flex;
+          align-items:center;
+          justify-content:space-between;
+          gap:12px;
+          margin:2px 2px 12px;
+        }
+
+        #navatar-card .cc-name{font-weight:700}
+
+        #navatar-card .cc-meta{
+          opacity:.95;
+          font-weight:500;
+        }
+
+        /* big portrait image, full and centered */
+        #navatar-card .cc-hero{
+          width:100%;
+          aspect-ratio:3/4;
+          border-radius:18px;
+          overflow:hidden;
+          background:#f1f5f9;
+          display:flex;
+          align-items:center;
+          justify-content:center;
+          margin-bottom:12px;
+        }
+
+        #navatar-card .cc-hero img{
+          width:100%;
+          height:100%;
+          object-fit:cover;
+        }
+
+        /* details block keeps your existing look */
+        #navatar-card .cc-fields{margin-top:8px}
+
+        /* mobile tweaks */
+        @media(max-width:480px){
+          #navatar-card{max-width:420px}
+          #navatar-card .cc-name{font-size:1.125rem}
+        }
       `}</style>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- restore navatar character card markup with distinct id and structured fields
- add page-scoped CSS for improved layout and responsive tweaks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...> is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68ac9e021b248329a1d1ac1f7c3b6c45