### PR TITLE
feat: self-host Inter font

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -23,18 +23,7 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
 
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      href="https://fonts.googleapis.com/css2?family=Fredoka+One:wght@400&family=Inter:wght@400;500;600;700&display=swap"
-      as="style"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Fredoka+One:wght@400&family=Inter:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Font imports removed: Inter is self-hosted -->
     <style>
       :root {
         --pad: clamp(12px, 2.5vw, 24px);

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -1,9 +1,26 @@
+/* Inter variable — local, self-hosted via @fontsource-variable */
+@import "@fontsource-variable/inter/index.css";
+
 html,
 body,
 #root {
   height: 100%;
   background: var(--bg);
   color: var(--fg);
+}
+
+html,
+body {
+  font-family: "Inter Variable", "Inter var", ui-sans-serif, system-ui,
+    -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+html {
+  font-synthesis-weight: none;
+  font-optical-sizing: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* Center pages like Worlds/Zones baseline from #286 */

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "three": "^0.160.0",
     "workbox-window": "^7.1.0",
     "nprogress": "^0.2.0",
-    "react-helmet-async": "^2.0.4"
+    "react-helmet-async": "^2.0.4",
+    "@fontsource-variable/inter": "^5.0.18"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",

--- a/src/components/HeadPreloads.tsx
+++ b/src/components/HeadPreloads.tsx
@@ -3,11 +3,7 @@ import { Helmet } from "react-helmet-async";
 export default function HeadPreloads() {
   return (
     <Helmet>
-      {/* Fonts */}
-      <link rel="preconnect" href="https://fonts.googleapis.com" />
-      <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-      <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
-      <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
+      {/* Inter is self-hosted; no font preconnects needed */}
 
       {/* Favicons */}
       <link rel="preload" as="image" href="/favicon-32x32.png" />

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,6 @@
     <meta name="color-scheme" content="light" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preload" as="style" href="/main.css" />
     <link
       rel="preload"

--- a/src/main.css
+++ b/src/main.css
@@ -1,3 +1,5 @@
+/* Inter variable — local, self-hosted via @fontsource-variable */
+@import "@fontsource-variable/inter/index.css";
 @import './styles/main.css';
 @import './styles/worlds.css';
 @import './styles/cart.css';
@@ -25,9 +27,21 @@
 @import "./styles/util.css";
 @import "./styles/nav-active.css";
 
+html,
 body {
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: "Inter Variable", "Inter var", ui-sans-serif, system-ui,
+    -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+html {
+  font-synthesis-weight: none;
+  font-optical-sizing: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
   opacity: 0;
   transition: opacity 0.6s ease-in-out;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -18,7 +18,7 @@
 @import "./styles/theme.css";
 @import "../app/styles/global-sections.css";
 :root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; --naturverse-blue: var(--nv-blue-700); }
-*{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
+*{box-sizing:border-box} body{margin:0;font-family:"Inter Variable","Inter var",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"}
 .wrap{max-width:1120px;margin:0 auto;padding:16px}
 .top{display:flex;gap:16px;align-items:center;border-bottom:1px solid var(--ring);padding-bottom:8px}
 .brand{font-weight:800;color:var(--ink);text-decoration:none;font-size:22px}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,7 +1,23 @@
+/* Inter variable — local, self-hosted via @fontsource-variable */
+@import "@fontsource-variable/inter/index.css";
 @import './cards.css';
 
 :root {
   --naturverse-blue: #2e6bff;
+}
+
+html,
+body {
+  font-family: "Inter Variable", "Inter var", ui-sans-serif, system-ui,
+    -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+html {
+  font-synthesis-weight: none;
+  font-optical-sizing: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* ================================


### PR DESCRIPTION
## Summary
- self-host Inter Variable with @fontsource-variable/inter
- set global font stack to Inter with system fallbacks and optical sizing
- drop external font preconnects/preloads

## Testing
- `npm install --no-package-lock` *(fails: 403 Forbidden fetching @fontsource-variable/inter)*
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1bce85bc8329ade59602462973f5