### PR TITLE
Add badges and best score tracking to mini quests

### DIFF
--- a/src/components/QuestShell.tsx
+++ b/src/components/QuestShell.tsx
@@ -1,6 +1,6 @@
 // src/components/QuestShell.tsx
 import React from 'react';
-import { saveProgress, getProgress, getCloudProgress } from '../lib/progress';
+import { saveQuestProgress, getQuestProgress, getQuestCloudProgress } from '../lib/progress';
 
 type Props = {
   slug: string;
@@ -14,10 +14,10 @@ export default function QuestShell({ slug, title, onRenderGame }: Props) {
   const [submitting, setSubmitting] = React.useState(false);
 
   React.useEffect(() => {
-    const local = getProgress(slug);
+    const local = getQuestProgress(slug);
     setBest(local.bestScore);
     setCompleted(local.completed);
-    getCloudProgress(slug).then((cloud) => {
+    getQuestCloudProgress(slug).then((cloud) => {
       if (cloud) {
         setBest(cloud.bestScore);
         setCompleted(cloud.completed);
@@ -27,8 +27,8 @@ export default function QuestShell({ slug, title, onRenderGame }: Props) {
 
   async function complete(score: number) {
     setSubmitting(true);
-    await saveProgress({ slug, score, completed: true });
-    const next = getProgress(slug);
+    await saveQuestProgress({ slug, score, completed: true });
+    const next = getQuestProgress(slug);
     setBest(next.bestScore);
     setCompleted(next.completed);
     setSubmitting(false);
@@ -39,8 +39,8 @@ export default function QuestShell({ slug, title, onRenderGame }: Props) {
       <header className="quest__header">
         <h1 id="quest-title">{title}</h1>
         <div className="quest__meta">
-          <span className="badge">{completed ? 'Completed' : 'New'}</span>
-          <span className="best">Best: {best}</span>
+          <span className="badge">{completed ? '✅ Completed' : '🔵 New'}</span>
+          <span className="badge best">⭐ Best: {best}</span>
         </div>
       </header>
 

--- a/src/components/miniquests/MiniQuestCard.tsx
+++ b/src/components/miniquests/MiniQuestCard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Badge from '../Badge';
-import { getProgress } from '../../lib/progress';
+import { getQuestProgress } from '../../lib/progress';
 
 type Props = {
   slug: string;
@@ -16,7 +16,7 @@ export default function MiniQuestCard({ slug, title, description, difficulty = 1
   const [completed, setCompleted] = useState(false);
 
   const refresh = async () => {
-    const p = await getProgress(slug);
+    const p = await getQuestProgress(slug);
     setBest(p.bestScore);
     setCompleted(p.completed);
   };
@@ -24,19 +24,19 @@ export default function MiniQuestCard({ slug, title, description, difficulty = 1
   useEffect(() => {
     refresh();
     const onStorage = (e: StorageEvent) => {
-      if (e.key === 'nv.quest.progress.v1') refresh();
+      if (e.key && e.key.startsWith('nv:progress:')) refresh();
     };
     window.addEventListener('storage', onStorage);
     return () => window.removeEventListener('storage', onStorage);
   }, [slug]);
 
-  const tone = completed ? 'success' : best && best > 0 ? 'info' : 'muted';
+  const tone = completed ? 'success' : 'info';
 
   return (
     <article className="card">
       <header className="card__header">
         <h3 className="card__title">{title}</h3>
-        <Badge tone={tone}>{completed ? 'Completed' : best && best > 0 ? 'Started' : 'New'}</Badge>
+        <Badge tone={tone}>{completed ? '✅ Completed' : '🔵 New'}</Badge>
       </header>
 
       <p className="card__meta">
@@ -51,7 +51,11 @@ export default function MiniQuestCard({ slug, title, description, difficulty = 1
 
       <footer className="card__footer">
         <span className="card__best">
-          Best: {best === null ? <span className="skeleton" style={{ width: 20 }} /> : <strong>{best}</strong>}
+          {best === null ? (
+            <span className="skeleton" style={{ width: 20 }} />
+          ) : (
+            <span>⭐ Best: <strong>{best}</strong></span>
+          )}
         </span>
         <Link className="btn" to={`/play/${slug}`}>
           Play

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -1,7 +1,7 @@
 // src/lib/progress.ts
 // Persists progress locally; syncs to Supabase when authed.
 
-type Progress = { bestScore: number; completed: boolean; updatedAt: string };
+export type QuestProgress = { bestScore: number; completed: boolean; updatedAt: string };
 
 const key = (slug: string) => `nv:progress:${slug}`;
 const nowISO = () => new Date().toISOString();
@@ -20,29 +20,29 @@ async function getSupabase() {
   return supabase;
 }
 
-export function getProgress(slug: string): Progress {
+export function getQuestProgress(slug: string): QuestProgress {
   const raw = localStorage.getItem(key(slug));
   if (!raw) return { bestScore: 0, completed: false, updatedAt: nowISO() };
   try {
-    return JSON.parse(raw) as Progress;
+    return JSON.parse(raw) as QuestProgress;
   } catch {
     return { bestScore: 0, completed: false, updatedAt: nowISO() };
   }
 }
 
-export function setLocal(slug: string, p: Progress) {
+export function setLocal(slug: string, p: QuestProgress) {
   localStorage.setItem(key(slug), JSON.stringify(p));
 }
 
-export async function saveProgress(params: {
+export async function saveQuestProgress(params: {
   slug: string;
   score: number;
   completed?: boolean;
 }) {
   const { slug, score, completed = false } = params;
-  const current = getProgress(slug);
+  const current = getQuestProgress(slug);
   const bestScore = Math.max(current.bestScore || 0, score);
-  const merged: Progress = {
+  const merged: QuestProgress = {
     bestScore,
     completed: current.completed || completed,
     updatedAt: nowISO(),
@@ -73,7 +73,7 @@ export async function saveProgress(params: {
   }
 }
 
-export async function getCloudProgress(slug: string) {
+export async function getQuestCloudProgress(slug: string) {
   try {
     const client = await getSupabase();
     if (!client) return null;
@@ -88,7 +88,7 @@ export async function getCloudProgress(slug: string) {
 
     if (!data) return null;
 
-    const merged: Progress = {
+    const merged: QuestProgress = {
       bestScore: data.best_score ?? 0,
       completed: !!data.completed,
       updatedAt: data.updated_at ?? nowISO(),

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 // src/pages/index.tsx (home strip hookup)
 import { QUESTS } from '../lib/quests';
-import { getProgress } from '../lib/progress';
+import { getQuestProgress } from '../lib/progress';
 import { Link } from 'react-router-dom'; // or next/link etc.
 
 function MiniQuestsStrip() {
@@ -9,12 +9,12 @@ function MiniQuestsStrip() {
       <h2 id="mini-quests">Mini-Quests in Thailandia</h2>
       <div className="grid">
         {QUESTS.map(q => {
-          const { bestScore } = getProgress(q.slug);
+          const { bestScore } = getQuestProgress(q.slug);
           return (
             <article key={q.slug} className="card">
               <h3>{q.title}</h3>
               <p className="muted">{q.description}</p>
-              <p className="muted">Best: {bestScore}</p>
+              <p className="muted">⭐ Best: {bestScore}</p>
               <Link to={`/play/${q.slug}`} className="btn btn-primary">Play</Link>
               <Link to={`/play/${q.slug}#leaderboard`} className="btn btn-link" style={{ marginLeft: 8 }}>
                 🏆 View leaderboard


### PR DESCRIPTION
## Summary
- track mini-quest completion and best scores via `QuestProgress`
- show quest status and best score badges on cards and quest shell

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Property 'error' does not exist on type 'AuthOtpResponse | undefined'.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fd26c84c8329834535eb554fc927