### PR TITLE
Performance: lazy-load images + lightweight <NVImage/> utility (no deps)

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,14 +128,6 @@
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
 
-    <!-- perf: lazy-enable all imgs that don't opt-out -->
-    <script>
-      document.addEventListener('DOMContentLoaded', () => {
-        document
-          .querySelectorAll('img:not([loading])')
-          .forEach((img) => img.setAttribute('loading', 'lazy'));
-      });
-    </script>
 
     <!-- Register service worker (gated) -->
     <script>
@@ -226,6 +218,20 @@
       <input type="email" name="email" />
       <textarea name="message"></textarea>
     </form>
+
+    <script>
+      // Progressive enhancement: add lazy+async to any <img> lacking them.
+      (function () {
+        try {
+          var imgs = document.querySelectorAll("img:not([loading])");
+          imgs.forEach(function (img) {
+            // Do not touch if explicitly eager
+            if (!img.hasAttribute("loading")) img.setAttribute("loading", "lazy");
+            if (!img.hasAttribute("decoding")) img.setAttribute("decoding", "async");
+          });
+        } catch {}
+      })();
+    </script>
 
 </body>
 </html>

--- a/public/_headers
+++ b/public/_headers
@@ -57,3 +57,6 @@
 /contact-success.html
   Cache-Control: no-cache, no-store, must-revalidate
   Content-Type: text/html; charset=utf-8
+
+/images/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Footer from './components/Footer';
 import './styles/footer.css';
 import SkipLink from './components/SkipLink';
 import './styles/a11y.css';
+import './styles/images.css';
 
 export default function App() {
   useEffect(() => {

--- a/src/styles/images.css
+++ b/src/styles/images.css
@@ -1,0 +1,48 @@
+/* Generic image helpers */
+.nv-img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  background: transparent;
+}
+
+/* wrapper handles placeholder transition */
+.nv-img-wrap {
+  overflow: hidden;
+}
+.nv-img-wrap .nv-img {
+  transition: opacity .25s ease;
+  opacity: 0;
+}
+.nv-img-wrap.is-loaded .nv-img {
+  opacity: 1;
+}
+.nv-img--placeholder {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Aspect-ratio helpers (opt-in) */
+.nv-aspect {
+  position: relative;
+  width: 100%;
+}
+.nv-aspect::before {
+  content: "";
+  display: block;
+  width: 100%;
+  padding-bottom: var(--nv-aspect, 56.25%); /* default 16:9 */
+}
+.nv-aspect > .nv-img-wrap,
+.nv-aspect > img,
+.nv-aspect > picture {
+  position: absolute;
+  inset: 0;
+}
+.nv-object-cover {
+  object-fit: cover;
+}
+

--- a/src/utils/NVImage.tsx
+++ b/src/utils/NVImage.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+
+/**
+ * Lightweight image helper with safe defaults:
+ * - lazy loads by default
+ * - async decoding
+ * - optional width/height to avoid CLS
+ * - supports placeholders via `placeholder` prop
+ */
+export type NVImageProps = Omit<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  "loading" | "decoding"
+> & {
+  /**
+   * If true, image will use loading="eager" and fetchpriority="high".
+   * Use ONLY for above-the-fold hero art.
+   */
+  priority?: boolean;
+  /** Low-res placeholder data URL or tiny SVG; optional */
+  placeholder?: string;
+};
+
+export default function NVImage({
+  priority = false,
+  placeholder,
+  src,
+  srcSet,
+  sizes,
+  alt = "",
+  className,
+  style,
+  ...rest
+}: NVImageProps) {
+  const props: React.ImgHTMLAttributes<HTMLImageElement> = {
+    src,
+    srcSet,
+    sizes,
+    alt,
+    className: className ? `nv-img ${className}` : "nv-img",
+    style,
+    decoding: "async",
+    loading: priority ? "eager" : "lazy",
+    // @ts-expect-error: fetchpriority is a valid HTML attribute
+    fetchpriority: priority ? "high" : undefined,
+    ...rest,
+  };
+
+  // If a placeholder is provided, show it until load.
+  const [loaded, setLoaded] = React.useState(!placeholder);
+  const onLoad = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+    setLoaded(true);
+    rest.onLoad?.(e);
+  };
+
+  return (
+    <span className={`nv-img-wrap${loaded ? " is-loaded" : ""}`} style={{ display: "inline-block", position: "relative" }}>
+      {placeholder && !loaded && (
+        <img
+          aria-hidden="true"
+          alt=""
+          className="nv-img nv-img--placeholder"
+          src={placeholder}
+          decoding="async"
+          loading="eager"
+          style={{ filter: "blur(8px)", transform: "scale(1.02)" }}
+        />
+      )}
+      <img {...props} onLoad={onLoad} />
+    </span>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add NVImage component for async-decoding, lazy-loading images with optional placeholders
- include global image helpers and import them in `App`
- progressively upgrade plain `<img>` tags and enable long-term caching for `/images/*`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations, and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0388414c88329a395499f7b58d0e8