### PR TITLE
fix: disable eval usage in Vite/React to resolve Netlify CSP white screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^20.14.11",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.0.0",
+    "@vitejs/plugin-react": "^4.2.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
     "vite": "^5.4.2",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,13 @@ import path from 'path';
 
 export default defineConfig({
   plugins: [
-    react(),
+    react({
+      // Disable dev-only transform that uses eval()
+      babel: {
+        plugins: [],
+      },
+      fastRefresh: false,
+    }),
     // Re-enable after we add valid icons & test:
     // VitePWA({
     //   registerType: 'autoUpdate',
@@ -61,7 +67,7 @@ export default defineConfig({
         },
       },
     },
-    sourcemap: true, // ensure production sourcemaps
+    sourcemap: false, // prevents inline eval source maps
     commonjsOptions: {
       // allow CJS in node_modules to be bundled
       include: [/node_modules/],


### PR DESCRIPTION
## Summary
- disable eval-based React refresh transform and turn off Fast Refresh
- build without sourcemaps to avoid inline eval
- bump `@vitejs/plugin-react` to ^4.2.1

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae62b2efb88329809cdf6e5da960ac