### PR TITLE
SEO basics: add robots.txt + sitemap.xml (zero-risk, no deps)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,3 +23,13 @@
   for = "/*"
   [headers.values]
     Cache-Control = "public, max-age=1800"
+
+[[headers]]
+  for = "/sitemap.xml"
+  [headers.values]
+    Content-Type = "application/xml; charset=utf-8"
+
+[[headers]]
+  for = "/robots.txt"
+  [headers.values]
+    Content-Type = "text/plain; charset=utf-8"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,8 @@
+# Naturverse robots policy
 User-agent: *
 Allow: /
 
-Sitemap: /sitemap.xml
+# Crawl-delay kept minimal to avoid throttling; adjust if needed.
+# Crawl-delay: 2
+
+Sitemap: https://thenaturverse.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>/</loc></url>
-  <url><loc>/worlds</loc></url>
-  <url><loc>/zones</loc></url>
-  <url><loc>/marketplace</loc></url>
-  <url><loc>/naturversity</loc></url>
-  <url><loc>/navatar</loc></url>
-  <url><loc>/passport</loc></url>
-  <url><loc>/naturbank</loc></url>
-  <url><loc>/turian</loc></url>
-  <url><loc>/profile</loc></url>
+  <!-- Top-level routes -->
+  <url><loc>https://thenaturverse.com/</loc><changefreq>daily</changefreq><priority>1.0</priority><lastmod>2025-08-28</lastmod></url>
+  <url><loc>https://thenaturverse.com/worlds</loc><changefreq>weekly</changefreq><priority>0.9</priority><lastmod>2025-08-28</lastmod></url>
+  <url><loc>https://thenaturverse.com/zones</loc><changefreq>weekly</changefreq><priority>0.9</priority><lastmod>2025-08-28</lastmod></url>
+  <url><loc>https://thenaturverse.com/marketplace</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2025-08-28</lastmod></url>
+  <url><loc>https://thenaturverse.com/wishlist</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2025-08-28</lastmod></url>
+  <url><loc>https://thenaturverse.com/naturversity</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2025-08-28</lastmod></url>
+  <url><loc>https://thenaturverse.com/naturbank</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2025-08-28</lastmod></url>
+  <url><loc>https://thenaturverse.com/navatar</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2025-08-28</lastmod></url>
+  <url><loc>https://thenaturverse.com/passport</loc><changefreq>weekly</changefreq><priority>0.5</priority><lastmod>2025-08-28</lastmod></url>
+  <url><loc>https://thenaturverse.com/turian</loc><changefreq>weekly</changefreq><priority>0.4</priority><lastmod>2025-08-28</lastmod></url>
 </urlset>


### PR DESCRIPTION
## Summary
- allow all crawlers and link to sitemap via `robots.txt`
- provide a static `sitemap.xml` for key Naturverse routes
- add Netlify headers for correct `Content-Type` on sitemap and robots

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type... and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b028b44eb88329892fa7f8ba2821d4