### PR TITLE
feat: scale navatar card image

### DIFF
--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -5,7 +5,7 @@ type Props = { navatar: Navatar };
 
 export default function NavatarCard({ navatar }: Props) {
   return (
-    <article id="navatar-card" className="nv-card">
+    <article id="navatar-card" className="nv-card navatar-card">
       <header className="cc-head">
         <span className="cc-name">{navatar.name || navatar.species}</span>
         <span className="cc-meta">
@@ -13,7 +13,7 @@ export default function NavatarCard({ navatar }: Props) {
         </span>
       </header>
 
-      <div className="cc-hero">
+      <div className="imageWrap">
         {navatar.imageDataUrl ? (
           <img
             src={navatar.imageDataUrl}

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -193,10 +193,10 @@ export default function NavatarPage() {
         }
 
         /* big portrait image, full and centered */
-        #navatar-card .cc-hero{
+        .navatar-card .imageWrap{
           width:100%;
           aspect-ratio:3/4;
-          border-radius:18px;
+          border-radius:14px;
           overflow:hidden;
           background:#f1f5f9;
           display:flex;
@@ -205,10 +205,13 @@ export default function NavatarPage() {
           margin-bottom:12px;
         }
 
-        #navatar-card .cc-hero img{
-          width:100%;
-          height:100%;
-          object-fit:cover;
+        .navatar-card .imageWrap img{
+          max-width:100%;
+          max-height:100%;
+          width:auto;
+          height:auto;
+          object-fit:contain;
+          display:block;
         }
 
         /* details block keeps your existing look */


### PR DESCRIPTION
## Summary
- ensure Navatar card image wrapper preserves aspect ratio and centers content
- adjust card root and wrapper classes for consistent styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')

------
https://chatgpt.com/codex/tasks/task_e_68aca2ed4c748329abbfaeb9e69a9217