### PR TITLE
feat: apply Naturverse blue styling to cart page

### DIFF
--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -1,37 +1,59 @@
-import { useCart } from "../lib/cart";
-import Breadcrumbs from "../components/Breadcrumbs";
+import { useCart } from '../lib/cart';
+import Breadcrumbs from '../components/Breadcrumbs';
 
-export default function CartPage(){
+export default function CartPage() {
   const { items, inc, dec, remove, subtotal } = useCart();
   return (
     <div className="nvrs-section cart">
-      <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Cart" }]} />
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Cart' }]} />
       <h1>Cart</h1>
-      {items.length===0 ? <p>Your cart is empty.</p> :
+      {items.length === 0 ? (
+        <p>Your cart is empty.</p>
+      ) : (
         <div className="nv-card">
-          {items.map(it=>(
-            <div key={it.id} style={{display:"grid", gridTemplateColumns:"64px 1fr auto", gap:"1rem", alignItems:"center", marginBottom:"1rem"}}>
-              <img src={it.image} alt="" width="64" height="64" style={{objectFit:"contain"}}/>
+          {items.map((it) => (
+            <div
+              key={it.id}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '64px 1fr auto',
+                gap: '1rem',
+                alignItems: 'center',
+                marginBottom: '1rem',
+              }}
+            >
+              <img src={it.image} alt="" width="64" height="64" style={{ objectFit: 'contain' }} />
               <div>
                 <div>{it.name}</div>
-                <div>${it.price.toFixed(2)}</div>
-                <div style={{display:"flex", gap:".5rem", marginTop:".25rem"}}>
-                  <button className="btn-ghost" onClick={()=>dec(it.id)}>−</button>
-                  <span>{it.qty}</span>
-                  <button className="btn-ghost" onClick={()=>inc(it.id)}>+</button>
-                  <button className="btn-danger" onClick={()=>remove(it.id)}>Remove</button>
+                <div className="price">${it.price.toFixed(2)}</div>
+                <div style={{ display: 'flex', gap: '.5rem', marginTop: '.25rem' }}>
+                  <div className="qty-control">
+                    <button onClick={() => dec(it.id)} aria-label="Decrease quantity">
+                      −
+                    </button>
+                    <input type="number" value={it.qty} readOnly aria-label="Quantity" />
+                    <button onClick={() => inc(it.id)} aria-label="Increase quantity">
+                      +
+                    </button>
+                  </div>
+                  <button className="btn-danger" onClick={() => remove(it.id)}>
+                    Remove
+                  </button>
                 </div>
               </div>
-              <div>${(it.qty*it.price).toFixed(2)}</div>
+              <div className="price">${(it.qty * it.price).toFixed(2)}</div>
             </div>
           ))}
-          <hr/>
-          <div style={{display:"flex", justifyContent:"space-between"}}>
-            <strong>Subtotal</strong><strong>${subtotal.toFixed(2)}</strong>
+          <hr />
+          <div className="subtotal" style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <strong>Subtotal</strong>
+            <strong>${subtotal.toFixed(2)}</strong>
           </div>
-          <button className="btn-primary w-full" style={{marginTop:"1rem"}}>Checkout (stub)</button>
+          <button className="btn-primary w-full" style={{ marginTop: '1rem' }}>
+            Checkout (stub)
+          </button>
         </div>
-      }
+      )}
     </div>
   );
 }

--- a/src/styles/cart.css
+++ b/src/styles/cart.css
@@ -242,3 +242,47 @@
   color: var(--nv-blue-600);
   cursor: pointer;
 }
+/* ==== Cart Page Fix ==== */
+.cart :is(h1, h2, h3, h4, h5, h6, p, span, label, small, a, strong) {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Breadcrumbs */
+.cart .breadcrumb,
+.cart .breadcrumb a {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Prices + subtotal labels */
+.cart .price,
+.cart .subtotal,
+.cart td,
+.cart th {
+  color: var(--naturverse-blue) !important;
+  font-weight: 600;
+}
+
+/* Checkout button */
+.cart .btn-primary {
+  background: linear-gradient(180deg, #3f7cff 0%, #2452ff 100%);
+  color: #fff !important;
+  border: none;
+  box-shadow: 0 6px 0 rgba(25, 55, 170, 0.35);
+}
+.cart .btn-primary:disabled {
+  opacity: 0.45;
+  box-shadow: none;
+}
+
+/* Quantity controls */
+.cart .qty-control button {
+  border: 2px solid var(--naturverse-blue);
+  color: var(--naturverse-blue);
+  background: #fff;
+  font-weight: bold;
+}
+.cart .qty-control input {
+  border: 1px solid var(--naturverse-blue);
+  color: var(--naturverse-blue);
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- tune Cart page text, buttons, and quantity controls with Naturverse blue scheme
- mark up prices and subtotal for consistent styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type ... is not assignable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad05753f348329a560991d15edd34a