### PR TITLE
Add telemetry & health guards for Naturverse MVP

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { organizationLd, websiteLd } from './lib/jsonld';
 import { CartProvider } from './lib/cart';
 import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
+import { logEvent } from './utils/telemetry';
 import './styles/magic.css';
 // TEMP: disable interactions while we isolate the crash
 // import { initInteractions } from './init/interactions';
@@ -12,6 +13,7 @@ import './init/runtime-logger'; // lightweight global error hooks
 
 export default function App() {
   useEffect(() => {
+    logEvent('AppStarted', { timestamp: Date.now() });
     // SAFE MODE: interactions temporarily disabled
   }, []);
   return (

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import { logEvent } from "../utils/telemetry";
 
 type Props = {
   children: React.ReactNode;
@@ -17,7 +18,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: unknown, info: unknown) {
-    // Keep this simple; sending to a logger can be added later.
+    logEvent("ErrorBoundary", { error });
     // eslint-disable-next-line no-console
     console.error("[naturverse] ErrorBoundary caught", error, info);
   }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createBrowserRouter } from 'react-router-dom';
+import { logEvent } from './utils/telemetry';
 
 import Home from './pages/Home';
 import WorldsIndex from './routes/worlds';
@@ -117,3 +118,14 @@ export const router = createBrowserRouter([
     ],
   },
 ]);
+
+if (typeof window !== 'undefined') {
+  let prev = window.location.pathname;
+  router.subscribe((state) => {
+    const next = state.location.pathname;
+    if (next !== prev) {
+      prev = next;
+      logEvent('RouteChange', { path: next });
+    }
+  });
+}

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -1,0 +1,4 @@
+export function logEvent(event: string, meta?: Record<string, unknown>) {
+  // eslint-disable-next-line no-console
+  console.info("[Telemetry]", event, meta);
+}


### PR DESCRIPTION
## Summary
- add telemetry helper for future external logging
- log app start and route changes
- report error boundary failures through telemetry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next', TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b01c095498832993c0e00d43961478