### PR TITLE
style: unify marketplace buttons

### DIFF
--- a/src/styles/marketplace.css
+++ b/src/styles/marketplace.css
@@ -1,3 +1,30 @@
+/* Marketplace button consistency */
+.marketplace button,
+.marketplace .save-btn,
+.marketplace .cart-btn {
+  background-color: var(--naturverse-blue) !important;
+  color: #fff !important;
+  border: none !important;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-weight: bold;
+  font-size: 15px;
+  cursor: pointer;
+  box-shadow: 0 2px 0 rgba(0,0,0,0.15);
+}
+
+/* Hover + active states */
+.marketplace button:hover,
+.marketplace .save-btn:hover,
+.marketplace .cart-btn:hover {
+  background-color: #0044cc !important; /* darker blue hover */
+}
+
+.marketplace button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Marketplace card layout uses shared card styles */
 .mp-card,
 .mp-card .mp-image,


### PR DESCRIPTION
## Summary
- unify all marketplace buttons to Naturverse blue for consistent action styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TS2345: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad09f74fbc8329b1aa123fa194e6dd