### PR TITLE
Unblank prod: relax CSP + add boot diagnostics + keep PWA off

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-  <script src="/kill-sw.js?v=1756258070" defer></script>
+  <script src="/kill-sw.js?v=1" defer></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Naturverse</title>

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,13 @@
 [build.environment]
   NODE_VERSION = "22"
 
+[[headers]]
+  for = "/*"
+  # Temporary CSP so app can execute while we debug.
+  # TODO: tighten after we confirm no eval usage remains.
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https:; connect-src 'self' https:; img-src 'self' https: data: blob:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/public/kill-sw.js
+++ b/public/kill-sw.js
@@ -4,20 +4,18 @@
   try {
     if ('serviceWorker' in navigator) {
       const regs = await navigator.serviceWorker.getRegistrations();
-      await Promise.allSettled(regs.map(r => r.unregister()));
+      await Promise.allSettled(regs.map((r) => r.unregister()));
     }
-    if (window.caches && caches.keys) {
+    if (window.caches?.keys) {
       const keys = await caches.keys();
-      await Promise.allSettled(keys.map(k => caches.delete(k)));
+      await Promise.allSettled(keys.map((k) => caches.delete(k)));
     }
-    // If this page request has ?kill-sw=1, drop it and reload cleanly
     const url = new URL(location.href);
     if (url.searchParams.has('kill-sw')) {
       url.searchParams.delete('kill-sw');
       location.replace(url.toString());
     }
   } catch (e) {
-    // Don't block render on errors
     console.warn('[kill-sw] failed:', e);
   }
 })();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,32 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
-import AppShell from './AppShell'
-import './index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import AppShell from './AppShell';
+import './index.css';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <AppShell/>
-    </BrowserRouter>
-  </React.StrictMode>
-)
+// --- Boot diagnostics: surface any runtime errors instead of a white screen
+window.addEventListener('error', (e) => {
+  console.error('[boot][error]', (e as ErrorEvent).error || e.message);
+});
+window.addEventListener('unhandledrejection', (e: PromiseRejectionEvent) => {
+  console.error('[boot][unhandledrejection]', e.reason);
+});
+console.log('[boot] starting…');
+
+try {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    </React.StrictMode>,
+  );
+} catch (err) {
+  console.error('[boot][render-failed]', err);
+  const pre = document.createElement('pre');
+  pre.style.padding = '16px';
+  pre.style.whiteSpace = 'pre-wrap';
+  pre.textContent = 'Boot failed:\n' + ((err as any)?.stack || String(err));
+  document.body.innerHTML = '';
+  document.body.appendChild(pre);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-// import { VitePWA } from 'vite-plugin-pwa';  // temporarily disabled
+// import { VitePWA } from 'vite-plugin-pwa';
 import path from 'path';
+
+const enablePWA = (process.env.VITE_ENABLE_PWA ?? 'false') === 'true';
 
 export default defineConfig({
   plugins: [
@@ -12,20 +14,25 @@ export default defineConfig({
       },
       fastRefresh: false,
     }),
-    // Re-enable after we add valid icons & test:
-    // VitePWA({
-    //   registerType: 'autoUpdate',
-    //   manifest: {
-    //     name: 'Naturverse',
-    //     short_name: 'Naturverse',
-    //     start_url: '/',
-    //     display: 'standalone',
-    //     background_color: '#ffffff',
-    //     theme_color: '#0ea5e9',
-    //     icons: [] // keep empty until real PNGs exist in /public
-    //   },
-    //   workbox: { clientsClaim: true, skipWaiting: true, cleanupOutdatedCaches: true }
-    // })
+    ...(enablePWA
+      ? [
+          /*
+          VitePWA({
+            registerType: 'autoUpdate',
+            manifest: {
+              name: 'Naturverse',
+              short_name: 'Naturverse',
+              start_url: '/',
+              display: 'standalone',
+              background_color: '#ffffff',
+              theme_color: '#0ea5e9',
+              icons: [] // keep empty until real PNGs exist in /public
+            },
+            workbox: { clientsClaim: true, skipWaiting: true, cleanupOutdatedCaches: true }
+          })
+          */
+        ]
+      : []),
   ],
   envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   resolve: {


### PR DESCRIPTION
## Summary
- add relaxed, temporary Content Security Policy for all paths
- include kill-sw service worker/cache cleaner and load it early
- expose boot diagnostics and keep PWA plugin disabled by default

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run typecheck` *(fails: Argument of type 'Partial<...>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68ae65070d908329ae33a5bc0574c779