### PR TITLE
Add boot error fallback to client app

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,8 +3,14 @@ import ReactDOM from 'react-dom/client';
 
 import App from './App';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+try {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+  console.log('[boot] rendered');
+} catch (err) {
+  console.error('[boot] render failed', err); // show full stack
+  document.body.innerHTML = "<pre style='color:red'>" + err + '</pre>';
+}


### PR DESCRIPTION
## Summary
- wrap client React root render in try/catch to log render and show error fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: type errors in various files)*

------
https://chatgpt.com/codex/tasks/task_e_68afc83f3e708329946e8743b0500228