### PR TITLE
Route progress + skeletons + lazy image

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@supabase/supabase-js": "^2.45.4",
     "@supabase/auth-helpers-react": "^0.5.0",
     "three": "^0.160.0",
-    "workbox-window": "^7.1.0"
+    "workbox-window": "^7.1.0",
+    "nprogress": "^0.2.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",

--- a/src/components/LazyImage.tsx
+++ b/src/components/LazyImage.tsx
@@ -1,0 +1,26 @@
+import { ImgHTMLAttributes, useState } from "react";
+import cn from "../utils/cn";
+
+type Props = ImgHTMLAttributes<HTMLImageElement>;
+
+export default function LazyImage({ className, onLoad, ...props }: Props) {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <img
+      loading="lazy"
+      decoding="async"
+      onLoad={(e) => {
+        setLoaded(true);
+        onLoad?.(e);
+      }}
+      className={cn(
+        "nv-img",
+        loaded ? "nv-img--ready" : "nv-img--blur",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+

--- a/src/components/RouteProgress.tsx
+++ b/src/components/RouteProgress.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { useNavigation } from "react-router-dom";
+import NProgress from "nprogress";
+
+import "../styles/nprogress.css";
+
+const RouteProgress = () => {
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    if (navigation.state === "loading") {
+      NProgress.start();
+    } else {
+      NProgress.done();
+    }
+  }, [navigation.state]);
+
+  return null;
+};
+
+export default RouteProgress;
+

--- a/src/layouts/Root.tsx
+++ b/src/layouts/Root.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 import SiteHeader from '../components/SiteHeader';
 import Footer from '../components/Footer';
+import RouteProgress from '../components/RouteProgress';
 
 export default function RootLayout() {
   return (
     <div className="nv-root">
       <SiteHeader />
+      <RouteProgress />
       <main className="pageRoot">
         <Outlet />
       </main>

--- a/src/styles/nprogress.css
+++ b/src/styles/nprogress.css
@@ -1,0 +1,39 @@
+/* ===== NProgress (Naturverse Blue) ===== */
+#nprogress { pointer-events: none; }
+#nprogress .bar {
+  background: var(--naturverse-blue, #2563eb);
+  position: fixed;
+  z-index: 9999;
+  top: 0; left: 0;
+  width: 100%; height: 3px;
+  box-shadow: 0 0 8px rgba(37,99,235,.35);
+}
+#nprogress .peg {
+  display: block; position: absolute; right: 0; width: 100px; height: 100%;
+  opacity: 1; transform: rotate(3deg) translate(0,-4px);
+  box-shadow: 0 0 10px var(--naturverse-blue, #2563eb), 0 0 5px var(--naturverse-blue, #2563eb);
+}
+#nprogress .spinner { display: none; }
+
+/* ===== Skeleton shimmer ===== */
+.nv-skeleton {
+  position: relative; overflow: hidden; border-radius: 12px; background: #e9efff;
+}
+.nv-skeleton::after {
+  content: ""; position: absolute; inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.6) 50%, rgba(255,255,255,0) 100%);
+  animation: nv-shimmer 1.15s infinite;
+}
+@keyframes nv-shimmer { 100% { transform: translateX(100%); } }
+
+/* Quick sizes you can use */
+.nv-skel-title { height: 28px; margin: 8px 0; }
+.nv-skel-line  { height: 14px; margin: 6px 0; }
+.nv-skel-btn   { height: 44px; border-radius: 14px; }
+
+/* ===== Blur-up images ===== */
+.nv-img { transition: filter .35s ease, opacity .35s ease; }
+.nv-img--blur { filter: blur(14px); opacity: .65; }
+.nv-img--ready { filter: blur(0); opacity: 1; }
+

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+export default function cn(
+  ...parts: (string | false | null | undefined)[]
+) {
+  return parts.filter(Boolean).join(" ");
+}
+


### PR DESCRIPTION
## Summary
- show a blue NProgress bar during route navigation
- add reusable lazy-loading image helper with blur-up effect
- introduce skeleton shimmer CSS and `cn` utility

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nprogress)*
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'workbox-window' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ad95f5dd888329ac0fce96a54e7006