### PR TITLE
feat: enforce Naturverse blue in Navatar text

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -91,3 +91,30 @@ label {
   color: var(--naturverse-blue) !important;
 }
 
+/* Navatar section */
+.navatar-card,
+.navatar-card h2,
+.navatar-card h3,
+.navatar-card h4,
+.navatar-card h5,
+.navatar-card p,
+.navatar-card span,
+.navatar-card label,
+.navatar-card .detail-label,
+.navatar-card .detail-value,
+.navatar-card .species,
+.navatar-card .powers,
+.navatar-card .backstory {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Creator form labels + detail text */
+.navatar-creator,
+.navatar-creator h2,
+.navatar-creator h3,
+.navatar-creator label,
+.navatar-creator p,
+.navatar-creator span {
+  color: var(--naturverse-blue) !important;
+}
+


### PR DESCRIPTION
## Summary
- ensure all Navatar card and creator text uses `var(--naturverse-blue)`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68ad01aeb1288329a9239b0f631ebe38