### PR TITLE
Global Search: worlds + zones + marketplace + quests (client-side, zero deps)

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import Icon from "./Icon";
+import SearchBar from "./SearchBar";
 
 export default function Nav() {
   return (
@@ -17,6 +18,9 @@ export default function Nav() {
       <a href="/contact" className="nv-nav-item">
         <Icon name="contact" size={18} /> Contact
       </a>
+      <div style={{ marginLeft: "auto", minWidth: 280 }}>
+        <SearchBar />
+      </div>
       <button className="nv-nav-menu" aria-label="Open menu">
         <Icon name="menu" size={20} />
       </button>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import styles from './NavBar.module.css';
 import './NavBar.css';
 import { useAuth } from '@/lib/auth-context';
+import SearchBar from './SearchBar';
 
 export default function NavBar() {
   const { ready, user } = useAuth();
@@ -48,6 +49,9 @@ export default function NavBar() {
           <NavLink to="/turian">Turian</NavLink>
         </nav>
 
+        <div style={{ marginLeft: "auto", minWidth: 280 }}>
+          <SearchBar />
+        </div>
         <div className={styles.right} key={user?.id ?? 'anon'}>
           {ready && user && (
             <>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { buildSearchIndex } from "../search/buildIndex";
+import { search, type SearchDoc } from "../search";
+import "./search.css";
+
+export default function SearchBar() {
+  const [q, setQ] = React.useState("");
+  const [open, setOpen] = React.useState(false);
+  const [results, setResults] = React.useState<SearchDoc[]>([]);
+  const indexRef = React.useRef<SearchDoc[] | null>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (!indexRef.current) indexRef.current = buildSearchIndex();
+  }, []);
+
+  React.useEffect(() => {
+    if (!q.trim()) { setResults([]); return; }
+    const docs = indexRef.current || [];
+    setResults(search(docs, q, 8));
+  }, [q]);
+
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "/" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        inputRef.current?.focus();
+        setOpen(true);
+      }
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  return (
+    <div className="nv-search">
+      <input
+        ref={inputRef}
+        className="nv-search__input"
+        type="search"
+        placeholder="Search worlds, zones, marketplace, quests…  (press / )"
+        value={q}
+        onChange={(e) => { setQ(e.target.value); setOpen(true); }}
+        onFocus={() => setOpen(true)}
+        aria-label="Global search"
+      />
+      {open && (q || results.length) ? (
+        <div className="nv-search__panel" role="listbox">
+          {results.length === 0 ? (
+            <div className="nv-search__empty">No results yet. Try another word.</div>
+          ) : results.map((r) => (
+            <a key={`${r.type}:${r.id}`} className="nv-search__item" href={r.url} role="option">
+              <span className={`nv-search__tag t-${r.type}`}>{r.type}</span>
+              <div className="nv-search__text">
+                <div className="nv-search__title">{r.title}</div>
+                <div className="nv-search__sum">{r.summary}</div>
+              </div>
+            </a>
+          ))}
+          <a className="nv-search__more" href={`/search?q=${encodeURIComponent(q)}`}>See all results →</a>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -5,6 +5,7 @@ import './site-header.css';
 import Img from './Img';
 import AuthButton from './AuthButton';
 import CartBadge from './CartBadge';
+import SearchBar from './SearchBar';
 import { supabase } from '@/lib/supabase-client';
 
 export default function SiteHeader() {
@@ -102,6 +103,9 @@ export default function SiteHeader() {
           </nav>
         </div>
         <div className="nav-right">
+          <div style={{ minWidth: 280 }}>
+            <SearchBar />
+          </div>
           <AuthButton />
           <CartBadge />
           <button

--- a/src/components/search.css
+++ b/src/components/search.css
@@ -1,0 +1,35 @@
+.nv-search { position: relative; max-width: 520px; width: 100%; }
+.nv-search__input {
+  width: 100%; padding: 10px 12px; border: 1px solid #e5e7eb; border-radius: 12px;
+}
+.nv-search__panel {
+  position: absolute; top: calc(100% + 6px); left: 0; right: 0;
+  border: 1px solid #e5e7eb; background: #fff; border-radius: 12px; overflow: hidden;
+  box-shadow: 0 12px 24px rgba(0,0,0,.08); z-index: 50;
+}
+.nv-search__item {
+  display: flex; gap: 10px; padding: 10px 12px; text-decoration: none; color: inherit;
+  border-top: 1px solid #f3f4f6;
+}
+.nv-search__item:first-child { border-top: 0; }
+.nv-search__item:hover { background: #f8fafc; }
+.nv-search__tag {
+  font-size: 11px; border-radius: 999px; padding: 2px 8px; height: fit-content;
+  border: 1px dashed rgba(0,0,0,.2);
+}
+.t-world { background: #eefaff; }
+.t-zone { background: #f4fbf0; }
+.t-product { background: #fff4f0; }
+.t-quest { background: #fbfaff; }
+.nv-search__title { font-weight: 700; }
+.nv-search__sum { font-size: 12px; opacity: .8; }
+.nv-search__more { display: block; padding: 10px 12px; text-align: right; text-decoration: none; border-top: 1px solid #f3f4f6; }
+.nv-search__empty { padding: 12px; opacity: .8; }
+
+@media (prefers-color-scheme: dark) {
+  .nv-search__input { border-color: #2a2f45; background: #0f152b; color: #eaf0ff; }
+  .nv-search__panel { border-color: #2a2f45; background: #0f152b; }
+  .nv-search__item { border-top-color: #1d2340; }
+  .nv-search__item:hover { background: #121733; }
+}
+

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { buildSearchIndex } from "../../search/buildIndex";
+import { search, type SearchDoc } from "../../search";
+import "../../components/search.css";
+
+const TYPES = ["all", "world", "zone", "product", "quest"] as const;
+type TypeFilter = typeof TYPES[number];
+
+export default function SearchPage() {
+  const sp = new URLSearchParams(location.search);
+  const initialQ = sp.get("q") || "";
+
+  const [q, setQ] = React.useState(initialQ);
+  const [type, setType] = React.useState<TypeFilter>("all");
+  const [results, setResults] = React.useState<SearchDoc[]>([]);
+
+  const index = React.useMemo(() => buildSearchIndex(), []);
+
+  React.useEffect(() => {
+    const all = search(index, q, 100);
+    const filtered = type === "all" ? all : all.filter(d => d.type === type);
+    setResults(filtered);
+  }, [q, type, index]);
+
+  React.useEffect(() => {
+    const params = new URLSearchParams();
+    if (q) params.set("q", q);
+    if (type !== "all") params.set("t", type);
+    history.replaceState(null, "", `${location.pathname}?${params.toString()}`);
+  }, [q, type]);
+
+  return (
+    <main style={{ maxWidth: 1100, margin: "24px auto", padding: "0 20px" }}>
+      <h1>Search</h1>
+      <div style={{ display: "flex", gap: 10, flexWrap: "wrap", margin: "12px 0 18px" }}>
+        <input
+          type="search"
+          className="nv-search__input"
+          placeholder="Search the Naturverse…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          autoFocus
+        />
+        <div className="tabs" role="tablist" aria-label="Filter by type">
+          {TYPES.map(t => (
+            <button
+              key={t}
+              role="tab"
+              aria-selected={t === type}
+              className={`tab ${t === type ? "is-active" : ""}`}
+              onClick={() => setType(t)}
+            >
+              {t[0].toUpperCase() + t.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <p style={{ opacity: .7 }}>{results.length} result{results.length === 1 ? "" : "s"}</p>
+
+      <div className="nv-search__panel" style={{ position: "static", boxShadow: "none" }}>
+        {results.length === 0 ? (
+          <div className="nv-search__empty">Nothing found. Try another phrase.</div>
+        ) : results.map(r => (
+          <a key={`${r.type}:${r.id}`} className="nv-search__item" href={r.url}>
+            <span className={`nv-search__tag t-${r.type}`}>{r.type}</span>
+            <div className="nv-search__text">
+              <div className="nv-search__title">{r.title}</div>
+              <div className="nv-search__sum">{r.summary}</div>
+            </div>
+          </a>
+        ))}
+      </div>
+    </main>
+  );
+}
+

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -40,6 +40,7 @@ import Privacy from './pages/Privacy';
 import Contact from './pages/Contact';
 import Accessibility from './pages/Accessibility';
 import About from './pages/About';
+import SearchPage from './pages/search';
 import NotFound from './pages/NotFound';
 import RootLayout from './layouts/Root';
 import RouteError from './routes/RouteError';
@@ -56,6 +57,8 @@ export const router = createBrowserRouter([
       { path: 'worlds/:slug/characters/:name', element: <CharacterPage /> },
       { path: 'zones', element: <ZonesPage /> },
       { path: 'zones/:slug', element: <ZoneDetail /> },
+      { path: 'search', element: <SearchPage /> },
+
       {
         path: 'marketplace',
         children: [

--- a/src/search/buildIndex.ts
+++ b/src/search/buildIndex.ts
@@ -1,0 +1,53 @@
+import { WORLDS } from "../data/worlds";
+import { ZONES } from "../data/zones";
+import { PRODUCTS } from "../data/products";
+import { listAllQuests } from "../utils/quests-store";
+import { SEED_QUESTS } from "../data/quests";
+import type { SearchDoc } from "./index";
+
+export function buildSearchIndex(): SearchDoc[] {
+  const quests = listAllQuests(SEED_QUESTS);
+
+  const worlds = WORLDS.map(w => ({
+    id: w.id,
+    type: "world" as const,
+    title: w.name,
+    slug: w.slug,
+    summary: w.summary,
+    tags: w.tags || [],
+    url: `/worlds/${w.slug}`
+  }));
+
+  const zones = ZONES.map(z => ({
+    id: z.slug,
+    type: "zone" as const,
+    title: z.name,
+    slug: z.slug,
+    summary: z.summary,
+    tags: [z.region],
+    url: `/zones/${z.slug}`
+  }));
+
+  const products = PRODUCTS.map(p => ({
+    id: p.id,
+    type: "product" as const,
+    title: p.name,
+    slug: p.slug,
+    summary: p.summary,
+    tags: p.tags || [p.category],
+    url: `/marketplace/${p.slug}`
+  }));
+
+  const questDocs = quests.map(q => ({
+    id: q.id,
+    type: "quest" as const,
+    title: q.title,
+    slug: q.slug,
+    summary: q.summary,
+    tags: q.kingdom ? [q.kingdom] : [],
+    url: `/quests/${q.slug}`
+  }));
+
+  return [...worlds, ...zones, ...products, ...questDocs];
+}
+

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,0 +1,56 @@
+type Base = {
+  id: string;
+  type: "world" | "zone" | "product" | "quest";
+  title: string;
+  slug: string;
+  summary: string;
+  tags?: string[];
+  url: string;
+};
+
+export type SearchDoc = Base;
+
+export function tokenize(s: string): string[] {
+  return s
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^\w\s-]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function scoreOne(doc: SearchDoc, q: string): number {
+  const hayTitle = doc.title.toLowerCase();
+  const haySummary = doc.summary.toLowerCase();
+  const haySlug = doc.slug.toLowerCase();
+  const hayTags = (doc.tags || []).map(t => t.toLowerCase());
+
+  const nq = q.toLowerCase();
+
+  let score = 0;
+  if (hayTitle.includes(nq)) score += 10;
+  if (haySlug.includes(nq)) score += 6;
+  if (haySummary.includes(nq)) score += 3;
+  if (hayTags.some(t => t.includes(nq))) score += 4;
+
+  // small token match bonus
+  const tokens = tokenize(q);
+  for (const t of tokens) {
+    if (hayTitle.includes(t)) score += 3;
+    if (haySummary.includes(t)) score += 1;
+  }
+  return score;
+}
+
+export function search(docs: SearchDoc[], query: string, limit = 20): SearchDoc[] {
+  if (!query.trim()) return [];
+  const q = query.trim();
+  const scored = docs
+    .map(d => ({ d, s: scoreOne(d, q) }))
+    .filter(x => x.s > 0)
+    .sort((a, b) => b.s - a.s)
+    .slice(0, limit)
+    .map(x => x.d);
+  return scored;
+}
+


### PR DESCRIPTION
## Summary
- add lightweight in-memory search engine and index builder for worlds, zones, products, and quests
- introduce SearchBar with `/` shortcut and instant dropdown results
- provide `/search` page with type filters and deep-linking; wired into router and headers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b051379d5483298843fa4caf5dcb70