### PR TITLE
Fix permalink assets, guard Supabase, show Thailandia Mini‑Quests

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,11 +1,13 @@
 {
   "name": "Naturverse",
   "short_name": "Naturverse",
-  "display": "standalone",
-  "start_url": "/",
-  "background_color": "#ffffff",
-  "theme_color": "#2563eb",
   "icons": [
-    { "src": "/favicon-512x512.png", "sizes": "512x512", "type": "image/png" }
-  ]
+    { "src": "favicon-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "favicon-512x512.png", "sizes": "512x512", "type": "image/png" }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#2563eb",
+  "background_color": "#ffffff"
 }
+

--- a/src/components/WorldExtras.tsx
+++ b/src/components/WorldExtras.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import MiniQuests from './MiniQuests';
+
+export default function WorldExtras() {
+  const [path, setPath] = React.useState<string>('');
+
+  React.useEffect(() => {
+    const read = () => setPath(location.pathname || '');
+    read();
+
+    const push = history.pushState;
+    const replace = history.replaceState;
+    const onNav = () => read();
+
+    (history as any).pushState = function (...args: any[]) {
+      const ret = push.apply(this, args as any);
+      window.dispatchEvent(new Event('naturverse:navigate'));
+      return ret;
+    };
+    (history as any).replaceState = function (...args: any[]) {
+      const ret = replace.apply(this, args as any);
+      window.dispatchEvent(new Event('naturverse:navigate'));
+      return ret;
+    };
+    addEventListener('popstate', onNav);
+    addEventListener('naturverse:navigate', onNav);
+
+    return () => {
+      removeEventListener('popstate', onNav);
+      removeEventListener('naturverse:navigate', onNav);
+      (history as any).pushState = push;
+      (history as any).replaceState = replace;
+    };
+  }, []);
+
+  const onThailandia = path.toLowerCase().startsWith('/worlds/thailandia');
+  if (!onThailandia) return null;
+
+  return (
+    <div style={{ maxWidth: 960, margin: '2rem auto', padding: '0 1rem' }}>
+      <MiniQuests />
+    </div>
+  );
+}
+

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,6 +1,18 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+let client: SupabaseClient | null = null;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export function getSupabase(): SupabaseClient | null {
+  const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+  const anon = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+  if (!url || !anon) return null;
+
+  if (!client) {
+    client = createClient(url, anon, { auth: { persistSession: false } });
+  }
+  return client;
+}
+
+// Legacy default export for modules that expect a client immediately
+export const supabase = getSupabase();
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,8 @@ import './styles/nvcard.css';
 import './app.css';
 import './styles/nv-sweep.css';
 import ToastProvider from './components/Toast';
-import { supabase } from '@/lib/supabase-client';
+import { getSupabase } from '@/lib/supabase-client';
+import WorldExtras from './components/WorldExtras';
 import './runtime-logger';
 import { prefetchGlob, prefetchOnHover } from './lib/prefetch';
 import './boot/warmup';
@@ -25,20 +26,28 @@ if (location.hostname.endsWith('.netlify.app')) {
 }
 
 async function bootstrap() {
-  const { data } = await supabase.auth.getSession();
+  const supabase = getSupabase();
+  const { data } = supabase ? await supabase.auth.getSession() : { data: { session: null } };
   const initialSession = data.session ?? null;
 
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-      {/* Ensure auth context wraps the entire app so Home gets updates immediately */}
+      {supabase ? (
         <AuthProvider initialSession={initialSession}>
           <ToastProvider>
             <BaseAuthProvider>
               <App />
+              <WorldExtras />
             </BaseAuthProvider>
           </ToastProvider>
         </AuthProvider>
-      </React.StrictMode>,
+      ) : (
+        <ToastProvider>
+          <App />
+          <WorldExtras />
+        </ToastProvider>
+      )}
+    </React.StrictMode>,
   );
 }
 

--- a/src/register-sw.ts
+++ b/src/register-sw.ts
@@ -1,10 +1,14 @@
 // Only runs in production builds
 if (import.meta.env.PROD && 'serviceWorker' in navigator) {
-  // vite-plugin-pwa injects /sw.js for us
-  import('workbox-window').then(({ Workbox }) => {
-    const wb = new Workbox('/sw.js');
-    wb.addEventListener('waiting', () => wb.messageSW({ type: 'SKIP_WAITING' }));
-    wb.addEventListener('controlling', () => window.location.reload());
-    wb.register();
-  });
+  const host = location.hostname;
+  const onNetlify = host.endsWith('.netlify.app');
+  if (!onNetlify) {
+    // vite-plugin-pwa injects /sw.js for us
+    import('workbox-window').then(({ Workbox }) => {
+      const wb = new Workbox('/sw.js');
+      wb.addEventListener('waiting', () => wb.messageSW({ type: 'SKIP_WAITING' }));
+      wb.addEventListener('controlling', () => window.location.reload());
+      wb.register();
+    });
+  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,13 +20,13 @@ export default defineConfig({
         short_name: 'Naturverse',
         theme_color: '#2563eb',
         background_color: '#ffffff',
-        start_url: '/',
+        start_url: '.',
         display: 'standalone',
         icons: [
-          { src: '/favicon-192x192.png', sizes: '192x192', type: 'image/png' },
-          { src: '/favicon-256x256.png', sizes: '256x256', type: 'image/png' },
+          { src: 'favicon-192x192.png', sizes: '192x192', type: 'image/png' },
+          { src: 'favicon-256x256.png', sizes: '256x256', type: 'image/png' },
           {
-            src: '/favicon-512x512.png',
+            src: 'favicon-512x512.png',
             sizes: '512x512',
             type: 'image/png',
             purpose: 'any maskable',
@@ -60,7 +60,8 @@ export default defineConfig({
       ],
     }),
   ],
-  base: '/', // fix asset URLs on Netlify permalinks & prod
+  // Use a relative base so assets resolve on Netlify permalinks and production
+  base: './',
   envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- use relative Vite base and manifest icon paths so Netlify permalink builds load assets
- lazily create Supabase client and skip auth wrappers when env vars are missing
- render Thailandia Mini‑Quests via new WorldExtras component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b06e858d888329b9cb5b14b1d97464