### PR TITLE
chore: make RouteFX independent of react-router

### DIFF
--- a/src/components/RouteFX.tsx
+++ b/src/components/RouteFX.tsx
@@ -1,50 +1,79 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
 
 /**
- * RouteFX
- * Runs tiny side-effects on route change, but can NEVER break render.
- * – scrolls to top
- * – moves focus to <main> (if present) for a11y
- * All ops are guarded and wrapped in try/catch.
+ * RouteFX (safe)
+ * - No react-router hooks (so it can mount anywhere, even outside <Router>)
+ * - Watches URL changes via history & popstate
+ * - Runs tiny, guarded side effects (scroll-to-top, focus <main>)
+ * - Can never crash render; always returns null
  */
-export default function RouteFX() {
-  const { pathname } = useLocation();
-
+export default function RouteFX(): null {
   useEffect(() => {
-    try {
-      // Guard for SSR / non-browser runtimes
-      if (typeof window !== "undefined") {
-        // Scroll to top, but tolerate unsupported smooth behavior
+    function runEffects() {
+      try {
+        // Scroll to top (prefer smooth when available)
         try {
           window.scrollTo({ top: 0, left: 0, behavior: "smooth" as ScrollBehavior });
         } catch {
           window.scrollTo(0, 0);
         }
-      }
 
-      // Focus main for screen readers if it exists
-      const main =
-        typeof document !== "undefined"
-          ? (document.querySelector("main") as HTMLElement | null)
-          : null;
-
-      if (main) {
-        // Ensure focusable
-        if (!main.hasAttribute("tabindex")) main.setAttribute("tabindex", "-1");
-        try {
-          main.focus({ preventScroll: true });
-        } catch {
-          // Older browsers
-          main.focus();
+        // Focus main for a11y (don’t throw if missing)
+        const main = document.querySelector("main") as HTMLElement | null;
+        if (main) {
+          if (!main.hasAttribute("tabindex")) main.setAttribute("tabindex", "-1");
+          try {
+            main.focus({ preventScroll: true });
+          } catch {
+            main.focus();
+          }
         }
+      } catch (err) {
+        // Never throw from here
+        console.warn("[Naturverse] RouteFX suppressed error:", err);
       }
-    } catch (err) {
-      // Absolutely never let this bubble to the ErrorBoundary
-      console.error("[naturverse] RouteFX error (guarded):", err);
     }
-  }, [pathname]);
 
-  // No UI, so render nothing
+    // Initial run
+    if (typeof window !== "undefined" && typeof document !== "undefined") {
+      runEffects();
+    }
+
+    // Listen for route changes without react-router
+    const origPush = history.pushState;
+    const origReplace = history.replaceState;
+
+    function fireNavEvent() {
+      window.dispatchEvent(new Event("naturverse:navigation"));
+    }
+
+    history.pushState = function (...args) {
+      const ret = origPush.apply(this, args as any);
+      fireNavEvent();
+      return ret;
+    } as any;
+
+    history.replaceState = function (...args) {
+      const ret = origReplace.apply(this, args as any);
+      fireNavEvent();
+      return ret;
+    } as any;
+
+    const onPop = () => fireNavEvent();
+    const onNV = () => runEffects();
+
+    window.addEventListener("popstate", onPop);
+    window.addEventListener("naturverse:navigation", onNV);
+
+    return () => {
+      // Cleanup & restore originals
+      history.pushState = origPush;
+      history.replaceState = origReplace;
+      window.removeEventListener("popstate", onPop);
+      window.removeEventListener("naturverse:navigation", onNV);
+    };
+  }, []);
+
   return null;
 }
+


### PR DESCRIPTION
## Summary
- replace RouteFX with a safe version that removes react-router hooks and guards DOM effects

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: existing type errors)


------
https://chatgpt.com/codex/tasks/task_e_68ad85459a8c83299859940e92b8de8f