### PR TITLE
Blue polish + cart layout (scoped)

### DIFF
--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -7,15 +7,17 @@ export default function Page({
   children,
   crumbs = [],
   dataPage,
+  className,
 }: {
   title: string;
   subtitle?: string;
   children: ReactNode;
   crumbs?: { href?: string; label: string }[];
   dataPage?: string;
+  className?: string;
 }) {
   return (
-    <div className="page-wrap">
+    <div className={`page-wrap${className ? ' ' + className : ''}`}> 
       <Breadcrumbs items={crumbs} />
       <main
         id="main"

--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -10,23 +10,14 @@ export default function CartPage() {
       {items.length === 0 ? (
         <p>Your cart is empty.</p>
       ) : (
-        <div className="nv-card">
+        <div className="nv-card cart-card">
           {items.map((it) => (
-            <div
-              key={it.id}
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '64px 1fr auto',
-                gap: '1rem',
-                alignItems: 'center',
-                marginBottom: '1rem',
-              }}
-            >
-              <img src={it.image} alt="" width="64" height="64" style={{ objectFit: 'contain' }} />
+            <div key={it.id} className="cart-line">
+              <img src={it.image} alt="" />
               <div>
-                <div>{it.name}</div>
-                <div className="price">${it.price.toFixed(2)}</div>
-                <div style={{ display: 'flex', gap: '.5rem', marginTop: '.25rem' }}>
+                <div className="title">{it.name}</div>
+                <div className="meta price">${it.price.toFixed(2)}</div>
+                <div className="qty-group">
                   <div className="qty">
                     <button onClick={() => dec(it.id)} aria-label="Decrease quantity">
                       −
@@ -41,13 +32,13 @@ export default function CartPage() {
                   </button>
                 </div>
               </div>
-              <div className="price">${(it.qty * it.price).toFixed(2)}</div>
+              <div className="meta price">${(it.qty * it.price).toFixed(2)}</div>
             </div>
           ))}
           <hr />
-          <div className="subtotal" style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <strong>Subtotal</strong>
-            <strong>${subtotal.toFixed(2)}</strong>
+          <div className="subtotal-row subtotal">
+            <strong className="label">Subtotal</strong>
+            <strong className="value">${subtotal.toFixed(2)}</strong>
           </div>
           <button className="btn-primary w-full" style={{ marginTop: '1rem' }}>
             Checkout (stub)

--- a/src/pages/worlds/WorldLayout.tsx
+++ b/src/pages/worlds/WorldLayout.tsx
@@ -11,7 +11,7 @@ export default function WorldLayout({
   children?: React.ReactNode;
 }) {
   return (
-    <main id="main" className="page-wrap">
+    <main id="main" className="page-wrap world-page">
       <h1>{title}</h1>
       <div className="cards">
         <div className="card">

--- a/src/pages/zones/Community.tsx
+++ b/src/pages/zones/Community.tsx
@@ -130,7 +130,7 @@ export default function Community() {
   };
 
   return (
-    <div className="page-wrap">
+    <div className="page-wrap zones-page2">
       <Breadcrumbs />
       <main id="main">
       <h1>🗳️🌍 Community</h1>

--- a/src/pages/zones/Culture.tsx
+++ b/src/pages/zones/Culture.tsx
@@ -15,6 +15,7 @@ export default function Culture() {
       <Page
         title="Culture"
         subtitle="Beliefs, holidays, and ceremonies across the 14 kingdoms."
+        className="zones-page2"
       >
       <div className="culture-grid grid gap-4 md:gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {kingdoms.map((k) => (

--- a/src/pages/zones/Future.tsx
+++ b/src/pages/zones/Future.tsx
@@ -3,7 +3,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function FutureZone() {
   return (
-      <div className="page-wrap">
+      <div className="page-wrap zones-page2">
         <Breadcrumbs />
         <main id="main" className="page">
 

--- a/src/pages/zones/Observations.tsx
+++ b/src/pages/zones/Observations.tsx
@@ -145,7 +145,7 @@ export default function Observations() {
   }, [list]);
 
   return (
-    <div className="page-wrap">
+    <div className="page-wrap zones-page2">
       <Breadcrumbs />
       <main id="main">
       <h1>📷🌿 Observations</h1>

--- a/src/pages/zones/Quizzes.tsx
+++ b/src/pages/zones/Quizzes.tsx
@@ -64,7 +64,7 @@ export default function Quizzes() {
   };
 
   return (
-    <div className="page-wrap">
+    <div className="page-wrap zones-page2">
       <Breadcrumbs />
       <main id="main">
       <h1>🎯 Quizzes</h1>

--- a/src/pages/zones/Stories.tsx
+++ b/src/pages/zones/Stories.tsx
@@ -85,7 +85,7 @@ export default function Stories() {
   };
 
   return (
-      <div className="page-wrap">
+      <div className="page-wrap zones-page2">
         <Breadcrumbs />
         <main id="main">
         <h1>📚✨ Stories</h1>

--- a/src/pages/zones/creator-lab.tsx
+++ b/src/pages/zones/creator-lab.tsx
@@ -6,7 +6,7 @@ import { setTitle } from "../_meta";
 export default function CreatorLabPage() {
   setTitle("Creator Lab");
   return (
-    <main className="container mx-auto px-4 py-8">
+    <main className="container mx-auto px-4 py-8 zones-page2">
 
       <Breadcrumbs
         items={[

--- a/src/routes/naturbank/index.tsx
+++ b/src/routes/naturbank/index.tsx
@@ -3,7 +3,7 @@ import HubGrid from '../../components/HubGrid';
 
 export default function Naturbank() {
   return (
-    <section className="space-y-6">
+    <section className="space-y-6 naturbank-page">
       <h2 className="text-2xl font-bold">Naturbank</h2>
       <HubGrid>
         <HubCard

--- a/src/routes/naturbank/learn.tsx
+++ b/src/routes/naturbank/learn.tsx
@@ -1,6 +1,6 @@
 export default function Learn() {
   return (
-    <section className="space-y-3">
+    <section className="space-y-3 naturbank-page">
       <h2 className="text-2xl font-bold">📘 Learn</h2>
       <p className="text-gray-600">Crypto basics & safety guides.</p>
       <p className="text-sm text-gray-500">Learning resources coming soon.</p>

--- a/src/routes/naturbank/nfts.tsx
+++ b/src/routes/naturbank/nfts.tsx
@@ -1,6 +1,6 @@
 export default function NFTs() {
   return (
-    <section className="space-y-3">
+    <section className="space-y-3 naturbank-page">
       <h2 className="text-2xl font-bold">🖼️ NFTs</h2>
       <p className="text-gray-600">Mint navatar cards & collectibles.</p>
       <p className="text-sm text-gray-500">NFT minting coming soon.</p>

--- a/src/routes/naturbank/token.tsx
+++ b/src/routes/naturbank/token.tsx
@@ -1,6 +1,6 @@
 export default function Token() {
   return (
-    <section className="space-y-3">
+    <section className="space-y-3 naturbank-page">
       <h2 className="text-2xl font-bold">🪙 NATUR Token</h2>
       <p className="text-gray-600">Earnings, redemptions, and ledger.</p>
       <p className="text-sm text-gray-500">Token details coming soon.</p>

--- a/src/routes/naturbank/wallet.tsx
+++ b/src/routes/naturbank/wallet.tsx
@@ -1,6 +1,6 @@
 export default function Wallet() {
   return (
-    <section className="space-y-3">
+    <section className="space-y-3 naturbank-page">
       <h2 className="text-2xl font-bold">🪙 Wallet</h2>
       <p className="text-gray-600">Demo address (placeholder): oxdemo...addr</p>
       <button className="rounded border px-3 py-1 opacity-60 cursor-not-allowed">Create Wallet (stub)</button>

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -121,3 +121,123 @@
 .lang-content h3 { margin-top: 16px; }
 .lang-content ul  { margin: 6px 0 18px; padding-left: 18px; }
 
+/* ===== Naturverse blue (var already exists) ===== */
+/* Fallback just in case */
+:root { --naturverse-blue: #2563ff; }
+
+/* ---------- CART (inner card wider + tidy line) ---------- */
+.cart-page .cart-card {
+  max-width: 720px;                 /* inner card can breathe on mobile & desktop */
+  width: 100%;
+}
+.cart-page .cart-card .cart-line {
+  display: grid;
+  grid-template-columns: 72px 1fr minmax(140px, 220px); /* img | title/labels | qty group */
+  align-items: center;
+  gap: 14px;
+  padding: 4px 0 10px;
+}
+.cart-page .cart-card .cart-line img,
+.cart-page .cart-card .cart-line .thumb {
+  width: 64px; height: 64px; object-fit: cover; border-radius: 8px;
+}
+.cart-page .cart-card .title,
+.cart-page .cart-card .meta {
+  color: var(--naturverse-blue) !important;
+}
+.cart-page .cart-card .qty-group {
+  display: grid;
+  grid-auto-flow: column;
+  align-items: center;
+  gap: 8px;
+  justify-content: end;
+}
+.cart-page .cart-card .qty-group input[type="number"],
+.cart-page .cart-card .qty-group input[type="text"] {
+  width: 120px; max-width: 160px;
+}
+.cart-page .cart-card .subtotal-row {
+  display: grid; grid-template-columns: 1fr auto; align-items: center;
+}
+.cart-page .cart-card .subtotal-row .label,
+.cart-page .cart-card .subtotal-row .value {
+  color: var(--naturverse-blue) !important;
+}
+
+/* ---------- NAVATAR: fix remaining “secondary” blacks ---------- */
+.navatar-page h2,
+.navatar-page h3,
+.navatar-page .section-title,
+.navatar-page label,
+.navatar-page .field-label,
+.navatar-page .help,
+.navatar-page .eyebrow,
+.navatar-page .muted,
+.navatar-page .card-title,
+.navatar-page .subhead {
+  color: var(--naturverse-blue) !important;
+}
+
+/* Character Card (already blue for you, keep consistent) */
+.navatar-page .character-card h3,
+.navatar-page .character-card .label,
+.navatar-page .character-card .value {
+  color: var(--naturverse-blue) !important;
+}
+
+/* ---------- NATURBANK: labels, stats, subheads ---------- */
+.naturbank-page h2,
+.naturbank-page h3,
+.naturbank-page .section-title,
+.naturbank-page .label,
+.naturbank-page .stat .label,
+.naturbank-page .stat .value,
+.naturbank-page .muted,
+.naturbank-page .subhead,
+.naturbank-page .eyebrow {
+  color: var(--naturverse-blue) !important;
+}
+
+/* ---------- ZONES (second-level screens) ---------- */
+.zones-page2 h2,
+.zones-page2 h3,
+.zones-page2 .section-title,
+.zones-page2 .tool-card .title,
+.zones-page2 .tool-card .subtitle,
+.zones-page2 .muted,
+.zones-page2 .eyebrow,
+.zones-page2 .subhead {
+  color: var(--naturverse-blue) !important;
+}
+
+/* ---------- WORLDS → inside a world (detail pages) ---------- */
+/* Use broad, but scoped selectors to catch seeder text */
+.world-page h2,
+.world-page h3,
+.world-page .section-title,
+.world-page .tile .title,
+.world-page .tile .subtitle,
+.world-page .muted,
+.world-page .eyebrow,
+.world-page .subhead,
+.world-page .label {
+  color: var(--naturverse-blue) !important;
+}
+
+/* ---------- Buttons in these pages (safety, consistent) ---------- */
+.navatar-page .btn,
+.naturbank-page .btn,
+.zones-page2 .btn,
+.world-page .btn {
+  background-color: var(--naturverse-blue) !important;
+  color: #fff !important;
+  border: none !important;
+}
+
+/* ---------- Don’t let imported “seeder” templates override us ---------- */
+.navatar-page [style*="color:#000"],
+.naturbank-page [style*="color:#000"],
+.zones-page2   [style*="color:#000"],
+.world-page    [style*="color:#000"] {
+  color: var(--naturverse-blue) !important;
+}


### PR DESCRIPTION
## Summary
- append Naturverse blue variable and scoped page color rules
- widen cart card, grid product lines, and tidy subtotal row
- expose Page className and add page scope hooks for Naturbank, Zones, and Worlds

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: TS errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68ad40edc36c83299983b1e98ff6d764