### PR TITLE
sec: enable RLS + add policies (quizzes, learning_modules, test_logs) and prebuild security check

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "vite build",
     "preview": "vite preview --port 5173",
     "typecheck": "tsc --noEmit",
-    "prebuild": "echo NODE_VERSION=$NODE_VERSION && node -v && npm -v"
+    "prebuild": "node scripts/security-check.mjs"
   },
   "dependencies": {
     "@vercel/og": "^0.8.2",
@@ -39,7 +39,8 @@
     "sharp": "^0.33.0",
     "glob": "^7.2.3",
     "@types/glob": "^7.2.0",
-    "@types/sharp": "^0.32.0"
+    "@types/sharp": "^0.32.0",
+    "undici": "^6.19.8"
   },
   "overrides": {
     "react-helmet-async": "^2.0.4"

--- a/scripts/security-check.mjs
+++ b/scripts/security-check.mjs
@@ -1,0 +1,72 @@
+try {
+  await import("undici/polyfill");
+} catch {}
+
+// Fails the build if RLS/policies drift on critical tables.
+// Requires: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in env (Netlify already has these)
+const required = ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"];
+for (const k of required) {
+  if (!process.env[k]) {
+    console.log(`[security-check] skipping (missing ${k})`);
+    process.exit(0);
+  }
+}
+const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = process.env;
+
+async function get(path, params = "") {
+  const url = `${SUPABASE_URL}/rest/v1/${path}${params}`;
+  const res = await fetch(url, {
+    headers: {
+      apikey: SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      Prefer: "count=exact"
+    }
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GET ${path} -> ${res.status}: ${text}`);
+  }
+  const data = await res.json();
+  const count = res.headers.get("content-range")?.split("/")?.[1];
+  return { data, count: count ? Number(count) : data.length };
+}
+
+// pg_meta exposes table + policy metadata via PostgREST
+// tables endpoint: pg_tables (schemaname, tablename)
+// policies endpoint: pg_policies (schemaname, tablename, cmd)
+async function main() {
+  const tables = ["learning_modules", "quizzes", "test_logs"];
+
+  // RLS flag lives in pg_class.relrowsecurity; pg_meta exposes it via pg_tables? (not always),
+  // fallback: try pg_policies existence as a proxy for enabled RLS on catalogs we control.
+  // We enforce presence of at least one SELECT policy on LMS tables and NO SELECT policy on test_logs.
+  const { data: pols } = await get(
+    "pg_policies",
+    `?schemaname=eq.public&tablename=in.(${tables.join(",")})`
+  );
+
+  const selPolicies = (name) =>
+    pols.filter((p) => p.tablename === name && p.cmd === "SELECT");
+
+  const lmSel = selPolicies("learning_modules").length;
+  const qSel = selPolicies("quizzes").length;
+  const tlSel = selPolicies("test_logs").length;
+
+  const errors = [];
+  if (lmSel === 0) errors.push("learning_modules has no SELECT policy");
+  if (qSel === 0) errors.push("quizzes has no SELECT policy");
+  if (tlSel > 0) errors.push("test_logs should not expose SELECT policies");
+
+  if (errors.length) {
+    console.error("[security-check] ✖ failed:\n- " + errors.join("\n- "));
+    process.exit(1);
+  } else {
+    console.log("[security-check] ✓ policies look good");
+  }
+}
+
+main().catch((e) => {
+  console.error("[security-check] error:", e.message || e);
+  // Don’t hard fail on meta endpoint differences; only fail on explicit policy problems above.
+  process.exit(0);
+});

--- a/supabase/migrations/20250827_security.sql
+++ b/supabase/migrations/20250827_security.sql
@@ -1,0 +1,95 @@
+-- Enable RLS where needed
+ALTER TABLE public.quizzes           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.learning_modules  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.test_logs         ENABLE ROW LEVEL SECURITY;
+
+-- OPTIONAL: If these tables already had RLS enabled, the ALTER is a no-op.
+
+-- READ-ONLY catalog access for site visitors.
+-- If you want only published rows exposed, set :USE_PUBLISHED_ONLY := true below.
+-- For now default to TRUE to be safe.
+DO $$
+DECLARE use_published_only boolean := true;
+BEGIN
+  IF use_published_only THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='learning_modules' AND column_name='is_published'
+    ) THEN
+      RAISE NOTICE 'public.learning_modules is missing is_published; exposing all rows';
+      use_published_only := false;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='quizzes' AND column_name='is_published'
+    ) THEN
+      RAISE NOTICE 'public.quizzes is missing is_published; exposing all rows';
+      use_published_only := false;
+    END IF;
+  END IF;
+
+  -- learning_modules: SELECT for anon + authenticated
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='learning_modules' AND policyname='read_learning_modules'
+  ) THEN
+    EXECUTE format($f$
+      CREATE POLICY read_learning_modules
+      ON public.learning_modules
+      FOR SELECT
+      TO anon, authenticated
+      USING (%s);
+    $f$, CASE WHEN use_published_only THEN 'COALESCE(is_published, true)' ELSE 'true' END);
+  END IF;
+
+  -- quizzes: SELECT for anon + authenticated
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='quizzes' AND policyname='read_quizzes'
+  ) THEN
+    EXECUTE format($f$
+      CREATE POLICY read_quizzes
+      ON public.quizzes
+      FOR SELECT
+      TO anon, authenticated
+      USING (%s);
+    $f$, CASE WHEN use_published_only THEN 'COALESCE(is_published, true)' ELSE 'true' END);
+  END IF;
+
+END $$;
+
+-- test_logs: NO public reads; allow INSERT only by service_role (Netlify functions).
+DO $$
+BEGIN
+  -- Remove any accidental SELECT policies
+  DELETE FROM pg_policies
+  WHERE schemaname='public' AND tablename='test_logs' AND cmd='SELECT';
+
+  -- Insert policy (service_role only)
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='test_logs' AND policyname='sr_insert_test_logs'
+  ) THEN
+    CREATE POLICY sr_insert_test_logs
+    ON public.test_logs
+    FOR INSERT
+    TO service_role
+    WITH CHECK (true);
+  END IF;
+END $$;
+
+-- Pin function search paths (update these function names if your warning lists differ)
+DO $$
+BEGIN
+  BEGIN
+    EXECUTE 'ALTER FUNCTION public.update_updated_at() SET search_path = public, extensions';
+  EXCEPTION WHEN undefined_function THEN
+    RAISE NOTICE 'Skipped: public.update_updated_at() not found';
+  END;
+
+  BEGIN
+    EXECUTE 'ALTER FUNCTION public.handle_new_user() SET search_path = public, extensions';
+  EXCEPTION WHEN undefined_function THEN
+    RAISE NOTICE 'Skipped: public.handle_new_user() not found';
+  END;
+END $$;


### PR DESCRIPTION
## Summary
- run security policy verification before builds
- enable row-level security and baseline policies for core tables

## Testing
- `npm run prebuild` *(fails: fetch failed)*
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68aea082a95483299665917464223f0b