### PR TITLE
Add Netlify environment guard + build polish

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -1,0 +1,19 @@
+# Deployment Quickstart
+
+This guide helps you deploy Naturverse with Netlify and Supabase.
+
+## Netlify
+
+1. Create a Netlify site and link it to this repository.
+2. In **Site settings → Environment variables**, define:
+   - `SUPABASE_URL`
+   - `SUPABASE_ANON_KEY`
+3. Deploy. The build will fail early if any of these values are missing.
+
+## Supabase
+
+1. Create a project at [Supabase](https://supabase.com/).
+2. Under **Project settings → API**, copy the project URL and anon key.
+3. Paste these values into Netlify's environment variables.
+
+That's it — push to main to trigger future deploys.

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
         z-index: 9999;
         width: 100%;
         box-sizing: border-box;
-        padding: 8px 12px;
+        padding: 8px 16px;
         background: #1e63ff; /* Naturverse blue */
         color: #fff;
         font: 600 14px/1.3 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm install && npm run build"
+  command = "npm install && node scripts/guard-netlify-env.mjs && npm run build"
   publish = "dist"
 
 [functions]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build:galleries": "node scripts/build-kingdom-gallery.js",
     "build": "npm run build:galleries && vite build",
     "preview": "vite preview --port 5173",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "guard:netlify": "node scripts/guard-netlify-env.mjs"
   },
   "dependencies": {
     "@vercel/og": "^0.8.2",

--- a/scripts/guard-netlify-env.mjs
+++ b/scripts/guard-netlify-env.mjs
@@ -1,0 +1,8 @@
+const required = ["SUPABASE_URL", "SUPABASE_ANON_KEY"];
+const missing = required.filter((key) => !process.env[key]);
+if (missing.length) {
+  console.error("\nMissing required environment variables:\n  " + missing.join("\n  "));
+  console.error("\nPlease set the variables in your Netlify project settings.\n");
+  process.exit(1);
+}
+console.log("Netlify environment check passed.");

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -38,8 +38,8 @@ export class ErrorBoundary extends React.Component<Props, State> {
 }
 
 function Fallback({
-  title = "Something went wrong.",
-  note = "You can try again, or head back to the home page.",
+  title = "Oops! A glitch in the Naturverse.",
+  note = "Please try again or head back home.",
   onRetry,
 }: {
   title?: string;

--- a/src/styles/home.module.css
+++ b/src/styles/home.module.css
@@ -8,6 +8,7 @@
 .hero{
   max-width: 980px;
   margin: 0 auto 1.25rem;
+  padding: 0 1rem;
   text-align: center;
 }
 
@@ -61,6 +62,7 @@
 .topTileTitle{
   font-weight: 800;
   font-size: 1.2rem;
+  display: block;
   margin-bottom: .25rem;
 }
 .disabled{


### PR DESCRIPTION
## Summary
- guard Netlify deploys by verifying required Supabase env vars
- upgrade error boundary with branded fallback message
- polish home banner spacing and Play/Learn/Earn card alignment
- document Netlify + Supabase setup

## Testing
- `env -u SUPABASE_URL -u SUPABASE_ANON_KEY node scripts/guard-netlify-env.mjs` (fails as expected)
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: TS errors in src/lib/api and src/pages/Navatar.tsx)
- `npm run build` (fails: Cannot find package '@vitejs/plugin-react-swc')

------
https://chatgpt.com/codex/tasks/task_e_68b01e76655c832997ba97621c7c8473