### PR TITLE
feat: add offline-first PWA support

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,15 +32,10 @@
       <meta name="twitter:image" content="/favicon-256x256.png" />
     <link rel="canonical" href="https://naturverse.netlify.app/" />
 
-    <!-- Preload the 64x64 (crisp and safe) so favicon appears immediately -->
-    <link rel="preload" as="image" href="/favicon-64x64.png" imagesizes="64x64" />
-    <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="alternate icon" href="/favicon.ico" />
-
-    <!-- Preload assets -->
-    <link rel="preload" href="/src/main.css" as="style" />
-    <link rel="stylesheet" href="/src/main.css" />
+      <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
+      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+      <link rel="alternate icon" href="/favicon.ico" />
+      <link rel="stylesheet" href="/src/main.css" />
 
     <!-- a11y: skip to content -->
     <style>

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Naturverse — Offline</title>
+  <link rel="stylesheet" href="/styles/offline.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>You're offline</h1>
+    <p>No worries — your Naturverse will be back as soon as you're online.</p>
+    <a class="btn" href="/" rel="nofollow">Try Home</a>
+  </main>
+</body>
+</html>

--- a/public/styles/offline.css
+++ b/public/styles/offline.css
@@ -1,0 +1,7 @@
+:root { --nv-blue:#2b64ff; --ink:#0b2545; --card:#f6f7fb; }
+* { box-sizing: border-box; }
+html,body { height:100%; margin:0; font-family:"Inter Variable",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial; background:#eef3ff; color:var(--ink);}
+.wrap{max-width:680px;margin:10vh auto;padding:24px;border-radius:16px;background:white;box-shadow:0 8px 24px rgba(0,0,0,.06)}
+h1{margin:0 0 12px;font-size:28px;color:var(--nv-blue)}
+p{margin:0 0 20px;line-height:1.5}
+.btn{display:inline-block;background:var(--nv-blue);color:#fff;text-decoration:none;padding:12px 16px;border-radius:12px;font-weight:700}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,9 @@ import './styles/magic.css';
 // TEMP: disable interactions while we isolate the crash
 // import { initInteractions } from './init/interactions';
 import './init/runtime-logger'; // lightweight global error hooks
+import { initPWA } from './pwa';
+import PwaToasts from './components/PwaToasts';
+import { NetworkBanner } from './hooks/useNetworkBanner';
 
 export default function App() {
   const [loading, setLoading] = useState(true);
@@ -20,6 +23,10 @@ export default function App() {
       setLoading(false);
     }, 800);
     return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    initPWA();
   }, []);
 
   if (loading) {
@@ -33,6 +40,7 @@ export default function App() {
   return (
     <CartProvider>
       <>
+        <NetworkBanner />
         {/* Global route side-effects (scroll & focus) */}
         <RouteFX />
         <CommandPaletteSafe />
@@ -50,6 +58,7 @@ export default function App() {
           </div>
         </main>
         <ToasterListener />
+        <PwaToasts />
       </>
     </CartProvider>
   );

--- a/src/components/HeadPreloads.tsx
+++ b/src/components/HeadPreloads.tsx
@@ -5,13 +5,11 @@ export default function HeadPreloads() {
     <Helmet>
       {/* Inter is self-hosted; no font preconnects needed */}
 
-      {/* Favicons */}
-      <link rel="preload" as="image" href="/favicon-32x32.png" />
-      <link rel="preload" as="image" href="/favicon-64x64.png" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
-      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-      <link rel="shortcut icon" href="/favicon.ico" />
+        {/* Favicons */}
+        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+        <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <link rel="shortcut icon" href="/favicon.ico" />
 
       {/* PWA meta */}
       <meta name="mobile-web-app-capable" content="yes" />

--- a/src/components/PwaToasts.tsx
+++ b/src/components/PwaToasts.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+const toastStyle: React.CSSProperties = {
+  position: "fixed", bottom: 16, left: 16, right: 16, zIndex: 9999,
+  display: "flex", gap: 12, alignItems: "center",
+  background: "white", color: "#0b2545", padding: "12px 14px",
+  borderRadius: 14, boxShadow: "0 12px 30px rgba(0,0,0,.12)"
+};
+const btnStyle: React.CSSProperties = {
+  marginLeft: "auto", background: "#2b64ff", color: "white",
+  border: "none", borderRadius: 12, padding: "8px 12px", fontWeight: 700, cursor: "pointer"
+};
+
+export default function PwaToasts() {
+  const [needRefresh, setNeedRefresh] = React.useState(false);
+  const [offlineReady, setOfflineReady] = React.useState(false);
+
+  React.useEffect(() => {
+    const nr = () => setNeedRefresh(true);
+    const or = () => setOfflineReady(true);
+    window.addEventListener('pwa:need-refresh', nr);
+    window.addEventListener('pwa:offline-ready', or);
+    return () => {
+      window.removeEventListener('pwa:need-refresh', nr);
+      window.removeEventListener('pwa:offline-ready', or);
+    };
+  }, []);
+
+  if (!needRefresh && !offlineReady) return null;
+
+  return (
+    <div style={toastStyle} role="status" aria-live="polite">
+      {needRefresh && (
+        <>
+          <span>New version ready.</span>
+          <button style={btnStyle} onClick={() => location.reload()}>Refresh</button>
+        </>
+      )}
+      {offlineReady && !needRefresh && (
+        <span>Offline ready — you can use Naturverse without internet.</span>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useNetworkBanner.tsx
+++ b/src/hooks/useNetworkBanner.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+export function useNetworkBanner() {
+  const [offline, setOffline] = React.useState(!navigator.onLine);
+  React.useEffect(() => {
+    const on = () => setOffline(false);
+    const off = () => setOffline(true);
+    window.addEventListener("online", on);
+    window.addEventListener("offline", off);
+    return () => { window.removeEventListener("online", on); window.removeEventListener("offline", off); };
+  }, []);
+  return offline;
+}
+
+export function NetworkBanner() {
+  const offline = useNetworkBanner();
+  if (!offline) return null;
+  return (
+    <div style={{
+      position:"fixed", top:0, left:0, right:0, zIndex:9998,
+      background:"#2b64ff", color:"#fff", padding:"8px 12px",
+      textAlign:"center", fontWeight:700
+    }}>
+      You’re offline — showing cached content.
+    </div>
+  );
+}

--- a/src/index.html
+++ b/src/index.html
@@ -9,14 +9,6 @@
     <meta name="color-scheme" content="light" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <link rel="preload" as="style" href="/main.css" />
-    <link
-      rel="preload"
-      as="image"
-      href="/turian-favicon-64.png"
-      imagesrcset="/turian-favicon-32.png 32w, /turian-favicon-64.png 64w"
-      imagesizes="64px"
-    />
   </head>
   <body>
     <a class="visually-hidden-focusable" href="#main-content">Skip to content</a>

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -1,0 +1,19 @@
+// Only runs in production builds by default
+import { registerSW } from 'virtual:pwa-register';
+
+export const initPWA = () => {
+  const updateSW = registerSW({
+    immediate: true,
+    onNeedRefresh() {
+      // show toast
+      const ev = new CustomEvent('pwa:need-refresh');
+      window.dispatchEvent(ev);
+    },
+    onOfflineReady() {
+      const ev = new CustomEvent('pwa:offline-ready');
+      window.dispatchEvent(ev);
+    },
+  });
+  // expose to a button if needed later
+  (window as any).forcePwaUpdate = updateSW;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,47 +11,41 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       injectRegister: 'auto',
-      workbox: {
-        globPatterns: ['**/*.{js,css,html,svg,png,ico,webp,woff2}'],
-        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+      includeAssets: ['favicon.ico', 'favicon.svg', 'icons/*'],
+      manifest: {
+        name: 'Naturverse',
+        short_name: 'Naturverse',
+        theme_color: '#2b64ff',
+        background_color: '#ffffff',
+        start_url: '/',
+        display: 'standalone',
+        icons: [
+          { src: '/favicon-128x128.png', sizes: '128x128', type: 'image/png', purpose: 'any' },
+          { src: '/favicon-256x256.png', sizes: '256x256', type: 'image/png', purpose: 'any' },
+        ],
       },
-        manifest: {
-          name: 'Naturverse',
-          short_name: 'Naturverse',
-          theme_color: '#2b64ff',
-          background_color: '#ffffff',
-          start_url: '/',
-          display: 'standalone',
-          icons: [
-            { src: '/favicon-128x128.png', sizes: '128x128', type: 'image/png', purpose: 'any' },
-            { src: '/favicon-256x256.png', sizes: '256x256', type: 'image/png', purpose: 'any' },
-          ],
-        },
-      // Runtime caching for stuff that isn’t in the precache
-      runtimeCaching: [
-        {
-          urlPattern: ({ request }) => request.destination === 'image',
-          handler: 'CacheFirst',
-          options: {
-            cacheName: 'nv-images',
-            expiration: {
-              maxEntries: 60,
-              maxAgeSeconds: 60 * 60 * 24 * 30,
+      workbox: {
+        navigateFallback: '/offline.html',
+        globPatterns: ['**/*.{js,css,html,ico,svg,png,webp,woff2}'],
+        runtimeCaching: [
+          {
+            urlPattern: ({ request }) => request.destination === 'image',
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'images',
+              expiration: { maxEntries: 120, maxAgeSeconds: 60 * 60 * 24 * 30 },
             },
           },
-        },
-        {
-          urlPattern: /https:\/\/[^/]*supabase\.co\/.*/i,
-          handler: 'StaleWhileRevalidate',
-          options: {
-            cacheName: 'nv-supabase',
-            expiration: {
-              maxEntries: 100,
-              maxAgeSeconds: 60 * 60 * 24,
+          {
+            urlPattern: ({ request }) => request.destination === 'font',
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'fonts',
+              expiration: { maxEntries: 20, maxAgeSeconds: 60 * 60 * 24 * 365 },
             },
           },
-        },
-      ],
+        ],
+      },
     }),
   ],
   envPrefix: ['VITE_', 'NEXT_PUBLIC_'],


### PR DESCRIPTION
## Summary
- add offline fallback page and styles
- register service worker with update/offline toasts and network banner
- refine Vite PWA config and remove unused preload tags

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next')*
- `npm run build` *(fails: ENOENT @fontsource-variable/inter/index.css)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1fcc3b948329bf67e6de8cb2301d