### PR TITLE
Harden interactions module for SSR environments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,14 @@ import { initInteractions } from './init/interactions';
 
 export default function App() {
   useEffect(() => {
-    initInteractions();
+    // Defer one frame to ensure DOM is ready and hydration settled
+    try {
+      if (typeof window !== 'undefined') {
+        requestAnimationFrame(() => initInteractions());
+      }
+    } catch (e) {
+      console && console.warn && console.warn('[naturverse] init skipped:', e);
+    }
   }, []);
   return (
     <CartProvider>

--- a/src/init/interactions.ts
+++ b/src/init/interactions.ts
@@ -5,6 +5,15 @@ import { burst } from "../utils/confetti";
  * Call once from App.tsx after DOM is ready.
  */
 export function initInteractions() {
+  // Hard guard for SSR and very old browsers / bots
+  if (
+    typeof window === "undefined" ||
+    typeof document === "undefined" ||
+    typeof MutationObserver === "undefined"
+  ) {
+    return;
+  }
+  try {
   // 1) Ripple on any button-like control
   const rippleTargets = () =>
     Array.from(
@@ -16,6 +25,7 @@ export function initInteractions() {
   const onDown = (ev: Event) => {
     const e = ev as MouseEvent;
     const target = e.currentTarget as HTMLElement;
+    if (!target) return;
     const rect = target.getBoundingClientRect();
     const span = document.createElement("span");
     span.className = "nv-ripple";
@@ -69,4 +79,8 @@ export function initInteractions() {
     });
   }
   attachConfetti();
+  } catch (err) {
+    // Never fail the app due to UI sugar
+    console && console.warn && console.warn("[naturverse] interactions init skipped:", err);
+  }
 }

--- a/src/utils/confetti.ts
+++ b/src/utils/confetti.ts
@@ -10,6 +10,8 @@ export function burst({
   colors = ["#2563eb", "#3b82f6", "#60a5fa", "#93c5fd", "#1d4ed8"],
   count = 40,
 }: Point & { colors?: string[]; count?: number }) {
+  // Guard for SSR / non-DOM environments
+  if (typeof window === "undefined" || typeof document === "undefined") return;
   const dpr = Math.max(1, window.devicePixelRatio || 1);
   const canvas = document.createElement("canvas");
   canvas.style.cssText =


### PR DESCRIPTION
## Summary
- Guard confetti burst against running in SSR/non-DOM contexts
- Protect interactions init from SSR/old browsers and wrap effects in try/catch
- Defer interaction setup in App to next frame and warn instead of throwing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: Cannot find module 'next' or its corresponding type declarations)


------
https://chatgpt.com/codex/tasks/task_e_68ad68f31af083299f6411b801a3c08a