### PR TITLE
feat: add command palette and lazy image

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { organizationLd, websiteLd } from './lib/jsonld';
 import { CartProvider } from './lib/cart';
 import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
+import CommandPalette from './components/CommandPalette';
 import './styles/magic.css';
 // TEMP: disable interactions while we isolate the crash
 // import { initInteractions } from './init/interactions';
@@ -19,6 +20,7 @@ export default function App() {
       <>
         {/* Global route side-effects (scroll & focus) */}
         <RouteFX />
+        <CommandPalette />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}

--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Img from './Img';
+import LazyImage from './LazyImage';
 
 export type CardData = {
   id: string;
@@ -39,7 +39,7 @@ export const CharacterCard: React.FC<{ data: CardData }> = ({ data }) => {
       <div className="nv-card__body">
         <div className="nv-card__avatar">
           {avatarDataUrl ? (
-            <Img src={avatarDataUrl} alt={`${name} avatar`} />
+            <LazyImage src={avatarDataUrl} alt={`${name} avatar`} width="100%" height="100%" />
           ) : (
             <div className="nv-card__avatar--placeholder">Add image</div>
           )}

--- a/src/components/CharacterGrid.tsx
+++ b/src/components/CharacterGrid.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import galleries from "../data/kingdom-galleries.json";
+import LazyImage from "./LazyImage";
 
 type Props = { kingdom: string };
 
@@ -28,19 +29,14 @@ export default function CharacterGrid({ kingdom }: Props) {
               borderRadius: "14px",
               padding: "10px",
               background: "#fff",
+              aspectRatio: "1 / 1",
             }}
           >
-            <img
+            <LazyImage
               src={src}
               alt=""
-              loading="lazy"
-              style={{
-                width: "100%",
-                aspectRatio: "1 / 1",
-                objectFit: "contain",
-                borderRadius: "8px",
-                display: "block",
-              }}
+              width="100%"
+              height="100%"
             />
           </a>
         );

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { score } from "../utils/fuzzy";
+import { smartShare } from "../utils/share";
+import { track } from "../utils/telemetry";
+
+type Item = { id: string; label: string; href?: string; action?: () => void; group?: string };
+
+const ROUTES: Item[] = [
+  { id: "home", label: "Home", href: "/" , group: "Navigate"},
+  { id: "worlds", label: "Worlds", href: "/worlds", group: "Navigate"},
+  { id: "zones", label: "Zones", href: "/zones", group: "Navigate"},
+  { id: "market", label: "Marketplace", href: "/marketplace", group: "Navigate"},
+  { id: "passport", label: "Passport", href: "/passport", group: "Navigate"},
+  { id: "naturbank", label: "NaturBank", href: "/naturbank", group: "Navigate"},
+  { id: "navatar", label: "Navatar", href: "/navatar", group: "Navigate"},
+  // Actions
+  { id: "share", label: "Share this page", group: "Actions", action: async () => {
+      const res = await smartShare({ title: document.title });
+      track.click("palette_share", { res });
+    }},
+  { id: "clear", label: "Clear local library", group: "Actions", action: () => {
+      localStorage.clear(); track.click("palette_clear");
+      alert("Local data cleared.");
+    }},
+];
+
+export default function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const navigate = useNavigate();
+  const loc = useLocation();
+
+  // close on route change
+  useEffect(() => { setOpen(false); setQ(""); }, [loc.pathname]);
+
+  // keyboard
+  useEffect(() => {
+    const on = (e: KeyboardEvent) => {
+      const mod = e.ctrlKey || e.metaKey;
+      if (mod && e.key.toLowerCase() === "k") { e.preventDefault(); setOpen(o => !o); }
+      if (e.key === "Escape") setOpen(false);
+      if (!open && e.key === "?") setOpen(true);
+    };
+    addEventListener("keydown", on);
+    return () => removeEventListener("keydown", on);
+  }, [open]);
+
+  const results = useMemo(() => {
+    const items = ROUTES;
+    if (!q) return items;
+    const scored = items
+      .map(i => ({ i, s: score(q, i.label) }))
+      .filter(x => x.s > 0)
+      .sort((a,b)=> b.s - a.s)
+      .map(x => x.i);
+    track.search(q, scored.length);
+    return scored;
+  }, [q]);
+
+  if (!open) return null;
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label="Command palette"
+      style={{
+        position: "fixed", inset: 0, background: "rgba(7,17,35,.36)",
+        display: "grid", placeItems: "start center", paddingTop: "12vh", zIndex: 9998
+      }}
+      onClick={() => setOpen(false)}
+    >
+      <div onClick={(e)=>e.stopPropagation()}
+        style={{
+          width: "min(720px, 92vw)", background: "white", borderRadius: 16,
+          boxShadow: "0 30px 80px rgba(0,0,0,.25)", overflow: "hidden"
+        }}>
+        <div style={{ padding: 14, borderBottom: "1px solid #ecf0ff" }}>
+          <input autoFocus value={q} onChange={(e)=>setQ(e.target.value)}
+            placeholder="Search pages and actions…"
+            style={{ width:"100%", padding:"12px 14px", borderRadius: 10, border:"1px solid #dfe7ff" }}/>
+        </div>
+        <div style={{ maxHeight: "50vh", overflow: "auto" }}>
+          {results.length === 0 && (
+            <div style={{ padding: 18, opacity:.7 }}>No results.</div>
+          )}
+          {results.map((r, idx) => (
+            <button key={r.id}
+              onClick={() => {
+                setOpen(false);
+                if (r.href) navigate(r.href);
+                else r.action?.();
+              }}
+              className="palette-row"
+              style={{
+                display:"flex", width:"100%", textAlign:"left",
+                padding: "12px 16px", gap:10, borderTop: idx? "1px solid #f3f6ff":"none",
+                background:"white"
+              }}
+              >
+              <span style={{ color:"#0b2545" }}>{r.label}</span>
+              {r.group && <span style={{ marginLeft:"auto", fontSize:12, opacity:.6 }}>{r.group}</span>}
+            </button>
+          ))}
+        </div>
+        <div style={{ padding:"8px 12px", fontSize:12, color:"#5b6e99", background:"#f7f9ff", display:"flex", gap:14 }}>
+          <span>⌘/Ctrl + K</span><span>·</span><span>Esc to close</span><span>·</span><span>?</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/LazyImage.tsx
+++ b/src/components/LazyImage.tsx
@@ -1,26 +1,63 @@
-import { ImgHTMLAttributes, useState } from "react";
-import cn from "../utils/cn";
+import { useEffect, useRef, useState } from "react";
 
-type Props = ImgHTMLAttributes<HTMLImageElement>;
+type Props = {
+  src: string;
+  alt: string;
+  width?: number | string;
+  height?: number | string;
+  previewSrc?: string; // tiny blur (optional)
+  className?: string;
+  onLoad?: () => void;
+};
 
-export default function LazyImage({ className, onLoad, ...props }: Props) {
+export default function LazyImage({ src, alt, width, height, previewSrc, className, onLoad }: Props) {
+  const ref = useRef<HTMLImageElement | null>(null);
   const [loaded, setLoaded] = useState(false);
+  const [err, setErr] = useState(false);
+  useEffect(() => {
+    if (!ref.current) return;
+    const el = ref.current;
+    const obs = new IntersectionObserver((entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          el.src = src; obs.disconnect();
+        }
+      }
+    }, { rootMargin: "200px" });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [src]);
 
   return (
-    <img
-      loading="lazy"
-      decoding="async"
-      onLoad={(e) => {
-        setLoaded(true);
-        onLoad?.(e);
-      }}
-      className={cn(
-        "nv-img",
-        loaded ? "nv-img--ready" : "nv-img--blur",
-        className
+    <div style={{ position: "relative", width, height }} className={className}>
+      {!loaded && (
+        <div style={{
+          position: "absolute", inset: 0, borderRadius: 12,
+          background: previewSrc
+            ? `center / cover no-repeat url(${previewSrc})`
+            : "linear-gradient(90deg,#eef3ff 25%,#f7faff 50%,#eef3ff 75%)",
+          animation: previewSrc ? undefined : "nv-shimmer 1.2s infinite",
+          filter: previewSrc ? "blur(12px)" : undefined
+        }}/>
       )}
-      {...props}
-    />
+      {!err ? (
+        <img
+          ref={ref}
+          alt={alt}
+          loading="lazy"
+          onLoad={() => { setLoaded(true); onLoad?.(); }}
+          onError={() => { setErr(true); }}
+          style={{
+            width: "100%", height: "100%", objectFit: "cover", borderRadius: 12,
+            opacity: loaded ? 1 : 0, transition: "opacity .3s ease"
+          }}
+        />
+      ) : (
+        <div style={{
+          position: "absolute", inset: 0, display: "grid", placeItems: "center",
+          color: "#6c7aa1", background: "#f0f5ff", borderRadius: 12, fontSize: 12
+        }}>image unavailable</div>
+      )}
+    </div>
   );
 }
-

--- a/src/components/NVErrorBoundary.tsx
+++ b/src/components/NVErrorBoundary.tsx
@@ -1,0 +1,30 @@
+import { Component, ReactNode } from "react";
+import { track } from "../utils/telemetry";
+
+type State = { hasError: boolean; message?: string };
+
+export default class NVErrorBoundary extends Component<{ children: ReactNode }, State> {
+  state: State = { hasError: false };
+  static getDerivedStateFromError(err: unknown) {
+    return { hasError: true, message: err instanceof Error ? err.message : String(err) };
+  }
+  componentDidCatch(err: unknown) {
+    track.error("NVErrorBoundary", err instanceof Error ? err.message : String(err));
+    // still allow Netlify/console to capture
+    console.error(err);
+  }
+  render() {
+    if (!this.state.hasError) return this.props.children;
+    return (
+      <main style={{ minHeight: "60vh", display: "grid", placeItems: "center" }}>
+        <div style={{ textAlign: "center" }}>
+          <h1 style={{ color: "var(--naturverse-blue)" }}>Something went wrong.</h1>
+          <p style={{ opacity: .8, maxWidth: 520, margin: "0 auto 12px" }}>
+            Please try again. If the issue persists, refresh the page.
+          </p>
+          <button className="btn" onClick={() => location.reload()}>Reload</button>
+        </div>
+      </main>
+    );
+  }
+}

--- a/src/components/WorldLayout.tsx
+++ b/src/components/WorldLayout.tsx
@@ -3,6 +3,7 @@ import { KINGDOMS, KingdomId } from '../data/kingdoms';
 import { mapFor } from '../data/maps';
 import '../styles/worlds.css';
 import CharacterGrid from './CharacterGrid';
+import LazyImage from './LazyImage';
 
 type Props = { id: KingdomId };
 
@@ -15,7 +16,7 @@ export default function WorldLayout({ id }: Props) {
 
       {/* Map hero */}
       <section className="world-hero-wrap card">
-        <img src={mapFor(id)} alt={`${k.title} map`} className="world-hero" loading="eager" />
+        <LazyImage src={mapFor(id)} alt={`${k.title} map`} className="world-hero" width="100%" height={520} />
         <div className="hero-meta">
           <h2>World Map</h2>
           <p>Zoom into landmarks, routes, and regions.</p>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import './styles/nv-sweep.css';
 import ToastProvider from './components/Toast';
 import SkipLink from './components/SkipLink';
 import OfflineBanner from './components/OfflineBanner';
+import NVErrorBoundary from './components/NVErrorBoundary';
 import { supabase } from '@/lib/supabase-client';
 import './runtime-logger';
 import { prefetchGlob, prefetchOnHover } from './lib/prefetch';
@@ -28,10 +29,12 @@ async function bootstrap() {
         <AuthProvider initialSession={initialSession}>
           <SkipLink />
           <ToastProvider>
-            <OfflineBanner />
-            <BaseAuthProvider>
-              <App />
-            </BaseAuthProvider>
+            <NVErrorBoundary>
+              <OfflineBanner />
+              <BaseAuthProvider>
+                <App />
+              </BaseAuthProvider>
+            </NVErrorBoundary>
           </ToastProvider>
         </AuthProvider>
       </React.StrictMode>,

--- a/src/styles/nv-sweep.css
+++ b/src/styles/nv-sweep.css
@@ -62,3 +62,18 @@
 
 :focus-visible { outline: 3px solid var(--naturverse-blue); outline-offset: 2px; }
 #main { outline: none; }
+
+.btn {
+  background: var(--naturverse-blue);
+  color: #fff;
+  border: none;
+  padding: 10px 14px;
+  border-radius: 12px;
+  box-shadow: 0 6px 0 rgba(11,37,69,.18);
+}
+.btn:active {
+  transform: translateY(1px);
+  box-shadow: 0 5px 0 rgba(11,37,69,.18);
+}
+
+.palette-row:hover { background: #f7faff; }

--- a/src/utils/fuzzy.ts
+++ b/src/utils/fuzzy.ts
@@ -1,0 +1,15 @@
+export function score(query: string, text: string) {
+  const q = query.trim().toLowerCase();
+  const t = text.toLowerCase();
+  if (!q) return 0;
+  if (t.startsWith(q)) return 100 - (t.length - q.length);
+  let i = 0, hits = 0;
+  for (const c of t) {
+    if (c === q[i]) {
+      i++;
+      hits++;
+      if (i === q.length) break;
+    }
+  }
+  return i === q.length ? 50 + hits : 0;
+}

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -1,0 +1,21 @@
+type Payload = Record<string, unknown>;
+
+const hasDL = () => typeof window !== "undefined" && Array.isArray((window as any).dataLayer);
+const push = (e: string, p: Payload = {}) => {
+  if (hasDL()) (window as any).dataLayer.push({ event: e, ...p });
+};
+
+export const track = {
+  pageview(path = location.pathname) {
+    push("nv_page", { path });
+  },
+  click(name: string, meta: Payload = {}) {
+    push("nv_click", { name, ...meta });
+  },
+  search(query: string, hits: number) {
+    push("nv_search", { query, hits });
+  },
+  error(where: string, message: string) {
+    push("nv_error", { where, message });
+  },
+};


### PR DESCRIPTION
## Summary
- add telemetry and fuzzy utilities
- implement NVErrorBoundary and LazyImage with blur-up
- introduce command palette with keyboard shortcuts and apply LazyImage to character and world imagery

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Partial<Omit<{ id: string; ... }>>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68adeb79da08832992e8e476e958a66d