### PR TITLE
Fix blank screen by updating CSP headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,6 +3,13 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Cache-Control: public, max-age=31536000, immutable
+  Content-Security-Policy: default-src 'self';
+    script-src 'self' 'unsafe-eval' 'unsafe-inline' https:;
+    style-src  'self' 'unsafe-inline' https:;
+    img-src    'self' data: https:;
+    connect-src 'self' https://*.supabase.co https://*.netlify.app https://*.netlify.com;
+    font-src   'self' https: data:;
+    frame-src  'self' https:;
 
 /*.html
   Content-Type: text/html; charset=UTF-8


### PR DESCRIPTION
## Summary
- allow unsafe-eval in site-wide CSP so current bundle renders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'Partial<Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "created_at" | "id" | "updated_at">>' is not assignable to parameter of type 'never'.)*

------
https://chatgpt.com/codex/tasks/task_e_68afd0a914208329a1bc0f7537498f31