### PR TITLE
feat: add share block with copy fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,15 @@
     "workbox-window": "^7.1.0",
     "nprogress": "^0.2.0",
     "react-helmet-async": "^2.0.4",
-    "@fontsource-variable/inter": "^5.0.18"
+    "@fontsource-variable/inter": "^5.0.18",
+    "copy-to-clipboard": "^3.3.3",
+    "react-share": "^5.1.1"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/copy-to-clipboard": "^3.2.9",
     "@vitejs/plugin-react-swc": "^3.7.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",

--- a/src/components/ShareBlock.tsx
+++ b/src/components/ShareBlock.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+
+// Lazy load optional libs so build/SSR never crash if anything is missing
+let copyToClipboard: ((text: string) => boolean) | null = null;
+async function ensureCopyLib() {
+  if (!copyToClipboard) {
+    try {
+      const mod = await import("copy-to-clipboard");
+      copyToClipboard = mod.default;
+    } catch {
+      copyToClipboard = null;
+    }
+  }
+}
+
+export type ShareBlockProps = {
+  title?: string;
+  text?: string;
+  url?: string;
+  className?: string;
+};
+
+export function ShareBlock({
+  title = "Naturverse",
+  text = "Come explore the Naturverse!",
+  url = typeof window !== "undefined" ? window.location.href : "",
+  className,
+}: ShareBlockProps) {
+  const [status, setStatus] = React.useState<string>("");
+
+  async function webShare() {
+    try {
+      if (navigator.share) {
+        await navigator.share({ title, text, url });
+        setStatus("Shared!");
+        return;
+      }
+    } catch {
+      // fallthrough to copy
+    }
+    // Fallback: copy the URL
+    await ensureCopyLib();
+    if (copyToClipboard && url) {
+      copyToClipboard(url);
+      setStatus("Link copied!");
+    } else {
+      setStatus("Copy unavailable");
+    }
+  }
+
+  return (
+    <div className={className ?? ""} style={{ display: "flex", gap: 8, alignItems: "center" }}>
+      <button onClick={webShare} className="btn btn-primary">
+        Share
+      </button>
+      {status && (
+        <span className="text-muted" aria-live="polite">
+          {status}
+        </span>
+      )}
+    </div>
+  );
+}
+

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { signInWithGoogle, sendMagicLink } from '@/lib/auth';
 import { useAuth } from '@/lib/auth-context';
 import ClickableCard from '@/components/ClickableCard';
+import { ShareBlock } from '@/components/ShareBlock';
 
 export default function Home() {
   const { user } = useAuth();
@@ -79,7 +80,6 @@ export default function Home() {
           </p>
         </ClickableCard>
       </section>
-
       {/* Bottom flow — text left-aligned */}
       <section className={styles.flowWrap}>
         <ClickableCard
@@ -143,6 +143,7 @@ export default function Home() {
           </div>
         </ClickableCard>
       </section>
+      <ShareBlock className="mt-4" />
     </main>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,7 +65,12 @@ export default defineConfig({
       // add others you always ship:
       // "zustand", "clsx", "dayjs", ...
       'react-helmet-async',
+      'copy-to-clipboard',
+      'react-share',
     ],
+  },
+  ssr: {
+    noExternal: ['react-share'],
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- add copy-to-clipboard and react-share dependencies
- configure Vite to prebundle and bundle react-share
- introduce ShareBlock component with navigator.share fallback and lazy copy support
- render ShareBlock on Home page

## Testing
- `npm install` *(fails: 403 Forbidden for @fontsource-variable/inter)*
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TypeScript errors)*
- `npm run build` *(fails: ENOENT @fontsource-variable/inter)*

------
https://chatgpt.com/codex/tasks/task_e_68ae275ec0748329b7a60882864ce4c2