### PR TITLE
Full Preload

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "@supabase/auth-helpers-react": "^0.5.0",
     "three": "^0.160.0",
     "workbox-window": "^7.1.0",
-    "nprogress": "^0.2.0"
+    "nprogress": "^0.2.0",
+    "react-helmet-async": "^1.3.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",

--- a/src/boot/Warmup.tsx
+++ b/src/boot/Warmup.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+
+/** requestIdleCallback polyfill */
+function onIdle(cb: () => void) {
+  // @ts-ignore
+  if (typeof window !== "undefined" && window.requestIdleCallback) {
+    // @ts-ignore
+    return window.requestIdleCallback(cb);
+  }
+  return setTimeout(cb, 150);
+}
+
+/**
+ * Warm-up route chunks & heavy components when the browser is idle.
+ * Each import is guarded; missing files are ignored safely.
+ */
+export default function Warmup() {
+  useEffect(() => {
+    const loaders: Array<() => Promise<unknown>> = [
+      // Top-level pages (two likely paths each, guarded)
+      () => import("../pages/Worlds").catch(() => {}),
+      () => import("../routes/worlds/index").catch(() => {}),
+      () => import("../pages/Zones").catch(() => {}),
+      () => import("../routes/zones/index").catch(() => {}),
+      () => import("../pages/Marketplace").catch(() => {}),
+      () => import("../routes/marketplace/index").catch(() => {}),
+      () => import("../pages/Naturversity").catch(() => {}),
+      () => import("../routes/naturversity/index").catch(() => {}),
+      () => import("../pages/NaturBank").catch(() => {}),
+      () => import("../routes/NaturBank").catch(() => {}),
+      () => import("../pages/Navatar").catch(() => {}),
+      () => import("../routes/Navatar").catch(() => {}),
+      () => import("../pages/Passport").catch(() => {}),
+      () => import("../routes/Passport").catch(() => {}),
+      () => import("../pages/Turian").catch(() => {}),
+      () => import("../routes/Turian").catch(() => {}),
+      // Popular zone subroutes
+      () => import("../routes/zones/arcade/index").catch(() => {}),
+      () => import("../routes/zones/music/index").catch(() => {}),
+    ];
+
+    // Stagger the warmup slightly so we don't spike bandwidth
+    loaders.forEach((load, i) => {
+      onIdle(() => setTimeout(() => load(), i * 120));
+    });
+  }, []);
+
+  return null;
+}

--- a/src/components/HeadPreloads.tsx
+++ b/src/components/HeadPreloads.tsx
@@ -1,0 +1,30 @@
+import { Helmet } from "react-helmet-async";
+
+/** 
+ * Safe head hints: preconnects + favicons.
+ * Only references files that exist in /public per your listing.
+ */
+export default function HeadPreloads() {
+  return (
+    <Helmet>
+      {/* Perf hints */}
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+      <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
+      <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
+
+      {/* Favicon family – preload a couple so the header icon is instant */}
+      <link rel="preload" as="image" href="/favicon-32x32.png" />
+      <link rel="preload" as="image" href="/favicon-64x64.png" />
+      {/* regular favicons (keep what you already had too) */}
+      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+      <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
+      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+      <link rel="shortcut icon" href="/favicon.ico" />
+
+      {/* modern PWA-capable tags to silence the console note */}
+      <meta name="mobile-web-app-capable" content="yes" />
+      <meta name="apple-mobile-web-app-capable" content="yes" />
+    </Helmet>
+  );
+}

--- a/src/layouts/Root.tsx
+++ b/src/layouts/Root.tsx
@@ -1,18 +1,26 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
+
+import HeadPreloads from '../components/HeadPreloads';
+import RouteProgress from '../components/RouteProgress';
+import Warmup from '../boot/Warmup';
 import SiteHeader from '../components/SiteHeader';
 import Footer from '../components/Footer';
-import RouteProgress from '../components/RouteProgress';
 
 export default function RootLayout() {
   return (
-    <div className="nv-root">
-      <SiteHeader />
+    <HelmetProvider>
+      <HeadPreloads />
       <RouteProgress />
-      <main className="pageRoot">
-        <Outlet />
-      </main>
-      <Footer />
-    </div>
+      <Warmup />
+      <div className="nv-root">
+        <SiteHeader />
+        <main className="pageRoot">
+          <Outlet />
+        </main>
+        <Footer />
+      </div>
+    </HelmetProvider>
   );
 }


### PR DESCRIPTION
## Summary
- preload critical favicon assets and font DNS through new `<HeadPreloads>` component
- warm route-level chunks with idle-loaded `<Warmup>` logic
- wrap root layout in `HelmetProvider` to host head hints, route progress bar, and preloading warmup

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nprogress)*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ad98fdb3808329844c5504c5643b17