### PR TITLE
Add global Footer + nav polish (safe, no deps)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import './styles/magic.css';
 // TEMP: disable interactions while we isolate the crash
 // import { initInteractions } from './init/interactions';
 import './init/runtime-logger'; // lightweight global error hooks
+import Footer from './components/Footer';
+import './styles/footer.css';
 
 export default function App() {
   useEffect(() => {
@@ -18,24 +20,27 @@ export default function App() {
   }, []);
   return (
     <CartProvider>
-      <>
-        {/* Global route side-effects (scroll & focus) */}
-        <RouteFX />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
-        />
-        <main id="main" className="nv-page">
-          <div className="container">
-            <RouterProvider router={router} />
-          </div>
-        </main>
-        <ToasterListener />
-      </>
+      <div id="nv-page">
+        <div className="nv-content">
+          {/* Global route side-effects (scroll & focus) */}
+          <RouteFX />
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
+          />
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
+          />
+          <main id="main">
+            <div className="container">
+              <RouterProvider router={router} />
+            </div>
+          </main>
+          <ToasterListener />
+        </div>
+        <Footer />
+      </div>
     </CartProvider>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,17 +1,22 @@
 import React from "react";
-import { FOOTER_LINKS } from "../data/footer";
 
 export default function Footer() {
+  const year = new Date().getFullYear();
   return (
-    <footer className="site-footer">
-      <div className="container" style={{display:"flex",justifyContent:"space-between",alignItems:"center",gap:12}}>
-        <small style={{ color: "var(--nv-blue-600)" }}>
-          © {new Date().getFullYear()} Naturverse™
-        </small>
-        <nav style={{display:"flex",gap:12,flexWrap:"wrap"}}>
-          {FOOTER_LINKS.map(l => (
-            <a key={l.href} href={l.href} className="muted">{l.label}</a>
-          ))}
+    <footer
+      role="contentinfo"
+      className="nv-footer"
+      aria-label="Site footer"
+    >
+      <div className="nv-footer__inner">
+        <p className="nv-footer__copy">© {year} Turian Media Company</p>
+
+        <nav aria-label="Footer">
+          <ul className="nv-footer__links">
+            <li><a href="/privacy" className="nv-footer__link">Privacy Policy</a></li>
+            <li><a href="/terms" className="nv-footer__link">Terms</a></li>
+            <li><a href="/contact" className="nv-footer__link">Contact</a></li>
+          </ul>
         </nav>
       </div>
     </footer>

--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -1,96 +1,20 @@
-.nv-header {
-  position: sticky;
-  top: 0;
-  z-index: 30;
-  background: var(--nv-bg);
-}
-.nv-header__inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 10px 16px;
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-.nv-brand {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  text-decoration: none;
-  color: inherit;
-}
-
-.nv-logo {
-  display: inline-block;
-}
-
+/* Tiny visual polish for the top navigation */
 .nv-nav {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 14px;
-  margin-left: auto;
-}
-.nv-nav a {
-  color: var(--nv-ink);
-  text-decoration: none;
-  opacity: 0.86;
-}
-.nv-nav a.active {
-  font-weight: 600;
-  opacity: 1;
+  --nv-pad-x: 14px;
+  padding: 10px var(--nv-pad-x);
 }
 
-.nv-nav-toggle {
-  display: none;
-  border: 1px solid var(--nv-border);
-  background: var(--nv-card-bg);
-  border-radius: 10px;
-  width: 36px;
-  height: 36px;
-  align-items: center;
-  justify-content: center;
-}
-.nv-burger {
-  width: 18px;
-  height: 2px;
-  background: var(--nv-ink);
-  position: relative;
-  display: block;
-}
-.nv-burger:before,
-.nv-burger:after {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: var(--nv-ink);
-}
-.nv-burger:before {
-  top: -6px;
-}
-.nv-burger:after {
-  top: 6px;
+.nv-nav__links a {
+  display: inline-block;
+  padding: 6px 8px;
+  border-radius: 8px;
 }
 
-@media (max-width: 860px) {
-  .nv-nav-toggle {
-    display: flex;
-  }
-  .nv-nav {
-    display: none;
-    position: absolute;
-    top: 56px;
-    left: 0;
-    right: 0;
-    padding: 10px 16px 14px;
-    background: var(--nv-bg);
-    border-bottom: 1px solid var(--nv-border);
-  }
-  .nv-nav.is-open {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px 18px;
-  }
+.nv-nav__links a:hover,
+.nv-nav__links a:focus-visible {
+  background: rgba(0,0,0,.05);
+}
+
+.nv-nav__links a[aria-current="page"] {
+  outline: 2px solid rgba(0,0,0,.08);
 }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { useState } from 'react';
 import styles from './NavBar.module.css';
+import './NavBar.css';
 import { useAuth } from '@/lib/auth-context';
 
 export default function NavBar() {
@@ -11,7 +12,7 @@ export default function NavBar() {
   const emoji = (user?.user_metadata?.navemoji as string) ?? '🧑';
 
   return (
-    <header className={styles.header}>
+    <header className={`${styles.header} nv-nav`}>
       <div className={`container ${styles.inner}`}>
         {/* Left brand (logo + wordmark) */}
         <a
@@ -35,27 +36,27 @@ export default function NavBar() {
           <span className="nv-brand text-nv-blue">Naturverse</span>
         </a>
 
-        <nav className={styles.links} aria-label="Primary">
-          <Link to="/worlds">Worlds</Link>
-          <Link to="/zones">Zones</Link>
-          <Link to="/marketplace">Marketplace</Link>
-          <Link to="/wishlist">Wishlist</Link>
-          <Link to="/naturversity">Naturversity</Link>
-          <Link to="/naturbank">NaturBank</Link>
-          <Link to="/navatar">Navatar</Link>
-          <Link to="/passport">Passport</Link>
-          <Link to="/turian">Turian</Link>
+        <nav className={`${styles.links} nv-nav__links`} aria-label="Primary">
+          <NavLink to="/worlds">Worlds</NavLink>
+          <NavLink to="/zones">Zones</NavLink>
+          <NavLink to="/marketplace">Marketplace</NavLink>
+          <NavLink to="/wishlist">Wishlist</NavLink>
+          <NavLink to="/naturversity">Naturversity</NavLink>
+          <NavLink to="/naturbank">NaturBank</NavLink>
+          <NavLink to="/navatar">Navatar</NavLink>
+          <NavLink to="/passport">Passport</NavLink>
+          <NavLink to="/turian">Turian</NavLink>
         </nav>
 
         <div className={styles.right} key={user?.id ?? 'anon'}>
           {ready && user && (
             <>
-              <Link to="/cart" aria-label="Cart" className={styles.cartBtn}>
+              <NavLink to="/cart" aria-label="Cart" className={styles.cartBtn}>
                 🛒
-              </Link>
-              <Link to="/profile" aria-label="Profile" className={styles.profileBtn}>
+              </NavLink>
+              <NavLink to="/profile" aria-label="Profile" className={styles.profileBtn}>
                 {emoji}
-              </Link>
+              </NavLink>
             </>
           )}
 
@@ -75,20 +76,20 @@ export default function NavBar() {
       <div className={`${styles.mobile} ${open ? styles.open : ''}`} onClick={() => setOpen(false)}>
         <div className={styles.sheet} onClick={(e) => e.stopPropagation()}>
           {ready && user && (
-            <Link to="/profile" className={styles.mobileProfile}>
+            <NavLink to="/profile" className={styles.mobileProfile}>
               <span className={styles.mobileEmoji}>{emoji}</span>
               <span>Profile</span>
-            </Link>
+            </NavLink>
           )}
-          <Link to="/worlds">Worlds</Link>
-          <Link to="/zones">Zones</Link>
-          <Link to="/marketplace">Marketplace</Link>
-          <Link to="/wishlist">Wishlist</Link>
-          <Link to="/naturversity">Naturversity</Link>
-          <Link to="/naturbank">NaturBank</Link>
-          <Link to="/navatar">Navatar</Link>
-          <Link to="/passport">Passport</Link>
-          <Link to="/turian">Turian</Link>
+          <NavLink to="/worlds">Worlds</NavLink>
+          <NavLink to="/zones">Zones</NavLink>
+          <NavLink to="/marketplace">Marketplace</NavLink>
+          <NavLink to="/wishlist">Wishlist</NavLink>
+          <NavLink to="/naturversity">Naturversity</NavLink>
+          <NavLink to="/naturbank">NaturBank</NavLink>
+          <NavLink to="/navatar">Navatar</NavLink>
+          <NavLink to="/passport">Passport</NavLink>
+          <NavLink to="/turian">Turian</NavLink>
         </div>
       </div>
     </header>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,9 +1,10 @@
+import React from "react";
+
 export default function Contact() {
   return (
-    <main id="main">
+    <main style={{ maxWidth: 900, margin: "24px auto", padding: "0 20px" }}>
       <h1>Contact</h1>
-      <p>Email: <a href="mailto:info@naturverse.com">info@naturverse.com</a></p>
-      <p>X / Twitter: <a href="https://x.com/turianthedurian" target="_blank" rel="noreferrer">@turianthedurian</a></p>
+      <p>Reach us at <a href="mailto:hello@thenaturverse.com">hello@thenaturverse.com</a>.</p>
     </main>
   );
 }

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,8 +1,10 @@
+import React from "react";
+
 export default function Privacy() {
   return (
-    <main id="main">
+    <main style={{ maxWidth: 900, margin: "24px auto", padding: "0 20px" }}>
       <h1>Privacy Policy</h1>
-      <p>We respect your privacy. This is placeholder content until the full policy is ready.</p>
+      <p>This is a placeholder. Replace with your real policy.</p>
     </main>
   );
 }

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,8 +1,10 @@
+import React from "react";
+
 export default function Terms() {
   return (
-    <main id="main">
+    <main style={{ maxWidth: 900, margin: "24px auto", padding: "0 20px" }}>
       <h1>Terms of Service</h1>
-      <p>These are placeholder terms. Full legal copy will be added later.</p>
+      <p>This is a placeholder. Replace with your real terms.</p>
     </main>
   );
 }

--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -1,45 +1,55 @@
-.site-footer {
+/* --- Footer base styles (low-risk) --- */
+.nv-footer {
+  border-top: 1px dashed rgba(0,0,0,.12);
+  margin-top: 24px;
+  background: #ffffff;
+}
+
+.nv-footer__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 16px 20px;
   display: flex;
+  gap: 16px;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
 }
 
-.footer-brand {
+.nv-footer__copy {
+  margin: 0;
+  font-size: 13px;
+  opacity: .8;
+}
+
+.nv-footer__links {
+  margin: 0;
+  padding: 0;
   display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 120px; /* keeps logo from shrinking to zero */
+  gap: 14px;
+  list-style: none;
 }
 
-.footer-brand img {
-  height: 28px;
-  width: auto;
-  display: block;
+.nv-footer__link {
+  font-size: 13px;
+  text-decoration: none;
+  border-bottom: 1px dotted transparent;
 }
 
-.footer-links,
-.footer-social {
+.nv-footer__link:hover,
+.nv-footer__link:focus-visible {
+  border-bottom-color: currentColor;
+}
+
+/* Sticky *when content is short* (no overlap) */
+#nv-page {
+  min-height: 100dvh;
   display: flex;
-  gap: 12px;
-  align-items: center;
-  white-space: nowrap;
+  flex-direction: column;
 }
-
-/* small screens: allow wrap but keep logo tidy */
-@media (max-width: 640px) {
-  .site-footer {
-    flex-wrap: wrap;
-    row-gap: 8px;
-  }
-  .footer-brand {
-    order: 0;
-  }
-  .footer-social {
-    order: 1;
-  }
-  .footer-links {
-    order: 2;
-  }
+#nv-page > .nv-content {
+  flex: 1 0 auto;
+}
+#nv-page > .nv-footer {
+  flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
- introduce Footer component with basic Privacy, Terms, and Contact links
- polish navigation hover/active states with lightweight CSS
- wrap App output so footer renders globally

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'Partial<Omit<...>>' is not assignable to parameter of type 'never')*


------
https://chatgpt.com/codex/tasks/task_e_68b024776aac8329ab7898e96b786ec6