### PR TITLE
PWA install prompt (deferred) + runtime flag to enable/disable SW

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -17,3 +17,13 @@ This guide helps you deploy Naturverse with Netlify and Supabase.
 3. Paste these values into Netlify's environment variables.
 
 That's it — push to main to trigger future deploys.
+
+## Deploy flags
+
+### Toggle PWA
+Set in Netlify → Site settings → Build & deploy → Environment variables
+
+- `VITE_ENABLE_PWA=true`  → enable service worker registration + install prompt
+- `VITE_ENABLE_PWA=false` → disable SW registration and hide install prompt
+
+**Default:** false (safer). Turn on only after verifying no offline-caching regressions.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <script src="/kill-sw.js?v=2" defer></script>
+    <script>
+      // Vite replaces %VITE_ENABLE_PWA% at build-time
+      window.__NV_PWA_ENABLED__ = "%VITE_ENABLE_PWA%" === "true";
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Naturverse</title>
     <!-- PWA manifest -->
@@ -133,15 +137,88 @@
       });
     </script>
 
-    <!-- Register baseline service worker -->
+    <!-- Register service worker (gated) -->
     <script>
-      if ("serviceWorker" in navigator) {
+      (function () {
+        if (!("serviceWorker" in navigator)) return;
+        if (!window.__NV_PWA_ENABLED__) {
+          console.info("[PWA] Disabled via VITE_ENABLE_PWA");
+          return;
+        }
         window.addEventListener("load", () => {
           navigator.serviceWorker
             .register("/sw.js")
-            .catch((err) => console.error("SW registration failed", err));
+            .then(() => console.info("[PWA] service worker registered"))
+            .catch((err) => console.error("[PWA] registration failed", err));
         });
+      })();
+    </script>
+
+    <!-- Install prompt banner (hidden until beforeinstallprompt) -->
+    <style>
+      #nv-install {
+        position: fixed; left: 12px; right: 12px; bottom: 12px;
+        display: none; gap: 10px; align-items: center; justify-content: space-between;
+        padding: 12px 14px; border-radius: 12px; background: #0b5fff; color: #fff;
+        box-shadow: 0 8px 24px rgba(0,0,0,.2); z-index: 2147483647;
+        font: 600 14px/1.3 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;
       }
+      #nv-install .nv-actions { display: flex; gap: 8px; }
+      #nv-install button {
+        appearance: none; border: 0; border-radius: 10px; padding: 8px 12px; cursor: pointer;
+        background: #fff; color: #0b5fff; font-weight: 700;
+      }
+      #nv-install button.nv-skip {
+        background: transparent; color: #fff; outline: 2px solid rgba(255,255,255,.6);
+      }
+    </style>
+
+    <div id="nv-install" role="dialog" aria-live="polite" aria-label="Install Naturverse">
+      <span>Install Naturverse?</span>
+      <div class="nv-actions">
+        <button type="button" id="nv-install-yes">Install</button>
+        <button type="button" id="nv-install-no" class="nv-skip">Not now</button>
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        if (!window.__NV_PWA_ENABLED__) return;
+        let deferred;
+        const bar = document.getElementById("nv-install");
+        const yes = document.getElementById("nv-install-yes");
+        const no  = document.getElementById("nv-install-no");
+
+        window.addEventListener("beforeinstallprompt", (e) => {
+          e.preventDefault();
+          deferred = e;
+          // Show prompt only on home route (avoid spamming during deep flows)
+          const isHome = location.pathname === "/" || location.pathname === "";
+          if (bar && isHome) bar.style.display = "flex";
+        });
+
+        yes?.addEventListener("click", async () => {
+          try {
+            bar.style.display = "none";
+            if (!deferred) return;
+            const r = await deferred.prompt();
+            // Optional: handle r.outcome === 'accepted'/'dismissed'
+            deferred = null;
+          } catch {}
+        });
+
+        no?.addEventListener("click", () => {
+          bar.style.display = "none";
+          deferred = null;
+          // Do not show again this session
+          sessionStorage.setItem("nv-install-skip", "1");
+        });
+
+        // If user already dismissed in this session, keep hidden
+        if (sessionStorage.getItem("nv-install-skip") === "1" && bar) {
+          bar.style.display = "none";
+        }
+      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- gate service worker registration behind `VITE_ENABLE_PWA`
- show an "Install Naturverse?" prompt when the browser fires `beforeinstallprompt`
- document new `VITE_ENABLE_PWA` deploy flag

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck` (fails: TS errors in src/lib/api and related files)


------
https://chatgpt.com/codex/tasks/task_e_68b03365288c8329b89266a27fec7964