### PR TITLE
feat: add route effects and magic styles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,18 @@
+import React from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { router } from './router';
 import { organizationLd, websiteLd } from './lib/jsonld';
 import { CartProvider } from './lib/cart';
 import ToasterListener from './components/Toaster';
+import RouteFX from './components/RouteFX';
+import './styles/magic.css';
 
 export default function App() {
   return (
     <CartProvider>
       <>
+        {/* Global route visual effects (page fade-in) */}
+        <RouteFX />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
@@ -16,13 +21,14 @@ export default function App() {
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
         />
-          <main id="main" className="nv-page">
-            <div className="container">
-              <RouterProvider router={router} />
-            </div>
-          </main>
+        <main id="main" className="nv-page">
+          <div className="container">
+            <RouterProvider router={router} />
+          </div>
+        </main>
         <ToasterListener />
       </>
     </CartProvider>
   );
 }
+

--- a/src/components/RouteFX.tsx
+++ b/src/components/RouteFX.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * RouteFX
+ * Adds a subtle page fade-in on every navigation.
+ * No wrappers or layout changes required—just mount once in App.
+ */
+export default function RouteFX() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const el = document.documentElement; // <html>
+    // Start state
+    el.classList.add('page-enter');
+    // Next frame -> animate in
+    const id = requestAnimationFrame(() => {
+      el.classList.add('page-enter-active');
+      // Clean up after transition ends
+      const clear = () => {
+        el.classList.remove('page-enter');
+        el.classList.remove('page-enter-active');
+      };
+      // Fallback in case transitionend doesn’t fire
+      const timer = setTimeout(clear, 600);
+      const onEnd = () => {
+        clear();
+        clearTimeout(timer);
+        el.removeEventListener('transitionend', onEnd);
+      };
+      el.addEventListener('transitionend', onEnd);
+    });
+    return () => cancelAnimationFrame(id);
+  }, [location.pathname]);
+
+  return null;
+}
+

--- a/src/styles/magic.css
+++ b/src/styles/magic.css
@@ -1,0 +1,63 @@
+/* Naturverse Magic UI (no new deps) */
+
+/* 1) Button Glow --------------------------------------------------------- */
+button,
+.btn,
+.button,
+[role="button"] {
+  transition: box-shadow 0.25s ease, transform 0.25s ease, opacity 0.25s ease;
+}
+button:hover,
+.btn:hover,
+.button:hover,
+[role="button"]:hover {
+  box-shadow: 0 0 10px var(--naturverse-blue, #2563eb),
+              0 6px 16px rgba(37, 99, 235, 0.25);
+  transform: translateY(-2px);
+}
+button:active,
+.btn:active,
+.button:active,
+[role="button"]:active {
+  transform: translateY(0);
+  box-shadow: 0 3px 8px rgba(0,0,0,0.12);
+}
+
+/* 2) Page Fade-In -------------------------------------------------------- */
+/* We toggle these classes on <html> during route changes. */
+.page-enter {
+  opacity: 0;
+  transform: translateY(10px);
+}
+.page-enter-active {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 420ms ease, transform 420ms ease;
+}
+
+/* Reduce motion for users who prefer it */
+@media (prefers-reduced-motion: reduce) {
+  .page-enter,
+  .page-enter-active {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
+  button,
+  .btn,
+  .button,
+  [role="button"] {
+    transition: none !important;
+  }
+}
+
+/* 3) Floating helper (opt-in per element) ------------------------------- */
+.floating {
+  animation: nv-float 4s ease-in-out infinite;
+}
+@keyframes nv-float {
+  0%   { transform: translateY(0); }
+  50%  { transform: translateY(-8px); }
+  100% { transform: translateY(0); }
+}
+


### PR DESCRIPTION
## Summary
- add global magic styles for button glow, page fade-in, and floating animation
- introduce `RouteFX` component to trigger page transition effects
- wire up global effects in `App` and import new stylesheet

## Testing
- `npm run typecheck` *(fails: No overload matches this call in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68ad600ef4a483298029f7c078755b7c