### PR TITLE
chore: remove copy-to-clipboard types

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@types/node": "^20.14.11",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@types/copy-to-clipboard": "^3.2.9",
     "@vitejs/plugin-react-swc": "^3.7.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",


### PR DESCRIPTION
## Summary
- remove unnecessary `@types/copy-to-clipboard` dev dependency

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck` (fails: Argument of type 'Partial<...>' is not assignable to parameter of type 'never' etc.)

------
https://chatgpt.com/codex/tasks/task_e_68ae28e6f8cc8329b50a6d2c1ee03e1b