### PR TITLE
feat: add brand logo and preload

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
 
     <!-- Preload assets -->
     <link rel="preload" as="style" href="/src/main.css" />
+    <link rel="preload" href="/favicon.svg" as="image" type="image/svg+xml" />
     <link
       rel="preload"
       as="font"

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -13,9 +13,27 @@ export default function NavBar() {
   return (
     <header className={styles.header}>
       <div className={`container ${styles.inner}`}>
-        <Link to="/" className={styles.brand}>
-          Naturverse
-        </Link>
+        {/* Left brand (logo + wordmark) */}
+        <a
+          href="/"
+          className="flex items-center gap-2"
+          aria-label="Naturverse home"
+        >
+          <picture>
+            <source srcSet="/favicon.svg" type="image/svg+xml" />
+            <img
+              src="/favicon-64x64.png"
+              alt="Naturverse"
+              className="nv-logo"
+              width={40}
+              height={40}
+              loading="eager"
+              decoding="async"
+            />
+          </picture>
+
+          <span className="nv-brand text-nv-blue">Naturverse</span>
+        </a>
 
         <nav className={styles.links} aria-label="Primary">
           <Link to="/worlds">Worlds</Link>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,45 @@
   --page-bg: #f8fbff; /* light blue background used across pages */
 }
 
+/* ---- Naturverse Navbar Brand ---- */
+:root {
+  /* tweak these once and all pages follow */
+  --nv-logo-size-sm: 40px;   /* mobile */
+  --nv-logo-size-md: 44px;   /* tablets */
+  --nv-logo-size-lg: 48px;   /* desktop */
+}
+
+/* consistent text color token already in your project */
+.text-nv-blue, .nv-brand { color: var(--naturverse-blue) !important; }
+
+.nv-logo {
+  width: var(--nv-logo-size-sm);
+  height: var(--nv-logo-size-sm);
+  display: block;            /* avoid inline-img baseline gap */
+  flex-shrink: 0;            /* never collapse in tight rows */
+}
+
+@media (min-width: 640px) {
+  .nv-logo {
+    width: var(--nv-logo-size-md);
+    height: var(--nv-logo-size-md);
+  }
+}
+
+@media (min-width: 1024px) {
+  .nv-logo {
+    width: var(--nv-logo-size-lg);
+    height: var(--nv-logo-size-lg);
+  }
+}
+
+/* Optional: balance wordmark size without changing your layout */
+.nv-brand {
+  font-weight: 800;
+  font-size: clamp(1.125rem, 1.6vw + 0.6rem, 1.5rem); /* ~18–24px fluid */
+  line-height: 1;
+}
+
 /* ===== Mobile hamburger: lines only, no pill ===== */
 @media (max-width: 768px){
   .nv-hamburger {


### PR DESCRIPTION
## Summary
- add responsive logo & wordmark link in nav bar
- define navbar brand sizing and color tokens
- preload SVG favicon for faster logo load

## Testing
- ⚠️ `npm test` (missing script)
- ❌ `npm run typecheck` (TS errors)


------
https://chatgpt.com/codex/tasks/task_e_68ad275c81fc8329a00b3a696b058556