### PR TITLE
feat: telemetry + feature flags (Plausible/Umami loader, Netlify log collector → Supabase, flags.json with overrides)

### DIFF
--- a/netlify/functions/event-collect.ts
+++ b/netlify/functions/event-collect.ts
@@ -1,0 +1,26 @@
+import { Handler } from '@netlify/functions'
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL as string
+const serviceKey  = process.env.SUPABASE_SERVICE_ROLE_KEY as string
+
+const supabase = createClient(supabaseUrl, serviceKey, { auth: { persistSession: false } })
+
+export const handler: Handler = async (evt) => {
+  if (evt.httpMethod !== 'POST') return { statusCode: 405, body: 'Method Not Allowed' }
+  try {
+    const payload = JSON.parse(evt.body || '{}')
+    const { error } = await supabase.from('client_logs').insert({
+      type: payload.type || 'event',
+      name: payload.name || 'unknown',
+      data: payload.data || null,
+      path: payload.path || null,
+      ua: payload.ua || null,
+      ts: payload.ts || new Date().toISOString()
+    })
+    if (error) throw error
+    return { statusCode: 200, body: 'ok' }
+  } catch (err: any) {
+    return { statusCode: 500, body: String(err?.message || err) }
+  }
+}

--- a/public/flags.json
+++ b/public/flags.json
@@ -1,0 +1,7 @@
+{
+  "enableTurianAI": true,
+  "showCreatorLab": true,
+  "enablePWAInstallPrompt": true,
+  "enableAnimations": true,
+  "enableShareButton": true
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -3,14 +3,19 @@ import SwUpdateToast from './components/SwUpdateToast'
 import InstallPrompt from './components/InstallPrompt'
 import { useRoutes } from 'react-router-dom'
 import { routes } from './router.lazy'
+import Analytics from './components/Analytics'
+import { useEffect } from 'react'
+import { logEvent } from './lib/logger'
 
 export default function AppShell(){
   const content = useRoutes(routes)
+  useEffect(()=>{ logEvent('app_loaded') },[])
   return (
     <ErrorBoundary>
       {content}
       <SwUpdateToast/>
       <InstallPrompt/>
+      <Analytics/>
     </ErrorBoundary>
   )
 }

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+
+export default function Analytics(){
+  useEffect(()=>{
+    if (import.meta.env.DEV) return
+    const provider = (import.meta.env.VITE_ANALYTICS_PROVIDER || 'plausible').toLowerCase()
+    const domain   = import.meta.env.VITE_ANALYTICS_DOMAIN
+    if (!domain) return
+
+    const s = document.createElement('script')
+    if (provider === 'umami') {
+      s.defer = true
+      s.setAttribute('data-website-id', import.meta.env.VITE_UMAMI_WEBSITE_ID || '')
+      s.src = import.meta.env.VITE_UMAMI_SRC || 'https://umami.naturverse.com/script.js'
+    } else {
+      s.defer = true
+      s.setAttribute('data-domain', domain)
+      s.src = 'https://plausible.io/js/script.js'
+    }
+    document.head.appendChild(s)
+    return ()=>{ document.head.removeChild(s) }
+  },[])
+  return null
+}

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,36 @@
+export type Flags = {
+  enableTurianAI: boolean
+  showCreatorLab: boolean
+  enablePWAInstallPrompt: boolean
+  enableAnimations: boolean
+  enableShareButton: boolean
+  [k: string]: any
+}
+
+let cached: Flags | null = null
+
+export async function getFlags(): Promise<Flags> {
+  if (cached) return cached
+  const res = await fetch('/flags.json', { cache: 'no-store' }).catch(()=>null)
+  const remote = (await res?.json().catch(()=>null)) || {}
+  const fromEnv = parseEnvFlags(import.meta.env.VITE_FLAGS)
+  const local = parseEnvFlags(localStorage.getItem('naturverse_flags') || '')
+  cached = { ...remote, ...fromEnv, ...local } as Flags
+  return cached
+}
+
+function parseEnvFlags(s?: string | any) {
+  try { return typeof s === 'string' ? JSON.parse(s) : (s || {}) } catch { return {} }
+}
+
+export function setLocalFlag(k: string, v: any) {
+  const current = parseEnvFlags(localStorage.getItem('naturverse_flags') || '{}')
+  current[k] = v
+  localStorage.setItem('naturverse_flags', JSON.stringify(current))
+  cached = null
+}
+
+export async function flag(k: keyof Flags, fallback=false){
+  const f = await getFlags()
+  return (f[k] ?? fallback) as boolean
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,22 @@
+type Event = { type: 'event'|'error'; name: string; data?: any; ts?: string; path?: string; ua?: string }
+const fnUrl = '/.netlify/functions/event-collect'
+
+export async function logEvent(name: string, data?: any){
+  const e: Event = { type:'event', name, data, ts:new Date().toISOString(), path: location.pathname, ua: navigator.userAgent }
+  output(e)
+}
+
+export async function logError(name: string, data?: any){
+  const e: Event = { type:'error', name, data, ts:new Date().toISOString(), path: location.pathname, ua: navigator.userAgent }
+  output(e)
+}
+
+async function output(e: Event){
+  if (import.meta.env.DEV) { console[e.type==='error'?'error':'log']('[nv]', e); return }
+  try {
+    await fetch(fnUrl, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(e) })
+  } catch (err) {
+    // fallback – don't crash the app
+    console.warn('[nv][log-fail]', err)
+  }
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,10 @@
+export {}
+declare global {
+  interface ImportMetaEnv {
+    readonly VITE_FLAGS?: string
+    readonly VITE_ANALYTICS_PROVIDER?: 'plausible'|'umami'
+    readonly VITE_ANALYTICS_DOMAIN?: string
+    readonly VITE_UMAMI_WEBSITE_ID?: string
+    readonly VITE_UMAMI_SRC?: string
+  }
+}


### PR DESCRIPTION
## Summary
- add runtime-configurable feature flags with local overrides
- integrate analytics loader for Plausible/Umami
- log events/errors in client and collect via Netlify function to Supabase

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "copy-to-clipboard" from ShareBlock.tsx)*
- `npm install copy-to-clipboard` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@fontsource-variable/inter)*

------
https://chatgpt.com/codex/tasks/task_e_68ae392dbf9083298faf7247284e65ac