### PR TITLE
fix: left-align Turian chat messages

### DIFF
--- a/src/styles/turian.css
+++ b/src/styles/turian.css
@@ -182,3 +182,23 @@
 /* Spacing tweaks so the panel breathes on mobile */
 .turian .card { padding: 18px; }
 .turian .chatCard { padding: 20px; border-radius: 16px; }
+
+/* Turian chat box layout fix */
+.chat-container,
+.chat-messages {
+  display: flex;
+  flex-direction: row !important;
+  align-items: flex-start !important;
+  justify-content: flex-start !important;
+  flex-wrap: wrap;
+  text-align: left !important;
+  margin-left: 0 !important;
+}
+
+/* Make text horizontal, left-aligned */
+.chat-message {
+  display: inline-block;
+  margin: 4px 8px;
+  color: var(--naturverse-blue) !important;
+  white-space: normal;
+}


### PR DESCRIPTION
## Summary
- force chat container and messages into horizontal flex layout
- ensure chat messages render inline and use Naturverse blue text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "id" | "created_at" | "updated_at">' is not assignable to parameter of type 'never[]' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ad08d55ae08329a386548d7c837dec