### PR TITLE
chore(prod): disable PWA by default + auto-unregister old SW to prevent white screen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ NEXT_PUBLIC_ENABLE_AUTO_STAMPS=true
 # Command Palette (experimental). Keep off in prod until enabled explicitly.
 VITE_ENABLE_PALETTE=false
 
+# Disable PWA by default (set to 0 to re-enable)
+VITE_DISABLE_PWA=1
+
 # Serverless only (set in Netlify UI → Site settings → Environment):
 OPENAI_API_KEY=
 VITE_ENABLE_GAMIFICATION=false

--- a/src/lib/killSW.ts
+++ b/src/lib/killSW.ts
@@ -1,0 +1,14 @@
+export async function killServiceWorkers() {
+  try {
+    if ('serviceWorker' in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map(r => r.unregister()));
+      // Also tell any active worker to stop controlling this page.
+      if (navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage({ type: 'SKIP_WAITING' });
+      }
+    }
+  } catch {
+    /* no-op */
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,13 @@ import './index.css';
 import { loadFlags } from './lib/flags';
 import { sendEvent } from './lib/telemetry';
 
+// safety: disable PWA by default in prod
+const DISABLE_PWA = import.meta.env.VITE_DISABLE_PWA !== '0';
+
+if (DISABLE_PWA && typeof window !== 'undefined') {
+  import('./lib/killSW').then(m => m.killServiceWorkers());
+}
+
 // ---- Boot diagnostics: never silently white-screen
 window.addEventListener('error', (e) =>
   console.error('[boot:error]', (e as ErrorEvent).error || e.message)

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -1,7 +1,10 @@
 // Only runs in production builds by default
 import { registerSW } from 'virtual:pwa-register';
 
+const DISABLE_PWA = import.meta.env.VITE_DISABLE_PWA !== '0';
+
 export const initPWA = () => {
+  if (DISABLE_PWA) return;
   const updateSW = registerSW({
     immediate: true,
     onNeedRefresh() {

--- a/src/register-sw.ts
+++ b/src/register-sw.ts
@@ -1,5 +1,7 @@
 // Only runs in production builds
-if (import.meta.env.PROD && 'serviceWorker' in navigator) {
+const DISABLE_PWA = import.meta.env.VITE_DISABLE_PWA !== '0';
+
+if (!DISABLE_PWA && import.meta.env.PROD && 'serviceWorker' in navigator) {
   // vite-plugin-pwa injects /sw.js for us
   import('workbox-window').then(({ Workbox }) => {
     const wb = new Workbox('/sw.js');


### PR DESCRIPTION
## Summary
- add killServiceWorkers helper to unregister any active service workers
- call killServiceWorkers at boot when VITE_DISABLE_PWA isn't '0'
- guard service worker registration behind VITE_DISABLE_PWA and default it to 1

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aedd7e1f88832986330d6391340b64