### PR TITLE
Add confetti and rewards utilities

### DIFF
--- a/lib/confetti.ts
+++ b/lib/confetti.ts
@@ -1,0 +1,28 @@
+export function confettiBurst(x = 0.5, y = 0.4) {
+  const root = document.createElement('div');
+  root.style.position = 'fixed';
+  root.style.inset = '0';
+  root.style.pointerEvents = 'none';
+  document.body.appendChild(root);
+  const N = 60;
+  for (let i = 0; i < N; i++) {
+    const p = document.createElement('div');
+    p.style.position = 'absolute';
+    p.style.left = `${x * window.innerWidth}px`;
+    p.style.top = `${y * window.innerHeight}px`;
+    p.style.width = '8px';
+    p.style.height = '12px';
+    p.style.background = ['#2f6dfc', '#1b50d8', '#4d8bff', '#2b6ffd'][i % 4];
+    p.style.borderRadius = '2px';
+    p.style.transform = `translate(-50%,-50%) rotate(${Math.random() * 360}deg)`;
+    p.style.transition = 'transform 900ms ease-out, opacity 900ms ease-out';
+    root.appendChild(p);
+    requestAnimationFrame(() => {
+      const dx = (Math.random() - 0.5) * 400;
+      const dy = (Math.random() - 0.9) * 600;
+      p.style.transform = `translate(calc(-50% + ${dx}px), calc(-50% + ${dy}px)) rotate(${Math.random() * 720}deg)`;
+      p.style.opacity = '0';
+    });
+  }
+  setTimeout(() => root.remove(), 1000);
+}

--- a/lib/rewards.ts
+++ b/lib/rewards.ts
@@ -1,0 +1,45 @@
+import { confettiBurst } from './confetti';
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const sb = (url && key) ? createClient(url, key) : null;
+
+type StampGrant = { world: string; inc?: number };
+
+const LOCAL_KEY = 'naturverse.passport.local';
+function getLocal() {
+  try {
+    return JSON.parse(localStorage.getItem(LOCAL_KEY) || '{}');
+  } catch { return {}; }
+}
+function setLocal(d: any) {
+  localStorage.setItem(LOCAL_KEY, JSON.stringify(d));
+}
+
+export async function grantStamp({ world, inc = 1 }: StampGrant) {
+  const data = getLocal();
+  data.worlds = data.worlds || {};
+  data.worlds[world] = (data.worlds[world] || 0) + inc;
+  setLocal(data);
+  confettiBurst();
+  if (!sb) return;
+  try {
+    const { data: { user } } = await sb.auth.getUser();
+    const uid = user?.id;
+    if (!uid) return;
+    await sb.rpc('grant_world_stamp', { p_user: uid, p_world: world, p_inc: inc });
+  } catch {
+    // ignore errors
+  }
+}
+
+export async function postScore(game: string, value: number) {
+  if (!sb) return;
+  try {
+    const { data: { user } } = await sb.auth.getUser();
+    await sb.from('scores').insert({ game, value, user_id: user?.id ?? null });
+  } catch {
+    // ignore errors
+  }
+}


### PR DESCRIPTION
## Summary
- add `confettiBurst` animation for celebratory effects
- add Supabase-aware rewards helper for stamps and score posts

## Testing
- `pnpm add @vercel/og` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next/link' ... and 30 other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad510160e48329a0e5a96ef3183a32