### PR TITLE
Mini-Quests: create, preview, save, and play (local-first, zero deps)

### DIFF
--- a/src/data/quests.ts
+++ b/src/data/quests.ts
@@ -1,0 +1,42 @@
+export type QuestStep = {
+  id: string;               // stable id for tracking completion
+  text: string;             // instruction
+  tip?: string;             // optional hint
+  minutes?: number;         // suggested time
+};
+
+export type Reward = {
+  type: "stamp" | "badge" | "xp";
+  code: string;             // e.g. "BREATH-STARTER"
+  amount?: number;          // e.g. 50 xp
+};
+
+export type Quest = {
+  id: string;
+  slug: string;
+  title: string;
+  summary: string;
+  kingdom?: string;         // optional category tag
+  steps: QuestStep[];
+  rewards?: Reward[];
+  createdAt: string;        // ISO
+  updatedAt: string;        // ISO
+};
+
+export const SEED_QUESTS: Quest[] = [
+  {
+    id: "q-breath-001",
+    slug: "first-breath",
+    title: "First Breath",
+    summary: "A gentle 3-step breath practice to calm your body.",
+    kingdom: "Air",
+    steps: [
+      { id: "s1", text: "Sit comfortably and put one hand on your belly.", minutes: 1 },
+      { id: "s2", text: "Inhale through your nose for 4, exhale for 6. Repeat 6 times.", tip: "If dizzy, slow down.", minutes: 2 },
+      { id: "s3", text: "Notice one thing you feel calmer about.", minutes: 1 }
+    ],
+    rewards: [{ type: "stamp", code: "AIR-BREATH-START" }],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  }
+];

--- a/src/pages/quests/[slug].tsx
+++ b/src/pages/quests/[slug].tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { getQuestBySlug, getQuestDone, setQuestDone } from "../../utils/quests-store";
+import { SEED_QUESTS } from "../../data/quests";
+
+export default function QuestDetail() {
+  const { slug = "" } = useParams();
+  const quest = getQuestBySlug(slug) || SEED_QUESTS.find(q => q.slug === slug);
+
+  const [done, setDone] = React.useState<Record<string, boolean>>(() => getQuestDone(slug));
+  const complete = quest ? quest.steps.every(s => done[s.id]) : false;
+
+  if (!quest) return <main style={{maxWidth:800, margin:"24px auto", padding:"0 20px"}}><p>Quest not found.</p></main>;
+
+  function toggle(id: string) {
+    const next = { ...done, [id]: !done[id] };
+    setDone(next);
+    setQuestDone(slug, next);
+  }
+
+  async function share() {
+    const url = new URL(location.pathname, location.origin).toString();
+    try {
+      const q = quest!;
+      if (navigator.share) await navigator.share({ title: q.title, text: q.summary, url });
+      else await navigator.clipboard.writeText(url);
+    } catch {}
+  }
+
+  return (
+    <main style={{ maxWidth: 800, margin:"24px auto", padding:"0 20px" }}>
+      <h1>{quest.title}</h1>
+      <p style={{ opacity:.8 }}>{quest.summary}</p>
+      {quest.kingdom && <p style={{ opacity:.7 }}>Kingdom: {quest.kingdom}</p>}
+
+      <ol style={{ display:"grid", gap:10, paddingLeft:20 }}>
+        {quest.steps.map((s, i) => (
+          <li key={s.id} style={{ border:"1px solid #e5e7eb", borderRadius:12, padding:12 }}>
+            <label style={{ display:"grid", gap:6, cursor:"pointer" }}>
+              <div style={{ display:"flex", gap:10, alignItems:"center" }}>
+                <input type="checkbox" checked={!!done[s.id]} onChange={()=>toggle(s.id)} />
+                <b>Step {i+1}</b>
+                {s.minutes ? <span style={{ opacity:.7 }}>(~{s.minutes} min)</span> : null}
+              </div>
+              <div>{s.text}</div>
+              {s.tip && <div style={{ fontSize:13, opacity:.75 }}>Tip: {s.tip}</div>}
+            </label>
+          </li>
+        ))}
+      </ol>
+
+      <div style={{ display:"flex", gap:10, marginTop:14 }}>
+        <button className="btn" onClick={share}>Share</button>
+        <a className="btn ghost" href="/quests">Back to quests</a>
+        {complete && <span style={{ alignSelf:"center", fontWeight:700, color:"#22c55e" }}>✓ Completed</span>}
+      </div>
+
+      {!!quest.rewards?.length && (
+        <div style={{ marginTop:18, border:"1px dashed #e5e7eb", borderRadius:12, padding:12 }}>
+          <b>Rewards</b>
+          <ul>
+            {quest.rewards.map((r, idx) => (
+              <li key={idx}>{r.type.toUpperCase()} — {r.code}{r.amount ? ` (+${r.amount})` : ""}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/pages/quests/index.tsx
+++ b/src/pages/quests/index.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { SEED_QUESTS } from "../../data/quests";
+import { listAllQuests } from "../../utils/quests-store";
+import "../../components/market.css";
+
+export default function QuestsList() {
+  const quests = listAllQuests(SEED_QUESTS);
+
+  return (
+    <main style={{ maxWidth: 1100, margin: "24px auto", padding: "0 20px" }}>
+      <h1>Mini-Quests</h1>
+      <p style={{ opacity:.8, marginTop:0 }}>Small, focused adventures you can do anywhere.</p>
+
+      <div style={{ display:"flex", gap:10, margin:"12px 0 18px" }}>
+        <a className="btn" href="/quests/new">Create a quest</a>
+      </div>
+
+      <div className="market-grid">
+        {quests.map(q => (
+          <article key={q.id} className="product">
+            <a className="product__image" href={`/quests/${q.slug}`} aria-label={`Open ${q.title}`}>
+              <div style={{display:"flex",alignItems:"center",justifyContent:"center",height:"100%",fontSize:36,background:"#f2f4f7"}}>⭐</div>
+            </a>
+            <div className="product__body">
+              <h3 className="product__title"><a href={`/quests/${q.slug}`}>{q.title}</a></h3>
+              <p className="product__summary">{q.summary}</p>
+              <p className="product__meta"><span className="product__cat">{q.kingdom || "General"}</span></p>
+              <div className="product__actions">
+                <a className="btn ghost" href={`/quests/${q.slug}`}>Open</a>
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/pages/quests/new.tsx
+++ b/src/pages/quests/new.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { Quest, QuestStep, Reward } from "../../data/quests";
+import { uid, slugify } from "../../utils/id";
+import { upsertQuest } from "../../utils/quests-store";
+import { validateQuest } from "../../utils/validate";
+
+export default function NewQuest() {
+  const [title, setTitle] = React.useState("");
+  const [summary, setSummary] = React.useState("");
+  const [kingdom, setKingdom] = React.useState("");
+  const [steps, setSteps] = React.useState<QuestStep[]>([
+    { id: uid(), text: "" }
+  ]);
+  const [rewards, setRewards] = React.useState<Reward[]>([]);
+  const [errors, setErrors] = React.useState<string[]>([]);
+
+  function addStep() {
+    setSteps(s => [...s, { id: uid(), text: "" }]);
+  }
+  function removeStep(id: string) {
+    setSteps(s => s.filter(x => x.id !== id));
+  }
+  function setStep(id: string, patch: Partial<QuestStep>) {
+    setSteps(s => s.map(x => (x.id === id ? { ...x, ...patch } : x)));
+  }
+  function addReward() {
+    setRewards(r => [...r, { type: "stamp", code: "" }]);
+  }
+  function setReward(i: number, patch: Partial<Reward>) {
+    setRewards(r => r.map((x, idx) => (idx === i ? { ...x, ...patch } : x)));
+  }
+  function removeReward(i: number) {
+    setRewards(r => r.filter((_, idx) => idx !== i));
+  }
+
+  function onSave(e: React.FormEvent) {
+    e.preventDefault();
+    const now = new Date().toISOString();
+    const quest: Quest = {
+      id: `q-${uid()}`,
+      slug: slugify(title || `quest-${uid()}`),
+      title: title.trim(),
+      summary: summary.trim(),
+      kingdom: kingdom || undefined,
+      steps: steps.map(s => ({ ...s, text: s.text.trim() })).filter(s => s.text),
+      rewards: rewards.filter(r => r.code?.trim()),
+      createdAt: now,
+      updatedAt: now
+    };
+    const errs = validateQuest(quest);
+    if (errs.length) { setErrors(errs); return; }
+    upsertQuest(quest);
+    location.assign(`/quests/${quest.slug}`);
+  }
+
+  return (
+    <main style={{ maxWidth: 900, margin:"24px auto", padding:"0 20px" }}>
+      <h1>Create a Mini-Quest</h1>
+      <p style={{ opacity:.8, marginTop:0 }}>Keep it short and friendly: 3–6 steps works best.</p>
+
+      {!!errors.length && (
+        <div style={{border:"1px solid #e11d48", padding:12, borderRadius:10, color:"#e11d48", marginBottom:12}}>
+          <b>Please fix:</b>
+          <ul>{errors.map((e,i)=><li key={i}>{e}</li>)}</ul>
+        </div>
+      )}
+
+      <form onSubmit={onSave} style={{ display:"grid", gap:12 }}>
+        <label style={{ display:"grid", gap:6 }}>
+          <span>Title</span>
+          <input required value={title} onChange={(e)=>setTitle(e.target.value)} placeholder="e.g., Calm Start" />
+        </label>
+
+        <label style={{ display:"grid", gap:6 }}>
+          <span>Summary</span>
+          <textarea required rows={3} value={summary} onChange={(e)=>setSummary(e.target.value)} placeholder="One-line description of the quest" />
+        </label>
+
+        <label style={{ display:"grid", gap:6 }}>
+          <span>Kingdom (optional)</span>
+          <input value={kingdom} onChange={(e)=>setKingdom(e.target.value)} placeholder="Air / Water / Earth / …" />
+        </label>
+
+        <fieldset style={{ border:"1px solid #e5e7eb", borderRadius:12, padding:12 }}>
+          <legend>Steps</legend>
+          <div style={{ display:"grid", gap:10 }}>
+            {steps.map((s, idx) => (
+              <div key={s.id} style={{ display:"grid", gap:6, border:"1px dashed #e5e7eb", borderRadius:10, padding:10 }}>
+                <label style={{ display:"grid", gap:6 }}>
+                  <span>Step {idx+1}</span>
+                  <input required value={s.text} onChange={(e)=>setStep(s.id,{ text: e.target.value })} placeholder="Instruction…" />
+                </label>
+                <div style={{ display:"flex", gap:10 }}>
+                  <input style={{ flex:1 }} value={s.tip || ""} onChange={(e)=>setStep(s.id,{ tip: e.target.value })} placeholder="Tip (optional)" />
+                  <input style={{ width:120 }} type="number" min={0} value={s.minutes || ""} onChange={(e)=>setStep(s.id,{ minutes: Number(e.target.value)||undefined })} placeholder="Minutes" />
+                </div>
+                {steps.length > 1 && <button type="button" className="btn danger" onClick={()=>removeStep(s.id)}>Remove step</button>}
+              </div>
+            ))}
+            <button type="button" className="btn ghost" onClick={addStep}>+ Add step</button>
+          </div>
+        </fieldset>
+
+        <fieldset style={{ border:"1px solid #e5e7eb", borderRadius:12, padding:12 }}>
+          <legend>Rewards (optional)</legend>
+          <div style={{ display:"grid", gap:10 }}>
+            {rewards.map((r, idx) => (
+              <div key={idx} style={{ display:"flex", gap:10 }}>
+                <select value={r.type} onChange={(e)=>setReward(idx,{ type: e.target.value as any })}>
+                  <option value="stamp">Stamp</option>
+                  <option value="badge">Badge</option>
+                  <option value="xp">XP</option>
+                </select>
+                <input style={{ flex:1 }} value={r.code} onChange={(e)=>setReward(idx,{ code: e.target.value })} placeholder="Code or name" />
+                <input style={{ width:120 }} type="number" min={0} value={r.amount || ""} onChange={(e)=>setReward(idx,{ amount: Number(e.target.value)||undefined })} placeholder="Amount" />
+                <button type="button" className="btn danger" onClick={()=>removeReward(idx)}>Remove</button>
+              </div>
+            ))}
+            <button type="button" className="btn ghost" onClick={addReward}>+ Add reward</button>
+          </div>
+        </fieldset>
+
+        <div style={{ display:"flex", gap:10 }}>
+          <button className="btn" type="submit">Save quest</button>
+          <a className="btn ghost" href="/quests">Cancel</a>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -12,6 +12,9 @@ import MarketplacePage from './pages/marketplace';
 import ProductPage from './pages/marketplace/[slug]';
 import CartPage from './pages/cart';
 import WishlistPage from './pages/wishlist';
+import QuestsList from './pages/quests';
+import NewQuest from './pages/quests/new';
+import QuestDetail from './pages/quests/[slug]';
 import Naturversity from './pages/Naturversity';
 import Teachers from './pages/naturversity/Teachers';
 import Partners from './pages/naturversity/Partners';
@@ -62,6 +65,9 @@ export const router = createBrowserRouter([
       },
       { path: 'cart', element: <CartPage /> },
       { path: 'wishlist', element: <WishlistPage /> },
+      { path: 'quests', element: <QuestsList /> },
+      { path: 'quests/new', element: <NewQuest /> },
+      { path: 'quests/:slug', element: <QuestDetail /> },
       {
         path: 'naturversity',
         element: <NaturversityLayout />,

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,8 @@
+export const uid = () => Math.random().toString(36).slice(2, 10);
+export function slugify(s: string) {
+  return s.toLowerCase().trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 64);
+}

--- a/src/utils/quests-store.ts
+++ b/src/utils/quests-store.ts
@@ -1,0 +1,42 @@
+import { Quest } from "../data/quests";
+
+const KEY = "nv_quests";
+const DONE_KEY = (slug: string) => `nv_quest_done_${slug}`;
+
+export function loadQuests(): Quest[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as Quest[]) : [];
+  } catch { return []; }
+}
+
+export function saveQuests(quests: Quest[]) {
+  try { localStorage.setItem(KEY, JSON.stringify(quests)); } catch {}
+}
+
+export function upsertQuest(q: Quest) {
+  const list = loadQuests();
+  const i = list.findIndex(x => x.id === q.id);
+  if (i >= 0) list[i] = q; else list.unshift(q);
+  saveQuests(list);
+}
+
+export function getQuestBySlug(slug: string): Quest | undefined {
+  return loadQuests().find(q => q.slug === slug);
+}
+
+export function listAllQuests(seed: Quest[]): Quest[] {
+  const local = loadQuests();
+  // De-dupe by id; prefer local (edited) over seed
+  const byId = new Map<string, Quest>(seed.map(q => [q.id, q]));
+  local.forEach(q => byId.set(q.id, q));
+  return Array.from(byId.values()).sort((a,b)=> (b.updatedAt>a.updatedAt?1:-1));
+}
+
+/** Per-quest step completion state (by step id) */
+export function getQuestDone(slug: string): Record<string, boolean> {
+  try { return JSON.parse(localStorage.getItem(DONE_KEY(slug)) || "{}"); } catch { return {}; }
+}
+export function setQuestDone(slug: string, done: Record<string, boolean>) {
+  try { localStorage.setItem(DONE_KEY(slug), JSON.stringify(done)); } catch {}
+}

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,0 +1,10 @@
+import { Quest } from "../data/quests";
+
+export function validateQuest(q: Quest): string[] {
+  const errs: string[] = [];
+  if (!q.title?.trim()) errs.push("Title is required.");
+  if (!q.summary?.trim()) errs.push("Summary is required.");
+  if (!q.steps?.length) errs.push("At least one step is required.");
+  if (q.steps.some(s => !s.text?.trim())) errs.push("Each step needs text.");
+  return errs;
+}


### PR DESCRIPTION
## Summary
- add quest type definitions and seed data
- localStorage-backed quest helpers and validators
- new /quests pages for listing, building, and playing quests

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b04d9e0fc08329b46b42538cbed516