### PR TITLE
fix(build): add Leaderboard stub to unblock Netlify deploy

### DIFF
--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+/**
+ * Temporary stub for Leaderboard so builds succeed.
+ * Replace with a real leaderboard later (scores, player names, etc.)
+ */
+export default function Leaderboard() {
+  return (
+    <div
+      style={{
+        textAlign: "center",
+        padding: "1rem",
+        color: "var(--naturverse-blue)",
+        border: "1px dashed var(--naturverse-blue)",
+        borderRadius: "8px",
+      }}
+    >
+      Leaderboard (coming soon)
+    </div>
+  );
+}

--- a/src/routes/zones/arcade/index.tsx
+++ b/src/routes/zones/arcade/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import Breadcrumbs from "../../../components/Breadcrumbs";
-import { Leaderboard } from "../../../components/Leaderboard";
+import Leaderboard from "../../../components/Leaderboard";
 import { postScore, autoGrantOncePerDay } from "@/lib/rewards";
 import { toast } from "@/components/Toaster";
 import "../../../styles/zone-widgets.css";


### PR DESCRIPTION
## Summary
- add temporary Leaderboard stub component
- fix arcade zone import to match casing and default export

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: cannot find modules and typing issues)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad5b84e8648329b8189c1e3008f4e3