### PR TITLE
style: unify zones detail titles

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -112,3 +112,16 @@
 /* Links that were defaulting to black in some panels */
 #zones-root a { color: var(--naturverse-blue) !important; }
 #zones-root a:visited { color: var(--naturverse-blue) !important; }
+
+/* ---- Zones: make all card/section titles blue on detail pages ---- */
+/* Works for Arcade, Music, Wellness, Stories, Quizzes, Observations,
+   Culture, Community (and any other /zones/* pages). */
+
+main.nv-page .panel h2,
+main.nv-page .panel h3,
+main.nv-page .panel .title,
+main.nv-page .card h2,
+main.nv-page .card h3 {
+  color: var(--naturverse-blue) !important;
+}
+


### PR DESCRIPTION
## Summary
- force zones panel and card headings to Naturverse blue

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "id" | "created_at" | "updated_at">' is not assignable to parameter of type 'never[]'.)*

------
https://chatgpt.com/codex/tasks/task_e_68acfad55e648329a14c6cfa3ba6be99