### PR TITLE
Share + Save + Skeletons + A11y polish (no deps)

### DIFF
--- a/src/components/SaveButton.tsx
+++ b/src/components/SaveButton.tsx
@@ -1,10 +1,47 @@
-import { useCart } from "../lib/cart";
-export default function SaveButton({ id }:{id:string}) {
-  const { saved, toggleSave } = useCart();
-  const on = !!saved[id];
+import { get, set } from "../utils/storage";
+import { useEffect, useState } from "react";
+import { useToast } from "./Toast";
+
+type Item = { id: string; kind: "world" | "zone" | "product" | "navatar"; title: string; href?: string; payload?: unknown; }
+const KEY = "library";
+
+export function useLibrary() {
+  const [items, setItems] = useState<Item[]>(() => get<Item[]>(KEY, []));
+  useEffect(() => {
+    const on = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { key: string };
+      if (detail?.key === KEY) setItems(get<Item[]>(KEY, []));
+    };
+    window.addEventListener("naturverse:v1:changed", on as EventListener);
+    return () => window.removeEventListener("naturverse:v1:changed", on as EventListener);
+  }, []);
+  return items;
+}
+
+export default function SaveButton(props: Item) {
+  const toast = useToast();
+  const items = get<Item[]>(KEY, []);
+  const exists = items.some(i => i.id === props.id);
+
+  function persist(next: Item[]) { set(KEY, next); }
+
   return (
-    <button className={on? "btn-solid" : "btn-outline"} onClick={()=>toggleSave(id)}>
-      {on ? "♥ Saved" : "♡ Save"}
+    <button
+      className="btn save-btn"
+      onClick={() => {
+        const list = get<Item[]>(KEY, []);
+        if (exists) {
+          persist(list.filter(i => i.id !== props.id));
+          toast({ text: "Removed from Library", kind: "warn" });
+        } else {
+          persist([{ ...props }, ...list].slice(0, 200));
+          toast({ text: "Saved to Library ⭐", kind: "ok" });
+        }
+      }}
+      aria-pressed={exists}
+      title={exists ? "Remove from Library" : "Save to Library"}
+    >
+      {exists ? "Saved" : "Save"}
     </button>
   );
 }

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,0 +1,20 @@
+import { smartShare } from "../utils/share";
+import { useToast } from "./Toast";
+
+export default function ShareButton({ title, text, url }: { title?: string; text?: string; url?: string; }) {
+  const toast = useToast();
+  return (
+    <button
+      className="btn share-btn"
+      onClick={async () => {
+        const res = await smartShare({ title, text, url });
+        if (res === "shared") toast({ text: "Shared ✅", kind: "ok" });
+        else if (res === "copied") toast({ text: "Link copied 📋", kind: "ok" });
+        else if (res === "unsupported") toast({ text: "Sharing not supported", kind: "warn" });
+        else toast({ text: "Share failed", kind: "err" });
+      }}
+    >
+      Share
+    </button>
+  );
+}

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,15 +1,30 @@
-import React from "react";
-
-export function CardSkeleton({ count = 6 }: { count?: number }) {
+export function Skeleton({ h=16, w="100%", r=10 }:{h?:number; w?:number|string; r?:number}) {
   return (
-    <div className="cards">
-      {Array.from({ length: count }).map((_, i) => (
-        <div key={i} className="card skeleton-card">
-          <div className="sk sk-img" />
-          <div className="sk sk-line" />
-          <div className="sk sk-line short" />
-        </div>
-      ))}
+    <div style={{
+      width: w, height: h, borderRadius: r,
+      background: "linear-gradient(90deg, #eef3ff 25%, #f6f9ff 37%, #eef3ff 63%)",
+      backgroundSize: "400% 100%", animation: "nv-shimmer 1.2s ease-in-out infinite"
+    }}/>
+  );
+}
+
+export function SkeletonCard() {
+  return (
+    <div style={{ padding: 16, borderRadius: 16, background: "white", boxShadow: "0 4px 24px rgba(0,0,0,.06)" }}>
+      <Skeleton h={180} r={12}/>
+      <div style={{ height: 12 }} />
+      <Skeleton h={18} w="70%"/>
+      <div style={{ height: 10 }} />
+      <Skeleton h={14} w="55%"/>
     </div>
   );
+}
+
+/* Global keyframes (inject once) */
+if (!document.getElementById("nv-shimmer-style")) {
+  const s = document.createElement("style");
+  s.id = "nv-shimmer-style";
+  s.textContent = `
+  @keyframes nv-shimmer { 0%{background-position:100% 0} 100%{background-position:0 0} }`;
+  document.head.appendChild(s);
 }

--- a/src/components/SkipLink.tsx
+++ b/src/components/SkipLink.tsx
@@ -1,0 +1,12 @@
+export default function SkipLink() {
+  return (
+    <a href="#main" style={{
+      position: "absolute", left: -9999, top: -9999, background: "#e8f1ff", color: "#0b2545",
+      padding: "8px 12px", borderRadius: 8
+    }}
+    onFocus={(e) => { e.currentTarget.style.left="12px"; e.currentTarget.style.top="12px"; }}
+    onBlur={(e) => { e.currentTarget.style.left="-9999px"; e.currentTarget.style.top="-9999px"; }}>
+      Skip to content
+    </a>
+  );
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+type ToastMsg = { id: number; text: string; kind?: "ok" | "warn" | "err" };
+const Ctx = createContext<(msg: Omit<ToastMsg, "id">) => void>(() => {});
+
+export function useToast() { return useContext(Ctx); }
+
+export default function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [items, setItems] = useState<ToastMsg[]>([]);
+  const push = (m: Omit<ToastMsg, "id">) => {
+    const id = Date.now() + Math.random();
+    setItems((x) => [...x, { id, ...m }]);
+    setTimeout(() => setItems((x) => x.filter(i => i.id !== id)), 2200);
+  };
+  return (
+    <Ctx.Provider value={push}>
+      {children}
+      <div style={{
+        position: "fixed", bottom: 18, left: 0, right: 0, display: "grid",
+        placeItems: "center", pointerEvents: "none", zIndex: 9999
+      }}>
+        {items.map(t => (
+          <div key={t.id} role="status" aria-live="polite"
+               style={{
+                 pointerEvents: "auto",
+                 background: t.kind==="err"?"#fde7e7":t.kind==="warn"?"#fff4d6":"#e8f1ff",
+                 color: t.kind==="err"?"#7a1e1e":t.kind==="warn"?"#5f4b00":"#0b2545",
+                 border: "1px solid rgba(0,0,0,.08)", padding: "10px 14px",
+                 borderRadius: 10, boxShadow: "0 8px 18px rgba(0,0,0,.08)"
+               }}>
+            {t.text}
+          </div>
+        ))}
+      </div>
+    </Ctx.Provider>
+  );
+}

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -1,22 +1,12 @@
-import React from "react";
-
-export function toast(msg: string) {
-  const el = document.createElement("div");
-  el.textContent = msg;
-  Object.assign(el.style, {
-    position: "fixed", left: "50%", bottom: "28px", transform: "translateX(-50%)",
-    background: "#2f6dfc", color: "#fff", padding: "10px 14px", borderRadius: "10px",
-    boxShadow: "0 8px 20px rgba(31,74,207,.25)", fontWeight: 800, zIndex: 9999
-  });
-  document.body.appendChild(el);
-  setTimeout(() => el.remove(), 1600);
-}
+import { useEffect } from "react";
+import { useToast } from "./Toast";
 
 export default function ToasterListener() {
-  React.useEffect(() => {
-    const onGrant = () => toast("Stamp earned!");
+  const toast = useToast();
+  useEffect(() => {
+    const onGrant = () => toast({ text: "Stamp earned!", kind: "ok" });
     window.addEventListener("natur:stamp-granted", onGrant);
     return () => window.removeEventListener("natur:stamp-granted", onGrant);
-  }, []);
+  }, [toast]);
   return null;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,8 @@ import './main.css';
 import './styles/nvcard.css';
 import './app.css';
 import './styles/nv-sweep.css';
-import SkipToContent from './components/SkipToContent';
+import ToastProvider from './components/Toast';
+import SkipLink from './components/SkipLink';
 import OfflineBanner from './components/OfflineBanner';
 import { supabase } from '@/lib/supabase-client';
 import './runtime-logger';
@@ -25,11 +26,13 @@ async function bootstrap() {
     <React.StrictMode>
       {/* Ensure auth context wraps the entire app so Home gets updates immediately */}
         <AuthProvider initialSession={initialSession}>
-          <SkipToContent />
-          <OfflineBanner />
-          <BaseAuthProvider>
-            <App />
-          </BaseAuthProvider>
+          <SkipLink />
+          <ToastProvider>
+            <OfflineBanner />
+            <BaseAuthProvider>
+              <App />
+            </BaseAuthProvider>
+          </ToastProvider>
         </AuthProvider>
       </React.StrictMode>,
   );

--- a/src/pages/marketplace/[slug].tsx
+++ b/src/pages/marketplace/[slug].tsx
@@ -26,7 +26,7 @@ export default function ProductPage(){
         <p>{p.blurb}</p>
         <div className="nv-cta">
           <AddToCartButton id={p.id} name={p.name} price={p.price} image={p.image}/>
-          <SaveButton id={p.id}/>
+          <SaveButton id={`product:${p.id}`} kind="product" title={p.name} href={`/marketplace/${p.id}`} />
         </div>
       </article>
     </main>

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -26,7 +26,7 @@ export default function MarketplacePage(){
             <p className="price">${p.price.toFixed(2)}</p>
             <div className="actions">
               <AddToCartButton id={p.id} name={p.name} price={p.price} image={p.image} />
-              <SaveButton id={p.id} />
+              <SaveButton id={`product:${p.id}`} kind="product" title={p.name} href={p.href} />
             </div>
           </article>
         ))}

--- a/src/routes/zones/arcade/index.tsx
+++ b/src/routes/zones/arcade/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import Breadcrumbs from "../../../components/Breadcrumbs";
 import { postScore, autoGrantOncePerDay } from "@/lib/rewards";
-import { toast } from "@/components/Toaster";
+import { useToast } from "@/components/Toast";
 import { FLAGS } from "../../../config/flags";
 import { safeLazy } from "../../../components/safeLazy";
 import type { default as Leaderboard } from "../../../components/Leaderboard";
@@ -37,6 +37,7 @@ export default function Arcade() {
 /* ---------- Reaction Timer ---------- */
 function ReactionTimer() {
   type Phase = "idle" | "wait" | "go" | "tooSoon" | "done";
+  const toast = useToast();
   const [phase, setPhase] = useState<Phase>("idle");
   const [results, setResults] = useState<number[]>([]);
   const startAt = useRef<number>(0);
@@ -63,7 +64,7 @@ function ReactionTimer() {
       setResults(next);
       try {
         postScore('reaction_timer', ms * -1);
-        autoGrantOncePerDay('Thailandia').then((granted) => granted && toast('Stamp earned!'));
+        autoGrantOncePerDay('Thailandia').then((granted) => granted && toast({ text: 'Stamp earned!', kind: 'ok' }));
       } catch {}
       if (next.length >= 5) setPhase("done");
       else startRound();

--- a/src/routes/zones/music/index.tsx
+++ b/src/routes/zones/music/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import Breadcrumbs from "../../../components/Breadcrumbs";
 import { autoGrantOncePerDay } from "@/lib/rewards";
-import { toast } from "@/components/Toaster";
+import { useToast } from "@/components/Toast";
 import "../../../styles/zone-widgets.css";
 
   export default function Music() {
@@ -250,6 +250,7 @@ const LYRICS: KLine[] = [
 ];
 
   function Karaoke() {
+    const toast = useToast();
     const [running, setRunning] = useState(false);
     const [bpm, setBpm] = useState(90);
     const [now, setNow] = useState(0);
@@ -274,7 +275,7 @@ const LYRICS: KLine[] = [
       if (now >= last && !grantedRef.current) {
         grantedRef.current = true;
         try {
-          autoGrantOncePerDay('Musiclandia').then((granted) => granted && toast('Stamp earned!'));
+          autoGrantOncePerDay('Musiclandia').then((granted) => granted && toast({ text: 'Stamp earned!', kind: 'ok' }));
         } catch {}
       }
     }, [now, running]);

--- a/src/styles/nv-sweep.css
+++ b/src/styles/nv-sweep.css
@@ -59,3 +59,6 @@
 
 /* Keep generic anchors blue everywhere (without touching nav) */
 .main a:not(.btn) { color: var(--naturverse-blue); }
+
+:focus-visible { outline: 3px solid var(--naturverse-blue); outline-offset: 2px; }
+#main { outline: none; }

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -1,0 +1,23 @@
+export async function smartShare(opts: {
+  title?: string;
+  text?: string;
+  url?: string;
+}): Promise<"shared" | "copied" | "unsupported" | "error"> {
+  const url = opts.url ?? window.location.href;
+  const title = opts.title ?? document.title;
+  const text = opts.text ?? "";
+
+  try {
+    if (navigator.share) {
+      await navigator.share({ title, text, url });
+      return "shared";
+    }
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(url);
+      return "copied";
+    }
+    return "unsupported";
+  } catch {
+    return "error";
+  }
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,26 @@
+const NS = "naturverse:v1";
+
+export function get<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(`${NS}:${key}`);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function set<T>(key: string, value: T) {
+  try {
+    localStorage.setItem(`${NS}:${key}`, JSON.stringify(value));
+    window.dispatchEvent(new CustomEvent(`${NS}:changed`, { detail: { key } }));
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+export function remove(key: string) {
+  try {
+    localStorage.removeItem(`${NS}:${key}`);
+    window.dispatchEvent(new CustomEvent(`${NS}:changed`, { detail: { key } }));
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- add localStorage helpers and Share API fallback util
- introduce Toast provider with Share/Save buttons and skeleton loading card
- wire skip link, focus ring, and toast provider across app
- replace legacy toasts with context hooks in arcade & music zones

## Testing
- `npm run typecheck` *(fails: Argument of type 'Partial<Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "created_at" | "id" | "updated_at">>' is not assignable to parameter of type 'never'.)*


------
https://chatgpt.com/codex/tasks/task_e_68ade6639e4c8329a9f148d02a5837ec