### PR TITLE
Add offline warm-cache (Vite PWA + Workbox)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Naturverse</title>
     <meta name="theme-color" content="#0ea5e9" />
 
-    <!-- PWA capability: modern + Apple (Safari still uses this) -->
+    <!-- Replace deprecated Apple-only meta with cross-platform one -->
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react-router-dom": "^6.28.0",
     "@supabase/supabase-js": "^2.45.4",
     "@supabase/auth-helpers-react": "^0.5.0",
-    "three": "^0.160.0"
+    "three": "^0.160.0",
+    "workbox-window": "^7.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",
@@ -26,7 +27,10 @@
     "@vitejs/plugin-react-swc": "^3.7.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vite-plugin-pwa": "^0.20.0"
   },
-  "engines": { "node": ">=20.0.0" }
+  "engines": {
+    "node": ">=20.0.0"
+  }
 }

--- a/public/_headers
+++ b/public/_headers
@@ -25,3 +25,13 @@
 /robots.txt
   Content-Type: text/plain; charset=utf-8
   Cache-Control: public, max-age=86400
+
+/sw.js
+  Cache-Control: no-cache
+
+/workbox-*.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/manifest.webmanifest
+  Content-Type: application/manifest+json
+  Cache-Control: no-cache

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -60,3 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 import './styles/overrides.css';
+
+if (import.meta.env.PROD) {
+  import('./register-sw');
+}

--- a/src/register-sw.ts
+++ b/src/register-sw.ts
@@ -1,0 +1,10 @@
+// Only runs in production builds
+if (import.meta.env.PROD && 'serviceWorker' in navigator) {
+  // vite-plugin-pwa injects /sw.js for us
+  import('workbox-window').then(({ Workbox }) => {
+    const wb = new Workbox('/sw.js');
+    wb.addEventListener('waiting', () => wb.messageSW({ type: 'SKIP_WAITING' }));
+    wb.addEventListener('controlling', () => window.location.reload());
+    wb.register();
+  });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,44 +1,95 @@
-import { defineConfig, splitVendorChunkPlugin } from "vite";
-import react from "@vitejs/plugin-react-swc";
-import path from "path";
+import { defineConfig, splitVendorChunkPlugin } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+import { VitePWA } from 'vite-plugin-pwa';
+import path from 'path';
 
 export default defineConfig({
   plugins: [
     react(),
     // keeps a stable vendor chunk so the browser can cache it longer
     splitVendorChunkPlugin(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      injectRegister: 'auto',
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,svg,png,ico,webp,woff2}'],
+        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+      },
+      manifest: {
+        name: 'Naturverse',
+        short_name: 'Naturverse',
+        theme_color: '#2563eb',
+        background_color: '#ffffff',
+        start_url: '/',
+        display: 'standalone',
+        icons: [
+          { src: '/favicon-192x192.png', sizes: '192x192', type: 'image/png' },
+          { src: '/favicon-256x256.png', sizes: '256x256', type: 'image/png' },
+          {
+            src: '/favicon-512x512.png',
+            sizes: '512x512',
+            type: 'image/png',
+            purpose: 'any maskable',
+          },
+        ],
+      },
+      // Runtime caching for stuff that isn’t in the precache
+      runtimeCaching: [
+        {
+          urlPattern: ({ request }) => request.destination === 'image',
+          handler: 'CacheFirst',
+          options: {
+            cacheName: 'nv-images',
+            expiration: {
+              maxEntries: 60,
+              maxAgeSeconds: 60 * 60 * 24 * 30,
+            },
+          },
+        },
+        {
+          urlPattern: /https:\/\/[^/]*supabase\.co\/.*/i,
+          handler: 'StaleWhileRevalidate',
+          options: {
+            cacheName: 'nv-supabase',
+            expiration: {
+              maxEntries: 100,
+              maxAgeSeconds: 60 * 60 * 24,
+            },
+          },
+        },
+      ],
+    }),
   ],
-  envPrefix: ["VITE_", "NEXT_PUBLIC_"],
+  envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve(__dirname, './src'),
     },
   },
   optimizeDeps: {
     // Force pre-bundling during dev & build warmup
     include: [
-      "react",
-      "react-dom",
-      "react-router-dom",
-      "@supabase/supabase-js",
-      "three",
+      'react',
+      'react-dom',
+      'react-router-dom',
+      '@supabase/supabase-js',
+      'three',
       // add others you always ship:
       // "zustand", "clsx", "dayjs", ...
     ],
   },
   build: {
-    outDir: "dist",
+    outDir: 'dist',
     rollupOptions: {
       external: [],
       output: {
         // Small, predictable chunks for better caching
         manualChunks(id) {
-          if (id.includes("node_modules")) {
-            if (id.includes("react-router")) return "vendor-router";
-            if (id.includes("@supabase")) return "vendor-supabase";
-            if (id.includes("react") || id.includes("react-dom"))
-              return "vendor-react";
-            return "vendor";
+          if (id.includes('node_modules')) {
+            if (id.includes('react-router')) return 'vendor-router';
+            if (id.includes('@supabase')) return 'vendor-supabase';
+            if (id.includes('react') || id.includes('react-dom')) return 'vendor-react';
+            return 'vendor';
           }
         },
       },


### PR DESCRIPTION
## Summary
- precache assets and runtime cache images and Supabase calls via Workbox
- register service worker for auto-updates and background refresh
- set headers and meta tags for proper PWA behavior

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite-plugin-pwa)*
- `npm run typecheck` *(fails: Cannot find module 'next', cannot find module 'workbox-window', and other TS errors)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad9190ca188329b7008c48386908bc