### PR TITLE
feat: add navatar system

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,25 @@
 import { Link } from 'react-router-dom'
 import styles from './Header.module.css'
 import { useAuth } from '../hooks/useAuth'
+import NavatarBadge from './NavatarBadge'
+import { getProfile } from '../lib/profile'
+import { useEffect, useState } from 'react'
 
 export default function Header() {
   const { user, loading } = useAuth()
+  const [svg, setSvg] = useState<string>()
+
+  useEffect(() => {
+    if (!user) { setSvg(undefined); return }
+    const cached = localStorage.getItem('navatar_svg')
+    if (cached) { setSvg(cached); return }
+    getProfile(user.id).then(p => {
+      if (p?.avatar_id) {
+        const c = localStorage.getItem('navatar_svg')
+        if (c) setSvg(c)
+      }
+    })
+  }, [user])
 
   return (
     <header className={styles.header}>
@@ -13,6 +29,7 @@ export default function Header() {
 
       {!loading && user && (
         <nav className={styles.nav}>
+          <NavatarBadge svg={svg} size={28} alt="Your Navatar" />
           <Link to="/worlds">Worlds</Link>
           <Link to="/zones">Zones</Link>
           <Link to="/marketplace">Marketplace</Link>

--- a/src/components/NavatarBadge.tsx
+++ b/src/components/NavatarBadge.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+type Props = { svg?: string; url?: string; size?: number; alt?: string; className?: string };
 
-type Props = { svg?: string; url?: string; size?: number; alt?: string };
-export default function NavatarBadge({ svg, url, size = 28, alt = 'Navatar' }: Props) {
-  if (url) return <img src={url} width={size} height={size} alt={alt} style={{ borderRadius: '50%' }} />;
-  if (!svg) return <div style={{ width: size, height: size, borderRadius: '50%', background: '#e6f2ff' }} />;
+export default function NavatarBadge({ svg, url, size = 28, alt = 'Navatar', className }: Props) {
+  if (url) return <img src={url} width={size} height={size} alt={alt} className={className} style={{borderRadius:'50%'}} />;
+  if (!svg) return <span aria-hidden className={className} style={{display:'inline-block',width:size,height:size,borderRadius:'50%',background:'#eaf1ff',border:'1px solid #cfe0ff'}}/>;
   return (
     <span
+      className={className}
       aria-label={alt}
-      style={{ display: 'inline-block', width: size, height: size, borderRadius: '50%', overflow: 'hidden' }}
+      style={{display:'inline-block',width:size,height:size,borderRadius:'50%',overflow:'hidden'}}
       dangerouslySetInnerHTML={{ __html: svg }}
     />
   );

--- a/src/components/NavatarPicker.tsx
+++ b/src/components/NavatarPicker.tsx
@@ -1,32 +1,27 @@
-import React from 'react';
 import { STARTER_NAVATARS } from '../data/navatars';
 import NavatarBadge from './NavatarBadge';
 
-export default function NavatarPicker({ value, onSelect, onSave, saving }: {
-  value?: string;
-  onSelect: (id: string) => void;
-  onSave: () => void;
-  saving?: boolean;
-}) {
+export default function NavatarPicker({
+  value, onSelect, onSave, saving
+}: { value?: string; onSelect: (id:string)=>void; onSave: ()=>void; saving?: boolean }) {
   return (
-    <div className="navatar-picker">
+    <section className="navatar-picker">
       <h2>Choose your Navatar</h2>
       <div className="grid">
-        {STARTER_NAVATARS.map((a) => (
-          <button
-            key={a.id}
-            className={`card ${value === a.id ? 'active' : ''}`}
-            onClick={() => onSelect(a.id)}
-            aria-pressed={value === a.id}
-          >
-            <NavatarBadge svg={a.svg} size={64} alt={a.name} />
+        {STARTER_NAVATARS.map(a => (
+          <button key={a.id}
+            className={`avatar-card ${value===a.id?'active':''}`}
+            onClick={()=>onSelect(a.id)}
+            aria-pressed={value===a.id}
+            type="button">
+            <NavatarBadge svg={a.svg} size={72} alt={a.name} />
             <div className="label">{a.name}</div>
           </button>
         ))}
       </div>
-      <button className="primary" disabled={!value || saving} onClick={onSave}>
-        {saving ? 'Saving…' : 'Save Navatar'}
+      <button className="primary" disabled={!value || saving} onClick={onSave} type="button">
+        {saving? 'Saving…' : 'Save Navatar'}
       </button>
-    </div>
+    </section>
   );
 }

--- a/src/data/navatars.ts
+++ b/src/data/navatars.ts
@@ -1,7 +1,10 @@
-export type Navatar = { id: string; name: string; tier: 'starter' | 'rare' | 'legend'; svg: string };
+export type Navatar = { id: string; name: string; tier: 'starter'|'rare'|'legend'; svg: string };
+
+const S = (p: string) => `<svg viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#2563eb" stroke-width="2"><circle cx="48" cy="48" r="44" fill="#eaf1ff"/><path d="${p}" fill="#bcd3ff"/></g></svg>`;
 
 export const STARTER_NAVATARS: Navatar[] = [
-  { id: 'leafling-01', name: 'Leafling', tier: 'starter', svg: `<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><circle cx="16" cy="16" r="16" fill="#a3e635"/></svg>` },
-  { id: 'leafling-02', name: 'Leafling', tier: 'starter', svg: `<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><rect width="32" height="32" rx="16" fill="#86efac"/></svg>` },
-  { id: 'seedling-01', name: 'Seedling', tier: 'starter', svg: `<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M16 2a14 14 0 1 0 0 28 14 14 0 0 0 0-28z" fill="#bbf7d0"/></svg>` },
+  { id:'leafling-01', name:'Leafling', tier:'starter', svg:S('M30 60c10-20 26-20 36 0-12 6-24 6-36 0z') },
+  { id:'leafling-02', name:'Leafling', tier:'starter', svg:S('M22 52c8-18 44-18 52 0-18 8-34 8-52 0z') },
+  { id:'seedling-01', name:'Seedling', tier:'starter', svg:S('M48 24c12 8 12 24 0 40-12-16-12-32 0-40z') },
+  { id:'sprout-01',   name:'Sprout',   tier:'starter', svg:S('M24 64c8-6 16-6 24 0 8-6 16-6 24 0-16 8-32 8-48 0z') },
 ];

--- a/src/lib/auth-gating.ts
+++ b/src/lib/auth-gating.ts
@@ -1,6 +1,8 @@
 import { getProfile } from './profile';
 
 export async function ensureNavatarOnFirstLogin(userId: string) {
-  const p = await getProfile(userId);
-  if (!p?.avatar_id) window.location.assign('/navatar');
+  try {
+    const p = await getProfile(userId);
+    if (!p?.avatar_id) window.location.assign('/navatar');
+  } catch { /* no-op */ }
 }

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,24 +1,21 @@
-import { getSupabase } from './supabase-client';
+import { supabase } from './supabaseClient';
 
-export type Profile = { id: string; display_name?: string | null; avatar_id?: string | null; avatar_url?: string | null };
+export type Profile = {
+  id: string;
+  display_name?: string | null;
+  avatar_id?: string | null;
+  avatar_url?: string | null;
+  updated_at?: string | null;
+};
 
-export async function getProfile(userId: string) {
-  const supabase = getSupabase();
-  if (!supabase) throw new Error('Supabase unavailable');
-  const { data, error } = await supabase
-    .from('profiles')
-    .select('*')
-    .eq('id', userId)
-    .maybeSingle();
-  if (error && (error as any).code === 'PGRST116') return null;
+export async function getProfile(userId: string): Promise<Profile | null> {
+  const { data, error } = await supabase!.from('profiles').select('*').eq('id', userId).maybeSingle();
   if (error) throw error;
-  return data as Profile;
+  return data ?? null;
 }
 
-export async function upsertProfile(p: Profile) {
-  const supabase = getSupabase();
-  if (!supabase) throw new Error('Supabase unavailable');
-  const { data, error } = await supabase.from('profiles').upsert(p).select().single();
+export async function upsertProfile(p: Profile): Promise<Profile> {
+  const { data, error } = await supabase!.from('profiles').upsert(p, { onConflict: 'id' }).select().single();
   if (error) throw error;
   return data as Profile;
 }

--- a/src/pages/navatar.tsx
+++ b/src/pages/navatar.tsx
@@ -1,32 +1,29 @@
 import { useEffect, useState } from 'react';
-import { useAuth } from '../hooks/useAuth';
-import { getProfile, upsertProfile } from '../lib/profile';
-import { STARTER_NAVATARS } from '../data/navatars';
-import NavatarPicker from '../components/NavatarPicker';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+import { STARTER_NAVATARS } from '../data/navatars';
+import { getProfile, upsertProfile } from '../lib/profile';
+import NavatarPicker from '../components/NavatarPicker';
 import '../styles/navatar.css';
 
-export default function NavatarSetupPage() {
+export default function NavatarPage() {
   const { user } = useAuth();
+  const nav = useNavigate();
   const [selected, setSelected] = useState<string>();
   const [saving, setSaving] = useState(false);
-  const nav = useNavigate();
 
   useEffect(() => {
     if (!user) return;
-    getProfile(user.id).then((p) => {
-      if (p?.avatar_id) {
-        nav('/');
-      } else if (p) {
-        setSelected(p.avatar_id ?? undefined);
-      }
-    });
-  }, [user, nav]);
+    (async () => {
+      const p = await getProfile(user.id);
+      if (p?.avatar_id) nav('/');
+    })();
+  }, [user]);
 
   async function save() {
     if (!user || !selected) return;
     setSaving(true);
-    const svg = STARTER_NAVATARS.find((a) => a.id === selected)?.svg ?? null;
+    const svg = STARTER_NAVATARS.find(a => a.id===selected)?.svg ?? '';
     await upsertProfile({ id: user.id, avatar_id: selected, avatar_url: null });
     localStorage.setItem('navatar_id', selected);
     if (svg) localStorage.setItem('navatar_svg', svg);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -28,7 +28,7 @@ import BankWallet from './pages/naturbank/Wallet';
 import BankToken from './pages/naturbank/Token';
 import BankNFTs from './pages/naturbank/NFTs';
 import BankLearn from './pages/naturbank/Learn';
-import NavatarSetupPage from './pages/navatar';
+import NavatarPage from './pages/navatar';
 import PassportPage from './pages/passport';
 import ProgressPage from './pages/progress';
 import LoginPage from './pages/Login';
@@ -98,7 +98,7 @@ export const router = createBrowserRouter([
       { path: 'contact', element: <Contact /> },
       { path: 'accessibility', element: <Accessibility /> },
       { path: 'about', element: <About /> },
-      { path: 'navatar', element: <NavatarSetupPage /> },
+      { path: 'navatar', element: <NavatarPage /> },
       { path: 'progress', element: <ProgressPage /> },
       { path: 'passport', element: <PassportPage /> },
       { path: 'auth/callback', element: <AuthCallback /> },

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,26 +1,19 @@
+.navatar-picker { max-width: 920px; margin: 0 auto; padding: 24px; }
+.navatar-picker h2 { font-size: 1.6rem; margin: 0 0 12px; }
+
 .navatar-picker .grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: 16px;
+  display: grid; gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(150px,1fr));
 }
-.navatar-picker .card {
-  border: 1px solid #e6ecff;
-  padding: 14px;
-  border-radius: 12px;
-  background: #fff;
+
+.navatar-picker .avatar-card {
+  border: 1px solid #e6ecff; border-radius: 12px; background: #fff;
+  padding: 14px; display: grid; place-items: center; gap: 8px;
 }
-.navatar-picker .card.active {
-  outline: 2px solid #3b82f6;
-}
-.navatar-picker .label {
-  margin-top: 8px;
-  font-weight: 600;
-  text-align: center;
-}
+.navatar-picker .avatar-card.active { outline: 2px solid #2563eb; }
+.navatar-picker .label { font-weight: 600; }
+
 .navatar-picker .primary {
-  margin-top: 16px;
-  padding: 10px 16px;
-  border-radius: 10px;
-  background: #2563eb;
-  color: #fff;
+  margin-top: 12px; padding: 10px 16px; border-radius: 10px;
+  background: #2563eb; color: #fff; border: none; font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- add starter navatar data and picker components
- store user navatar profile and gate first login
- render cached navatar badge in header

## Testing
- `npm run typecheck` *(fails: Property 'error' does not exist on type 'AuthOtpResponse | undefined'.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1039cfaec83299ac9066b16e11237