### PR TITLE
Add registry-powered command palette with telemetry

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,29 +1,49 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { score } from "../utils/fuzzy";
-import { smartShare } from "../utils/share";
 import { track } from "../utils/telemetry";
+import { WORLDS, ZONES } from "../data/registry";
 
 type Item = { id: string; label: string; href?: string; action?: () => void; group?: string };
 
-const ROUTES: Item[] = [
-  { id: "home", label: "Home", href: "/" , group: "Navigate"},
-  { id: "worlds", label: "Worlds", href: "/worlds", group: "Navigate"},
-  { id: "zones", label: "Zones", href: "/zones", group: "Navigate"},
-  { id: "market", label: "Marketplace", href: "/marketplace", group: "Navigate"},
-  { id: "passport", label: "Passport", href: "/passport", group: "Navigate"},
-  { id: "naturbank", label: "NaturBank", href: "/naturbank", group: "Navigate"},
-  { id: "navatar", label: "Navatar", href: "/navatar", group: "Navigate"},
-  // Actions
-  { id: "share", label: "Share this page", group: "Actions", action: async () => {
-      const res = await smartShare({ title: document.title });
-      track.click("palette_share", { res });
-    }},
-  { id: "clear", label: "Clear local library", group: "Actions", action: () => {
-      localStorage.clear(); track.click("palette_clear");
-      alert("Local data cleared.");
-    }},
-];
+function baseItems(): Item[] {
+  const nav: Item[] = [
+    { id: "home", label: "Home", href: "/", group: "Navigate" },
+    { id: "worlds", label: "Worlds", href: "/worlds", group: "Navigate" },
+    { id: "zones", label: "Zones", href: "/zones", group: "Navigate" },
+    { id: "marketplace", label: "Marketplace", href: "/marketplace", group: "Navigate" },
+    { id: "passport", label: "Passport", href: "/passport", group: "Navigate" },
+    { id: "naturbank", label: "NaturBank", href: "/naturbank", group: "Navigate" },
+    { id: "navatar", label: "Navatar", href: "/navatar", group: "Navigate" },
+  ];
+  const worldLinks: Item[] = WORLDS.map(w => ({
+    id: `world:${w.slug}`, label: `World • ${w.name}`, href: `/worlds/${w.slug}`, group: "Deep link"
+  }));
+  const zoneLinks: Item[] = ZONES.map(z => ({
+    id: `zone:${z.slug}`, label: `Zone • ${z.name}`, href: `/zones/${z.slug}`, group: "Deep link"
+  }));
+  const actions: Item[] = [
+    {
+      id: "share", label: "Share this page", group: "Actions",
+      action: async () => {
+        try {
+          if (navigator.share) {
+            await navigator.share({ title: document.title, url: location.href });
+            track.click("palette_share", { ok: true });
+          } else {
+            await navigator.clipboard.writeText(location.href);
+            alert("Link copied to clipboard.");
+          }
+        } catch (e) { track.error("palette_share", (e as Error).message); }
+      }
+    },
+    {
+      id: "clear", label: "Clear local cache", group: "Actions",
+      action: () => { localStorage.clear(); track.click("palette_clear"); alert("Local data cleared."); }
+    },
+  ];
+  return [...nav, ...worldLinks, ...zoneLinks, ...actions];
+}
 
 export default function CommandPalette() {
   const [open, setOpen] = useState(false);
@@ -31,10 +51,7 @@ export default function CommandPalette() {
   const navigate = useNavigate();
   const loc = useLocation();
 
-  // close on route change
   useEffect(() => { setOpen(false); setQ(""); }, [loc.pathname]);
-
-  // keyboard
   useEffect(() => {
     const on = (e: KeyboardEvent) => {
       const mod = e.ctrlKey || e.metaKey;
@@ -42,67 +59,48 @@ export default function CommandPalette() {
       if (e.key === "Escape") setOpen(false);
       if (!open && e.key === "?") setOpen(true);
     };
-    addEventListener("keydown", on);
-    return () => removeEventListener("keydown", on);
+    addEventListener("keydown", on); return () => removeEventListener("keydown", on);
   }, [open]);
 
+  const items = useMemo(baseItems, []);
   const results = useMemo(() => {
-    const items = ROUTES;
     if (!q) return items;
-    const scored = items
-      .map(i => ({ i, s: score(q, i.label) }))
-      .filter(x => x.s > 0)
-      .sort((a,b)=> b.s - a.s)
-      .map(x => x.i);
+    const scored = items.map(i => ({ i, s: score(q, i.label) }))
+      .filter(x => x.s > 0).sort((a,b)=> b.s - a.s).map(x=>x.i);
     track.search(q, scored.length);
     return scored;
-  }, [q]);
+  }, [q, items]);
 
   if (!open) return null;
-
   return (
     <div role="dialog" aria-modal="true" aria-label="Command palette"
-      style={{
-        position: "fixed", inset: 0, background: "rgba(7,17,35,.36)",
-        display: "grid", placeItems: "start center", paddingTop: "12vh", zIndex: 9998
-      }}
-      onClick={() => setOpen(false)}
-    >
+      style={{ position:"fixed", inset:0, background:"rgba(7,17,35,.36)",
+               display:"grid", placeItems:"start center", paddingTop:"12vh", zIndex:9998 }}
+      onClick={() => setOpen(false)}>
       <div onClick={(e)=>e.stopPropagation()}
-        style={{
-          width: "min(720px, 92vw)", background: "white", borderRadius: 16,
-          boxShadow: "0 30px 80px rgba(0,0,0,.25)", overflow: "hidden"
-        }}>
-        <div style={{ padding: 14, borderBottom: "1px solid #ecf0ff" }}>
+           style={{ width:"min(720px,92vw)", background:"white", borderRadius:16,
+                    boxShadow:"0 30px 80px rgba(0,0,0,.25)", overflow:"hidden" }}>
+        <div style={{ padding:14, borderBottom:"1px solid #ecf0ff" }}>
           <input autoFocus value={q} onChange={(e)=>setQ(e.target.value)}
             placeholder="Search pages and actions…"
-            style={{ width:"100%", padding:"12px 14px", borderRadius: 10, border:"1px solid #dfe7ff" }}/>
+            style={{ width:"100%", padding:"12px 14px", borderRadius:10, border:"1px solid #dfe7ff" }}/>
         </div>
-        <div style={{ maxHeight: "50vh", overflow: "auto" }}>
-          {results.length === 0 && (
-            <div style={{ padding: 18, opacity:.7 }}>No results.</div>
-          )}
+        <div style={{ maxHeight:"50vh", overflow:"auto" }}>
+          {results.length === 0 && <div style={{ padding:18, opacity:.7 }}>No results.</div>}
           {results.map((r, idx) => (
             <button key={r.id}
-              onClick={() => {
-                setOpen(false);
-                if (r.href) navigate(r.href);
-                else r.action?.();
-              }}
+              onClick={() => { setOpen(false); r.href ? navigate(r.href) : r.action?.(); }}
               className="palette-row"
-              style={{
-                display:"flex", width:"100%", textAlign:"left",
-                padding: "12px 16px", gap:10, borderTop: idx? "1px solid #f3f6ff":"none",
-                background:"white"
-              }}
-              >
+              style={{ display:"flex", width:"100%", textAlign:"left",
+                       padding:"12px 16px", gap:10,
+                       borderTop: idx? "1px solid #f3f6ff":"none", background:"white" }}>
               <span style={{ color:"#0b2545" }}>{r.label}</span>
               {r.group && <span style={{ marginLeft:"auto", fontSize:12, opacity:.6 }}>{r.group}</span>}
             </button>
           ))}
         </div>
         <div style={{ padding:"8px 12px", fontSize:12, color:"#5b6e99", background:"#f7f9ff", display:"flex", gap:14 }}>
-          <span>⌘/Ctrl + K</span><span>·</span><span>Esc to close</span><span>·</span><span>?</span>
+          <span>⌘/Ctrl + K</span><span>·</span><span>Esc</span><span>·</span><span>?</span>
         </div>
       </div>
     </div>

--- a/src/components/LazyImage.tsx
+++ b/src/components/LazyImage.tsx
@@ -5,24 +5,27 @@ type Props = {
   alt: string;
   width?: number | string;
   height?: number | string;
-  previewSrc?: string; // tiny blur (optional)
+  previewSrc?: string; // low-res or data URL (optional)
   className?: string;
   onLoad?: () => void;
 };
 
-export default function LazyImage({ src, alt, width, height, previewSrc, className, onLoad }: Props) {
+export default function LazyImage({
+  src, alt, width = "100%", height = "100%", previewSrc, className, onLoad
+}: Props) {
   const ref = useRef<HTMLImageElement | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [err, setErr] = useState(false);
+
   useEffect(() => {
-    if (!ref.current) return;
     const el = ref.current;
+    if (!el) return;
+    // Load immediately if IntersectionObserver unsupported
+    if (!("IntersectionObserver" in window)) { el.src = src; return; }
     const obs = new IntersectionObserver((entries) => {
-      for (const e of entries) {
-        if (e.isIntersecting) {
-          el.src = src; obs.disconnect();
-        }
-      }
+      entries.forEach((e) => {
+        if (e.isIntersecting) { el.src = src; obs.disconnect(); }
+      });
     }, { rootMargin: "200px" });
     obs.observe(el);
     return () => obs.disconnect();
@@ -31,14 +34,16 @@ export default function LazyImage({ src, alt, width, height, previewSrc, classNa
   return (
     <div style={{ position: "relative", width, height }} className={className}>
       {!loaded && (
-        <div style={{
-          position: "absolute", inset: 0, borderRadius: 12,
-          background: previewSrc
-            ? `center / cover no-repeat url(${previewSrc})`
-            : "linear-gradient(90deg,#eef3ff 25%,#f7faff 50%,#eef3ff 75%)",
-          animation: previewSrc ? undefined : "nv-shimmer 1.2s infinite",
-          filter: previewSrc ? "blur(12px)" : undefined
-        }}/>
+        <div
+          style={{
+            position: "absolute", inset: 0, borderRadius: 12,
+            background: previewSrc
+              ? `center / cover no-repeat url(${previewSrc})`
+              : "linear-gradient(90deg,#eef3ff 25%,#f7faff 50%,#eef3ff 75%)",
+            animation: previewSrc ? undefined : "nv-shimmer 1.2s infinite",
+            filter: previewSrc ? "blur(14px)" : undefined
+          }}
+        />
       )}
       {!err ? (
         <img
@@ -46,17 +51,19 @@ export default function LazyImage({ src, alt, width, height, previewSrc, classNa
           alt={alt}
           loading="lazy"
           onLoad={() => { setLoaded(true); onLoad?.(); }}
-          onError={() => { setErr(true); }}
+          onError={() => setErr(true)}
           style={{
             width: "100%", height: "100%", objectFit: "cover", borderRadius: 12,
-            opacity: loaded ? 1 : 0, transition: "opacity .3s ease"
+            opacity: loaded ? 1 : 0, transition: "opacity .28s ease"
           }}
         />
       ) : (
-        <div style={{
-          position: "absolute", inset: 0, display: "grid", placeItems: "center",
-          color: "#6c7aa1", background: "#f0f5ff", borderRadius: 12, fontSize: 12
-        }}>image unavailable</div>
+        <div
+          style={{
+            position: "absolute", inset: 0, display: "grid", placeItems: "center",
+            color: "#6c7aa1", background: "#f0f5ff", borderRadius: 12, fontSize: 12
+          }}
+        >image unavailable</div>
       )}
     </div>
   );

--- a/src/components/RouteFX.tsx
+++ b/src/components/RouteFX.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { track } from "../utils/telemetry";
 
 /**
  * RouteFX (safe)
@@ -11,6 +12,7 @@ export default function RouteFX(): null {
   useEffect(() => {
     function runEffects() {
       try {
+        track.pageview(location.pathname);
         // Scroll to top (prefer smooth when available)
         try {
           window.scrollTo({ top: 0, left: 0, behavior: "smooth" as ScrollBehavior });

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -1,0 +1,17 @@
+// Small, safe deep-links used by the Command Palette.
+// Add to or edit as you grow.
+export const WORLDS: { name: string; slug: string }[] = [
+  { name: "Thailandia", slug: "thailandia" },
+  { name: "Brazilandia", slug: "brazillandia" },
+  { name: "Chilandia", slug: "chilandia" },
+  { name: "Indillandia", slug: "indillandia" },
+  { name: "Australandia", slug: "australandia" },
+  { name: "Amerilandia", slug: "amerilandia" },
+];
+
+export const ZONES: { name: string; slug: string }[] = [
+  { name: "Arcade", slug: "arcade" },
+  { name: "Music", slug: "music" },
+  { name: "Stories", slug: "stories" },
+  { name: "Quests", slug: "quests" },
+];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import './main.css';
 import './styles/nvcard.css';
 import './app.css';
 import './styles/nv-sweep.css';
+import './styles/nv-ui.css';
 import ToastProvider from './components/Toast';
 import SkipLink from './components/SkipLink';
 import OfflineBanner from './components/OfflineBanner';

--- a/src/styles/nv-ui.css
+++ b/src/styles/nv-ui.css
@@ -1,0 +1,5 @@
+/* Naturverse micro-UI helpers (no framework deps) */
+.btn{background:var(--naturverse-blue,#2a57ff);color:#fff;border:none;padding:10px 14px;border-radius:12px;box-shadow:0 6px 0 rgba(11,37,69,.18);cursor:pointer}
+.btn:active{transform:translateY(1px);box-shadow:0 5px 0 rgba(11,37,69,.18)}
+.palette-row:hover{background:#f7faff}
+@keyframes nv-shimmer{0%{background-position:-200px 0}100%{background-position:200px 0}}

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -1,12 +1,11 @@
 type Payload = Record<string, unknown>;
-
-const hasDL = () => typeof window !== "undefined" && Array.isArray((window as any).dataLayer);
-const push = (e: string, p: Payload = {}) => {
-  if (hasDL()) (window as any).dataLayer.push({ event: e, ...p });
+const hasDL = () =>
+  typeof window !== "undefined" && Array.isArray((window as any).dataLayer);
+const push = (event: string, p: Payload = {}) => {
+  if (hasDL()) (window as any).dataLayer.push({ event, ...p });
 };
-
 export const track = {
-  pageview(path = location.pathname) {
+  pageview(path = (typeof location !== "undefined" ? location.pathname : "/")) {
     push("nv_page", { path });
   },
   click(name: string, meta: Payload = {}) {


### PR DESCRIPTION
## Summary
- preload registry of Worlds and Zones for deep command-palette links
- track page views on navigation and enhance LazyImage
- add micro UI styles and import them globally

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'Partial<...>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68adf1a30c008329bf12af7b42c10f4a