### PR TITLE
Add feature flags + safe no-op telemetry (disabled by default)

### DIFF
--- a/netlify/functions/event-collect.ts
+++ b/netlify/functions/event-collect.ts
@@ -1,7 +1,15 @@
-import type { Handler } from '@netlify/functions'
+import type { Handler } from '@netlify/functions';
 
-export const handler: Handler = async (evt) => {
-  if (evt.httpMethod !== 'POST') return { statusCode: 405, body: 'Method Not Allowed' }
-  return { statusCode: 204, body: '' } // always succeed; no logging for now
-}
+// Always return 204; never throw. If env isn’t configured, just no-op.
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod !== 'POST') return { statusCode: 204 };
+    // Optionally parse but ignore; this endpoint is intentionally inert in prod
+    // const payload = JSON.parse(event.body || '{}');
+    return { statusCode: 204 };
+  } catch {
+    return { statusCode: 204 };
+  }
+};
+export default handler;
 

--- a/public/flags.json
+++ b/public/flags.json
@@ -1,4 +1,5 @@
 {
+  "telemetry": false,
   "enableTurianAI": true,
   "showCreatorLab": true,
   "enablePWAInstallPrompt": true,

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,15 @@
+// Safe, optional client – never throws
+type Event = { name: string; props?: Record<string, unknown> };
+
+export async function sendEvent(evt: Event) {
+  try {
+    await fetch('/.netlify/functions/event-collect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(evt),
+    });
+  } catch {
+    // swallow – telemetry must never break UX
+  }
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,8 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import AppShell from './AppShell';
 import './index.css';
+import { loadFlags } from './lib/flags';
+import { sendEvent } from './lib/telemetry';
 
 // ---- Boot diagnostics: never silently white-screen
 window.addEventListener('error', (e) =>
@@ -31,6 +33,12 @@ function mount() {
       </React.StrictMode>,
     );
     console.log('[boot] rendered');
+    (async () => {
+      const flags = await loadFlags();
+      if (flags.telemetry) {
+        sendEvent({ name: 'pageview' });
+      }
+    })();
   } catch (err) {
     console.error('[boot] render failed:', err);
     const pre = document.createElement('pre');


### PR DESCRIPTION
## Summary
- add minimal runtime flags loader
- send safe telemetry if flag enabled
- ensure event-collect Netlify function always returns 204

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: [security-check] error: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aeda6bc5808329b665786ae0f83115