### PR TITLE
Mini-Quests — show status & best score on Home

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+// simple badge component with tone variants
+interface Props {
+  children: React.ReactNode;
+  tone?: 'default' | 'success' | 'info' | 'muted';
+}
+
+export default function Badge({ children, tone = 'default' }: Props) {
+  const cls =
+    tone === 'success'
+      ? 'badge badge--success'
+      : tone === 'info'
+        ? 'badge badge--info'
+        : tone === 'muted'
+          ? 'badge badge--muted'
+          : 'badge';
+  return <span className={cls}>{children}</span>;
+}

--- a/src/components/miniquests/MiniQuestCard.tsx
+++ b/src/components/miniquests/MiniQuestCard.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Badge from '../Badge';
+import { getProgress } from '../../lib/progress';
+
+type Props = {
+  slug: string;
+  title: string;
+  blurb: string;
+  difficulty?: number;
+  zone?: string;
+};
+
+export default function MiniQuestCard({ slug, title, blurb, difficulty = 1, zone }: Props) {
+  const [best, setBest] = useState(0);
+  const [status, setStatus] = useState<'new' | 'started' | 'completed'>('new');
+
+  const refresh = () => {
+    const p = getProgress(slug);
+    setBest(Number(p?.score || 0));
+    setStatus((p?.status as any) || 'new');
+  };
+
+  useEffect(() => {
+    refresh();
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === 'nv.quest.progress.v1') refresh();
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [slug]);
+
+  const tone = status === 'completed' ? 'success' : status === 'started' ? 'info' : 'muted';
+
+  return (
+    <article className="card">
+      <header className="card__header">
+        <h3 className="card__title">{title}</h3>
+        <Badge tone={tone}>
+          {status === 'new' ? 'New' : status[0].toUpperCase() + status.slice(1)}
+        </Badge>
+      </header>
+
+      <p className="card__meta">
+        {zone ? <Badge tone="muted">{zone}</Badge> : null} <Badge tone="muted">•</Badge>{' '}
+        <Badge tone="muted">
+          {'★'.repeat(difficulty)}
+          {'☆'.repeat(Math.max(0, 5 - difficulty))}
+        </Badge>
+      </p>
+
+      <p className="card__blurb">{blurb}</p>
+
+      <footer className="card__footer">
+        <span className="card__best">
+          Best: <strong>{best}</strong>
+        </span>
+        <Link className="btn" to={`/play/${slug}`}>
+          Play
+        </Link>
+      </footer>
+    </article>
+  );
+}

--- a/src/components/miniquests/MiniQuestSection.tsx
+++ b/src/components/miniquests/MiniQuestSection.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import MiniQuestCard from './MiniQuestCard';
+import { MINI_QUESTS } from '../../data/miniquests';
+
+export default function MiniQuestSection() {
+  return (
+    <section aria-labelledby="mini-quests">
+      <h2 id="mini-quests">Mini-Quests in Thailandia</h2>
+      <div className="mq-grid">
+        {MINI_QUESTS.map((q) => (
+          <MiniQuestCard
+            key={q.slug}
+            slug={q.slug}
+            title={q.title}
+            blurb={q.blurb}
+            difficulty={q.difficulty}
+            zone={q.zone}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -57,11 +57,14 @@ export function localUnlockZone(userId: string, slug: string) {
   } catch {}
 }
 
-type QuestProgress = Record<string, {
-  status: 'new' | 'started' | 'completed';
-  score: number;
-  updatedAt: string;
-}>;
+type QuestProgress = Record<
+  string,
+  {
+    status: 'new' | 'started' | 'completed';
+    score: number;
+    updatedAt: string;
+  }
+>;
 
 function readQuestLocal(): QuestProgress {
   try {
@@ -89,18 +92,16 @@ export async function saveProgress(
   if (supabase) {
     const { data: user } = await supabase.auth.getUser();
     if (user?.user) {
-      await supabase
-        .from('quest_progress')
-        .upsert(
-          {
-            user_id: user.user.id,
-            quest_slug: slug,
-            score,
-            status,
-            updated_at: now,
-          },
-          { onConflict: 'user_id,quest_slug' },
-        );
+      await supabase.from('quest_progress').upsert(
+        {
+          user_id: user.user.id,
+          quest_slug: slug,
+          score,
+          status,
+          updated_at: now,
+        },
+        { onConflict: 'user_id,quest_slug' },
+      );
     }
   }
 }
@@ -110,3 +111,6 @@ export function getProgress(slug: string) {
   return state[slug] ?? { status: 'new' as const, score: 0, updatedAt: '' };
 }
 
+export function getAllProgress() {
+  return JSON.parse(localStorage.getItem(QUEST_LS_KEY) || '{}') as Record<string, any>;
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { signInWithGoogle, sendMagicLink } from '@/lib/auth';
 import { useAuth } from '@/lib/auth-context';
 import ClickableCard from '@/components/ClickableCard';
-import MiniQuests from '../components/MiniQuests';
+import MiniQuestSection from '../components/miniquests/MiniQuestSection';
 import SearchBox from '../components/SearchBox';
 
 export default function Home() {
@@ -26,7 +26,10 @@ export default function Home() {
               onClick={async () => {
                 const email = prompt('Enter your email to get a magic link:')?.trim();
                 if (email) {
-                  sessionStorage.setItem('post-auth-redirect', window.location.pathname + window.location.search);
+                  sessionStorage.setItem(
+                    'post-auth-redirect',
+                    window.location.pathname + window.location.search,
+                  );
                   await sendMagicLink(email);
                 }
               }}
@@ -37,7 +40,10 @@ export default function Home() {
               type="button"
               className={styles.cta}
               onClick={async () => {
-                sessionStorage.setItem('post-auth-redirect', window.location.pathname + window.location.search);
+                sessionStorage.setItem(
+                  'post-auth-redirect',
+                  window.location.pathname + window.location.search,
+                );
                 await signInWithGoogle();
               }}
             >
@@ -48,13 +54,23 @@ export default function Home() {
       </section>
 
       <div className="nv-what">
-        <span role="img" aria-label="sparkles">✨</span>
+        <span role="img" aria-label="sparkles">
+          ✨
+        </span>
         <strong> What’s New</strong>
-        <span> Mini-quests and Zones Explorer are coming soon! This message confirms the latest deploy is live ✅</span>
+        <span>
+          {' '}
+          Mini-quests and Zones Explorer are coming soon! This message confirms the latest deploy is
+          live ✅
+        </span>
       </div>
 
       <div className="nv-home-tools">
-        <SearchBox onFocus={() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))} />
+        <SearchBox
+          onFocus={() =>
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))
+          }
+        />
       </div>
 
       {/* Top feature tiles — text centered */}
@@ -96,7 +112,7 @@ export default function Home() {
         </ClickableCard>
       </section>
 
-      <MiniQuests />
+      <MiniQuestSection />
 
       {/* Bottom flow — text left-aligned */}
       <section className={styles.flowWrap}>
@@ -128,13 +144,11 @@ export default function Home() {
               <>
                 <Link to="/worlds" className={styles.flowLink}>
                   Worlds
-                </Link>
-                {' '}
+                </Link>{' '}
                 ·{' '}
                 <Link to="/zones" className={styles.flowLink}>
                   Zones
-                </Link>
-                {' '}
+                </Link>{' '}
                 ·{' '}
                 <Link to="/marketplace" className={styles.flowLink}>
                   Marketplace

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import { useAuth } from '@/lib/auth-context';
 import { Link, useNavigate } from 'react-router-dom';
 import { signInWithGoogle } from '@/lib/auth';
 import styles from '@/styles/home.module.css';
+import MiniQuestSection from '../components/miniquests/MiniQuestSection';
 
 export default function Home() {
   const { user } = useAuth();
@@ -22,7 +23,8 @@ export default function Home() {
       <section className={styles.hero}>
         <h1 className={styles.title}>Welcome to the Naturverse™</h1>
         <p className={styles.tagline}>
-          A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.
+          A playful world of kingdoms, characters, and quests that teach wellness, creativity, and
+          kindness.
         </p>
         {!isAuthed && (
           <div className={styles.authRow}>
@@ -39,8 +41,8 @@ export default function Home() {
       <div className="mt-4 p-4 bg-yellow-100 border border-yellow-300 rounded-md text-yellow-900 shadow">
         <h2 className="text-lg font-semibold">🌟 What’s New</h2>
         <p>
-          Mini-quests and Zones Explorer are coming soon! This message confirms the latest deploy
-          is live ✅
+          Mini-quests and Zones Explorer are coming soon! This message confirms the latest deploy is
+          live ✅
         </p>
       </div>
 
@@ -59,7 +61,8 @@ export default function Home() {
             <Link to="/naturbank" className={styles.topTile}>
               <span className={styles.topTileTitle}>Earn</span>
               <span>
-                Collect badges, save favorites, and build your Navatar card.<br />
+                Collect badges, save favorites, and build your Navatar card.
+                <br />
                 <em>Natur Coin — coming soon</em>
               </span>
             </Link>
@@ -77,13 +80,16 @@ export default function Home() {
             <div className={`${styles.topTile} ${styles.disabled}`} aria-disabled="true">
               <span className={styles.topTileTitle}>Earn</span>
               <span>
-                Collect badges, save favorites, and build your Navatar card.<br />
+                Collect badges, save favorites, and build your Navatar card.
+                <br />
                 <em>Natur Coin — coming soon</em>
               </span>
             </div>
           </>
         )}
       </div>
+
+      <MiniQuestSection />
 
       {/* Bottom flow (LEFT aligned text; bold blue links) */}
       <div className={styles.flowCard}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,52 +1,164 @@
-@import "./styles/util.css";
-@import "./styles/bank.css";
-@import "./styles/passport.css";
-@import "./styles/turian.css";
-@import "./styles/profile.css";
-@import "./styles/global.css";
-@import "./styles/layout.css";
-@import "./styles/hub.css";
-@import "./styles/crumbs.css";
-@import "./styles/header.css";
-@import "./styles/navbar.css";
-@import "./styles/kingdom.css";
-@import "./styles/brandmark.css";
-@import "./styles/site.css";
-@import "./styles/nv-images.css";
-@import "./styles/marketplace.css";
-@import "./styles/home.css";
-@import "./styles/theme.css";
-@import "../app/styles/global-sections.css";
-:root { --ink:#0b2545; --muted:#6c7676; --card:#f6f7fb; --ring:#dbe2ef; --radius:14px; --naturverse-blue: var(--nv-blue-700); }
-*{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui,Segoe UI,Roboto}
-.wrap{max-width:1120px;margin:0 auto;padding:16px}
-.top{display:flex;gap:16px;align-items:center;border-bottom:1px solid var(--ring);padding-bottom:8px}
-.brand{font-weight:800;color:var(--ink);text-decoration:none;font-size:22px}
-.tabs{display:flex;gap:12px;flex-wrap:wrap}
-.tab{padding:6px 10px;border-radius:8px;text-decoration:none;color:var(--ink)}
-.tab.active{background:var(--card);border:1px solid var(--ring)}
-.h1{font-size:28px;margin:18px 0 8px;font-weight:800;color:var(--ink)}
-.h2{font-size:20px;margin:14px 0 8px;color:var(--ink)}
-.p{color:var(--muted)}
-.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:16px;margin-top:12px}
-.card{border:1px solid #ececec;border-radius:var(--radius);background:#fff;padding:14px}
-.card h3{margin:0 0 6px 0}
-.small{font-size:13px;color:var(--muted)}
-.list{margin:6px 0 0 18px}
-.main{min-height:60vh}
-.foot{margin-top:24px;color:var(--muted);font-size:13px}
-.btn{display:inline-block;padding:8px 12px;border:1px solid var(--ring);border-radius:10px;text-decoration:none}
-.input{width:100%;padding:10px;border:1px solid var(--ring);border-radius:10px}
-.row{display:flex;gap:8px;align-items:center}
-.card .split{display:grid;grid-template-columns:1fr 1fr;gap:12px 16px}
-.card .coming{margin-top:8px}
-
+@import './styles/util.css';
+@import './styles/bank.css';
+@import './styles/passport.css';
+@import './styles/turian.css';
+@import './styles/profile.css';
+@import './styles/global.css';
+@import './styles/layout.css';
+@import './styles/hub.css';
+@import './styles/crumbs.css';
+@import './styles/header.css';
+@import './styles/navbar.css';
+@import './styles/kingdom.css';
+@import './styles/brandmark.css';
+@import './styles/site.css';
+@import './styles/nv-images.css';
+@import './styles/marketplace.css';
+@import './styles/home.css';
+@import './styles/miniquests.css';
+@import './styles/theme.css';
+@import '../app/styles/global-sections.css';
+:root {
+  --ink: #0b2545;
+  --muted: #6c7676;
+  --card: #f6f7fb;
+  --ring: #dbe2ef;
+  --radius: 14px;
+  --naturverse-blue: var(--nv-blue-700);
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    Segoe UI,
+    Roboto;
+}
+.wrap {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 16px;
+}
+.top {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  border-bottom: 1px solid var(--ring);
+  padding-bottom: 8px;
+}
+.brand {
+  font-weight: 800;
+  color: var(--ink);
+  text-decoration: none;
+  font-size: 22px;
+}
+.tabs {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.tab {
+  padding: 6px 10px;
+  border-radius: 8px;
+  text-decoration: none;
+  color: var(--ink);
+}
+.tab.active {
+  background: var(--card);
+  border: 1px solid var(--ring);
+}
+.h1 {
+  font-size: 28px;
+  margin: 18px 0 8px;
+  font-weight: 800;
+  color: var(--ink);
+}
+.h2 {
+  font-size: 20px;
+  margin: 14px 0 8px;
+  color: var(--ink);
+}
+.p {
+  color: var(--muted);
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 16px;
+  margin-top: 12px;
+}
+.card {
+  border: 1px solid #ececec;
+  border-radius: var(--radius);
+  background: #fff;
+  padding: 14px;
+}
+.card h3 {
+  margin: 0 0 6px 0;
+}
+.small {
+  font-size: 13px;
+  color: var(--muted);
+}
+.list {
+  margin: 6px 0 0 18px;
+}
+.main {
+  min-height: 60vh;
+}
+.foot {
+  margin-top: 24px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.btn {
+  display: inline-block;
+  padding: 8px 12px;
+  border: 1px solid var(--ring);
+  border-radius: 10px;
+  text-decoration: none;
+}
+.input {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid var(--ring);
+  border-radius: 10px;
+}
+.row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.card .split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px 16px;
+}
+.card .coming {
+  margin-top: 8px;
+}
 
 /* card image block */
-.card-img { display:flex; align-items:center; justify-content:center; margin-right:12px; }
-.card-img img { width:44px; height:44px; border-radius:8px; object-fit:cover; }
-@media (min-width: 1024px){
-  .card-img img { width:52px; height:52px; }
+.card-img {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 12px;
+}
+.card-img img {
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+@media (min-width: 1024px) {
+  .card-img img {
+    width: 52px;
+    height: 52px;
+  }
 }
 
 /* brand alignment */
@@ -56,21 +168,42 @@
   gap: 8px;
   text-decoration: none;
 }
-.brand__logo { display: inline-block; border-radius: 6px; }
-.brand__name { font-weight: 800; color: #111827; }
-@media (max-width: 640px){
-  .brand__name { font-weight: 800; }
-  .brand__logo { width: 22px; height: 22px; }
+.brand__logo {
+  display: inline-block;
+  border-radius: 6px;
+}
+.brand__name {
+  font-weight: 800;
+  color: #111827;
+}
+@media (max-width: 640px) {
+  .brand__name {
+    font-weight: 800;
+  }
+  .brand__logo {
+    width: 22px;
+    height: 22px;
+  }
 }
 
-
-
 /* reusable brand */
-.brand-mark { display: inline-flex; align-items: center; }
-.brand-logo { display: block; }
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+}
+.brand-logo {
+  display: block;
+}
 .sr-only {
-  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
-  overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* ===== Zones blue scope (isolated) ===== */
@@ -79,12 +212,29 @@
 }
 
 /* Headings, labels, breadcrumbs, and small text inside Zones */
-#zones-root :is(h1, h2, h3, h4, h5, h6,
-  .lead, .subhead, .desc, .help,
-  .chip, .pill, .tag,
-  small, label, .label,
-  nav.breadcrumbs a, nav.breadcrumbs span,
-  .card-title, .card-subtitle) {
+#zones-root
+  :is(
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    .lead,
+    .subhead,
+    .desc,
+    .help,
+    .chip,
+    .pill,
+    .tag,
+    small,
+    label,
+    .label,
+    nav.breadcrumbs a,
+    nav.breadcrumbs span,
+    .card-title,
+    .card-subtitle
+  ) {
   color: var(--naturverse-blue) !important;
 }
 
@@ -110,8 +260,12 @@
 }
 
 /* Links that were defaulting to black in some panels */
-#zones-root a { color: var(--naturverse-blue) !important; }
-#zones-root a:visited { color: var(--naturverse-blue) !important; }
+#zones-root a {
+  color: var(--naturverse-blue) !important;
+}
+#zones-root a:visited {
+  color: var(--naturverse-blue) !important;
+}
 
 /* ---- Zones: make all card/section titles blue on detail pages ---- */
 /* Works for Arcade, Music, Wellness, Stories, Quizzes, Observations,
@@ -132,7 +286,7 @@ header .brand,
 header .logo a,
 footer .brand,
 footer .logo a,
-footer a[href="/"] {
+footer a[href='/'] {
   color: var(--naturverse-blue) !important;
   font-size: 1.35rem !important;
   font-weight: 700 !important;
@@ -145,7 +299,7 @@ footer a[href="/"] {
 header .logo a:hover,
 footer .brand:hover,
 footer .logo a:hover,
-footer a[href="/"]:hover {
+footer a[href='/']:hover {
   color: var(--naturverse-blue) !important;
   text-decoration: none;
 }
@@ -169,4 +323,3 @@ footer img {
   height: 28px !important;
   width: auto !important;
 }
-

--- a/src/styles/miniquests.css
+++ b/src/styles/miniquests.css
@@ -1,0 +1,56 @@
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  background: #eef;
+  border: 1px solid #cfe;
+}
+.badge--success {
+  background: #e9f7ef;
+  border-color: #bfe6cd;
+}
+.badge--info {
+  background: #eaf4ff;
+  border-color: #c9e4ff;
+}
+.badge--muted {
+  background: #f4f4f5;
+  border-color: #e6e6e7;
+  color: #555;
+}
+
+.card {
+  border: 1px solid #e6e6e7;
+  border-radius: 12px;
+  padding: 14px;
+  background: #fff;
+}
+.card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+.card__title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+.card__meta {
+  margin: 0.25rem 0 0.5rem 0;
+  color: #5b6b7a;
+}
+.card__blurb {
+  margin: 0.25rem 0 0.75rem 0;
+}
+.card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.mq-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 14px;
+}


### PR DESCRIPTION
## Summary
- add generic `Badge` component with tone variants
- introduce `MiniQuestCard` with progress badge and best score
- render `MiniQuestSection` on the homepage and expose all quest progress

## Testing
- `npm run typecheck` *(fails: Property 'error' does not exist on type 'AuthOtpResponse | undefined')*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react-swc')*

------
https://chatgpt.com/codex/tasks/task_e_68b0f490cb848329ab63b47c9e035a8b