### PR TITLE
Performance: prefetch internal routes + add loading skeletons (no deps)

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,5 +233,49 @@
       })();
     </script>
 
+    <script>
+      // Prefetch internal routes on hover/idle to speed up navigation
+      (function () {
+        try {
+          const isInternal = (a) => a.origin === location.origin && !a.hash;
+          const prefetch = (href) => {
+            if (!href) return;
+            const link = document.createElement("link");
+            link.rel = "prefetch";
+            link.href = href;
+            link.as = "document";
+            document.head.appendChild(link);
+          };
+
+          // Prefetch when user hovers or touches a link
+          document.addEventListener(
+            "mouseover",
+            (e) => {
+              const a = e.target && (e.target.closest ? e.target.closest("a") : null);
+              if (a && isInternal(a)) prefetch(a.href);
+            },
+            { passive: true }
+          );
+
+          document.addEventListener(
+            "touchstart",
+            (e) => {
+              const a = e.target && (e.target.closest ? e.target.closest("a") : null);
+              if (a && isInternal(a)) prefetch(a.href);
+            },
+            { passive: true }
+          );
+
+          // Idle prefetch of common routes (adjust list if needed)
+          const common = ["/worlds", "/zones", "/marketplace"];
+          if ("requestIdleCallback" in window) {
+            requestIdleCallback(() => common.forEach((p) => prefetch(p)));
+          } else {
+            setTimeout(() => common.forEach((p) => prefetch(p)), 1200);
+          }
+        } catch {}
+      })();
+    </script>
+
 </body>
 </html>

--- a/public/_headers
+++ b/public/_headers
@@ -60,3 +60,7 @@
 
 /images/*
   Cache-Control: public, max-age=31536000, immutable
+
+/*
+  Link: </worlds>; rel=prefetch, </zones>; rel=prefetch
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { CartProvider } from './lib/cart';
 import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
 import { logEvent } from './utils/telemetry';
+import RouteFallback from './routes/RouteFallback';
 import './styles/magic.css';
 // TEMP: disable interactions while we isolate the crash
 // import { initInteractions } from './init/interactions';
@@ -15,6 +16,7 @@ import './styles/footer.css';
 import SkipLink from './components/SkipLink';
 import './styles/a11y.css';
 import './styles/images.css';
+import './components/skeleton.css';
 
 export default function App() {
   useEffect(() => {
@@ -35,20 +37,22 @@ export default function App() {
           role="main"
           aria-label="Main content"
         >
-          {/* Global route side-effects (scroll & focus) */}
-          <RouteFX />
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
-          />
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
-          />
-          <div className="container">
-            <RouterProvider router={router} />
-          </div>
-          <ToasterListener />
+          <React.Suspense fallback={<RouteFallback />}>
+            {/* Global route side-effects (scroll & focus) */}
+            <RouteFX />
+            <script
+              type="application/ld+json"
+              dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
+            />
+            <script
+              type="application/ld+json"
+              dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
+            />
+            <div className="container">
+              <RouterProvider router={router} />
+            </div>
+            <ToasterListener />
+          </React.Suspense>
         </main>
 
         <Footer />

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,30 +1,40 @@
-export function Skeleton({ h=16, w="100%", r=10 }:{h?:number; w?:number|string; r?:number}) {
+import React from "react";
+import "./skeleton.css";
+
+type Props = {
+  width?: number | string;
+  height?: number | string;
+  circle?: boolean;
+  style?: React.CSSProperties;
+  className?: string;
+};
+
+export default function Skeleton({ width = "100%", height = 16, circle = false, style, className }: Props) {
+  const styles: React.CSSProperties = {
+    width,
+    height,
+    borderRadius: circle ? "9999px" : 10,
+    ...style,
+  };
+  return <span className={`nv-skel ${className ?? ""}`} style={styles} aria-hidden="true" />;
+}
+
+export function SkeletonText({ lines = 3 }: { lines?: number }) {
   return (
-    <div style={{
-      width: w, height: h, borderRadius: r,
-      background: "linear-gradient(90deg, #eef3ff 25%, #f6f9ff 37%, #eef3ff 63%)",
-      backgroundSize: "400% 100%", animation: "nv-shimmer 1.2s ease-in-out infinite"
-    }}/>
+    <div className="nv-skel-stack" aria-hidden="true">
+      {Array.from({ length: lines }).map((_, i) => (
+        <Skeleton key={i} height={14} style={{ marginBottom: 10, width: i === lines - 1 ? "60%" : "100%" }} />
+      ))}
+    </div>
   );
 }
 
 export function SkeletonCard() {
   return (
-    <div style={{ padding: 16, borderRadius: 16, background: "white", boxShadow: "0 4px 24px rgba(0,0,0,.06)" }}>
-      <Skeleton h={180} r={12}/>
-      <div style={{ height: 12 }} />
-      <Skeleton h={18} w="70%"/>
-      <div style={{ height: 10 }} />
-      <Skeleton h={14} w="55%"/>
+    <div className="nv-skel-card" aria-hidden="true">
+      <Skeleton height={160} style={{ marginBottom: 12 }} />
+      <SkeletonText lines={2} />
     </div>
   );
 }
 
-/* Global keyframes (inject once) */
-if (!document.getElementById("nv-shimmer-style")) {
-  const s = document.createElement("style");
-  s.id = "nv-shimmer-style";
-  s.textContent = `
-  @keyframes nv-shimmer { 0%{background-position:100% 0} 100%{background-position:0 0} }`;
-  document.head.appendChild(s);
-}

--- a/src/components/skeleton.css
+++ b/src/components/skeleton.css
@@ -1,0 +1,26 @@
+/* ===== Lightweight skeleton shimmer ===== */
+.nv-skel {
+  display: inline-block;
+  background: linear-gradient(90deg, #f2f4f7 25%, #eceff3 37%, #f2f4f7 63%);
+  background-size: 400% 100%;
+  animation: nv-skel 1.2s ease-in-out infinite;
+}
+@keyframes nv-skel {
+  0% { background-position: 100% 50%; }
+  100% { background-position: 0 50%; }
+}
+.nv-skel-stack { display: grid; }
+.nv-skel-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 12px;
+  background: #fff;
+}
+@media (prefers-color-scheme: dark) {
+  .nv-skel { background: linear-gradient(90deg, #1b2140 25%, #222a4d 37%, #1b2140 63%); }
+  .nv-skel-card { border-color: #2a2f45; background: #0f152b; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .nv-skel { animation: none; }
+}
+

--- a/src/routes/RouteFallback.tsx
+++ b/src/routes/RouteFallback.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { SkeletonCard, SkeletonText } from "../components/Skeleton";
+
+/** Generic fallback while route chunks load */
+export default function RouteFallback() {
+  return (
+    <main style={{ maxWidth: 1100, margin: "24px auto", padding: "0 20px" }} aria-busy="true">
+      <div style={{ display: "grid", gap: 16 }}>
+        <SkeletonText lines={3} />
+        <div style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))" }}>
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+      </div>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- prefetch internal links on hover and idle
- wrap router in Suspense with branded loading fallback
- add lightweight Skeleton components and styles
- hint common route prefetch via HTTP `Link` header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TS errors: Cannot find module 'next' or its corresponding type declarations; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b03ac7a5848329b883ca4cbf4bd1e5