### PR TITLE
feat: image shrink pipeline (sharp optimizer → WebP responsive, NVImage auto-picks optimized assets)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build:galleries": "node scripts/build-kingdom-gallery.js",
-    "build": "npm run build:galleries && vite build",
+    "optimize:images": "node --loader ts-node/esm scripts/optimize-images.ts",
+    "build": "npm run build:galleries && npm run optimize:images && vite build",
     "preview": "vite preview --port 5173",
     "typecheck": "tsc --noEmit"
   },
@@ -33,7 +34,9 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
     "vite": "^5.4.2",
-    "vite-plugin-pwa": "^0.20.0"
+    "vite-plugin-pwa": "^0.20.0",
+    "sharp": "^0.33.0",
+    "glob": "^7.2.3"
   },
   "overrides": {
     "react-helmet-async": "^2.0.4"

--- a/scripts/optimize-images.ts
+++ b/scripts/optimize-images.ts
@@ -1,0 +1,32 @@
+import sharp from 'sharp'
+import glob from 'glob'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const srcDirs = ['public/assets', 'public/kingdoms', 'public/Languages', 'public/Mapsmain', 'public/Marketplace']
+const outDir = 'public/optimized'
+
+async function run() {
+  await fs.mkdir(outDir, { recursive: true })
+  const files = srcDirs.flatMap(d => glob.sync(`${d}/**/*.{png,jpg,jpeg}`))
+
+  for (const f of files) {
+    const rel = path.relative('public', f)
+    const base = path.join(outDir, rel.replace(/\.(png|jpe?g)$/i,''))
+    await fs.mkdir(path.dirname(base), { recursive: true })
+
+    const sizes = [320, 640, 960, 1280]
+    for (const w of sizes) {
+      const outPath = `${base}-${w}.webp`
+      try {
+        await sharp(f).resize({ width: w }).webp({ quality: 80 }).toFile(outPath)
+        console.log('✅', outPath)
+      } catch (err) {
+        console.warn('❌ Failed', f, err)
+      }
+    }
+  }
+}
+
+run()
+

--- a/src/components/NVImage.tsx
+++ b/src/components/NVImage.tsx
@@ -1,13 +1,17 @@
 type Props = React.ImgHTMLAttributes<HTMLImageElement> & {w?:number[]}
-const toCdn = (src:string, w:number)=> `${src}?nf_resize=fit&w=${w}`
+
+const toOptimized = (src:string, w:number)=>{
+  // if you pass /assets/foo.png, it will try /optimized/assets/foo-640.webp
+  return src.replace(/^\/?/, '/optimized/').replace(/\.(png|jpe?g)$/i, `-${w}.webp`)
+}
+
 export default function NVImage({src='', alt='', w=[320,640,960,1280], loading='lazy', ...rest}:Props){
-  const srcset = w.map(px=>`${toCdn(src,px)} ${px}w`).join(', ')
+  if(!src) return null
+  const srcset = w.map(px=>`${toOptimized(src,px)} ${px}w`).join(', ')
   const sizes = '(max-width: 768px) 90vw, 1200px'
-  const webp   = (src||'').replace(/\.(png|jpg|jpeg)$/i,'.webp')
   return (
     <picture>
-      <source type="image/webp" srcSet={srcset.replaceAll(src, webp)} sizes={sizes} />
-      <img src={toCdn(src, w[1]||640)} srcSet={srcset} sizes={sizes} alt={alt} loading={loading} decoding="async" {...rest}/>
+      <img src={toOptimized(src, w[1]||640)} srcSet={srcset} sizes={sizes} alt={alt} loading={loading} decoding="async" {...rest}/>
     </picture>
   )
 }


### PR DESCRIPTION
## Summary
- add `optimize-images` script that builds responsive WebP assets via sharp
- integrate optimizer in build flow and add sharp/glob dev dependencies
- update `NVImage` component to load pre-optimized assets

## Testing
- `npm run build` *(fails: node:internal/modules/run_main:123 triggerUncaughtException)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3a17cd7c8329a2d23fe9717e6687