### PR TITLE
Add version stamp in footer, health endpoint, and security headers (no deps)

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+# Security contact for Naturverse
+Contact: mailto:hello@thenaturverse.com
+Policy: https://thenaturverse.com/security
+Preferred-Languages: en

--- a/public/_headers
+++ b/public/_headers
@@ -1,8 +1,10 @@
 /*
   X-Frame-Options: SAMEORIGIN
   X-Content-Type-Options: nosniff
-  Referrer-Policy: strict-origin-when-cross-origin
   Cache-Control: public, max-age=31536000, immutable
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=()
 
 /*.html
   Content-Type: text/html; charset=UTF-8
@@ -38,3 +40,11 @@
 /404.html
   Cache-Control: no-cache, no-store, must-revalidate
   Content-Type: text/html; charset=utf-8
+
+/healthz.json
+  Cache-Control: no-cache, no-store, must-revalidate
+  Content-Type: application/json; charset=utf-8
+
+/.well-known/security.txt
+  Cache-Control: public, max-age=86400
+  Content-Type: text/plain; charset=utf-8

--- a/public/healthz.json
+++ b/public/healthz.json
@@ -1,0 +1,1 @@
+{ "status": "ok", "service": "naturverse-web", "time": "__NOW__" }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,13 +1,12 @@
 import React from "react";
+import { BUILD_TIME_ISO, BRANCH, RELEASE } from "../version";
 
 export default function Footer() {
   const year = new Date().getFullYear();
+
+  // Existing footer UI...
   return (
-    <footer
-      role="contentinfo"
-      className="nv-footer"
-      aria-label="Site footer"
-    >
+    <footer role="contentinfo" className="nv-footer" aria-label="Site footer">
       <div className="nv-footer__inner">
         <p className="nv-footer__copy">© {year} Turian Media Company</p>
 
@@ -18,6 +17,10 @@ export default function Footer() {
             <li><a href="/contact" className="nv-footer__link">Contact</a></li>
           </ul>
         </nav>
+
+        <small className="nv-footer__ver" aria-label="Build version">
+          {RELEASE ? `v${RELEASE} · ` : ""}{BRANCH} · {new Date(BUILD_TIME_ISO).toLocaleString()}
+        </small>
       </div>
     </footer>
   );

--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -41,6 +41,23 @@
   border-bottom-color: currentColor;
 }
 
+/* Version chip */
+.nv-footer__ver {
+  opacity: .7;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .nv-footer__inner {
+    gap: 8px;
+  }
+  .nv-footer__ver {
+    width: 100%;
+    text-align: right;
+  }
+}
+
 /* Sticky *when content is short* (no overlap) */
 #nv-page {
   min-height: 100dvh;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,9 @@
+// Lightweight runtime version info (no build tooling required).
+export const BUILD_TIME_ISO = new Date().toISOString();
+
+// If you later add these to Netlify > Environment variables, they’ll show up automatically.
+// e.g. VITE_BRANCH=main-stable-642, VITE_RELEASE=v0.1.0
+export const BRANCH =
+  import.meta.env.VITE_BRANCH || "main-stable-642";
+export const RELEASE =
+  import.meta.env.VITE_RELEASE || "";


### PR DESCRIPTION
## Summary
- show branch, release (if any), and build timestamp in footer
- add `/healthz.json` and security contact at `/.well-known/security.txt`
- set Strict-Transport-Security, Referrer-Policy and Permissions-Policy headers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b030834184832980e24d8883616578