### PR TITLE
Wire Mini-Quests to Supabase with safe fallback

### DIFF
--- a/src/components/MiniQuests.tsx
+++ b/src/components/MiniQuests.tsx
@@ -1,23 +1,37 @@
 import React from 'react';
+import { fetchMiniQuests, type MiniQuest } from '../lib/miniquests';
 
 export default function MiniQuests() {
-  const quests = [
-    { title: 'Explore Thailandia', desc: 'Visit the first kingdom and meet Turian.' },
-    { title: 'Earn Your First Stamp', desc: 'Complete a quiz and unlock a passport stamp.' },
-    { title: 'Meet a Friend', desc: 'Say hello to Coconut Cruze in Lotus Lake.' },
-  ];
+  const [quests, setQuests] = React.useState<MiniQuest[] | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    fetchMiniQuests().then(q => { if (mounted) setQuests(q); });
+    return () => { mounted = false; };
+  }, []);
 
   return (
     <section className="mini-quests">
       <h2 className="text-xl font-bold mt-8 mb-4">Mini-Quests</h2>
-      <ul className="space-y-3">
-        {quests.map((q, i) => (
-          <li key={i} className="border p-3 rounded-md bg-blue-50">
-            <strong>{q.title}</strong>
-            <p className="text-sm text-gray-600">{q.desc}</p>
-          </li>
-        ))}
-      </ul>
+
+      {!quests && (
+        <div className="text-sm text-gray-500">Loading quests…</div>
+      )}
+
+      {quests && quests.length > 0 && (
+        <ul className="space-y-3">
+          {quests.map((q, i) => (
+            <li key={i} className="border p-3 rounded-md bg-blue-50">
+              <strong>{q.title}</strong>
+              <p className="text-sm text-gray-600">{q.description}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {quests && quests.length === 0 && (
+        <div className="text-sm text-gray-500">No quests yet.</div>
+      )}
     </section>
   );
 }

--- a/src/lib/miniquests.ts
+++ b/src/lib/miniquests.ts
@@ -1,0 +1,33 @@
+import { supabase } from './supabaseClient';
+
+export type MiniQuest = { title: string; description: string; sort?: number };
+
+const FALLBACK: MiniQuest[] = [
+  { title: 'Explore Thailandia', description: 'Visit the first kingdom and meet Turian.', sort: 1 },
+  { title: 'Earn Your First Stamp', description: 'Complete a quiz and unlock a passport stamp.', sort: 2 },
+  { title: 'Meet a Friend', description: 'Say hello to Coconut Cruze in Lotus Lake.', sort: 3 },
+];
+
+/**
+ * Fetch quests from Supabase. Falls back to the local list when:
+ * - Supabase client is not available in this environment
+ * - Query fails
+ * - No rows are returned
+ */
+export async function fetchMiniQuests(): Promise<MiniQuest[]> {
+  if (!supabase) return FALLBACK;
+  try {
+    const { data, error } = await supabase
+      .from('mini_quests_public')
+      .select('title, description, sort')
+      .order('sort', { ascending: true });
+
+    if (error) return FALLBACK;
+    if (!data || data.length === 0) return FALLBACK;
+
+    return data as MiniQuest[];
+  } catch {
+    return FALLBACK;
+  }
+}
+

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,10 +1,14 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const url = import.meta.env.VITE_SUPABASE_URL;
-const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
+// Guarded creation so preview/permalink builds without env don't crash.
+const url = (import.meta as any)?.env?.VITE_SUPABASE_URL as string | undefined;
+const key = (import.meta as any)?.env?.VITE_SUPABASE_ANON_KEY as string | undefined;
 
-// If running on preview and no env, return a no-op client
-export const supabase =
-  url && key
-    ? createClient(url, key)
-    : { from: () => ({ select: async () => ({ data: [], error: null }) }) } as any;
+let supabase: SupabaseClient | null = null;
+if (typeof url === 'string' && url && typeof key === 'string' && key) {
+  supabase = createClient(url, key, {
+    auth: { persistSession: false },
+  });
+}
+
+export { supabase };


### PR DESCRIPTION
- Adds a guarded Supabase client (no runtime crash if env vars are missing)
- MiniQuests now fetches from table/view `mini_quests_public` (title, description, sort)
- Graceful states: loading -> data | fallback | empty; errors fall back silently
- Keeps previous hardcoded quests as offline/preview fallback

------
https://chatgpt.com/codex/tasks/task_e_68b06a6d9eb8832982a716909bb7d026