### PR TITLE
🎯 Feature: Navatar Progress Stepper (linked to Quizzes & Stamps)

### DIFF
--- a/src/components/NavatarStepper.tsx
+++ b/src/components/NavatarStepper.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import "./stepper.css";
+
+// Types
+type Step = {
+  key: string;
+  label: string;
+};
+
+type Props = {
+  userId?: string;
+  steps?: Step[];
+  current?: string; // override if provided
+};
+
+// Default step sequence
+const DEFAULT_STEPS: Step[] = [
+  { key: "intro", label: "Intro" },
+  { key: "quiz", label: "First Quiz" },
+  { key: "stamp", label: "Earn Stamp" },
+  { key: "zone", label: "Unlock Zone" },
+  { key: "done", label: "Completion" }
+];
+
+export default function NavatarStepper({ userId, steps = DEFAULT_STEPS, current }: Props) {
+  const [active, setActive] = React.useState<string>(current || "intro");
+
+  // In real app: fetch from Supabase
+  React.useEffect(() => {
+    if (!userId || current) return;
+    // Fallback logic: simulate user progress
+    // Replace with Supabase fetch when hooked up
+    const saved = localStorage.getItem("nv_progress_" + userId);
+    if (saved) setActive(saved);
+  }, [userId, current]);
+
+  return (
+    <div className="stepper">
+      {steps.map((s, i) => {
+        const isActive = s.key === active;
+        const isDone = steps.findIndex(st => st.key === active) > i;
+        return (
+          <div key={s.key} className={`step ${isActive ? "is-active" : ""} ${isDone ? "is-done" : ""}`}>
+            <div className="step__dot">{isDone ? "✓" : i + 1}</div>
+            <div className="step__label">{s.label}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/stepper.css
+++ b/src/components/stepper.css
@@ -1,0 +1,34 @@
+.stepper {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin: 20px 0;
+}
+.step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  flex: 1;
+}
+.step__dot {
+  width: 34px; height: 34px;
+  border-radius: 50%;
+  background: #e5e7eb;
+  display: flex; align-items: center; justify-content: center;
+  font-weight: bold;
+  margin-bottom: 6px;
+}
+.step.is-active .step__dot {
+  background: #1e63ff; color: #fff;
+}
+.step.is-done .step__dot {
+  background: #22c55e; color: #fff;
+}
+.step__label {
+  font-size: 13px;
+  max-width: 80px;
+}
+@media (prefers-color-scheme: dark) {
+  .step__dot { background: #2a2f45; color: #eaf0ff; }
+}

--- a/src/pages/progress/index.tsx
+++ b/src/pages/progress/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import NavatarStepper from "../../components/NavatarStepper";
+
+export default function ProgressPage() {
+  // Simulate logged-in user
+  const userId = "demo-user-123";
+
+  return (
+    <main style={{ maxWidth: 800, margin: "24px auto", padding: "0 20px" }}>
+      <h1>Navatar Progress</h1>
+      <p style={{ opacity: .8 }}>Track your journey through quizzes, stamps, and zones.</p>
+      <NavatarStepper userId={userId} />
+    </main>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -27,6 +27,7 @@ import BankNFTs from './pages/naturbank/NFTs';
 import BankLearn from './pages/naturbank/Learn';
 import NavatarPage from './pages/Navatar';
 import PassportPage from './pages/passport';
+import ProgressPage from './pages/progress';
 import LoginPage from './pages/Login';
 import Turian from './routes/turian';
 import ProfilePage from './pages/profile';
@@ -83,6 +84,7 @@ export const router = createBrowserRouter([
       { path: 'accessibility', element: <Accessibility /> },
       { path: 'about', element: <About /> },
         { path: 'navatar', element: <NavatarPage /> },
+        { path: 'progress', element: <ProgressPage /> },
         { path: 'passport', element: <PassportPage /> },
         { path: 'auth/callback', element: <AuthCallback /> },
         { path: 'login', element: <LoginPage /> },


### PR DESCRIPTION
## Summary
- introduce reusable `<NavatarStepper />` component
- default steps from intro through completion with local storage fallback
- add `/progress` demo page and wire it into the router

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0492539fc832990247194e7c90651