### PR TITLE
Fix react-helmet-async bundling and warmup routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "three": "^0.160.0",
     "workbox-window": "^7.1.0",
     "nprogress": "^0.2.0",
-    "react-helmet-async": "^1.3.0"
+    "react-helmet-async": "1.3.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",

--- a/src/boot/Warmup.tsx
+++ b/src/boot/Warmup.tsx
@@ -17,22 +17,12 @@ function onIdle(cb: () => void) {
 export default function Warmup() {
   useEffect(() => {
     const loaders: Array<() => Promise<unknown>> = [
-      () => import("../pages/Worlds").catch(() => {}),
       () => import("../routes/worlds/index").catch(() => {}),
-      () => import("../pages/Zones").catch(() => {}),
       () => import("../routes/zones/index").catch(() => {}),
-      () => import("../pages/Marketplace").catch(() => {}),
       () => import("../routes/marketplace/index").catch(() => {}),
-      () => import("../pages/Naturversity").catch(() => {}),
-      () => import("../routes/naturversity/index").catch(() => {}),
-      () => import("../pages/NaturBank").catch(() => {}),
-      () => import("../routes/NaturBank").catch(() => {}),
-      () => import("../pages/Navatar").catch(() => {}),
-      () => import("../routes/Navatar").catch(() => {}),
-      () => import("../pages/Passport").catch(() => {}),
-      () => import("../routes/Passport").catch(() => {}),
-      () => import("../pages/Turian").catch(() => {}),
-      () => import("../routes/Turian").catch(() => {}),
+      () => import("../routes/naturbank/index").catch(() => {}),
+      () => import("../routes/navatar/index").catch(() => {}),
+      () => import("../routes/turian/index").catch(() => {}),
       // Zone subroutes
       () => import("../routes/zones/arcade/index").catch(() => {}),
       () => import("../routes/zones/music/index").catch(() => {}),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,6 +74,7 @@ export default defineConfig({
       'react-router-dom',
       '@supabase/supabase-js',
       'three',
+      'react-helmet-async',
       // add others you always ship:
       // "zustand", "clsx", "dayjs", ...
     ],
@@ -95,5 +96,8 @@ export default defineConfig({
       },
     },
     sourcemap: true, // ensure production sourcemaps
+    commonjsOptions: {
+      include: [/node_modules/],
+    },
   },
 });


### PR DESCRIPTION
## Summary
- pin `react-helmet-async` version and ensure Vite prebundles it
- adjust build to include commonjs node_modules
- warmup actual routes instead of missing pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9d502ef883299486844718583037