### PR TITLE
Add ripple and confetti interactions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { router } from './router';
 import { organizationLd, websiteLd } from './lib/jsonld';
@@ -6,8 +6,12 @@ import { CartProvider } from './lib/cart';
 import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
 import './styles/magic.css';
+import { initInteractions } from './init/interactions';
 
 export default function App() {
+  useEffect(() => {
+    initInteractions();
+  }, []);
   return (
     <CartProvider>
       <>

--- a/src/init/interactions.ts
+++ b/src/init/interactions.ts
@@ -1,0 +1,72 @@
+import { burst } from "../utils/confetti";
+
+/**
+ * Initializes button ripple + confetti for checkout.
+ * Call once from App.tsx after DOM is ready.
+ */
+export function initInteractions() {
+  // 1) Ripple on any button-like control
+  const rippleTargets = () =>
+    Array.from(
+      document.querySelectorAll<HTMLButtonElement | HTMLElement>(
+        'button, .btn, .button, [role="button"]'
+      )
+    );
+
+  const onDown = (ev: Event) => {
+    const e = ev as MouseEvent;
+    const target = e.currentTarget as HTMLElement;
+    const rect = target.getBoundingClientRect();
+    const span = document.createElement("span");
+    span.className = "nv-ripple";
+    span.style.left = `${e.clientX - rect.left}px`;
+    span.style.top = `${e.clientY - rect.top}px`;
+    target.appendChild(span);
+    span.addEventListener("animationend", () => span.remove(), { once: true });
+  };
+
+  const attachRipple = (el: Element) => {
+    el.removeEventListener("mousedown", onDown as any);
+    el.addEventListener("mousedown", onDown as any);
+    el.removeEventListener("touchstart", onDown as any);
+    el.addEventListener("touchstart", onDown as any, { passive: true });
+  };
+  rippleTargets().forEach(attachRipple);
+
+  // As routes/components mount later, keep observing for new buttons.
+  const mo = new MutationObserver(() => {
+    rippleTargets().forEach(attachRipple);
+    tagCheckoutButtons(); // keep tagging if new buttons appear
+    attachConfetti();
+  });
+  mo.observe(document.body, { childList: true, subtree: true });
+
+  // 2) Confetti on "Checkout (stub)" — tag button automatically
+  function tagCheckoutButtons() {
+    const btns = document.querySelectorAll("button, .btn, .button");
+    btns.forEach((b: any) => {
+      const text = (b.textContent || "").toLowerCase();
+      if (!b.dataset || b.dataset.confetti === "true") return;
+      if (text.includes("checkout")) {
+        (b as HTMLElement).setAttribute("data-confetti", "true");
+      }
+    });
+  }
+  tagCheckoutButtons();
+
+  function attachConfetti() {
+    const targets = document.querySelectorAll<HTMLElement>('[data-confetti="true"]');
+    targets.forEach((btn) => {
+      const handler = (e: MouseEvent) => {
+        const rect = btn.getBoundingClientRect();
+        burst({
+          x: rect.left + rect.width / 2,
+          y: rect.top + rect.height / 2,
+        });
+      };
+      btn.removeEventListener("click", handler as any);
+      btn.addEventListener("click", handler as any);
+    });
+  }
+  attachConfetti();
+}

--- a/src/styles/magic.css
+++ b/src/styles/magic.css
@@ -6,6 +6,8 @@ button,
 .button,
 [role="button"] {
   transition: box-shadow 0.25s ease, transform 0.25s ease, opacity 0.25s ease;
+  position: relative;            /* for ripple */
+  overflow: hidden;              /* clip ripple */
 }
 button:hover,
 .btn:hover,
@@ -59,5 +61,24 @@ button:active,
   0%   { transform: translateY(0); }
   50%  { transform: translateY(-8px); }
   100% { transform: translateY(0); }
+}
+
+/* 4) Button Ripple ------------------------------------------------------- */
+.nv-ripple {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  width: 12px;
+  height: 12px;
+  background: radial-gradient(circle, rgba(255,255,255,0.35) 0%, rgba(255,255,255,0.15) 40%, rgba(255,255,255,0) 70%);
+  animation: nv-ripple 520ms ease-out forwards;
+  will-change: transform, opacity;
+}
+@keyframes nv-ripple {
+  to {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(12);
+  }
 }
 

--- a/src/utils/confetti.ts
+++ b/src/utils/confetti.ts
@@ -1,0 +1,71 @@
+/**
+ * Tiny canvas confetti (dependency-free).
+ * Usage: burst({x, y, colors?, count?})
+ */
+type Point = { x: number; y: number };
+
+export function burst({
+  x,
+  y,
+  colors = ["#2563eb", "#3b82f6", "#60a5fa", "#93c5fd", "#1d4ed8"],
+  count = 40,
+}: Point & { colors?: string[]; count?: number }) {
+  const dpr = Math.max(1, window.devicePixelRatio || 1);
+  const canvas = document.createElement("canvas");
+  canvas.style.cssText =
+    "position:fixed;inset:0;pointer-events:none;z-index:9999";
+  document.body.appendChild(canvas);
+  const ctx = canvas.getContext("2d")!;
+
+  function resize() {
+    canvas.width = Math.floor(window.innerWidth * dpr);
+    canvas.height = Math.floor(window.innerHeight * dpr);
+  }
+  resize();
+
+  const cx = x * dpr;
+  const cy = y * dpr;
+  const parts = Array.from({ length: count }, () => ({
+    x: cx,
+    y: cy,
+    vx: (Math.random() - 0.5) * 8 * dpr,
+    vy: (Math.random() - 0.9) * 10 * dpr,
+    g: 0.25 * dpr,
+    r: Math.random() * 3 * dpr + 2 * dpr,
+    c: colors[Math.floor(Math.random() * colors.length)],
+    life: 60 + Math.random() * 20,
+  }));
+
+  let raf = 0;
+  const step = () => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    let alive = 0;
+    for (const p of parts) {
+      if (p.life <= 0) continue;
+      alive++;
+      p.vy += p.g;
+      p.x += p.vx;
+      p.y += p.vy;
+      p.life--;
+      ctx.beginPath();
+      ctx.fillStyle = p.c as string;
+      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    if (alive > 0) {
+      raf = requestAnimationFrame(step);
+    } else {
+      cancelAnimationFrame(raf);
+      canvas.remove();
+    }
+  };
+  raf = requestAnimationFrame(step);
+
+  // clean up on resize to avoid weird scaling
+  const onResize = () => {
+    cancelAnimationFrame(raf);
+    canvas.remove();
+    window.removeEventListener("resize", onResize);
+  };
+  window.addEventListener("resize", onResize, { once: true });
+}


### PR DESCRIPTION
## Summary
- add ripple and confetti styles to buttons
- provide dependency-free confetti utility and interaction initializer
- initialize interactions on app load

## Testing
- `npm run typecheck` (fails: No overload matches this call errors)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad65bdd5788329b4c522dad999b7c6