### PR TITLE
Add working Contact form via Netlify Forms (safe, no deps)

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,5 +220,12 @@
         }
       })();
     </script>
-  </body>
+  <!-- Netlify Forms detection: hidden static form (do not remove) -->
+    <form name="contact" netlify netlify-honeypot="bot-field" hidden>
+      <input type="text" name="name" />
+      <input type="email" name="email" />
+      <textarea name="message"></textarea>
+    </form>
+
+</body>
 </html>

--- a/public/_headers
+++ b/public/_headers
@@ -53,3 +53,7 @@
 /sw.js
   Cache-Control: no-cache, no-store, must-revalidate
   Content-Type: application/javascript; charset=utf-8
+
+/contact-success.html
+  Cache-Control: no-cache, no-store, must-revalidate
+  Content-Type: text/html; charset=utf-8

--- a/public/contact-success.html
+++ b/public/contact-success.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Message sent — Naturverse</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="robots" content="noindex" />
+  <style>
+    :root { color-scheme: light dark; }
+    body { margin:0; font: 16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial; display:grid; min-height:100vh; place-items:center; background:#fff; }
+    .card { max-width:720px; padding:24px; border:1px solid #E5E7EB; border-radius:12px; box-shadow: 0 6px 18px rgba(0,0,0,.06); }
+    h1 { margin:0 0 8px; font-size:22px; }
+    p { margin:8px 0; opacity:.9; }
+    a.btn { display:inline-block; margin-top:14px; padding:10px 14px; border-radius:8px; background:#1e63ff; color:#fff; text-decoration:none; }
+    @media (prefers-color-scheme: dark) {
+      body { background:#0b1020; color:#eaf0ff; }
+      .card { border-color:#2a2f45; background:#0f152b; }
+    }
+  </style>
+</head>
+<body>
+  <main class="card" role="main" aria-label="Contact success">
+    <h1>Thanks — your message was sent!</h1>
+    <p>We’ll get back to you soon.</p>
+    <p><a class="btn" href="/">Return to Naturverse</a></p>
+  </main>
+</body>
+</html>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,10 +1,140 @@
 import React from "react";
 
+function encode(data: Record<string, string>) {
+  return Object.keys(data)
+    .map((k) => encodeURIComponent(k) + "=" + encodeURIComponent(data[k] ?? ""))
+    .join("&");
+}
+
 export default function Contact() {
+  const [state, setState] = React.useState<{ sending?: boolean; error?: string | null }>({});
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setState({ sending: true, error: null });
+
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    // Netlify needs the "form-name" field to match the hidden static form
+    formData.set("form-name", "contact");
+
+    try {
+      await fetch("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: encode(Object.fromEntries(formData as any)),
+      });
+      // On success, route to success page
+      window.location.assign("/contact/success");
+    } catch (err: any) {
+      setState({ sending: false, error: err?.message || "Failed to send. Please try again." });
+    }
+  }
+
   return (
     <main style={{ maxWidth: 900, margin: "24px auto", padding: "0 20px" }}>
       <h1>Contact</h1>
-      <p>Reach us at <a href="mailto:hello@thenaturverse.com">hello@thenaturverse.com</a>.</p>
+      <p>Have a question or idea for Naturverse? Send us a message.</p>
+
+      <form
+        name="contact"
+        method="POST"
+        data-netlify="true"
+        data-netlify-honeypot="bot-field"
+        action="/contact/success"
+        onSubmit={handleSubmit}
+        style={{ marginTop: 16, display: "grid", gap: 12, maxWidth: 640 }}
+      >
+        {/* Honeypot field for bots */}
+        <input type="hidden" name="form-name" value="contact" />
+        <div style={{ display: "none" }}>
+          <label>
+            Don’t fill this out: <input name="bot-field" />
+          </label>
+        </div>
+
+        <label style={{ display: "grid", gap: 6 }}>
+          <span>Name</span>
+          <input
+            name="name"
+            type="text"
+            required
+            placeholder="Your name"
+            autoComplete="name"
+            style={input}
+          />
+        </label>
+
+        <label style={{ display: "grid", gap: 6 }}>
+          <span>Email</span>
+          <input
+            name="email"
+            type="email"
+            required
+            placeholder="you@example.com"
+            autoComplete="email"
+            style={input}
+          />
+        </label>
+
+        <label style={{ display: "grid", gap: 6 }}>
+          <span>Message</span>
+          <textarea
+            name="message"
+            required
+            placeholder="How can we help?"
+            rows={6}
+            style={textarea}
+          />
+        </label>
+
+        {state.error && (
+          <p role="alert" style={{ color: "#b00020", margin: 0 }}>
+            {state.error}
+          </p>
+        )}
+
+        <div style={{ display: "flex", gap: 8 }}>
+          <button type="submit" disabled={state.sending} style={btnPrimary}>
+            {state.sending ? "Sending…" : "Send message"}
+          </button>
+          <button type="reset" disabled={state.sending} style={btnGhost}>
+            Reset
+          </button>
+        </div>
+
+        <p style={{ fontSize: 12, opacity: 0.7 }}>
+          By submitting, you agree to our <a href="/privacy">Privacy Policy</a>.
+        </p>
+      </form>
     </main>
   );
 }
+
+const input: React.CSSProperties = {
+  border: "1px solid #E5E7EB",
+  borderRadius: 10,
+  padding: "10px 12px",
+  font: "16px system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial",
+};
+
+const textarea = { ...input, resize: "vertical" } as React.CSSProperties;
+
+const btnPrimary: React.CSSProperties = {
+  appearance: "none",
+  border: "none",
+  borderRadius: 10,
+  padding: "10px 14px",
+  background: "#1e63ff",
+  color: "#fff",
+  fontWeight: 700,
+  cursor: "pointer",
+};
+
+const btnGhost: React.CSSProperties = {
+  ...btnPrimary,
+  background: "transparent",
+  color: "#1e63ff",
+  border: "2px solid #1e63ff",
+};
+


### PR DESCRIPTION
## Summary
- add hidden static contact form so Netlify detects it
- replace `/contact` placeholder with Netlify-powered form and honeypot
- add static success page and configure headers to disable caching

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b03701e4c08329a0687913c6b14f03