### PR TITLE
Disable new modules and ensure sourcemaps

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -1,5 +1,5 @@
 export const FLAGS = {
-  ENABLE_GAMIFICATION: (import.meta.env.VITE_ENABLE_GAMIFICATION ?? 'false') === 'true',
-  ENABLE_LEADERBOARD:  (import.meta.env.VITE_ENABLE_LEADERBOARD ?? 'false') === 'true',
-  ENABLE_STREAKS:      (import.meta.env.VITE_ENABLE_STREAKS ?? 'false') === 'true',
+  ENABLE_GAMIFICATION: false,
+  ENABLE_LEADERBOARD:  false,
+  ENABLE_STREAKS:      false,
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,6 @@ export default defineConfig({
     rollupOptions: {
       external: [],
     },
-    sourcemap: true,
+    sourcemap: true, // ensure production sourcemaps
   }
 });


### PR DESCRIPTION
## Summary
- Disable gamification, leaderboard, and streaks features by default
- Ensure production builds generate sourcemaps for debugging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ad73f9e0788329b9ed66f0cdd6ab5a