### PR TITLE
fix: uncenter Turian chat layout

### DIFF
--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -98,96 +98,100 @@ export default function TurianPage() {
 
   return (
     <div id="turian-page" className="nvrs-section turian nv-secondary-scope">
-        <Page
-          title="Turian the Durian"
-          subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet."
-          dataPage="turian"
-        >
-      <Meta title="Turian — Naturverse" description="Offline AI assistant demo." />
+      <Page
+        title="Turian the Durian"
+        subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet."
+        dataPage="turian"
+      >
+        <Meta title="Turian — Naturverse" description="Offline AI assistant demo." />
 
-      <div className="nv-card" style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 12 }}>
-        {mascotSrc ? (
-          <Img src={mascotSrc} alt="Turian favicon" width={32} height={32} style={{ borderRadius: 8 }} />
-        ) : (
-          <span role="img" aria-label="durian" style={{ fontSize: 32 }}>🥭</span>
-        )}
-        <div>
-          <strong>Chat with Turian</strong>
-          <div className="nv-muted">Coming soon: live help across Worlds, Zones, and Marketplace.</div>
-        </div>
-      </div>
-
-        {!hasHistory && (
-          <div className="samplePrompts">
-            {prompts.map((s, i) => (
-              <button key={i} className="promptChip" onClick={() => ask(s)}>
-                {s}
-              </button>
-            ))}
-          </div>
-        )}
-
-      <div className="turian-panel">
-        <div className="turian-msgs" ref={listRef} aria-live="polite">
-          {history.map(m => (
-            <div key={m.id} className={"msg " + m.role}>
-              {m.role === "turian" && (
-                <div className="turian-avatar">
-                  <Img
-                    src="/favicon.ico"
-                    alt="Turian"
-                    width={28}
-                    height={28}
-                    className="turian-avatar-img"
-                    style={{ borderRadius: 6 }}
-                  />
-                </div>
+        <section className="turian-chat">
+          <div className="chatCard">
+            <div className="nv-card" style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 12 }}>
+              {mascotSrc ? (
+                <Img src={mascotSrc} alt="Turian favicon" width={32} height={32} style={{ borderRadius: 8 }} />
+              ) : (
+                <span role="img" aria-label="durian" style={{ fontSize: 32 }}>🥭</span>
               )}
-              <div className="bubble">
-                {m.text.split("\n").map((ln, i) => <p key={i}>{ln}</p>)}
+              <div>
+                <strong>Chat with Turian</strong>
+                <div className="nv-muted">Coming soon: live help across Worlds, Zones, and Marketplace.</div>
               </div>
             </div>
-          ))}
-          {!hasHistory && (
-            <div className="msg turian">
-              <div className="turian-avatar">
-                <Img
-                  src="/favicon.ico"
-                  alt="Turian"
-                  width={28}
-                  height={28}
-                  className="turian-avatar-img"
-                  style={{ borderRadius: 6 }}
+
+            {!hasHistory && (
+              <div className="samplePrompts">
+                {prompts.map((s, i) => (
+                  <button key={i} className="promptChip" onClick={() => ask(s)}>
+                    {s}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            <div className="turian-panel">
+              <div className="turian-msgs" ref={listRef} aria-live="polite">
+                {history.map(m => (
+                  <div key={m.id} className={"msg " + m.role}>
+                    {m.role === "turian" && (
+                      <div className="turian-avatar">
+                        <Img
+                          src="/favicon.ico"
+                          alt="Turian"
+                          width={28}
+                          height={28}
+                          className="turian-avatar-img"
+                          style={{ borderRadius: 6 }}
+                        />
+                      </div>
+                    )}
+                    <div className="bubble">
+                      {m.text.split("\n").map((ln, i) => <p key={i}>{ln}</p>)}
+                    </div>
+                  </div>
+                ))}
+                {!hasHistory && (
+                  <div className="msg turian">
+                    <div className="turian-avatar">
+                      <Img
+                        src="/favicon.ico"
+                        alt="Turian"
+                        width={28}
+                        height={28}
+                        className="turian-avatar-img"
+                        style={{ borderRadius: 6 }}
+                      />
+                    </div>
+                    <div className="bubble">
+                      <p>Try a suggestion above or ask something like:</p>
+                      <p><em>“Give me 3 eco-quests for Madagas­caria.”</em></p>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <form className="turian-input inputRow" onSubmit={onSubmit}>
+                <input
+                  aria-label="Ask Turian"
+                  placeholder="Ask Turian anything…"
+                  value={text}
+                  onChange={(e) => setText(e.target.value)}
                 />
-              </div>
-              <div className="bubble">
-                <p>Try a suggestion above or ask something like:</p>
-                <p><em>“Give me 3 eco-quests for Madagas­caria.”</em></p>
-              </div>
+                <button className="btn" type="submit">Ask</button>
+                <button
+                  type="button"
+                  className="btn outline"
+                  onClick={() => { setHistory([]); write([]); }}
+                  title="Clear conversation"
+                >
+                  Clear
+                </button>
+              </form>
             </div>
-          )}
-        </div>
 
-        <form className="turian-input inputWrap" onSubmit={onSubmit}>
-          <input
-            aria-label="Ask Turian"
-            placeholder="Ask Turian anything…"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-          />
-          <button className="btn" type="submit">Ask</button>
-          <button
-            type="button"
-            className="btn outline"
-            onClick={() => { setHistory([]); write([]); }}
-            title="Clear conversation"
-          >
-            Clear
-          </button>
-        </form>
-      </div>
-
-      <p className="meta">Coming soon: real AI tutor connected across Worlds, Zones, Marketplace, and Naturbank; context-aware hints; quest generation; and Supabase history.</p>
+            <p className="fineprint">Coming soon: real AI tutor connected across Worlds, Zones, Marketplace, and Naturbank; context-aware hints; quest generation; and Supabase history.</p>
+          </div>
+        </section>
       </Page>
     </div>
   );

--- a/src/styles/turian.css
+++ b/src/styles/turian.css
@@ -274,10 +274,54 @@
   white-space: nowrap;
 }
 
-/* 3) Input row: keep left alignment inside the chat box */
-#turian-page .inputWrap { display: flex; gap: .75rem; align-items: center; }
-#turian-page .inputWrap input[type="text"],
-#turian-page .inputWrap textarea { text-align: left !important; }
+/* ===== Turian chat: UNLOCK CENTER, FORCE LEFT LAYOUT ===== */
+#turian-page .turian-chat,                 /* container */
+#turian-page .turian-chat * {
+  text-align: left !important;
+}
 
-/* Footer blurb under the chat box */
-#turian-page .fineprint { text-align: left !important; margin-left: 0 !important; }
+/* kill any vertical-centering hacks */
+#turian-page .turian-chat [style*="translateY"],
+#turian-page .turian-chat.vcenter,
+#turian-page .turian-chat .vcenter {
+  transform: none !important;
+}
+#turian-page .turian-chat [style*="top:"],
+#turian-page .turian-chat [style*="left:"],
+#turian-page .turian-chat .absolute,
+#turian-page .turian-chat .centered {
+  position: static !important;
+  top: auto !important;
+  left: auto !important;
+}
+
+/* chat card layout */
+#turian-page .turian-chat .chatCard {
+  display: block !important;
+}
+
+/* input row: text box grows, button at right */
+#turian-page .turian-chat .inputRow {
+  display: flex !important;
+  align-items: center !important;
+  gap: .75rem !important;
+}
+#turian-page .turian-chat .inputRow input,
+#turian-page .turian-chat .inputRow textarea {
+  flex: 1 1 auto !important;
+  text-align: left !important;
+}
+#turian-page .turian-chat .inputRow input::placeholder,
+#turian-page .turian-chat .inputRow textarea::placeholder {
+  text-align: left !important;
+}
+
+/* “Here’s a playful 3-stop itinerary …” prompts: normal flowing text */
+#turian-page .turian-chat .promptText,
+#turian-page .turian-chat .sampleText,
+#turian-page .turian-chat .fineprint {
+  display: block !important;
+  white-space: normal !important;
+  overflow: visible !important;
+  margin: .5rem 0 0 0 !important;
+}


### PR DESCRIPTION
## Summary
- force Turian chat box into a normal left-to-right flow
- wrap chat UI in `.turian-chat` hooks and adjust input row markup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')*


------
https://chatgpt.com/codex/tasks/task_e_68ad12553e2483298854eab2106d4900