### PR TITLE
chore(pwa): fix manifest/icons + font preload; quiet optional upsert

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,9 +34,22 @@
       <meta name="twitter:image" content="/favicon-256x256.png" />
     <link rel="canonical" href="https://naturverse.netlify.app/" />
 
-      <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
-      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-      <link rel="alternate icon" href="/favicon.ico" />
+      <link rel="icon" href="/favicon.ico" sizes="any" />
+      <link
+        rel="icon"
+        type="image/png"
+        href="/favicon-256x256.png"
+        sizes="256x256"
+      />
+      <link rel="apple-touch-icon" href="/favicon-256x256.png" />
+      <link rel="manifest" href="/manifest.webmanifest" />
+      <link
+        rel="preload"
+        href="/fonts/your-main-font.woff2"
+        as="font"
+        type="font/woff2"
+        crossorigin
+      />
       <link rel="stylesheet" href="/src/main.css" />
 
     <!-- a11y: skip to content -->

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -4,9 +4,8 @@
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#2b64ff",
+  "theme_color": "#0ea5e9",
   "icons": [
-    { "src": "/favicon-128x128.png", "sizes": "128x128", "type": "image/png", "purpose": "any" },
-    { "src": "/favicon-256x256.png", "sizes": "256x256", "type": "image/png", "purpose": "any" }
+    { "src": "/favicon-256x256.png", "sizes": "256x256", "type": "image/png" }
   ]
 }


### PR DESCRIPTION
## Summary
- add PWA manifest with 256px icon
- update index.html icons and font preload
- make profile upsert resilient and warn on errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TS errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68affaa9aaa8832984e9040ae0348813