### PR TITLE
style: apply blue theme to Navatar text

### DIFF
--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -5,7 +5,7 @@ type Props = { navatar: Navatar };
 
 export default function NavatarCard({ navatar }: Props) {
   return (
-    <article id="navatar-card" className="nv-card navatar-card">
+    <article id="navatar-card" className="nv-card navatar-card character-card">
       <header className="cc-head">
         <span className="cc-name">{navatar.name || navatar.species}</span>
         <span className="cc-meta">

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -67,7 +67,7 @@ export default function NavatarPage() {
   }
 
   return (
-    <div className="nvrs-section navatar page-wrap nv-secondary-scope">
+    <div className="nvrs-section navatar page-wrap nv-secondary-scope nav-page">
       <PageHead title="Naturverse — Navatar Creator" description="Design your character and save cards." />
       <Meta title="Navatar Creator — Naturverse" description="Design your character and save cards." />
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Navatar" }]} />

--- a/src/styles/naturverse-blue.css
+++ b/src/styles/naturverse-blue.css
@@ -127,3 +127,26 @@ hr,
 .line {
   border-color: var(--naturverse-blue) !important;
 }
+
+/* Navatar Page Fix - force all text to blue */
+.nav-page,
+.nav-page h1,
+.nav-page h2,
+.nav-page h3,
+.nav-page label,
+.nav-page p,
+.nav-page span,
+.nav-page .card,
+.nav-page .card * {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Character Card text */
+.character-card,
+.character-card h1,
+.character-card h2,
+.character-card h3,
+.character-card p,
+.character-card span {
+  color: var(--naturverse-blue) !important;
+}


### PR DESCRIPTION
## Summary
- ensure Navatar page container has `nav-page` class and character card uses `character-card`
- force Navatar and character card text to use Naturverse blue theme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0abb8ee0832980ca51ac7fd62724