### PR TITLE
Zones Unlocks: visual lock state, Supabase sync, and gentle gating

### DIFF
--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -1,0 +1,55 @@
+import { supabase } from '@/lib/supabase-client';
+
+const LS_KEY = (userId: string) => `nv_unlocked_zones_${userId}`;
+
+/**
+ * Get unlocked zone slugs for a user.
+ * Priority: Supabase -> localStorage -> empty.
+ *
+ * Expected schemas (choose whichever exists in your DB):
+ * 1) zone_unlocks: { user_id: string; zone_slug: string }
+ * 2) stamps table with zone_slug column: { user_id: string; zone_slug: string }
+ */
+export async function getUnlockedZones(userId: string): Promise<Set<string>> {
+  if (!userId) return new Set();
+
+  // Try 1: explicit unlocks table
+  const { data: unlocks1, error: e1 } = await supabase
+    .from('zone_unlocks')
+    .select('zone_slug')
+    .eq('user_id', userId);
+
+  if (!e1 && unlocks1 && unlocks1.length) {
+    return new Set(unlocks1.map((r) => r.zone_slug));
+  }
+
+  // Try 2: infer from stamps table if it has zone_slug
+  const { data: unlocks2, error: e2 } = await supabase
+    .from('stamps')
+    .select('zone_slug')
+    .eq('user_id', userId);
+
+  if (!e2 && unlocks2 && unlocks2.length && 'zone_slug' in (unlocks2[0] ?? {})) {
+    return new Set(unlocks2.map((r: any) => r.zone_slug).filter(Boolean));
+  }
+
+  // Fallback: localStorage
+  try {
+    const raw = localStorage.getItem(LS_KEY(userId));
+    const arr: string[] = raw ? JSON.parse(raw) : [];
+    return new Set(arr);
+  } catch {
+    return new Set();
+  }
+}
+
+/** Dev utility: locally mark a zone unlocked (for demos) */
+export function localUnlockZone(userId: string, slug: string) {
+  try {
+    const key = LS_KEY(userId);
+    const arr: string[] = JSON.parse(localStorage.getItem(key) || '[]');
+    if (!arr.includes(slug)) arr.push(slug);
+    localStorage.setItem(key, JSON.stringify(arr));
+  } catch {}
+}
+

--- a/src/pages/zones/[slug].tsx
+++ b/src/pages/zones/[slug].tsx
@@ -1,19 +1,43 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import { ZONES } from "../../data/zones";
+import { getUnlockedZones } from "../../lib/progress";
+import "./zones-unlock.css";
 
 export default function ZoneDetail() {
   const { slug } = useParams();
   const zone = ZONES.find(z => z.slug === slug);
+  const userId = "demo-user-123";
+
+  const [isUnlocked, setIsUnlocked] = React.useState<boolean>(true);
+
+  React.useEffect(() => {
+    (async () => {
+      const set = await getUnlockedZones(userId);
+      setIsUnlocked(slug ? set.has(slug) : false);
+    })();
+  }, [slug, userId]);
 
   if (!zone) return <main><p>Zone not found.</p></main>;
+
+  if (!isUnlocked) {
+    return (
+      <main style={{ maxWidth: 800, margin: "24px auto", padding: "0 20px" }}>
+        <h1>{zone.emoji} {zone.name}</h1>
+        <p style={{ opacity: .8 }}>{zone.region}</p>
+        <div className="zone-gate">
+          <p>This zone is locked. Earn its stamp to unlock.</p>
+          <p><a className="btn" href="/progress">Go to Progress</a></p>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main style={{ maxWidth: 800, margin: "24px auto", padding: "0 20px" }}>
       <h1>{zone.emoji} {zone.name}</h1>
       <p style={{ opacity: .8 }}>{zone.region}</p>
       <p>{zone.summary}</p>
-
       <p style={{ marginTop: 20 }}>
         <a className="btn" href="/zones">← Back to Zones</a>
       </p>

--- a/src/pages/zones/index.tsx
+++ b/src/pages/zones/index.tsx
@@ -1,43 +1,83 @@
 import React from "react";
 import { ZONES } from "../../data/zones";
 import "../../components/market.css";
+import "./zones-unlock.css";
+import { getUnlockedZones, localUnlockZone } from "../../lib/progress";
 
 export default function ZonesPage() {
+  // Replace with real auth user id when wired
+  const userId = "demo-user-123";
+  const [unlocked, setUnlocked] = React.useState<Set<string>>(new Set());
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let active = true;
+    (async () => {
+      setLoading(true);
+      const set = await getUnlockedZones(userId);
+      if (active) setUnlocked(set);
+      setLoading(false);
+    })();
+    return () => { active = false; };
+  }, [userId]);
+
+  function mockUnlock(slug: string) {
+    // Dev-friendly demo: lets you unlock locally
+    localUnlockZone(userId, slug);
+    setUnlocked(new Set([...Array.from(unlocked), slug]));
+  }
+
   return (
     <main style={{ maxWidth: 1100, margin: "24px auto", padding: "0 20px" }}>
       <h1 style={{ marginBottom: 10 }}>Zones Explorer</h1>
       <p style={{ opacity: .8, marginTop: 0 }}>
-        Discover the magical regions of the Naturverse.
+        Discover the magical regions of the Naturverse. Locked zones show a padlock until you earn a stamp.
       </p>
 
       <div className="market-grid">
-        {ZONES.map(z => (
-          <article key={z.slug} className="product">
-            <a className="product__image" href={`/zones/${z.slug}`} aria-label={`Open ${z.name}`}>
-              <div style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                fontSize: "42px",
-                height: "100%",
-                background: "#f2f4f7"
-              }}>{z.emoji}</div>
-            </a>
-            <div className="product__body">
-              <h3 className="product__title">
-                <a href={`/zones/${z.slug}`}>{z.name}</a>
-              </h3>
-              <p className="product__meta">
-                <span className="product__cat">{z.region}</span>
-              </p>
-              <p className="product__summary">{z.summary}</p>
-              <div className="product__actions">
-                <a className="btn ghost" href={`/zones/${z.slug}`}>Explore</a>
+        {ZONES.map(z => {
+          const isUnlocked = unlocked.has(z.slug);
+          return (
+            <article key={z.slug} className={`product zone-card ${isUnlocked ? "is-unlocked" : "is-locked"}`}>
+              <a
+                className="product__image"
+                href={isUnlocked ? `/zones/${z.slug}` : `/zones/${z.slug}`}
+                aria-label={`Open ${z.name}`}
+              >
+                <div className="zone-emoji">{z.emoji}</div>
+                {!isUnlocked && <div className="zone-lock" aria-hidden="true">🔒</div>}
+                {isUnlocked && <div className="zone-ribbon">UNLOCKED</div>}
+              </a>
+
+              <div className="product__body">
+                <h3 className="product__title">
+                  <a href={`/zones/${z.slug}`}>{z.name}</a>
+                </h3>
+                <p className="product__meta">
+                  <span className="product__cat">{z.region}</span>
+                </p>
+                <p className="product__summary">{z.summary}</p>
+
+                <div className="product__actions">
+                  {isUnlocked ? (
+                    <a className="btn" href={`/zones/${z.slug}`}>Explore</a>
+                  ) : (
+                    <>
+                      <a className="btn ghost" href="/progress">Earn stamp to unlock</a>
+                      {/* Dev/demo helper; remove when auth is wired */}
+                      <button className="btn ghost" onClick={() => mockUnlock(z.slug)} title="Dev unlock (local)">
+                        Dev unlock
+                      </button>
+                    </>
+                  )}
+                </div>
               </div>
-            </div>
-          </article>
-        ))}
+            </article>
+          );
+        })}
       </div>
+
+      {loading && <p style={{ opacity: .6, marginTop: 12 }}>Syncing your unlocks…</p>}
     </main>
   );
 }

--- a/src/pages/zones/zones-unlock.css
+++ b/src/pages/zones/zones-unlock.css
@@ -1,0 +1,31 @@
+.zone-card .zone-emoji {
+  display: flex; align-items: center; justify-content: center;
+  font-size: 42px; height: 100%; background: #f2f4f7;
+}
+
+.zone-card.is-locked .product__image {
+  position: relative;
+  filter: grayscale(0.1);
+}
+.zone-lock {
+  position: absolute; right: 10px; top: 8px; font-size: 20px;
+  background: rgba(0,0,0,.5); color: #fff; padding: 4px 8px; border-radius: 8px;
+}
+
+.zone-card.is-unlocked .product__image { position: relative; }
+.zone-ribbon {
+  position: absolute; left: -8px; top: 10px;
+  transform: rotate(-8deg);
+  background: #22c55e; color: #fff; font-weight: 800;
+  padding: 4px 10px; border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,.18);
+}
+
+.zone-gate {
+  margin-top: 18px;
+  padding: 16px; border: 1px dashed #e5e7eb; border-radius: 12px; background: #fff;
+}
+@media (prefers-color-scheme: dark) {
+  .zone-card .zone-emoji { background: #1b2140; }
+  .zone-gate { border-color: #2a2f45; background: #0f152b; }
+}


### PR DESCRIPTION
## Summary
- fetch zone unlocks from Supabase with localStorage fallback
- display locked and unlocked states on zones grid with ribbons and padlocks
- gate zone detail view until unlocked with link to progress

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b04ad48bf4832995fe6aaaf4f54933