### PR TITLE
feat: add preload and warmup helpers

### DIFF
--- a/src/boot/Warmup.tsx
+++ b/src/boot/Warmup.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
-/** requestIdleCallback polyfill */
 function onIdle(cb: () => void) {
+  // Polyfill requestIdleCallback
   // @ts-ignore
   if (typeof window !== "undefined" && window.requestIdleCallback) {
     // @ts-ignore
@@ -11,13 +11,12 @@ function onIdle(cb: () => void) {
 }
 
 /**
- * Warm-up route chunks & heavy components when the browser is idle.
- * Each import is guarded; missing files are ignored safely.
+ * Preload popular routes + chunks during idle time.
+ * All imports are wrapped in catch() to avoid breaking if missing.
  */
 export default function Warmup() {
   useEffect(() => {
     const loaders: Array<() => Promise<unknown>> = [
-      // Top-level pages (two likely paths each, guarded)
       () => import("../pages/Worlds").catch(() => {}),
       () => import("../routes/worlds/index").catch(() => {}),
       () => import("../pages/Zones").catch(() => {}),
@@ -34,12 +33,11 @@ export default function Warmup() {
       () => import("../routes/Passport").catch(() => {}),
       () => import("../pages/Turian").catch(() => {}),
       () => import("../routes/Turian").catch(() => {}),
-      // Popular zone subroutes
+      // Zone subroutes
       () => import("../routes/zones/arcade/index").catch(() => {}),
       () => import("../routes/zones/music/index").catch(() => {}),
     ];
 
-    // Stagger the warmup slightly so we don't spike bandwidth
     loaders.forEach((load, i) => {
       onIdle(() => setTimeout(() => load(), i * 120));
     });

--- a/src/components/HeadPreloads.tsx
+++ b/src/components/HeadPreloads.tsx
@@ -1,8 +1,7 @@
 import { Helmet } from "react-helmet-async";
 
-/** 
- * Safe head hints: preconnects + favicons.
- * Only references files that exist in /public per your listing.
+/**
+ * Global preloads: fonts, favicons, PWA meta.
  */
 export default function HeadPreloads() {
   return (
@@ -13,16 +12,25 @@ export default function HeadPreloads() {
       <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
       <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
 
-      {/* Favicon family – preload a couple so the header icon is instant */}
+      {/* Favicon family */}
       <link rel="preload" as="image" href="/favicon-32x32.png" />
       <link rel="preload" as="image" href="/favicon-64x64.png" />
-      {/* regular favicons (keep what you already had too) */}
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
+      <link
+        rel="icon"
+        type="image/png"
+        sizes="32x32"
+        href="/favicon-32x32.png"
+      />
+      <link
+        rel="icon"
+        type="image/png"
+        sizes="64x64"
+        href="/favicon-64x64.png"
+      />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
       <link rel="shortcut icon" href="/favicon.ico" />
 
-      {/* modern PWA-capable tags to silence the console note */}
+      {/* PWA tags */}
       <meta name="mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-capable" content="yes" />
     </Helmet>


### PR DESCRIPTION
## Summary
- add global head preloads for fonts, favicons and PWA tags
- warm up popular routes during idle time

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TS2339: Property 'id' does not exist on type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68ad9a651a9c832995dd5756404fc365