### PR TITLE
feat: style Navatar and NaturBank pages, align cart quantity controls

### DIFF
--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -71,7 +71,7 @@ export default function NavatarPage() {
       <PageHead title="Naturverse — Navatar Creator" description="Design your character and save cards." />
       <Meta title="Navatar Creator — Naturverse" description="Design your character and save cards." />
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Navatar" }]} />
-      <main id="main" data-page="navatar" className="page container">
+      <main id="main" data-page="navatar" className="page container navatar-page">
         <h1>Navatar Creator</h1>
         <p>Choose a base type, customize details, and save your character card.</p>
 

--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from '../components/Breadcrumbs';
 export default function CartPage() {
   const { items, inc, dec, remove, subtotal } = useCart();
   return (
-    <div className="nvrs-section cart">
+    <main data-page="cart" className="nvrs-section cart cart-page">
       <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Cart' }]} />
       <h1>Cart</h1>
       {items.length === 0 ? (
@@ -27,7 +27,7 @@ export default function CartPage() {
                 <div>{it.name}</div>
                 <div className="price">${it.price.toFixed(2)}</div>
                 <div style={{ display: 'flex', gap: '.5rem', marginTop: '.25rem' }}>
-                  <div className="qty-control">
+                  <div className="qty">
                     <button onClick={() => dec(it.id)} aria-label="Decrease quantity">
                       −
                     </button>
@@ -54,6 +54,6 @@ export default function CartPage() {
           </button>
         </div>
       )}
-    </div>
+    </main>
   );
 }

--- a/src/pages/naturbank.tsx
+++ b/src/pages/naturbank.tsx
@@ -101,17 +101,18 @@ export default function NaturBankPage() {
 
   if (loading)
     return (
-      <main id="naturbank">
-        <div id="main" data-page="naturbank">
-          <h1>NaturBank</h1>
-          <p>Loading…</p>
-        </div>
+      <main id="main" data-page="naturbank" className="naturbank-page">
+        <h1>NaturBank</h1>
+        <p>Loading…</p>
       </main>
     );
 
   return (
-    <main id="naturbank">
-      <div id="main" data-page="naturbank" className="nvrs-section naturbank page-wrap nv-secondary-scope">
+    <main
+      id="main"
+      data-page="naturbank"
+      className="nvrs-section naturbank page-wrap nv-secondary-scope naturbank-page"
+    >
       <Breadcrumbs />
       <div className="bank">
       <h1>NaturBank</h1>
@@ -168,7 +169,6 @@ export default function NaturBankPage() {
       </section>
 
       <p className="muted small">Coming soon: real wallet connect, custodial accounts, and redemptions.</p>
-      </div>
       </div>
     </main>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,7 +1,7 @@
 @import './cards.css';
 
 :root {
-  --naturverse-blue: var(--nv-blue-700, #1f4ed8);
+  --naturverse-blue: #2e6bff;
 }
 
 /* ================================
@@ -517,5 +517,118 @@ footer span {
 
 footer a:hover {
   text-decoration: underline; /* optional: blue underline on hover */
+}
+
+/* =========================
+   Naturverse Blue helpers
+   ========================= */
+
+/* -------- Navatar: force secondary text & buttons to blue -------- */
+[data-page="navatar"], .navatar-page {
+  /* nothing layout-changing here */
+}
+[data-page="navatar"] h1,
+[data-page="navatar"] h2,
+[data-page="navatar"] h3,
+[data-page="navatar"] .section-title,
+[data-page="navatar"] .card-title,
+[data-page="navatar"] .label,
+[data-page="navatar"] .subtle,
+[data-page="navatar"] a {
+  color: var(--naturverse-blue) !important;
+}
+[data-page="navatar"] button,
+[data-page="navatar"] .btn {
+  background: var(--naturverse-blue) !important;
+  color: #fff !important;
+  border: none !important;
+}
+
+/* -------- NaturBank: force secondary text & buttons to blue ------- */
+[data-page="naturbank"], .naturbank-page { }
+[data-page="naturbank"] h1,
+[data-page="naturbank"] h2,
+[data-page="naturbank"] h3,
+[data-page="naturbank"] .section-title,
+[data-page="naturbank"] .card-title,
+[data-page="naturbank"] .label,
+[data-page="naturbank"] .stat,
+[data-page="naturbank"] a {
+  color: var(--naturverse-blue) !important;
+}
+[data-page="naturbank"] button,
+[data-page="naturbank"] .btn {
+  background: var(--naturverse-blue) !important;
+  color: #fff !important;
+  border: none !important;
+}
+
+/* Optional: inputs look consistent next to blue labels */
+[data-page="naturbank"] input,
+[data-page="navatar"] input,
+[data-page="naturbank"] textarea,
+[data-page="navatar"] textarea {
+  border-color: rgba(46,107,255,.35);
+}
+
+/* =========================
+   Cart quantity control fix
+   ========================= */
+/* Markup doesn’t have to change; these selectors try to be forgiving */
+.cart-page .qty,
+.cart-page [data-component="qty"],
+.cart-page .quantity,
+.cart-page .quantity-controls {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* The minus/plus buttons */
+.cart-page .qty button,
+.cart-page .quantity button,
+.cart-page [data-qty="decr"],
+.cart-page [data-qty="incr"] {
+  width: 44px; height: 44px;
+  border-radius: 12px;
+  border: 2px solid var(--naturverse-blue);
+  background: #fff;
+  color: var(--naturverse-blue);
+  font-size: 26px;
+  line-height: 1;
+  font-weight: 700;
+  display: inline-flex; align-items: center; justify-content: center;
+  box-shadow: 0 3px 0 rgba(0,0,0,.12);
+}
+
+/* The number field */
+.cart-page .qty input[type="number"],
+.cart-page .quantity input[type="number"],
+.cart-page [data-qty="input"] {
+  width: 80px;
+  height: 44px;
+  text-align: center;
+  border: 2px solid var(--naturverse-blue);
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 18px;
+  appearance: textfield;
+}
+.cart-page .qty input::-webkit-outer-spin-button,
+.cart-page .qty input::-webkit-inner-spin-button {
+  -webkit-appearance: none; margin: 0;
+}
+
+/* Make sure the remove button doesn’t overlap the qty */
+.cart-page .cart-item .remove,
+.cart-page .remove-item {
+  align-self: center;
+}
+
+/* Product thumbnail never overflows the row */
+.cart-page .cart-item img {
+  max-height: 96px;
+  width: auto;
+  object-fit: contain;
 }
 


### PR DESCRIPTION
## Summary
- add page-specific hooks to Navatar, NaturBank, and Cart pages
- enforce Naturverse blue color scheme and button styling for Navatar and NaturBank
- align Cart quantity controls on a single row with new styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its type declarations, and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad351a5c2c8329b910f5a467cd6ed2