### PR TITLE
fix(build): add three dep and stub ShareNavatar to satisfy case-sensitive import

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.28.0",
     "@supabase/supabase-js": "^2.45.4",
-    "@supabase/auth-helpers-react": "^0.5.0"
+    "@supabase/auth-helpers-react": "^0.5.0",
+    "three": "^0.160.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",

--- a/src/components/ShareNavatar.tsx
+++ b/src/components/ShareNavatar.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+/**
+ * Temporary stub so Netlify builds are green.
+ * Replace with the real share widget when ready.
+ */
+export default function ShareNavatar() {
+  return null; // or a minimal <div style={{display:'none'}} />
+}
+

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -7,7 +7,7 @@ import NavatarCard from "../components/NavatarCard";
 import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
 import PageHead from "../components/PageHead";
-import { ShareNavatar } from "../components/ShareNavatar";
+import ShareNavatar from "../components/ShareNavatar";
 
 const BASES: NavatarBase[] = ["Animal", "Fruit", "Insect", "Spirit"];
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  optimizeDeps: { include: ["three"] },
   build: {
     outDir: "dist",
     rollupOptions: {


### PR DESCRIPTION
## Summary
- add `three` to dependencies and pre-bundle via Vite optimizeDeps
- stub `ShareNavatar` component so builds resolve the import case-sensitively
- import `ShareNavatar` with exact casing from Navatar page

## Testing
- `npm install --package-lock=false` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vercel%2Fog)*
- `npm run build` *(fails: Could not resolve "../../../components/Leaderboard" from "src/routes/zones/arcade/index.tsx")*


------
https://chatgpt.com/codex/tasks/task_e_68ad5997fda48329be862d0c0dad1d49