### PR TITLE
Fix blank branch deploy: add visible boot fallback + relax CSP only for branch deploys

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,10 +61,57 @@
         z-index: 1000;
       }
     </style>
+    <!-- Boot fallback styles (visible before JS) -->
+    <style>
+      #boot {
+        position: fixed;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        font: 600 18px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+        background: #ffffff;
+        color: #0eae5e;
+        letter-spacing: .2px;
+      }
+      #boot small {
+        display: block;
+        margin-top: .5rem;
+        color: #667085;
+        font-weight: 500;
+      }
+      .hidden {
+        display: none !important;
+      }
+    </style>
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
+    <!-- NEW: visible immediately so branch deploys never look blank -->
+    <div id="boot">
+      Naturverse is loading…
+      <small>If this takes more than a few seconds, refresh the page.</small>
+    </div>
+
     <div id="root"></div>
+
+    <!-- Hide boot screen once the app sets window.__NATURVERSE_READY__ -->
+    <script>
+      (function () {
+        function hideBoot() {
+          var el = document.getElementById('boot');
+          if (el) el.classList.add('hidden');
+        }
+        if (window.__NATURVERSE_READY__) hideBoot();
+        else window.addEventListener('naturverse:ready', hideBoot, { once: true });
+        document.addEventListener('DOMContentLoaded', function () {
+          // secondary timeout just in case hydration finishes slightly later
+          setTimeout(function () {
+            if (window.__NATURVERSE_READY__) hideBoot();
+          }, 0);
+        });
+      })();
+    </script>
+
     <script type="module" src="/src/main.tsx"></script>
 
     <!-- perf: lazy-enable all imgs that don't opt-out -->

--- a/netlify.toml
+++ b/netlify.toml
@@ -37,3 +37,17 @@
   for = "/index.html"
   [headers.values]
     Cache-Control = "no-store, must-revalidate"
+
+# Branch deploys: make CSP permissive so previews don’t white-screen,
+# and ensure the service worker cannot get stuck.
+[context."branch-deploy"]
+
+  [[context."branch-deploy".headers]]
+  for = "/*"
+    [context."branch-deploy".headers.values]
+    Content-Security-Policy = "default-src 'self' https: data: blob:; script-src 'self' https: 'unsafe-inline' 'unsafe-eval'; style-src 'self' https: 'unsafe-inline'; img-src 'self' https: data: blob:; font-src 'self' https: data:; connect-src 'self' https: wss:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'"
+
+  [[context."branch-deploy".headers]]
+  for = "/sw.js"
+    [context."branch-deploy".headers.values]
+    Cache-Control = "no-store, no-cache, must-revalidate, max-age=0"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,12 @@ import { GlobalErrorBoundary } from './components/GlobalErrorBoundary';
 
 ensureNoServiceWorker();
 
+declare global {
+  interface Window {
+    __NATURVERSE_READY__?: boolean;
+  }
+}
+
 // ---- Boot diagnostics: never silently white-screen
 window.addEventListener('error', (e) => {
   console.error('[naturverse] window error', (e as ErrorEvent).error ?? e.message ?? e);
@@ -38,6 +44,8 @@ function mount() {
         </GlobalErrorBoundary>
       </React.StrictMode>,
     );
+    window.__NATURVERSE_READY__ = true;
+    window.dispatchEvent(new Event('naturverse:ready'));
     console.log('[boot] rendered');
     (async () => {
       const flags = await loadFlags();


### PR DESCRIPTION
## Summary
- add boot screen so branch deploys aren't blank
- hide boot screen when React signals readiness
- relax Content-Security-Policy and disable SW caching for branch deploys

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afd36c7e9c83298c054bd3efaa50eb