### PR TITLE
feat: safely warm up routes

### DIFF
--- a/src/boot/warmup.ts
+++ b/src/boot/warmup.ts
@@ -1,15 +1,46 @@
-/**
- * Safe warmup: defer-heavy imports until after first paint,
- * avoid importing non-existent pages at build time.
- */
-export function warmup() {
-  if (typeof window === 'undefined') return;
+// Safe route warmup: never fail the build if a route doesn't exist.
+// In dev this preloads typical pages for a snappier first navigation.
+// In prod it quietly no-ops if anything is missing.
 
-  // Preload a few real route bundles *lazily* and ignore failures.
-  const ok = (p: Promise<unknown>) => p.catch(() => {});
-  queueMicrotask(() => {
-    ok(import('../pages/Home'));
-    ok(import('../pages/Passport'));
-    ok(import('../pages/Marketplace'));
-  });
+async function warmupRoutes() {
+  // List the pages you *expect* to exist. Missing ones will be skipped safely.
+  // Adjust this list anytime you add/remove pages—no risk to the build.
+  const routes = [
+    "../pages/Home",
+    "../pages/Worlds",
+    "../pages/Zones",
+    "../pages/Marketplace",
+    "../pages/Wishlist",
+    "../pages/Naturversity",
+    "../pages/NaturBank",
+    "../pages/Navatar",
+    "../pages/Passport",
+    "../pages/Turian",
+    // Add any nested routes you actually have, e.g.:
+    // "../routes/zones/arcade/index",
+    // "../routes/worlds/thailandia/index",
+  ];
+
+  // Only try to warm during client runtime; SSR/build stays safe regardless.
+  // Still fine to run in prod—errors are caught and ignored.
+  for (const route of routes) {
+    try {
+      // Dynamic + vite-ignore prevents Rollup from resolving at build time.
+      await import(/* @vite-ignore */ route);
+      if (import.meta?.env?.DEV) {
+        // eslint-disable-next-line no-console
+        console.log(`[warmup] preloaded: ${route}`);
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(`[warmup] skipped missing route: ${route}`);
+    }
+  }
+}
+
+// Kick off; do not await so it never blocks app startup.
+try {
+  warmupRoutes();
+} catch {
+  /* swallow */
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,7 @@ import SkipToContent from './components/SkipToContent';
 import { supabase } from '@/lib/supabase-client';
 import './runtime-logger';
 import { prefetchGlob, prefetchOnHover } from './lib/prefetch';
-import { warmup } from './boot/warmup';
+import './boot/warmup';
 
 async function bootstrap() {
   const { data } = await supabase.auth.getSession();
@@ -33,8 +33,6 @@ async function bootstrap() {
       </AuthProvider>
     </React.StrictMode>,
   );
-  // kick off after scheduling first paint
-  setTimeout(warmup, 0);
 }
 
 bootstrap();


### PR DESCRIPTION
## Summary
- dynamically preload expected routes at startup
- log and skip missing routes instead of failing build
- invoke warmup via side-effect import in client entry

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: Cannot find module 'next' or its corresponding type declarations, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68ada4a8eeec832986d8c949f297eb6c