### PR TITLE
fix: add GlobalErrorBoundary and guard optional integrations

### DIFF
--- a/src/GlobalErrorBoundary.tsx
+++ b/src/GlobalErrorBoundary.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export class GlobalErrorBoundary extends React.Component<{ children: React.ReactNode }, { err?: any }> {
+  state = { err: undefined as any };
+
+  static getDerivedStateFromError(err: any) {
+    return { err };
+  }
+
+  componentDidCatch(err: any, info: any) {
+    console.error('[boot] render failed', err, info);
+  }
+
+  render() {
+    if (!this.state.err) return this.props.children as any;
+    return (
+      <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif' }}>
+        <h1>Something went wrong</h1>
+        <pre style={{ whiteSpace: 'pre-wrap' }}>
+          {String(this.state.err?.stack || this.state.err)}
+        </pre>
+      </div>
+    );
+  }
+}

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,9 +1,14 @@
 import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
-export function createClient() {
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.error('[supabase] missing env: VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY');
+}
+
+export function createClient(): any {
+  if (!supabaseUrl || !supabaseAnonKey) return null;
   return createSupabaseClient(supabaseUrl, supabaseAnonKey);
 }
 

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -1,0 +1,10 @@
+export function getMetaMask() {
+  try {
+    // @ts-ignore
+    const { ethereum } = window;
+    if (!ethereum || !ethereum.isMetaMask) return null;
+    return ethereum;
+  } catch {
+    return null;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import './index.css';
 import { loadFlags } from './lib/flags';
 import { sendEvent } from './lib/telemetry';
 import { ensureNoServiceWorker } from './lib/disableSW';
+import { GlobalErrorBoundary } from './GlobalErrorBoundary';
 
 ensureNoServiceWorker();
 
@@ -31,7 +32,9 @@ function mount() {
     root.render(
       <React.StrictMode>
         <BrowserRouter>
-          <AppShell />
+          <GlobalErrorBoundary>
+            <AppShell />
+          </GlobalErrorBoundary>
         </BrowserRouter>
       </React.StrictMode>,
     );
@@ -47,8 +50,7 @@ function mount() {
     const pre = document.createElement('pre');
     pre.style.padding = '16px';
     pre.style.whiteSpace = 'pre-wrap';
-    pre.textContent = 'Boot failed:\n' + ((err as any)?.stack || String(err));
-    document.body.innerHTML = '';
+    pre.textContent = String((err as any)?.stack || err);
     document.body.appendChild(pre);
   }
 }


### PR DESCRIPTION
## Summary
- wrap app with a global error boundary
- guard optional MetaMask client
- validate Supabase env vars and avoid hard crash when missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Partial<Omit...' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afc9cdc5e083299ba7043fe59d9fee