### PR TITLE
Reliability mega-PR: global ErrorBoundary + offline banner + SPA fallbacks (no deps)

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,5 +277,19 @@
       })();
     </script>
 
-</body>
+    <script>
+      // If a navigation happens while offline and fetch fails, show /offline.html.
+      (function () {
+        if (!('serviceWorker' in navigator)) return; // SW handles most offline
+        // As an extra safety: intercept top-level navigations that fail.
+        window.addEventListener('error', function (e) {
+          try {
+            var isChunkLoad = e && e.message && /Loading chunk/i.test(e.message);
+            if (isChunkLoad && !navigator.onLine) location.href = '/offline.html';
+          } catch {}
+        });
+      })();
+    </script>
+
+  </body>
 </html>

--- a/public/_headers
+++ b/public/_headers
@@ -64,3 +64,7 @@
 /*
   Link: </worlds>; rel=prefetch, </zones>; rel=prefetch
 
+
+/offline.html
+  Cache-Control: no-cache, no-store, must-revalidate
+  Content-Type: text/html; charset=utf-8

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>You're offline — Naturverse</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="robots" content="noindex" />
+  <style>
+    :root { color-scheme: light dark; }
+    body { margin:0; font: 16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial; display:grid; min-height:100vh; place-items:center; }
+    .card { max-width:720px; padding:24px; border:1px solid #E5E7EB; border-radius:12px; box-shadow: 0 6px 18px rgba(0,0,0,.06); }
+    h1 { margin:0 0 8px; font-size:22px; }
+    p { margin:8px 0; opacity:.9; }
+    a.btn, button.btn { display:inline-block; margin-top:14px; padding:10px 14px; border-radius:8px; background:#1e63ff; color:#fff; text-decoration:none; border:0; cursor:pointer; }
+    @media (prefers-color-scheme: dark) {
+      .card { border-color:#2a2f45; background:#0f152b; color:#eaf0ff; }
+    }
+  </style>
+</head>
+<body>
+  <main class="card" role="main" aria-label="Offline page">
+    <h1>You’re offline</h1>
+    <p>Naturverse needs a connection for some features. Reconnect and try again.</p>
+    <button class="btn" onclick="location.reload()">Retry</button>
+    <a class="btn" href="/">Go to home</a>
+  </main>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,9 @@ import SkipLink from './components/SkipLink';
 import './styles/a11y.css';
 import './styles/images.css';
 import './components/skeleton.css';
+import ErrorBoundary from './components/ErrorBoundary';
+import NetworkBanner from './components/NetworkBanner';
+import './components/network.css';
 
 export default function App() {
   useEffect(() => {
@@ -24,39 +27,42 @@ export default function App() {
     // SAFE MODE: interactions temporarily disabled
   }, []);
   return (
-    <CartProvider>
-      <div id="nv-page">
-        {/* Keyboard-accessible jump link (first focusable on the page) */}
-        <SkipLink />
+    <ErrorBoundary>
+      <CartProvider>
+        <div id="nv-page">
+          {/* Keyboard-accessible jump link (first focusable on the page) */}
+          <SkipLink />
+          <NetworkBanner />
 
-        {/* Convert content wrapper into the "main" landmark and jump target */}
-        <main
-          id="main"
-          className="nv-content"
-          tabIndex={-1}
-          role="main"
-          aria-label="Main content"
-        >
-          <React.Suspense fallback={<RouteFallback />}>
-            {/* Global route side-effects (scroll & focus) */}
-            <RouteFX />
-            <script
-              type="application/ld+json"
-              dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
-            />
-            <script
-              type="application/ld+json"
-              dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
-            />
-            <div className="container">
-              <RouterProvider router={router} />
-            </div>
-            <ToasterListener />
-          </React.Suspense>
-        </main>
+          {/* Convert content wrapper into the "main" landmark and jump target */}
+          <main
+            id="main"
+            className="nv-content"
+            tabIndex={-1}
+            role="main"
+            aria-label="Main content"
+          >
+            <React.Suspense fallback={<RouteFallback />}>
+              {/* Global route side-effects (scroll & focus) */}
+              <RouteFX />
+              <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
+              />
+              <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
+              />
+              <div className="container">
+                <RouterProvider router={router} />
+              </div>
+              <ToasterListener />
+            </React.Suspense>
+          </main>
 
-        <Footer />
-      </div>
-    </CartProvider>
+          <Footer />
+        </div>
+      </CartProvider>
+    </ErrorBoundary>
   );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,111 +1,41 @@
-import React from "react";
-import { useNavigate } from "react-router-dom";
-import { logEvent } from "../utils/telemetry";
+import * as React from "react";
+import "./error.css";
 
-type Props = {
-  children: React.ReactNode;
-  fallbackTitle?: string;
-  fallbackNote?: string;
-};
+type Props = { children: React.ReactNode };
+type State = { error: Error | null };
 
-type State = { hasError: boolean };
+export default class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
 
-export class ErrorBoundary extends React.Component<Props, State> {
-  state: State = { hasError: false };
-
-  static getDerivedStateFromError() {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error) {
+    return { error };
   }
 
-  componentDidCatch(error: unknown, info: unknown) {
-    logEvent("ErrorBoundary", { error });
-    // eslint-disable-next-line no-console
-    console.error("[naturverse] ErrorBoundary caught", error, info);
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // Optional: hook up to telemetry later
+    console.error("App error:", error, info);
   }
 
-  reset = () => this.setState({ hasError: false });
+  reset = () => {
+    this.setState({ error: null });
+    // Try a soft reload to recover route state
+    location.reload();
+  };
 
   render() {
-    if (!this.state.hasError) return this.props.children;
-    return (
-      <Fallback
-        title={this.props.fallbackTitle}
-        note={this.props.fallbackNote}
-        onRetry={this.reset}
-      />
-    );
+    if (this.state.error) {
+      return (
+        <main className="nv-err" role="alert" aria-live="assertive">
+          <h1>Something went wrong</h1>
+          <p>We hit an unexpected error. Try reloading the page.</p>
+          <pre className="nv-err__msg">{this.state.error.message}</pre>
+          <div className="nv-err__actions">
+            <button onClick={this.reset}>Reload</button>
+            <a className="btn" href="/">Go home</a>
+          </div>
+        </main>
+      );
+    }
+    return this.props.children;
   }
 }
-
-function Fallback({
-  title = "Oops! A glitch in the Naturverse.",
-  note = "Please try again or head back home.",
-  onRetry,
-}: {
-  title?: string;
-  note?: string;
-  onRetry: () => void;
-}) {
-  const navigate = useNavigate();
-
-  return (
-    <div
-      style={{
-        minHeight: "60vh",
-        display: "grid",
-        placeItems: "center",
-        padding: "2rem 1rem",
-      }}
-    >
-      <div
-        style={{
-          maxWidth: 720,
-          width: "100%",
-          background: "white",
-          borderRadius: 16,
-          boxShadow: "0 8px 24px rgba(0,0,0,0.08)",
-          border: "1px solid #e6eefc",
-          padding: "24px",
-        }}
-      >
-        <h1 style={{ color: "var(--naturverse-blue)", margin: "0 0 8px" }}>
-          {title}
-        </h1>
-        <p style={{ margin: "0 0 16px", color: "#234" }}>{note}</p>
-
-        <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-          <button
-            onClick={() => navigate("/")}
-            style={btnStyle}
-            aria-label="Go home"
-          >
-            Go home
-          </button>
-          <button onClick={onRetry} style={btnGhostStyle} aria-label="Try again">
-            Try again
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-const btnStyle: React.CSSProperties = {
-  background: "var(--naturverse-blue)",
-  color: "white",
-  border: "none",
-  borderRadius: 12,
-  padding: "12px 16px",
-  fontWeight: 700,
-  boxShadow: "0 6px 0 rgba(0,0,0,0.12)",
-  cursor: "pointer",
-};
-
-const btnGhostStyle: React.CSSProperties = {
-  ...btnStyle,
-  background: "transparent",
-  color: "var(--naturverse-blue)",
-  border: "2px solid var(--naturverse-blue)",
-  boxShadow: "none",
-};
-

--- a/src/components/NetworkBanner.tsx
+++ b/src/components/NetworkBanner.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import useOnline from "../hooks/useOnline";
+import "./network.css";
+
+export default function NetworkBanner() {
+  const online = useOnline();
+  const [hidden, setHidden] = React.useState(false);
+
+  React.useEffect(() => {
+    // Show again whenever we go offline
+    if (!online) setHidden(false);
+  }, [online]);
+
+  if (online || hidden) return null;
+
+  return (
+    <div className="nv-net">
+      <span>You’re offline. Some actions may not work.</span>
+      <div className="nv-net__actions">
+        <button onClick={() => location.reload()}>Retry</button>
+        <button className="ghost" onClick={() => setHidden(true)}>Dismiss</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/error.css
+++ b/src/components/error.css
@@ -1,0 +1,14 @@
+.nv-err { max-width: 860px; margin: 24px auto; padding: 0 20px; }
+.nv-err__msg {
+  overflow: auto; white-space: pre-wrap;
+  border: 1px solid #e5e7eb; background: #fff; padding: 12px; border-radius: 10px;
+}
+.nv-err__actions { display: flex; gap: 10px; margin-top: 12px; }
+.nv-err__actions .btn,
+.nv-err__actions button {
+  appearance: none; border-radius: 10px; padding: 10px 14px; border: 0; background: #1e63ff; color: #fff; font-weight: 700; cursor: pointer;
+}
+.nv-err__actions a.btn { text-decoration: none; display: inline-flex; align-items: center; }
+@media (prefers-color-scheme: dark) {
+  .nv-err__msg { border-color: #2a2f45; background: #0f152b; color: #eaf0ff; }
+}

--- a/src/components/network.css
+++ b/src/components/network.css
@@ -1,0 +1,24 @@
+.nv-net {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: #e11d48;
+  color: #fff;
+  font-weight: 600;
+}
+.nv-net__actions { display: inline-flex; gap: 8px; }
+.nv-net__actions button {
+  appearance: none; border: 0; border-radius: 10px; padding: 8px 12px; cursor: pointer;
+  background: #fff; color: #e11d48; font-weight: 800;
+}
+.nv-net__actions .ghost {
+  background: transparent; color: #fff; outline: 2px solid rgba(255,255,255,.7);
+}
+@media (prefers-color-scheme: dark) {
+  .nv-net { background: #9f1239; }
+}

--- a/src/hooks/useOnline.ts
+++ b/src/hooks/useOnline.ts
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+export default function useOnline() {
+  const [online, setOnline] = React.useState<boolean>(navigator.onLine);
+  React.useEffect(() => {
+    const on = () => setOnline(true);
+    const off = () => setOnline(false);
+    window.addEventListener("online", on);
+    window.addEventListener("offline", off);
+    return () => {
+      window.removeEventListener("online", on);
+      window.removeEventListener("offline", off);
+    };
+  }, []);
+  return online;
+}

--- a/src/hooks/useRouteChange.ts
+++ b/src/hooks/useRouteChange.ts
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+/** Fire a callback when SPA route changes (hash and pushState) */
+export default function useRouteChange(handler: () => void) {
+  React.useEffect(() => {
+    let origPush = history.pushState;
+    let origReplace = history.replaceState;
+    const emit = () => handler();
+
+    history.pushState = function (this: any, ...args: any[]) {
+      const r = origPush.apply(this, args as any);
+      emit();
+      return r;
+    } as any;
+    history.replaceState = function (this: any, ...args: any[]) {
+      const r = origReplace.apply(this, args as any);
+      emit();
+      return r;
+    } as any;
+
+    window.addEventListener("popstate", emit);
+    window.addEventListener("hashchange", emit);
+
+    return () => {
+      history.pushState = origPush;
+      history.replaceState = origReplace;
+      window.removeEventListener("popstate", emit);
+      window.removeEventListener("hashchange", emit);
+    };
+  }, [handler]);
+}

--- a/src/layouts/Root.tsx
+++ b/src/layouts/Root.tsx
@@ -6,7 +6,7 @@ import HeadPreloads from '../components/HeadPreloads';
 import RouteProgress from '../components/RouteProgress';
 import SiteHeader from '../components/SiteHeader';
 import Footer from '../components/Footer';
-import { ErrorBoundary } from '../components/ErrorBoundary';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 export default function RootLayout() {
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,6 @@ import './styles/nvcard.css';
 import './app.css';
 import './styles/nv-sweep.css';
 import ToastProvider from './components/Toast';
-import OfflineBanner from './components/OfflineBanner';
 import { supabase } from '@/lib/supabase-client';
 import './runtime-logger';
 import { prefetchGlob, prefetchOnHover } from './lib/prefetch';
@@ -35,7 +34,6 @@ async function bootstrap() {
       {/* Ensure auth context wraps the entire app so Home gets updates immediately */}
         <AuthProvider initialSession={initialSession}>
           <ToastProvider>
-            <OfflineBanner />
             <BaseAuthProvider>
               <App />
             </BaseAuthProvider>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -39,11 +39,13 @@ import Accessibility from './pages/Accessibility';
 import About from './pages/About';
 import NotFound from './pages/NotFound';
 import RootLayout from './layouts/Root';
+import RouteError from './routes/RouteError';
 
 export const router = createBrowserRouter([
   {
     path: '/',
     element: <RootLayout />,
+    errorElement: <RouteError />,
     children: [
       { index: true, element: <Home /> },
       { path: 'worlds', element: <WorldsExplorer /> },

--- a/src/routes/RouteError.tsx
+++ b/src/routes/RouteError.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import "../components/error.css";
+
+export default function RouteError() {
+  return (
+    <main className="nv-err" role="alert" aria-live="assertive">
+      <h1>We couldn’t load this page.</h1>
+      <p>Please check your connection, then try again.</p>
+      <div className="nv-err__actions">
+        <button onClick={() => location.reload()}>Retry</button>
+        <a className="btn" href="/">Go home</a>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add hooks for detecting network status and SPA route changes
- show sticky offline banner with retry/dismiss
- wrap app with global ErrorBoundary and route-level error fallback
- serve static offline.html and guard chunk-load failures offline

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b04bdb51b08329bf77e4494092866b