### PR TITLE
chore: disable interactions and add runtime logger

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,18 +6,13 @@ import { CartProvider } from './lib/cart';
 import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
 import './styles/magic.css';
-import { initInteractions } from './init/interactions';
+// TEMP: disable interactions while we isolate the crash
+// import { initInteractions } from './init/interactions';
+import './init/runtime-logger'; // lightweight global error hooks
 
 export default function App() {
   useEffect(() => {
-    // Defer one frame to ensure DOM is ready and hydration settled
-    try {
-      if (typeof window !== 'undefined') {
-        requestAnimationFrame(() => initInteractions());
-      }
-    } catch (e) {
-      console && console.warn && console.warn('[naturverse] init skipped:', e);
-    }
+    // SAFE MODE: interactions temporarily disabled
   }, []);
   return (
     <CartProvider>

--- a/src/init/runtime-logger.ts
+++ b/src/init/runtime-logger.ts
@@ -1,0 +1,33 @@
+/**
+ * Tiny runtime logger so we can see the real error before the error boundary.
+ * Safe in prod; prints to console only (no UI).
+ */
+if (typeof window !== 'undefined') {
+  // Avoid double-registering in fast refresh
+  // @ts-ignore
+  if (!window.__nvLoggerInstalled) {
+    // @ts-ignore
+    window.__nvLoggerInstalled = true;
+    window.addEventListener('error', (ev) => {
+      // eslint-disable-next-line no-console
+      console.error(
+        '[naturverse] window.onerror',
+        ev.message,
+        ev.error || '(no error object)',
+        ev.filename,
+        ev.lineno,
+        ev.colno,
+      );
+    });
+    window.addEventListener('unhandledrejection', (ev) => {
+      // eslint-disable-next-line no-console
+      console.error(
+        '[naturverse] unhandledrejection',
+        ev.reason || '(no reason)',
+      );
+    });
+    // eslint-disable-next-line no-console
+    console.log('[naturverse] runtime logger active');
+  }
+}
+


### PR DESCRIPTION
## Summary
- disable interactions initialization for safe mode
- add lightweight runtime logger to capture window errors

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6b9571d88329b0b3488f56d7b83e