### PR TITLE
feat: add rewards utilities and shareable navatar

### DIFF
--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const sb = (supabaseUrl && supabaseAnon) ? createClient(supabaseUrl, supabaseAnon) : null;
+
+type Row = { value: number; created_at: string };
+
+export function Leaderboard({ game }: { game: string }) {
+  const [top, setTop] = React.useState<Row[]>([]);
+  const [mine, setMine] = React.useState<number | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      if (!sb) return; // hide in demo mode
+      const topq = await sb.from('scores')
+        .select('value,created_at')
+        .eq('game', game)
+        .order('value', { ascending: false })
+        .limit(10);
+      if (mounted && !topq.error) setTop(topq.data as Row[]);
+
+      const u = await sb.auth.getUser();
+      const uid = u.data.user?.id;
+      if (uid) {
+        const myq = await sb.from('scores')
+          .select('value').eq('game', game).eq('user_id', uid)
+          .order('value', { ascending: false }).limit(1);
+        if (!myq.error && myq.data?.length) setMine(myq.data[0].value as number);
+      }
+    })();
+    return ()=>{mounted=false};
+  }, [game]);
+
+  if (!sb) return null;
+
+  return (
+    <div className="card" style={{ marginTop: 16 }}>
+      <h3 style={{ color: 'var(--naturverse-blue)' }}>Leaderboard</h3>
+      <ol>
+        {top.map((r, i) => (
+          <li key={i} style={{ color: 'var(--naturverse-blue)' }}>
+            {r.value}
+          </li>
+        ))}
+      </ol>
+      {mine != null && (
+        <div style={{ marginTop: 8, fontWeight: 600, color: 'var(--naturverse-blue)' }}>
+          Your best: {mine}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ShareNavatar.tsx
+++ b/components/ShareNavatar.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+type Card = {
+  name?: string;
+  species?: string;
+  date?: string;
+  imageUrl?: string;
+  powers?: string[];
+  backstory?: string;
+};
+
+function toToken(obj: any) {
+  return encodeURIComponent(Buffer.from(JSON.stringify(obj)).toString('base64'));
+}
+
+export function ShareNavatar({ card }: { card: Card }) {
+  const [busy, setBusy] = React.useState(false);
+
+  async function handleShare() {
+    try {
+      setBusy(true);
+      const token = toToken(card);
+      const url = `${location.origin}/api/og/navatar?d=${token}`;
+      if ((navigator as any).share) {
+        await (navigator as any).share({ title: 'My Navatar', text: card.name || 'My Navatar', url });
+      } else {
+        // download fallback
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${(card.name||'navatar').replace(/\s+/g,'_')}.png`;
+        a.click();
+      }
+    } finally { setBusy(false); }
+  }
+
+  return (
+    <button className="btn btn-primary" onClick={handleShare} disabled={busy}>
+      {busy ? 'Preparing…' : 'Share card'}
+    </button>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@vercel/og": "^0.8.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.28.0",

--- a/pages/api/og/navatar.ts
+++ b/pages/api/og/navatar.ts
@@ -1,0 +1,61 @@
+import type { NextApiRequest } from 'next';
+import { ImageResponse } from '@vercel/og';
+
+export const config = { runtime: 'edge' };
+
+function fromToken(t?: string) {
+  try {
+    if (!t) return {};
+    const json = Buffer.from(decodeURIComponent(t), 'base64').toString('utf8');
+    return JSON.parse(json);
+  } catch { return {}; }
+}
+
+export default async function handler(req: NextApiRequest) {
+  const { searchParams } = new URL(req.url!);
+  const data = fromToken(searchParams.get('d'));
+
+  const name = data.name ?? 'Navatar';
+  const species = data.species ?? '';
+  const date = data.date ?? '';
+  const powers = Array.isArray(data.powers) ? data.powers.join(' · ') : '';
+  const backstory = (data.backstory ?? '').slice(0, 240);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: 1200, height: 630,
+          display: 'flex', flexDirection: 'row', gap: 32,
+          background: '#f4f8ff', padding: 48,
+          fontFamily: 'ui-sans-serif, system-ui',
+          color: '#1b50d8'
+        }}
+      >
+        <div style={{
+          width: 360, height: 360, background: 'white', borderRadius: 24,
+          boxShadow: '0 12px 40px rgba(0,0,0,.12)', display: 'flex',
+          alignItems: 'center', justifyContent: 'center'
+        }}>
+          {/* If you have an imageUrl, render it; else a placeholder */}
+          {data.imageUrl
+            ? <img src={data.imageUrl} width={360} height={360} style={{ objectFit:'cover', borderRadius: 24 }} />
+            : <div style={{fontSize: 120}}>🧿</div>}
+        </div>
+        <div style={{ display:'flex', flexDirection:'column', flex:1 }}>
+          <div style={{ fontSize: 64, fontWeight: 800 }}>{name}</div>
+          <div style={{ fontSize: 28, marginTop: 8 }}>{species} • {date}</div>
+          {powers && <div style={{ fontSize: 28, marginTop: 16 }}>{powers}</div>}
+          {backstory && (
+            <div style={{
+              marginTop: 24, fontSize: 28, lineHeight: 1.35,
+              color: '#133fb0', maxWidth: 740
+            }}>{backstory}</div>
+          )}
+          <div style={{ marginTop: 'auto', fontSize: 24, opacity: .6 }}>thenaturverse.com</div>
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 }
+  );
+}

--- a/src/lib/confetti.ts
+++ b/src/lib/confetti.ts
@@ -1,0 +1,30 @@
+// super tiny confetti (no deps)
+export function confettiBurst(x = 0.5, y = 0.4) {
+  const root = document.createElement('div');
+  root.style.position = 'fixed';
+  root.style.inset = '0';
+  root.style.pointerEvents = 'none';
+  document.body.appendChild(root);
+
+  const N = 60;
+  for (let i = 0; i < N; i++) {
+    const p = document.createElement('div');
+    p.style.position = 'absolute';
+    p.style.left = `${x * window.innerWidth}px`;
+    p.style.top = `${y * window.innerHeight}px`;
+    p.style.width = '8px';
+    p.style.height = '12px';
+    p.style.background = ['#2f6dfc','#1b50d8','#4d8bff','#2b6ffd'][i%4];
+    p.style.borderRadius = '2px';
+    p.style.transform = `translate(-50%,-50%) rotate(${Math.random()*360}deg)`;
+    p.style.transition = 'transform 900ms ease-out, opacity 900ms ease-out';
+    root.appendChild(p);
+    requestAnimationFrame(() => {
+      const dx = (Math.random() - 0.5) * 400;
+      const dy = (Math.random() - 0.9) * 600; // mostly up
+      p.style.transform = `translate(calc(-50% + ${dx}px), calc(-50% + ${dy}px)) rotate(${Math.random()*720}deg)`;
+      p.style.opacity = '0';
+    });
+  }
+  setTimeout(()=>root.remove(), 1000);
+}

--- a/src/lib/rewards.ts
+++ b/src/lib/rewards.ts
@@ -1,0 +1,53 @@
+import { confettiBurst } from './confetti';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const sb = (supabaseUrl && supabaseAnon)
+  ? createClient(supabaseUrl, supabaseAnon)
+  : null;
+
+type StampGrant = { world: string; inc?: number; reason?: string };
+
+const LOCAL_KEY = 'naturverse.passport.local';
+function getLocalPassport() {
+  try { return JSON.parse(localStorage.getItem(LOCAL_KEY) || '{}'); } catch { return {}; }
+}
+function setLocalPassport(data: any) { localStorage.setItem(LOCAL_KEY, JSON.stringify(data)); }
+
+/** Grant a world stamp locally, and upsert in Supabase if available. */
+export async function grantStamp({ world, inc = 1 }: StampGrant) {
+  // Local (always)
+  const data = getLocalPassport();
+  data.worlds = data.worlds || {};
+  data.worlds[world] = (data.worlds[world] || 0) + inc;
+  setLocalPassport(data);
+  confettiBurst();
+
+  // Cloud (if signed in + sb present)
+  try {
+    if (!sb) return;
+    const { data: { user } } = await sb.auth.getUser();
+    const uid = user?.id;
+    if (!uid) return;
+    // use RPC if available, else client upsert
+    const rpc = await sb.rpc('grant_world_stamp', { p_user: uid, p_world: world, p_inc: inc });
+    if (rpc.error) {
+      // fallback: insert or update
+      await sb.from('user_world_stamps').upsert(
+        { user_id: uid, world, count: inc, last_granted_at: new Date().toISOString() },
+        { onConflict: 'user_id,world', ignoreDuplicates: false }
+      );
+    }
+  } catch {}
+}
+
+/** Post a score safely */
+export async function postScore(game: string, value: number) {
+  try {
+    if (!sb) return; // silently no-op in local demo
+    const { data: { user } } = await sb.auth.getUser();
+    const uid = user?.id ?? null;
+    await sb.from('scores').insert({ game, value, user_id: uid });
+  } catch {}
+}

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -7,6 +7,7 @@ import NavatarCard from "../components/NavatarCard";
 import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
 import PageHead from "../components/PageHead";
+import { ShareNavatar } from "../components/ShareNavatar";
 
 const BASES: NavatarBase[] = ["Animal", "Fruit", "Insect", "Spirit"];
 
@@ -126,16 +127,26 @@ export default function NavatarPage() {
           </div>
         </section>
 
-        <section className="panel">
-          <h2>Character Card</h2>
-          <div className="navatar-card-wrap">
-            <NavatarCard navatar={draft} />
-          </div>
+          <section className="panel">
+            <h2>Character Card</h2>
+            <div className="navatar-card-wrap">
+              <NavatarCard navatar={draft} />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <ShareNavatar card={{
+                name: draft.name,
+                species: draft.species,
+                date: new Date().toLocaleDateString(),
+                imageUrl: draft.imageDataUrl,
+                powers: draft.powers,
+                backstory: draft.backstory,
+              }} />
+            </div>
 
-          <h3 style={{marginTop:16}}>Library (local)</h3>
-          {library.length === 0 && <p>No saved Navatars yet.</p>}
-          <ul className="lib">
-            {library.map(n => (
+            <h3 style={{marginTop:16}}>Library (local)</h3>
+            {library.length === 0 && <p>No saved Navatars yet.</p>}
+            <ul className="lib">
+              {library.map(n => (
               <li key={n.id}>
                 <button
                   type="button"

--- a/src/routes/zones/arcade/index.tsx
+++ b/src/routes/zones/arcade/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import Breadcrumbs from "../../../components/Breadcrumbs";
+import { Leaderboard } from "../../../components/Leaderboard";
+import { grantStamp, postScore } from "@/lib/rewards";
 import "../../../styles/zone-widgets.css";
 
 export default function Arcade() {
@@ -14,6 +16,7 @@ export default function Arcade() {
           <div className="zone-title">⚡ Reaction Timer</div>
           <div className="zone-sub">Wait for green, then tap as fast as you can. Best of 5.</div>
           <ReactionTimer />
+          <Leaderboard game="reaction_timer" />
         </section>
 
         <section className="zone-card">
@@ -53,6 +56,8 @@ function ReactionTimer() {
       const ms = Math.round(performance.now() - startAt.current);
       const next = [...results, ms];
       setResults(next);
+      postScore('reaction_timer', ms * -1);
+      grantStamp({ world: 'Thailandia', inc: 1 });
       if (next.length >= 5) setPhase("done");
       else startRound();
     }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -664,3 +664,8 @@ footer a:hover {
 .cart-page .remove-item {
   align-self: center;
 }
+
+/* Safety net so secondary headings/labels inside cards default to blue */
+.card h3, .card h4, .card .label, .card .section-title {
+  color: var(--naturverse-blue);
+}

--- a/supabase/migrations/2025-08-26-add_scores_and_stamps.sql
+++ b/supabase/migrations/2025-08-26-add_scores_and_stamps.sql
@@ -1,0 +1,55 @@
+-- scores: simple per-game table
+create table if not exists public.scores (
+  id uuid primary key default gen_random_uuid(),
+  game text not null,
+  user_id uuid,
+  value numeric not null,
+  created_at timestamptz not null default now()
+);
+
+-- rank performance
+create index if not exists scores_game_value_idx on public.scores (game, value desc, created_at desc);
+
+-- stamps: one row per (user, world)
+create table if not exists public.user_world_stamps (
+  user_id uuid not null,
+  world text not null,
+  count int not null default 0,
+  last_granted_at timestamptz not null default now(),
+  primary key (user_id, world)
+);
+
+-- RLS (read all, write own)
+alter table public.scores enable row level security;
+alter table public.user_world_stamps enable row level security;
+
+do $$ begin
+  create policy scores_read on public.scores for select using (true);
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy scores_write on public.scores
+  for insert with check (auth.uid() is null or auth.uid() = user_id);
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy stamps_read on public.user_world_stamps for select using (true);
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create policy stamps_write on public.user_world_stamps
+  for insert with check (auth.uid() is null or auth.uid() = user_id)
+  ;
+exception when duplicate_object then null; end $$;
+
+-- upsert helper (optional; can also be done client-side)
+create or replace function public.grant_world_stamp(p_user uuid, p_world text, p_inc int default 1)
+returns void language plpgsql as $$
+begin
+  insert into public.user_world_stamps (user_id, world, count)
+  values (p_user, p_world, greatest(p_inc,1))
+  on conflict (user_id, world)
+  do update set
+    count = public.user_world_stamps.count + greatest(p_inc,1),
+    last_granted_at = now();
+end $$;


### PR DESCRIPTION
## Summary
- add @vercel/og dependency
- add scores and stamps tables with RLS policies
- lightweight confetti, rewards helpers, and leaderboard component
- shareable Navatar card with edge OG image endpoint
- wire Reaction Timer to post scores and grant stamps

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_68ad4ce4dcbc8329a3587c0212e1865b