### PR TITLE
style: apply Turian page blue theme and prompt chips

### DIFF
--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -14,25 +14,39 @@ const read = (): Msg[] => {
 const write = (v: Msg[]) => { try { localStorage.setItem(K, JSON.stringify(v.slice(-30))); } catch {} };
 
 const SUGGESTIONS: { section: string; items: string[] }[] = [
-  { section: "Worlds", items: [
-    "Give me a 3-stop itinerary for Thailandia.",
-    "Fun facts about penguins in Antarctiland.",
-    "Create a scavenger list for Europalia."
-  ]},
-  { section: "Zones", items: [
-    "Pitch a 1-minute karaoke theme for Music.",
-    "Daily stretch routine for Wellness (5 mins).",
-    "Quest ideas for Creator Lab characters."
-  ]},
-  { section: "Naturbank", items: [
-    "Explain NATUR coin in kid-friendly terms.",
-    "How would a wallet work here (high level)?"
-  ]},
-  { section: "Marketplace", items: [
-    "3 merch ideas tied to Kiwilandia.",
-    "How to word a wishlist description for a tee?"
-  ]},
+  {
+    section: "Worlds",
+    items: [
+      "Give me a 3-stop itinerary for Thailandia.",
+      "Fun facts about penguins in Antarctiland.",
+      "Create a scavenger list for Europalia.",
+    ],
+  },
+  {
+    section: "Zones",
+    items: [
+      "Pitch a 1-minute karaoke theme for Music.",
+      "Daily stretch routine for Wellness (5 mins).",
+      "Quest ideas for Creator Lab characters.",
+    ],
+  },
+  {
+    section: "Naturbank",
+    items: [
+      "Explain NATUR coin in kid-friendly terms.",
+      "How would a wallet work here (high level)?",
+    ],
+  },
+  {
+    section: "Marketplace",
+    items: [
+      "3 merch ideas tied to Kiwilandia.",
+      "How to word a wishlist description for a tee?",
+    ],
+  },
 ];
+const SAMPLE_PROMPTS = SUGGESTIONS.flatMap((g) => g.items);
+
 
 // Use site favicon as Turian's mascot for consistent branding
 const mascotSrc = "/favicon.ico";
@@ -80,10 +94,10 @@ export default function TurianPage() {
   }, [history.length]);
 
   const hasHistory = history.length > 0;
-  const groupedSuggestions = useMemo(() => SUGGESTIONS, []);
+  const prompts = useMemo(() => SAMPLE_PROMPTS, []);
 
   return (
-    <div className="nvrs-section turian nv-secondary-scope">
+    <div id="turian-page" className="nvrs-section turian nv-secondary-scope">
         <Page
           title="Turian the Durian"
           subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet."
@@ -103,22 +117,15 @@ export default function TurianPage() {
         </div>
       </div>
 
-      {!hasHistory && (
-        <div className="turian-suggestions turian-quests">
-          {groupedSuggestions.map(group => (
-            <div className="turian-card" key={group.section}>
-              <div className="turian-card-h">
-                <span className="label">{group.section}</span>
-              </div>
-              <div className="chips">
-                {group.items.map((s, i) => (
-                  <button key={i} className="chip" onClick={() => ask(s)}>{s}</button>
-                ))}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+        {!hasHistory && (
+          <div className="samplePrompts">
+            {prompts.map((s, i) => (
+              <button key={i} className="promptChip" onClick={() => ask(s)}>
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
 
       <div className="turian-panel">
         <div className="turian-msgs" ref={listRef} aria-live="polite">
@@ -161,7 +168,7 @@ export default function TurianPage() {
           )}
         </div>
 
-        <form className="turian-input" onSubmit={onSubmit}>
+        <form className="turian-input inputWrap" onSubmit={onSubmit}>
           <input
             aria-label="Ask Turian"
             placeholder="Ask Turian anything…"

--- a/src/styles/turian.css
+++ b/src/styles/turian.css
@@ -202,3 +202,82 @@
   color: var(--naturverse-blue) !important;
   white-space: normal;
 }
+
+/* ===== Turian page only =====
+   Wrap the page in an id or class like <main id="turian-page"> …
+   (If you already have one, keep it; these selectors include common fallbacks.)
+*/
+#turian-page,
+[data-route="turian"],
+.page--turian {}
+
+/* 1) Force all “secondary” text + UI to Naturverse blue */
+#turian-page a,
+#turian-page h1, #turian-page h2, #turian-page h3,
+#turian-page .title,
+#turian-page .subtitle,
+#turian-page .label,
+#turian-page .price,
+#turian-page .fineprint,
+#turian-page .muted,
+#turian-page .pill,
+#turian-page .link {
+  color: var(--naturverse-blue) !important;
+  border-color: var(--naturverse-blue) !important;
+}
+
+/* Buttons */
+#turian-page .btn-primary {
+  background: var(--naturverse-blue) !important;
+  color: #fff !important;
+  border-color: var(--naturverse-blue) !important;
+}
+#turian-page .btn-ghost,
+#turian-page .btn-outline {
+  background: transparent !important;
+  color: var(--naturverse-blue) !important;
+  border: 2px solid var(--naturverse-blue) !important;
+}
+
+/* 2) Fix the “sample prompts” text: stop centering, stop stacking.
+      Make them left-aligned chips in a horizontal scroll row. */
+#turian-page .samplePrompts,
+#turian-page .comingSoonCopy {
+  /* kill any inherited centering/absolute positioning */
+  position: static !important;
+  display: block !important;
+  text-align: left !important;
+  margin: .25rem 0 0 0 !important;
+  white-space: normal !important;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+/* If those prompts live in a flex row that was vertically centered, un-center it */
+#turian-page .chatDemoRow { align-items: stretch !important; }
+
+/* Turn the prompts into horizontal chips (scrollable) */
+#turian-page .samplePrompts {
+  display: flex !important;
+  gap: .6rem;
+  overflow-x: auto;
+  padding: .25rem 0;
+}
+#turian-page .samplePrompts::-webkit-scrollbar { height: 6px; }
+#turian-page .promptChip {
+  flex: 0 0 auto;
+  padding: .5rem .75rem;
+  border-radius: 999px;
+  border: 2px solid var(--naturverse-blue);
+  color: var(--naturverse-blue);
+  background: rgba(40, 120, 255, .06);
+  white-space: nowrap;
+}
+
+/* 3) Input row: keep left alignment inside the chat box */
+#turian-page .inputWrap { display: flex; gap: .75rem; align-items: center; }
+#turian-page .inputWrap input[type="text"],
+#turian-page .inputWrap textarea { text-align: left !important; }
+
+/* Footer blurb under the chat box */
+#turian-page .fineprint { text-align: left !important; margin-left: 0 !important; }


### PR DESCRIPTION
## Summary
- enforce Naturverse blue palette across Turian page elements
- replace vertical suggestions with horizontal scrollable prompt chips
- ensure chat input and prompts align left within Turian page wrapper

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck` (fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "id" | "created_at" | "updated_at">' is not assignable to parameter of type 'never[]')


------
https://chatgpt.com/codex/tasks/task_e_68ad0ea59970832990dd99391454107f