### PR TITLE
feat: auto-create profiles with sync and upsert helper

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,16 +1,15 @@
-import { createClient } from '@supabase/supabase-js';
-import type { Database } from '../types/db';
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '../types/db'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
 
 if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase environment variables');
+  throw new Error('Missing Supabase environment variables')
 }
 
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
   auth: {
     persistSession: true,
-    detectSessionInUrl: true,
   },
-});
+})

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -5,6 +5,8 @@ export type Database = {
         Row: {
           id: string;
           email: string | null;
+          username: string | null;
+          full_name: string | null;
           display_name: string | null;
           avatar_url: string | null;
           kid_safe: boolean | null;
@@ -15,6 +17,8 @@ export type Database = {
         Insert: {
           id: string;
           email?: string | null;
+          username?: string | null;
+          full_name?: string | null;
           display_name?: string | null;
           avatar_url?: string | null;
           kid_safe?: boolean | null;


### PR DESCRIPTION
## Summary
- extend profiles schema with username and full name
- auto-create and sync profile records from auth.users
- add helper to upsert current user's profile
- load Supabase config from Vite env vars

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0f4984cc8329a43b6a88d4c75f1e