### PR TITLE
Add Mini-Quests UI to homepage

### DIFF
--- a/src/components/MiniQuests.tsx
+++ b/src/components/MiniQuests.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function MiniQuests() {
+  const quests = [
+    { title: 'Explore Thailandia', desc: 'Visit the first kingdom and meet Turian.' },
+    { title: 'Earn Your First Stamp', desc: 'Complete a quiz and unlock a passport stamp.' },
+    { title: 'Meet a Friend', desc: 'Say hello to Coconut Cruze in Lotus Lake.' },
+  ];
+
+  return (
+    <section className="mini-quests">
+      <h2 className="text-xl font-bold mt-8 mb-4">Mini-Quests</h2>
+      <ul className="space-y-3">
+        {quests.map((q, i) => (
+          <li key={i} className="border p-3 rounded-md bg-blue-50">
+            <strong>{q.title}</strong>
+            <p className="text-sm text-gray-600">{q.desc}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { signInWithGoogle, sendMagicLink } from '@/lib/auth';
 import { useAuth } from '@/lib/auth-context';
 import ClickableCard from '@/components/ClickableCard';
+import MiniQuests from '../components/MiniQuests';
 
 export default function Home() {
   const { user } = useAuth();
@@ -87,6 +88,8 @@ export default function Home() {
           </p>
         </ClickableCard>
       </section>
+
+      <MiniQuests />
 
       {/* Bottom flow — text left-aligned */}
       <section className={styles.flowWrap}>


### PR DESCRIPTION
- Adds "Mini-Quests" section under Play/Learn/Earn
- Shows 3 starter quests with title + short description
- Placeholder only, wired later to DB

------
https://chatgpt.com/codex/tasks/task_e_68b0697bfcb88329b74640ceb28053f6