### PR TITLE
Add Vite PWA plugin configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-// import { VitePWA } from 'vite-plugin-pwa'; // keep disabled for now
+import { VitePWA } from 'vite-plugin-pwa';
 import path from 'path';
 
 export default defineConfig({
@@ -12,8 +12,9 @@ export default defineConfig({
       },
       fastRefresh: false,
     }),
-    // Re-enable later behind an env flag once icons & SW are confirmed good.
-    // VitePWA({ /* ... */ }),
+    // Completely disable for now:
+    // VitePWA({ disable: true })
+    VitePWA({ registerType: 'autoUpdate', disable: true }),
   ],
   envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   resolve: {


### PR DESCRIPTION
## Summary
- enable VitePWA plugin import
- configure auto-update registration while keeping service worker disabled

## Testing
- `npm run typecheck` *(fails: Cannot find module 'virtual:pwa-register' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afc3bac6048329b6b1477c3bd373e3