### PR TITLE
Polish: blue theme sweep + instant favicon + safe warmup + offline banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,26 +32,11 @@
     <meta name="twitter:image" content="/favicon-512.png" />
     <link rel="canonical" href="https://naturverse.netlify.app/" />
 
-    <!-- ====================
-         Favicon & Preload Fix
-         ==================== -->
-    <link rel="preload" href="/favicon-32x32.png" as="image" type="image/png" importance="high" />
-    <link rel="preload" href="/favicon-64x64.png" as="image" type="image/png" importance="high" />
-    <link rel="preload" href="/favicon-128x128.png" as="image" type="image/png" importance="high" />
-    <link rel="preload" href="/favicon-256x256.png" as="image" type="image/png" importance="high" />
-
-    <!-- Standard Favicons -->
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <!-- Preload the 64x64 (crisp and safe) so favicon appears immediately -->
+    <link rel="preload" as="image" href="/favicon-64x64.png" imagesizes="64x64" />
     <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
-    <link rel="icon" type="image/png" sizes="128x128" href="/favicon-128x128.png" />
-    <link rel="icon" type="image/png" sizes="256x256" href="/favicon-256x256.png" />
-    <link rel="icon" href="/favicon.ico" />
-
-    <!-- Apple / iOS -->
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-256x256.png" />
-
-    <!-- SVG fallback (scales well in modern browsers) -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="alternate icon" href="/favicon.ico" />
 
     <!-- Preload assets -->
     <link rel="preload" href="/src/main.css" as="style" />

--- a/src/boot/warmup.ts
+++ b/src/boot/warmup.ts
@@ -1,46 +1,50 @@
-// Safe route warmup: never fail the build if a route doesn't exist.
-// In dev this preloads typical pages for a snappier first navigation.
-// In prod it quietly no-ops if anything is missing.
+// Safe, network-friendly warmup for route chunks
+// - Uses import.meta.glob to discover *existing* pages
+// - Only preloads when idle & on decent connections
 
-async function warmupRoutes() {
-  // List the pages you *expect* to exist. Missing ones will be skipped safely.
-  // Adjust this list anytime you add/remove pages—no risk to the build.
-  const routes = [
-    "../pages/Home",
-    "../pages/Worlds",
-    "../pages/Zones",
-    "../pages/Marketplace",
-    "../pages/Wishlist",
-    "../pages/Naturversity",
-    "../pages/NaturBank",
-    "../pages/Navatar",
-    "../pages/Passport",
-    "../pages/Turian",
-    // Add any nested routes you actually have, e.g.:
-    // "../routes/zones/arcade/index",
-    // "../routes/worlds/thailandia/index",
-  ];
+type Loader = () => Promise<unknown>;
 
-  // Only try to warm during client runtime; SSR/build stays safe regardless.
-  // Still fine to run in prod—errors are caught and ignored.
-  for (const route of routes) {
-    try {
-      // Dynamic + vite-ignore prevents Rollup from resolving at build time.
-      await import(/* @vite-ignore */ route);
-      if (import.meta?.env?.DEV) {
-        // eslint-disable-next-line no-console
-        console.log(`[warmup] preloaded: ${route}`);
-      }
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn(`[warmup] skipped missing route: ${route}`);
-    }
+const pages = import.meta.glob('../pages/**/*.tsx') as Record<string, Loader>;
+
+// Pick the routes you want to warm (keys must exist or we skip)
+const CANDIDATES = [
+  '../pages/Worlds.tsx',
+  '../pages/Zones.tsx',
+  '../pages/Marketplace.tsx',
+  '../pages/Wishlist.tsx',
+  '../pages/Naturversity.tsx',
+  '../pages/NaturBank.tsx',
+  '../pages/Navatar.tsx',
+  '../pages/Passport.tsx',
+  '../pages/Turian.tsx',
+  '../pages/Cart.tsx',
+];
+
+function warm(key: string) {
+  const loader = pages[key];
+  if (typeof loader === 'function') {
+    loader().catch(() => {
+      // silently ignore; never break runtime
+    });
   }
 }
 
-// Kick off; do not await so it never blocks app startup.
-try {
-  warmupRoutes();
-} catch {
-  /* swallow */
+function isGoodConnection() {
+  // @ts-ignore – NetworkInformation isn't in TS lib by default everywhere
+  const info = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  if (!info) return true;
+  const save = 'saveData' in info && info.saveData;
+  const downlink = 'downlink' in info ? Number(info.downlink) : 1;
+  return !save && downlink >= 1;
+}
+
+const start = () => CANDIDATES.forEach(warm);
+
+if (isGoodConnection()) {
+  if ('requestIdleCallback' in window) {
+    // @ts-ignore
+    requestIdleCallback(start, { timeout: 3000 });
+  } else {
+    setTimeout(start, 1200);
+  }
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import { FOOTER_LINKS } from "../data/footer";
 
 export default function Footer() {
   return (
-    <footer>
+    <footer className="site-footer">
       <div className="container" style={{display:"flex",justifyContent:"space-between",alignItems:"center",gap:12}}>
         <small style={{ color: "var(--nv-blue-600)" }}>
           © {new Date().getFullYear()} Naturverse™

--- a/src/components/OfflineBanner.tsx
+++ b/src/components/OfflineBanner.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+export default function OfflineBanner() {
+  const [online, setOnline] = useState(navigator.onLine);
+  useEffect(() => {
+    const up = () => setOnline(true);
+    const down = () => setOnline(false);
+    window.addEventListener("online", up);
+    window.addEventListener("offline", down);
+    return () => {
+      window.removeEventListener("online", up);
+      window.removeEventListener("offline", down);
+    };
+  }, []);
+
+  if (online) return null;
+
+  return (
+    <div
+      role="status"
+      style={{
+        background: "#fffae6",
+        color: "#5b4600",
+        borderBottom: "1px solid #ffe58f",
+        padding: "6px 12px",
+        textAlign: "center",
+        fontWeight: 600,
+      }}
+    >
+      You’re offline. Changes may not save until you reconnect.
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,9 @@ import './styles/edu.css';
 import './main.css';
 import './styles/nvcard.css';
 import './app.css';
+import './styles/nv-sweep.css';
 import SkipToContent from './components/SkipToContent';
+import OfflineBanner from './components/OfflineBanner';
 import { supabase } from '@/lib/supabase-client';
 import './runtime-logger';
 import { prefetchGlob, prefetchOnHover } from './lib/prefetch';
@@ -22,13 +24,14 @@ async function bootstrap() {
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       {/* Ensure auth context wraps the entire app so Home gets updates immediately */}
-      <AuthProvider initialSession={initialSession}>
-        <SkipToContent />
-        <BaseAuthProvider>
-          <App />
-        </BaseAuthProvider>
-      </AuthProvider>
-    </React.StrictMode>,
+        <AuthProvider initialSession={initialSession}>
+          <SkipToContent />
+          <OfflineBanner />
+          <BaseAuthProvider>
+            <App />
+          </BaseAuthProvider>
+        </AuthProvider>
+      </React.StrictMode>,
   );
 }
 

--- a/src/pages/zones/Community.tsx
+++ b/src/pages/zones/Community.tsx
@@ -130,7 +130,7 @@ export default function Community() {
   };
 
   return (
-    <div className="page-wrap zones-page2">
+    <div className="page-wrap zones-page zones-page2">
       <Breadcrumbs />
       <main id="main">
       <h1>🗳️🌍 Community</h1>

--- a/src/pages/zones/Culture.tsx
+++ b/src/pages/zones/Culture.tsx
@@ -15,7 +15,7 @@ export default function Culture() {
       <Page
         title="Culture"
         subtitle="Beliefs, holidays, and ceremonies across the 14 kingdoms."
-        className="zones-page2"
+        className="zones-page zones-page2"
       >
       <div className="culture-grid grid gap-4 md:gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {kingdoms.map((k) => (

--- a/src/pages/zones/Future.tsx
+++ b/src/pages/zones/Future.tsx
@@ -3,7 +3,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 
 export default function FutureZone() {
   return (
-      <div className="page-wrap zones-page2">
+      <div className="page-wrap zones-page zones-page2">
         <Breadcrumbs />
         <main id="main" className="page">
 

--- a/src/pages/zones/Observations.tsx
+++ b/src/pages/zones/Observations.tsx
@@ -145,7 +145,7 @@ export default function Observations() {
   }, [list]);
 
   return (
-    <div className="page-wrap zones-page2">
+    <div className="page-wrap zones-page zones-page2">
       <Breadcrumbs />
       <main id="main">
       <h1>📷🌿 Observations</h1>

--- a/src/pages/zones/Quizzes.tsx
+++ b/src/pages/zones/Quizzes.tsx
@@ -64,7 +64,7 @@ export default function Quizzes() {
   };
 
   return (
-    <div className="page-wrap zones-page2">
+    <div className="page-wrap zones-page zones-page2">
       <Breadcrumbs />
       <main id="main">
       <h1>🎯 Quizzes</h1>

--- a/src/pages/zones/Stories.tsx
+++ b/src/pages/zones/Stories.tsx
@@ -85,7 +85,7 @@ export default function Stories() {
   };
 
   return (
-      <div className="page-wrap zones-page2">
+      <div className="page-wrap zones-page zones-page2">
         <Breadcrumbs />
         <main id="main">
         <h1>📚✨ Stories</h1>

--- a/src/pages/zones/creator-lab.tsx
+++ b/src/pages/zones/creator-lab.tsx
@@ -6,7 +6,7 @@ import { setTitle } from "../_meta";
 export default function CreatorLabPage() {
   setTitle("Creator Lab");
   return (
-    <main className="container mx-auto px-4 py-8 zones-page2">
+    <main className="container mx-auto px-4 py-8 zones-page zones-page2">
 
       <Breadcrumbs
         items={[

--- a/src/routes/navatar/index.tsx
+++ b/src/routes/navatar/index.tsx
@@ -2,8 +2,8 @@ import { useState } from "react";
 const types = ["Animal","Fruit","Insect","Spirit"] as const;
 export default function Navatar() {
   const [sel,setSel] = useState<typeof types[number] | null>("Animal");
-  return (
-    <section className="space-y-4">
+    return (
+      <section className="space-y-4 navatar-page">
       <h2 className="text-2xl font-bold">Navatar Creator</h2>
       <p className="text-gray-600">Choose a base type and generate a backstory later.</p>
       <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-4">

--- a/src/routes/worlds/[slug].tsx
+++ b/src/routes/worlds/[slug].tsx
@@ -11,11 +11,11 @@ export default function WorldDetail() {
   const folder = SLUG_TO_FOLDER[slug];
   if (!world) return <p>World not found.</p>;
 
-  return (
-    <article>
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/worlds", label: "Worlds" }, { label: world.title }]} />
-      <h1>{world.title}</h1>
-      <p>Zoom into landmarks, routes, and regions.</p>
+    return (
+      <article className="world-page">
+        <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/worlds", label: "Worlds" }, { label: world.title }]} />
+        <h1>{world.title}</h1>
+        <p>Zoom into landmarks, routes, and regions.</p>
 
       <div className="nv-hero-img-wrapper">
         <img

--- a/src/routes/worlds/characters/[name].tsx
+++ b/src/routes/worlds/characters/[name].tsx
@@ -10,11 +10,11 @@ export default function CharacterPage() {
     (ext) => `/kingdoms/${folder}/${fileGuess}${ext}`,
   );
 
-  return (
-    <div>
-      <nav className="text-sm" aria-label="Breadcrumb">
-        <Link to="/">Home</Link> <span>/</span>{" "}
-        <Link to="/worlds">Worlds</Link> <span>/</span>{" "}
+    return (
+      <div className="world-page">
+        <nav className="text-sm" aria-label="Breadcrumb">
+          <Link to="/">Home</Link> <span>/</span>{" "}
+          <Link to="/worlds">Worlds</Link> <span>/</span>{" "}
         <Link to={`/worlds/${slug}`}>{folder}</Link> <span>/</span>{" "}
         <span className="font-medium">{fileGuess}</span>
       </nav>

--- a/src/routes/zones/arcade/index.tsx
+++ b/src/routes/zones/arcade/index.tsx
@@ -10,8 +10,8 @@ import "../../../styles/zone-widgets.css";
 const LeaderboardSafe = safeLazy<typeof Leaderboard>(() => import("../../../components/Leaderboard"));
 
 export default function Arcade() {
-  return (
-    <main className="container">
+    return (
+      <main className="container zones-page">
       <Breadcrumbs />
       <h2 className="section-title">Arcade</h2>
       <p className="section-lead">Mini-games, leaderboards &amp; tournaments.</p>

--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -5,11 +5,11 @@ import { setTitle } from "../../pages/_meta";
 
 export default function Zones() {
   setTitle("Zones");
-  return (
-    <div>
-      <Breadcrumbs />
-      <h1>Zones</h1>
-      <div className="cards grid-gap">
+    return (
+      <div className="zones-page">
+        <Breadcrumbs />
+        <h1>Zones</h1>
+        <div className="cards grid-gap">
         {ZONES.map((z) => (
           <a key={z.href} className="card" href={z.href}>
             <h2>{z.title}</h2>

--- a/src/routes/zones/music/index.tsx
+++ b/src/routes/zones/music/index.tsx
@@ -4,9 +4,9 @@ import { autoGrantOncePerDay } from "@/lib/rewards";
 import { toast } from "@/components/Toaster";
 import "../../../styles/zone-widgets.css";
 
-export default function Music() {
-  return (
-    <main className="container">
+  export default function Music() {
+    return (
+      <main className="container zones-page">
       <Breadcrumbs />
       <h2 className="section-title">Music</h2>
       <p className="section-lead">Karaoke, beats &amp; song maker (client-only).</p>

--- a/src/routes/zones/wellness/index.tsx
+++ b/src/routes/zones/wellness/index.tsx
@@ -2,9 +2,9 @@ import { useEffect, useRef, useState } from "react";
 import Breadcrumbs from "../../../components/Breadcrumbs";
 import "../../../styles/zone-widgets.css";
 
-export default function Wellness() {
-  return (
-    <main className="container">
+  export default function Wellness() {
+    return (
+      <main className="container zones-page">
       <Breadcrumbs />
       <h2 className="section-title">Wellness</h2>
       <p className="section-lead">Yoga, breathing, stretches, mindful quests (client-only).</p>

--- a/src/styles/nv-sweep.css
+++ b/src/styles/nv-sweep.css
@@ -1,0 +1,61 @@
+/* Naturverse blue sweep: scoped so it won't surprise other pages */
+:root {
+  --naturverse-blue: var(--nv-blue-700, #2b64ff);
+}
+
+/* Footer links */
+.site-footer a,
+.footer a { color: var(--naturverse-blue) !important; }
+
+/* --- NaturBank --- */
+.naturbank-page h1,
+.naturbank-page h2,
+.naturbank-page h3,
+.naturbank-page .label,
+.naturbank-page .section-title,
+.naturbank-page .card-title,
+.naturbank-page .balance-title,
+.naturbank-page .transactions-title,
+.naturbank-page .tile-title { color: var(--naturverse-blue) !important; }
+
+.naturbank-page .btn,
+.naturbank-page button {
+  background: var(--naturverse-blue);
+  color: white !important;
+  border: none;
+}
+
+/* --- Navatar Creator --- */
+.navatar-page h1,
+.navatar-page h2,
+.navatar-page h3,
+.navatar-page .section-title,
+.navatar-page label,
+.navatar-page .label,
+.navatar-page .card-title { color: var(--naturverse-blue) !important; }
+
+.navatar-page .btn,
+.navatar-page button {
+  background: var(--naturverse-blue);
+  color: white !important;
+  border: none;
+}
+
+/* --- Zones hub & child pages --- */
+.zones-page h1,
+.zones-page h2,
+.zones-page h3,
+.zones-page .section-title,
+.zones-page .card-title,
+.zones-page .label { color: var(--naturverse-blue) !important; }
+
+/* --- Worlds (internal/zoom) --- */
+.world-page h1,
+.world-page h2,
+.world-page h3,
+.world-page .section-title,
+.world-page .card-title,
+.world-page .label { color: var(--naturverse-blue) !important; }
+
+/* Keep generic anchors blue everywhere (without touching nav) */
+.main a:not(.btn) { color: var(--naturverse-blue); }


### PR DESCRIPTION
## Summary
- add scoped Naturverse blue theme stylesheet and apply page classes
- ensure instant favicon and mobile web app meta
- replace warmup with safe dynamic preloading and add offline banner

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Property 'id' does not exist on type 'never' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68adae4109d88329a707900768da1324