### PR TITLE
feat: add scoped Turian page and chat endpoint stub

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import { prisma } from './db';
 import { registerRoutes } from './routes';
 import { observations } from './routes/observations';
 import todosRouter from './routes/todos';
+import turianChatRouter from './routes/turian-chat';
 import { setupVite, serveStatic, log } from './vite';
 
 const app = express();
@@ -30,6 +31,7 @@ app.get('/api/db/health', async (req, res) => {
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+app.use('/api/turian-chat', turianChatRouter);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/routes/turian-chat.ts
+++ b/server/routes/turian-chat.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.post('/', (req, res) => {
+  const { message } = req.body as { message?: string };
+  return res.status(200).json({ reply: `Turian heard: ${message}` });
+});
+
+export default router;

--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -1,40 +1,60 @@
 import React from "react";
-import Page from "../components/Page";
-import Meta from "../components/Meta";
-import { Img } from "../components";
-import { setTitle } from "./_meta";
+import "./turian.css";
 
-// Use site favicon as Turian's mascot for consistent branding
-const mascotSrc = "/favicon.ico";
+/** Optional: drop-in hook you can wire later */
+function useTurianChat() {
+  // Wire this to your API route when ready
+  async function send(message: string): Promise<string> {
+    const res = await fetch("/api/turian-chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message }),
+    });
+    const data = await res.json().catch(() => ({}));
+    return data?.reply ?? "";
+  }
+  return { send };
+}
 
-export default function TurianPage() {
-  setTitle("Turian");
+export default function Turian() {
+  // const { send } = useTurianChat(); // keep for later
   return (
-    <div id="turian-page" className="nvrs-section turian nv-secondary-scope">
-      <Page
-        title="Turian the Durian"
-        subtitle="Ask for tips, quests, and facts. This is an offline demo—no external calls or models yet."
-        dataPage="turian"
-      >
-        <Meta title="Turian — Naturverse" description="Offline AI assistant demo." />
-        <section className="turian-chat">
-          <div className="chatCard">
-            <div className="nv-card" style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 12 }}>
-              {mascotSrc ? (
-                <Img src={mascotSrc} alt="Turian favicon" width={32} height={32} style={{ borderRadius: 8 }} />
-              ) : (
-                <span role="img" aria-label="durian" style={{ fontSize: 32 }}>🥭</span>
-              )}
-              <div>
-                <strong>Chat with Turian</strong>
-                <div className="nv-muted">Chat feature temporarily disabled.</div>
-              </div>
-            </div>
-            <p className="fineprint">Live chat coming soon.</p>
-          </div>
-        </section>
-      </Page>
-    </div>
+    <main className="turian-page" role="main" aria-labelledby="turian-title">
+      <nav className="turian-breadcrumb">
+        <a href="/">Home</a> <span>/</span> <span>Turian</span>
+      </nav>
+
+      <header className="turian-hero">
+        <h1 id="turian-title">Turian the Durian</h1>
+        <p className="lead">
+          Ask for tips, quests, and facts. This is an offline demo—no external
+          calls or models yet.
+        </p>
+      </header>
+
+      {/* Status card (kept), chat fully removed */}
+      <section className="turian-card" aria-live="polite">
+        <div className="turian-card__title">Chat with Turian</div>
+        <p className="turian-card__text">Chat feature temporarily disabled.</p>
+      </section>
+
+      <p className="coming-soon">Live chat coming soon.</p>
+
+      {/* ------- When you’re ready, drop a new chat form here -------
+      <form className="turian-chat" onSubmit={async (e) => {
+        e.preventDefault();
+        const form = e.currentTarget as HTMLFormElement;
+        const input = form.querySelector("input[name='q']") as HTMLInputElement;
+        // const reply = await send(input.value);
+        // show reply in your UI
+        input.value = "";
+      }}>
+        <label htmlFor="turian-q" className="sr-only">Ask Turian</label>
+        <input id="turian-q" name="q" placeholder="Ask Turian anything…" />
+        <button type="submit" className="btn-primary">Ask</button>
+      </form>
+      ------------------------------------------------------------- */}
+    </main>
   );
 }
 

--- a/src/pages/turian.css
+++ b/src/pages/turian.css
@@ -1,0 +1,113 @@
+/* All styles are scoped to .turian-page so nothing leaks */
+.turian-page {
+  --nv-blue: var(--naturverse-blue, #2f6bff);
+  --nv-bg: #eef5ff;
+  --nv-white: #ffffff;
+  --nv-radius: 16px;
+  --nv-shadow: 0 6px 20px rgba(0, 40, 160, 0.08);
+
+  padding: 28px 0 60px;
+  background: transparent;
+  color: var(--nv-blue);
+}
+
+/* Breadcrumb */
+.turian-page .turian-breadcrumb {
+  margin: 0 24px 12px;
+  font-size: 15px;
+}
+.turian-page .turian-breadcrumb a {
+  color: var(--nv-blue) !important;
+  text-decoration: underline;
+}
+
+/* Hero */
+.turian-page .turian-hero {
+  margin: 0 24px 18px;
+  background: var(--nv-bg);
+  border-radius: var(--nv-radius);
+  padding: 22px 22px 18px;
+  box-shadow: var(--nv-shadow);
+}
+.turian-page h1 {
+  margin: 0 0 8px 0;
+  font-size: 34px;
+  line-height: 1.15;
+  color: var(--nv-blue) !important;
+}
+.turian-page .lead {
+  margin: 0;
+  font-weight: 500;
+  color: var(--nv-blue) !important;
+}
+
+/* Status card */
+.turian-page .turian-card {
+  margin: 16px 24px 8px;
+  background: var(--nv-white);
+  border-radius: var(--nv-radius);
+  box-shadow: var(--nv-shadow);
+  padding: 18px 20px;
+  text-align: left;              /* ensure left alignment */
+}
+.turian-page .turian-card__title {
+  font-weight: 800;
+  font-size: 20px;
+  margin-bottom: 6px;
+  color: var(--nv-blue) !important;
+}
+.turian-page .turian-card__text {
+  margin: 0;
+  color: var(--nv-blue) !important;
+}
+
+/* “Coming soon” */
+.turian-page .coming-soon {
+  margin: 14px 24px 0;
+  font-weight: 700;
+  color: var(--nv-blue) !important;
+}
+
+/* Optional future chat form (kept here but not rendered) */
+.turian-page .turian-chat {
+  margin: 18px 24px 0;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+  text-align: left;              /* NEVER centered again */
+}
+.turian-page .turian-chat input {
+  border-radius: 14px;
+  border: 2px solid rgba(47,107,255,0.28);
+  padding: 14px 16px;
+  font-size: 16px;
+  color: var(--nv-blue);
+  outline: none;
+  background: var(--nv-white);
+}
+.turian-page .turian-chat input::placeholder {
+  color: rgba(47, 107, 255, 0.75);
+}
+.turian-page .btn-primary {
+  background: var(--nv-blue);
+  color: var(--nv-white) !important;
+  border: none;
+  border-radius: 14px;
+  padding: 12px 18px;
+  font-weight: 800;
+  box-shadow: 0 6px 0 rgba(47, 107, 255, 0.35);
+  cursor: pointer;
+}
+.turian-page .btn-primary:active {
+  transform: translateY(1px);
+  box-shadow: 0 5px 0 rgba(47, 107, 255, 0.35);
+}
+
+/* Utility */
+.turian-page .sr-only {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+}


### PR DESCRIPTION
## Summary
- replace Turian page with scoped blue layout and placeholder chat
- add dedicated stylesheet scoped to `.turian-page`
- introduce `/api/turian-chat` stub and register express route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: type errors in existing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ad215a6a488329983ceafc6d265f11