### PR TITLE
Add PWA manifest + baseline service worker for Naturverse

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,14 @@
     <script src="/kill-sw.js?v=2" defer></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Naturverse</title>
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <!-- PWA manifest -->
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#1e66ff" />
 
-    <!-- Replace deprecated Apple-only meta with cross-platform one -->
-    <meta name="mobile-web-app-capable" content="yes" />
+    <!-- iOS install hints -->
+    <link rel="apple-touch-icon" href="/favicon-192x192.png" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 
     <!-- === Naturverse SEO defaults (safe, no runtime/deps) === -->
     <link rel="canonical" href="https://thenaturverse.com" />
@@ -18,9 +21,6 @@
       name="description"
       content="Naturverse — a playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness."
     />
-
-    <!-- PWA / UI hints -->
-    <meta name="theme-color" content="#1e66ff" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
@@ -72,10 +72,6 @@
     }
     </script>
     <!-- === / JSON-LD === -->
-
-    <!-- Optional iOS hints (safe if present) -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <link rel="apple-touch-icon" href="/favicon-192x192.png" />
 
     <!-- Preload the 64x64 (crisp and safe) so favicon appears immediately -->
     <link rel="preload" as="image" href="/favicon-64x64.png" imagesizes="64x64" />
@@ -135,6 +131,17 @@
           .querySelectorAll('img:not([loading])')
           .forEach((img) => img.setAttribute('loading', 'lazy'));
       });
+    </script>
+
+    <!-- Register baseline service worker -->
+    <script>
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker
+            .register("/sw.js")
+            .catch((err) => console.error("SW registration failed", err));
+        });
+      }
     </script>
   </body>
 </html>

--- a/public/_headers
+++ b/public/_headers
@@ -27,15 +27,12 @@
   Content-Type: text/plain; charset=utf-8
   Cache-Control: public, max-age=86400
 
-/sw.js
-  Cache-Control: no-cache
+  /workbox-*.js
+    Cache-Control: public, max-age=31536000, immutable
 
-/workbox-*.js
-  Cache-Control: public, max-age=31536000, immutable
-
-/manifest.webmanifest
-  Content-Type: application/manifest+json; charset=utf-8
-  Cache-Control: no-cache
+  /manifest.webmanifest
+    Content-Type: application/manifest+json; charset=utf-8
+    Cache-Control: no-cache
 
 /404.html
   Cache-Control: no-cache, no-store, must-revalidate
@@ -48,3 +45,11 @@
 /.well-known/security.txt
   Cache-Control: public, max-age=86400
   Content-Type: text/plain; charset=utf-8
+
+/manifest.json
+  Cache-Control: no-cache, no-store, must-revalidate
+  Content-Type: application/json; charset=utf-8
+
+/sw.js
+  Cache-Control: no-cache, no-store, must-revalidate
+  Content-Type: application/javascript; charset=utf-8

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "Naturverse",
+  "short_name": "Naturverse",
+  "description": "A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#1e66ff",
+  "orientation": "portrait-primary",
+  "icons": [
+    { "src": "/favicon-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/favicon-512x512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,31 @@
+// Naturverse service worker (baseline, cache-first for static assets only)
+// Caution: minimal to avoid offline bugs.
+
+const CACHE_NAME = "naturverse-static-v1";
+const ASSETS = ["/", "/index.html", "/favicon-192x192.png", "/manifest.json"];
+
+self.addEventListener("install", (evt) => {
+  evt.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener("activate", (evt) => {
+  evt.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.map((k) => k !== CACHE_NAME && caches.delete(k)))
+    )
+  );
+});
+
+self.addEventListener("fetch", (evt) => {
+  const { request } = evt;
+  if (request.method !== "GET") return;
+  if (request.url.includes("/api/")) return; // never cache API calls
+
+  evt.respondWith(
+    caches.match(request).then(
+      (resp) => resp || fetch(request).catch(() => caches.match("/index.html"))
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- add manifest.json for Naturverse PWA
- add baseline service worker with static caching
- register service worker and PWA hints in index.html
- configure headers for manifest and service worker

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'Partial<...>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68b0319100108329a94f9607f95658ad