### PR TITLE
Hardening pass — guard Command Palette, make profile upsert optional, fix font preloads (no deps)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ NEXT_PUBLIC_SITE_URL=https://thenaturverse.com
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN=thenaturverse.com
 NEXT_PUBLIC_ENABLE_AUTO_STAMPS=true
 
+# Command Palette (experimental). Keep off in prod until enabled explicitly.
+VITE_ENABLE_PALETTE=false
+
 # Serverless only (set in Netlify UI → Site settings → Environment):
 OPENAI_API_KEY=
 VITE_ENABLE_GAMIFICATION=false

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
       href="/fonts/your-main-font.woff2"
       as="font"
       type="font/woff2"
-      crossorigin
+      crossorigin="anonymous"
     />
     <link rel="stylesheet" href="/src/main.css" />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { organizationLd, websiteLd } from './lib/jsonld';
 import { CartProvider } from './lib/cart';
 import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
-import CommandPalette from './components/CommandPalette';
+import CommandPaletteSafe from './components/CommandPalette';
 import './styles/magic.css';
 // TEMP: disable interactions while we isolate the crash
 // import { initInteractions } from './init/interactions';
@@ -35,7 +35,7 @@ export default function App() {
       <>
         {/* Global route side-effects (scroll & focus) */}
         <RouteFX />
-        <CommandPalette />
+        <CommandPaletteSafe />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,108 +1,69 @@
-import { useEffect, useMemo, useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
-import { score } from "../utils/fuzzy";
-import { track } from "../utils/telemetry";
-import { WORLDS, ZONES } from "../data/registry";
+// Robust, client-only Command Palette wrapper.
+// If disabled or anything fails, it renders null and never crashes the app.
+import React from 'react';
 
-type Item = { id: string; label: string; href?: string; action?: () => void; group?: string };
+const ENABLED = import.meta.env.VITE_ENABLE_PALETTE === 'true';
 
-function baseItems(): Item[] {
-  const nav: Item[] = [
-    { id: "home", label: "Home", href: "/", group: "Navigate" },
-    { id: "worlds", label: "Worlds", href: "/worlds", group: "Navigate" },
-    { id: "zones", label: "Zones", href: "/zones", group: "Navigate" },
-    { id: "marketplace", label: "Marketplace", href: "/marketplace", group: "Navigate" },
-    { id: "passport", label: "Passport", href: "/passport", group: "Navigate" },
-    { id: "naturbank", label: "NaturBank", href: "/naturbank", group: "Navigate" },
-    { id: "navatar", label: "Navatar", href: "/navatar", group: "Navigate" },
-  ];
-  const worldLinks: Item[] = WORLDS.map(w => ({
-    id: `world:${w.slug}`, label: `World • ${w.name}`, href: `/worlds/${w.slug}`, group: "Deep link"
-  }));
-  const zoneLinks: Item[] = ZONES.map(z => ({
-    id: `zone:${z.slug}`, label: `Zone • ${z.name}`, href: `/zones/${z.slug}`, group: "Deep link"
-  }));
-  const actions: Item[] = [
-    {
-      id: "share", label: "Share this page", group: "Actions",
-      action: async () => {
-        try {
-          if (navigator.share) {
-            await navigator.share({ title: document.title, url: location.href });
-            track.click("palette_share", { ok: true });
-          } else {
-            await navigator.clipboard.writeText(location.href);
-            alert("Link copied to clipboard.");
-          }
-        } catch (e) { track.error("palette_share", (e as Error).message); }
-      }
-    },
-    {
-      id: "clear", label: "Clear local cache", group: "Actions",
-      action: () => { localStorage.clear(); track.click("palette_clear"); alert("Local data cleared."); }
-    },
-  ];
-  return [...nav, ...worldLinks, ...zoneLinks, ...actions];
+function isClient() {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
 }
 
-export default function CommandPalette() {
-  const [open, setOpen] = useState(false);
-  const [q, setQ] = useState("");
-  const navigate = useNavigate();
-  const loc = useLocation();
+export default function CommandPaletteSafe() {
+  const [Inner, setInner] = React.useState<React.ComponentType | null>(null);
 
-  useEffect(() => { setOpen(false); setQ(""); }, [loc.pathname]);
-  useEffect(() => {
-    const on = (e: KeyboardEvent) => {
-      const mod = e.ctrlKey || e.metaKey;
-      if (mod && e.key.toLowerCase() === "k") { e.preventDefault(); setOpen(o => !o); }
-      if (e.key === "Escape") setOpen(false);
-      if (!open && e.key === "?") setOpen(true);
+  React.useEffect(() => {
+    if (!ENABLED) return; // feature flag off -> no-op
+    if (!isClient()) return; // SSR/first pass safety
+
+    let mounted = true;
+    (async () => {
+      try {
+        const mod = await import('./CommandPaletteInner'); // existing palette logic moved here
+        if (mounted) setInner(() => mod.default || (mod as any).CommandPalette || null);
+      } catch (err) {
+        // Never throw in prod
+        if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
+          console.warn('[naturverse] CommandPalette disabled (load failed):', err);
+        }
+      }
+    })();
+
+    return () => {
+      mounted = false;
     };
-    addEventListener("keydown", on); return () => removeEventListener("keydown", on);
-  }, [open]);
+  }, []);
 
-  const items = useMemo(baseItems, []);
-  const results = useMemo(() => {
-    if (!q) return items;
-    const scored = items.map(i => ({ i, s: score(q, i.label) }))
-      .filter(x => x.s > 0).sort((a,b)=> b.s - a.s).map(x=>x.i);
-    track.search(q, scored.length);
-    return scored;
-  }, [q, items]);
-
-  if (!open) return null;
+  if (!ENABLED || !Inner) return null;
   return (
-    <div role="dialog" aria-modal="true" aria-label="Command palette"
-      style={{ position:"fixed", inset:0, background:"rgba(7,17,35,.36)",
-               display:"grid", placeItems:"start center", paddingTop:"12vh", zIndex:9998 }}
-      onClick={() => setOpen(false)}>
-      <div onClick={(e)=>e.stopPropagation()}
-           style={{ width:"min(720px,92vw)", background:"white", borderRadius:16,
-                    boxShadow:"0 30px 80px rgba(0,0,0,.25)", overflow:"hidden" }}>
-        <div style={{ padding:14, borderBottom:"1px solid #ecf0ff" }}>
-          <input autoFocus value={q} onChange={(e)=>setQ(e.target.value)}
-            placeholder="Search pages and actions…"
-            style={{ width:"100%", padding:"12px 14px", borderRadius:10, border:"1px solid #dfe7ff" }}/>
-        </div>
-        <div style={{ maxHeight:"50vh", overflow:"auto" }}>
-          {results.length === 0 && <div style={{ padding:18, opacity:.7 }}>No results.</div>}
-          {results.map((r, idx) => (
-            <button key={r.id}
-              onClick={() => { setOpen(false); r.href ? navigate(r.href) : r.action?.(); }}
-              className="palette-row"
-              style={{ display:"flex", width:"100%", textAlign:"left",
-                       padding:"12px 16px", gap:10,
-                       borderTop: idx? "1px solid #f3f6ff":"none", background:"white" }}>
-              <span style={{ color:"#0b2545" }}>{r.label}</span>
-              {r.group && <span style={{ marginLeft:"auto", fontSize:12, opacity:.6 }}>{r.group}</span>}
-            </button>
-          ))}
-        </div>
-        <div style={{ padding:"8px 12px", fontSize:12, color:"#5b6e99", background:"#f7f9ff", display:"flex", gap:14 }}>
-          <span>⌘/Ctrl + K</span><span>·</span><span>Esc</span><span>·</span><span>?</span>
-        </div>
-      </div>
-    </div>
+    <ErrorCatcher>
+      <Inner />
+    </ErrorCatcher>
   );
 }
+
+function ErrorCatcher({ children }: { children: React.ReactNode }) {
+  const [ok, setOk] = React.useState(true);
+  return ok ? (
+    <React.Suspense fallback={null}>
+      <Boundary onError={() => setOk(false)}>{children}</Boundary>
+    </React.Suspense>
+  ) : null;
+}
+
+// Minimal error boundary
+class Boundary extends React.Component<{ onError: () => void }, { hasError: boolean }> {
+  state = { hasError: false } as { hasError: boolean };
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  componentDidCatch() {
+    try {
+      this.props.onError();
+    } catch {}
+  }
+  render() {
+    return this.state.hasError ? null : (this.props.children as React.ReactNode);
+  }
+}
+

--- a/src/components/CommandPaletteInner.tsx
+++ b/src/components/CommandPaletteInner.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { score } from "../utils/fuzzy";
+import { track } from "../utils/telemetry";
+import { WORLDS, ZONES } from "../data/registry";
+
+type Item = {
+  id: string;
+  label: string;
+  href?: string;
+  action?: () => void;
+  group?: string;
+};
+
+function baseItems(): Item[] {
+  const nav: Item[] = [
+    { id: "home", label: "Home", href: "/", group: "Navigate" },
+    { id: "worlds", label: "Worlds", href: "/worlds", group: "Navigate" },
+    { id: "zones", label: "Zones", href: "/zones", group: "Navigate" },
+    { id: "marketplace", label: "Marketplace", href: "/marketplace", group: "Navigate" },
+    { id: "passport", label: "Passport", href: "/passport", group: "Navigate" },
+    { id: "naturbank", label: "NaturBank", href: "/naturbank", group: "Navigate" },
+    { id: "navatar", label: "Navatar", href: "/navatar", group: "Navigate" },
+  ];
+  const worldLinks: Item[] = WORLDS.map((w) => ({
+    id: `world:${w.slug}`,
+    label: `World • ${w.name}`,
+    href: `/worlds/${w.slug}`,
+    group: "Deep link",
+  }));
+  const zoneLinks: Item[] = ZONES.map((z) => ({
+    id: `zone:${z.slug}`,
+    label: `Zone • ${z.name}`,
+    href: `/zones/${z.slug}`,
+    group: "Deep link",
+  }));
+  const actions: Item[] = [
+    {
+      id: "share",
+      label: "Share this page",
+      group: "Actions",
+      action: async () => {
+        try {
+          if (navigator.share) {
+            await navigator.share({ title: document.title, url: location.href });
+            track.click("palette_share", { ok: true });
+          } else {
+            await navigator.clipboard.writeText(location.href);
+            alert("Link copied to clipboard.");
+          }
+        } catch (e) {
+          track.error("palette_share", (e as Error).message);
+        }
+      },
+    },
+    {
+      id: "clear",
+      label: "Clear local cache",
+      group: "Actions",
+      action: () => {
+        localStorage.clear();
+        track.click("palette_clear");
+        alert("Local data cleared.");
+      },
+    },
+  ];
+  return [...nav, ...worldLinks, ...zoneLinks, ...actions];
+}
+
+export default function CommandPaletteInner() {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const navigate = useNavigate();
+  const loc = useLocation();
+
+  useEffect(() => {
+    setOpen(false);
+    setQ("");
+  }, [loc.pathname]);
+  useEffect(() => {
+    const on = (e: KeyboardEvent) => {
+      const mod = e.ctrlKey || e.metaKey;
+      if (mod && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+      if (e.key === "Escape") setOpen(false);
+      if (!open && e.key === "?") setOpen(true);
+    };
+    addEventListener("keydown", on);
+    return () => removeEventListener("keydown", on);
+  }, [open]);
+
+  const items = useMemo(baseItems, []);
+  const results = useMemo(() => {
+    if (!q) return items;
+    const scored = items
+      .map((i) => ({ i, s: score(q, i.label) }))
+      .filter((x) => x.s > 0)
+      .sort((a, b) => b.s - a.s)
+      .map((x) => x.i);
+    track.search(q, scored.length);
+    return scored;
+  }, [q, items]);
+
+  if (!open) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(7,17,35,.36)",
+        display: "grid",
+        placeItems: "start center",
+        paddingTop: "12vh",
+        zIndex: 9998,
+      }}
+      onClick={() => setOpen(false)}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: "min(720px,92vw)",
+          background: "white",
+          borderRadius: 16,
+          boxShadow: "0 30px 80px rgba(0,0,0,.25)",
+          overflow: "hidden",
+        }}
+      >
+        <div style={{ padding: 14, borderBottom: "1px solid #ecf0ff" }}>
+          <input
+            autoFocus
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search pages and actions…"
+            style={{
+              width: "100%",
+              padding: "12px 14px",
+              borderRadius: 10,
+              border: "1px solid #dfe7ff",
+            }}
+          />
+        </div>
+        <div style={{ maxHeight: "50vh", overflow: "auto" }}>
+          {results.length === 0 && (
+            <div style={{ padding: 18, opacity: 0.7 }}>No results.</div>
+          )}
+          {results.map((r, idx) => (
+            <button
+              key={r.id}
+              onClick={() => {
+                setOpen(false);
+                r.href ? navigate(r.href) : r.action?.();
+              }}
+              className="palette-row"
+              style={{
+                display: "flex",
+                width: "100%",
+                textAlign: "left",
+                padding: "12px 16px",
+                gap: 10,
+                borderTop: idx ? "1px solid #f3f6ff" : "none",
+                background: "white",
+              }}
+            >
+              <span style={{ color: "#0b2545" }}>{r.label}</span>
+              {r.group && (
+                <span style={{ marginLeft: "auto", fontSize: 12, opacity: 0.6 }}>
+                  {r.group}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+        <div
+          style={{
+            padding: "8px 12px",
+            fontSize: 12,
+            color: "#5b6e99",
+            background: "#f7f9ff",
+            display: "flex",
+            gap: 14,
+          }}
+        >
+          <span>⌘/Ctrl + K</span>
+          <span>·</span>
+          <span>Esc</span>
+          <span>·</span>
+          <span>?</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { CommandPaletteInner as CommandPalette };
+

--- a/src/lib/upsertProfile.ts
+++ b/src/lib/upsertProfile.ts
@@ -14,12 +14,14 @@ export async function upsertProfile(userId: string, email: string | null) {
     );
     if (error) throw error;
   } catch (err: any) {
-    if (!warned) {
+    if (!warned && import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
       console.info(
         '[naturverse] optional profile upsert unavailable (ok in demo):',
         err?.message ?? err,
       );
       warned = true;
     }
+    // swallow in prod
   }
 }


### PR DESCRIPTION
## Summary
- gate the Command Palette behind VITE_ENABLE_PALETTE and load the real palette lazily on client
- make optional profile upsert log only in dev and never throw
- correct font preload tags in index.html

## Testing
- `npm run typecheck` *(fails: TS2769 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae14b31bdc8329859962a34d7aa10e