### PR TITLE
feat: add warmup preloads

### DIFF
--- a/src/boot/Warmup.tsx
+++ b/src/boot/Warmup.tsx
@@ -1,19 +1,13 @@
 import { useEffect } from "react";
 
 function onIdle(cb: () => void) {
-  // Polyfill requestIdleCallback
-  // @ts-ignore
-  if (typeof window !== "undefined" && window.requestIdleCallback) {
+  if (typeof window !== "undefined" && "requestIdleCallback" in window) {
     // @ts-ignore
     return window.requestIdleCallback(cb);
   }
-  return setTimeout(cb, 150);
+  return setTimeout(cb, 120);
 }
 
-/**
- * Preload popular routes + chunks during idle time.
- * All imports are wrapped in catch() to avoid breaking if missing.
- */
 export default function Warmup() {
   useEffect(() => {
     const loaders: Array<() => Promise<unknown>> = [
@@ -33,13 +27,13 @@ export default function Warmup() {
       () => import("../routes/Passport").catch(() => {}),
       () => import("../pages/Turian").catch(() => {}),
       () => import("../routes/Turian").catch(() => {}),
-      // Zone subroutes
+      // zones subroutes
       () => import("../routes/zones/arcade/index").catch(() => {}),
       () => import("../routes/zones/music/index").catch(() => {}),
     ];
 
     loaders.forEach((load, i) => {
-      onIdle(() => setTimeout(() => load(), i * 120));
+      onIdle(() => setTimeout(() => load(), i * 150));
     });
   }, []);
 

--- a/src/components/HeadPreloads.tsx
+++ b/src/components/HeadPreloads.tsx
@@ -1,36 +1,23 @@
 import { Helmet } from "react-helmet-async";
 
-/**
- * Global preloads: fonts, favicons, PWA meta.
- */
 export default function HeadPreloads() {
   return (
     <Helmet>
-      {/* Perf hints */}
+      {/* Fonts */}
       <link rel="preconnect" href="https://fonts.googleapis.com" />
       <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
       <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
       <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
 
-      {/* Favicon family */}
+      {/* Favicons */}
       <link rel="preload" as="image" href="/favicon-32x32.png" />
       <link rel="preload" as="image" href="/favicon-64x64.png" />
-      <link
-        rel="icon"
-        type="image/png"
-        sizes="32x32"
-        href="/favicon-32x32.png"
-      />
-      <link
-        rel="icon"
-        type="image/png"
-        sizes="64x64"
-        href="/favicon-64x64.png"
-      />
+      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+      <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
       <link rel="shortcut icon" href="/favicon.ico" />
 
-      {/* PWA tags */}
+      {/* PWA meta */}
       <meta name="mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-capable" content="yes" />
     </Helmet>


### PR DESCRIPTION
## Summary
- add `<HeadPreloads>` for fonts, favicons, and PWA tags
- warm up common routes with idle-time chunk prefetching

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find package 'vite-plugin-pwa')*

------
https://chatgpt.com/codex/tasks/task_e_68ad9c9814e88329a39f8a744f993521