### PR TITLE
chore: expand netlify env guard

### DIFF
--- a/scripts/guard-netlify-env.mjs
+++ b/scripts/guard-netlify-env.mjs
@@ -1,8 +1,19 @@
-const required = ["SUPABASE_URL", "SUPABASE_ANON_KEY"];
-const missing = required.filter((key) => !process.env[key]);
+const NEED = {
+  SUPABASE_URL: ["VITE_SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_URL"],
+  SUPABASE_ANON_KEY: ["VITE_SUPABASE_ANON_KEY", "NEXT_PUBLIC_SUPABASE_ANON_KEY"],
+};
+
+const missing = [];
+for (const base of Object.keys(NEED)) {
+  const found =
+    process.env[base] ?? NEED[base].map((k) => process.env[k]).find(Boolean);
+  if (!found)
+    missing.push(`${base} (or ${NEED[base].join(" / ")})`);
+}
+
 if (missing.length) {
-  console.error("\nMissing required environment variables:\n  " + missing.join("\n  "));
-  console.error("\nPlease set the variables in your Netlify project settings.\n");
+  console.error(`Missing required env var(s): ${missing.join(", ")}`);
   process.exit(1);
 }
 console.log("Netlify environment check passed.");
+


### PR DESCRIPTION
## Summary
- broaden Netlify env check to consider Vite and Next.js variable aliases

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' and other type errors)*
- `SUPABASE_URL=https://example.com SUPABASE_ANON_KEY=xyz node scripts/guard-netlify-env.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b0229251548329a993939c1eeeb009