### PR TITLE
chore(build): lock Node to 20.x

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,6 @@
   publish = "dist"
   node_version = "20"
 
-[build.environment]
-  NODE_VERSION = "20"
-
 # 🔁 SPA fallback to prevent 404 on client routes
 [[redirects]]
   from = "/*"
@@ -23,3 +20,6 @@
   for = "/sw.js"
   [headers.values]
     Cache-Control = "no-cache"
+
+[build.environment]
+  NODE_VERSION = "20"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "packageManager": "npm@10",
   "engines": {
-    "node": ">=18.17 <21"
+    "node": "20.x"
   }
 }


### PR DESCRIPTION
## Summary
- pin Node engine at 20.x in package.json
- ensure Netlify build uses Node 20 and sets NODE_VERSION env

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Partial<...>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68ae48e4e80483299898fc96cb2e014b