### PR TITLE
Feature: Add "What’s New" card to homepage for deploy confirmation

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -41,6 +41,14 @@ export default function Home() {
         )}
       </section>
 
+      <div className="mt-4 p-4 bg-yellow-100 border border-yellow-300 rounded-md text-yellow-900 shadow">
+        <h2 className="text-lg font-semibold">🌟 What’s New</h2>
+        <p>
+          Mini-quests and Zones Explorer are coming soon! This message confirms the latest deploy
+          is live ✅
+        </p>
+      </div>
+
       {/* Top feature tiles — text centered */}
       <section className={styles.featureGrid}>
         <ClickableCard

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -35,6 +35,14 @@ export default function Home() {
         )}
       </section>
 
+      <div className="mt-4 p-4 bg-yellow-100 border border-yellow-300 rounded-md text-yellow-900 shadow">
+        <h2 className="text-lg font-semibold">🌟 What’s New</h2>
+        <p>
+          Mini-quests and Zones Explorer are coming soon! This message confirms the latest deploy
+          is live ✅
+        </p>
+      </div>
+
       {/* Top tiles (centered; disabled when signed out) */}
       <div className={styles.topTiles}>
         {isAuthed ? (


### PR DESCRIPTION
## Summary
- showcase upcoming features with a yellow "What's New" card on the homepage
- replicate card on alternate index page to ensure visibility across builds

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b055e8cc348329bc0898e181ce652a