### PR TITLE
style: unify Naturversity colors

### DIFF
--- a/app/naturversity/page.tsx
+++ b/app/naturversity/page.tsx
@@ -4,7 +4,7 @@ import ComingSoonBanner from "@/components/coming-soon-banner";
 
 export default function Naturversity() {
   return (
-    <main className="naturverse-bg min-h-screen py-12">
+    <main className="naturversity-page naturverse-bg min-h-screen py-12">
       <div className="container mx-auto px-4 md:px-6">
         <Breadcrumbs items={[{ href: '/', label: 'Home' }, { label: 'Naturversity' }]} />
         <h1 className="naturverse-title">Naturversity</h1>

--- a/src/layouts/Naturversity.tsx
+++ b/src/layouts/Naturversity.tsx
@@ -3,7 +3,7 @@ import "../styles/naturversity.css";
 
 export default function NaturversityLayout() {
   return (
-    <div className="nvrs-naturversity">
+    <div className="nvrs-naturversity naturversity-page">
       <Outlet />
     </div>
   );

--- a/src/styles/naturversity.css
+++ b/src/styles/naturversity.css
@@ -53,3 +53,27 @@
 .nvrs-naturversity .item {
   background: #fff;
 }
+
+/* Fix Naturversity colors */
+.naturversity-page h2,
+.naturversity-page h3,
+.naturversity-page .section-title,
+.naturversity-page .card-title,
+.naturversity-page a,
+.naturversity-page .label {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Teacher cards labels */
+.naturversity-page .teacher-card span,
+.naturversity-page .teacher-card strong {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Buttons in Naturversity */
+.naturversity-page button,
+.naturversity-page .btn {
+  background-color: var(--naturverse-blue) !important;
+  color: white !important;
+  border: none;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,8 @@
 @import './cards.css';
+
+:root {
+  --naturverse-blue: var(--nv-blue-700, #1f4ed8);
+}
 /* Primary button used across Naturversity */
 .btn-primary {
   @apply bg-blue-600 text-white font-extrabold uppercase tracking-wide
@@ -182,4 +186,28 @@ a {
 
 a:hover {
   text-decoration: underline;
+}
+
+/* Fix Naturversity colors */
+.naturversity-page h2,
+.naturversity-page h3,
+.naturversity-page .section-title,
+.naturversity-page .card-title,
+.naturversity-page a,
+.naturversity-page .label {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Teacher cards labels */
+.naturversity-page .teacher-card span,
+.naturversity-page .teacher-card strong {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Buttons in Naturversity */
+.naturversity-page button,
+.naturversity-page .btn {
+  background-color: var(--naturverse-blue) !important;
+  color: white !important;
+  border: none;
 }


### PR DESCRIPTION
## Summary
- enforce Naturverse blue accents across Naturversity sections
- scope Naturversity pages with a shared class for consistent styling
- expose Naturverse blue CSS variable globally for reuse

## Testing
- `npm run typecheck` *(fails: Argument of type ... is not assignable to parameter of type 'never')*


------
https://chatgpt.com/codex/tasks/task_e_68acff388d10832989994d8bd8f698ed