### PR TITLE
feat(worlds): scope to naturverse blue

### DIFF
--- a/src/routes/worlds/index.tsx
+++ b/src/routes/worlds/index.tsx
@@ -3,7 +3,7 @@ import { WORLDS } from "../../data/worlds";
 
 export default function WorldsIndex() {
   return (
-    <div className="nvrs-section worlds">
+    <main id="main" className="nvrs-section worlds nv-page page-worlds">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "Worlds" }]} />
       <h1>Worlds</h1>
       <section className="nv-grid">
@@ -22,6 +22,6 @@ export default function WorldsIndex() {
           </a>
         ))}
       </section>
-    </div>
+    </main>
   );
 }

--- a/src/styles/worlds.css
+++ b/src/styles/worlds.css
@@ -84,3 +84,26 @@
     grid-template-columns: 2fr 1fr;
   }
 }
+
+/* Worlds — force all secondary/caption text to Naturverse Blue */
+.page-worlds :is(p, small, .muted, .subtle, .desc, .kicker, .eyebrow) {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Card subtitles under the map images */
+.page-worlds .card :is(.subtitle, .subhead, .summary) {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Breadcrumbs on this page */
+.page-worlds .crumbs a,
+.page-worlds .crumbs {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Safety: links in cards remain blue even after visit */
+.page-worlds .card a,
+.page-worlds .card a:visited {
+  color: var(--naturverse-blue) !important;
+}
+


### PR DESCRIPTION
## Summary
- tag Worlds page root with `nv-page page-worlds`
- force Worlds text and breadcrumbs to use Naturverse Blue

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "id" | "created_at" | "updated_at">' is not assignable to parameter of type 'never[]'.)*

------
https://chatgpt.com/codex/tasks/task_e_68acf9ba3fbc83299f14d02da25daa77