### PR TITLE
chore: add lightweight “Naturverse is Live ✨” banner (safe baseline check)

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,42 @@
     </style>
   </head>
   <body>
+    <!-- BEGIN: Safe production banner -->
+    <style>
+      #prod-banner {
+        position: sticky;
+        top: 0;
+        z-index: 9999;
+        width: 100%;
+        box-sizing: border-box;
+        padding: 8px 12px;
+        background: #1e63ff; /* Naturverse blue */
+        color: #fff;
+        font: 600 14px/1.3 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+        text-align: center;
+        letter-spacing: .1px;
+      }
+      #prod-banner a {
+        color: #fff;
+        text-decoration: underline;
+        text-underline-offset: 2px;
+      }
+      #prod-banner[hidden] { display: none; }
+    </style>
+
+    <div id="prod-banner" hidden>
+      Naturverse is Live ✨ — Welcome explorers!
+    </div>
+
+    <script>
+      // Show the banner only on the homepage.
+      try {
+        var isHome = (location.pathname === "/" || location.pathname === "");
+        var el = document.getElementById("prod-banner");
+        if (el && isHome) el.hidden = false;
+      } catch (_) {}
+    </script>
+    <!-- END: Safe production banner -->
     <a class="skip-link" href="#main">Skip to content</a>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>


### PR DESCRIPTION
## Summary
- add minimal blue banner to verify Codex → PR → Netlify loop
- pure HTML/CSS/JS on entry page; framework untouched
- banner appears only on root path, hidden elsewhere

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b017c407c083298cafc37eb6460a54