### PR TITLE
feat: add navatar creation flow

### DIFF
--- a/netlify/functions/navatar-generate.ts
+++ b/netlify/functions/navatar-generate.ts
@@ -1,0 +1,44 @@
+import type { Handler } from '@netlify/functions';
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY!;
+
+export const handler: Handler = async (event) => {
+  try {
+    const { prompt, n = 4, size = '512x512' } = JSON.parse(event.body || '{}');
+    if (!prompt || typeof prompt !== 'string') {
+      return { statusCode: 400, body: 'Missing prompt' };
+    }
+
+    if (prompt.length > 400) {
+      return { statusCode: 400, body: 'Prompt too long (max 400 chars)' };
+    }
+
+    const composed = `Thailandia Flat style, cute mascot avatar, clean shapes, no text, white/soft background, 1:1. ${prompt}`;
+
+    const r = await fetch('https://api.openai.com/v1/images/generations', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-image-1',
+        prompt: composed,
+        size,
+        n,
+        response_format: 'b64_json',
+      }),
+    });
+
+    if (!r.ok) {
+      const t = await r.text();
+      return { statusCode: 500, body: t };
+    }
+
+    const json = await r.json();
+    const images = (json?.data || []).map((d: any) => d.b64_json);
+    return { statusCode: 200, body: JSON.stringify({ images }) };
+  } catch (e: any) {
+    return { statusCode: 500, body: JSON.stringify({ error: e?.message || 'Server error' }) };
+  }
+};

--- a/netlify/functions/navatar-save.ts
+++ b/netlify/functions/navatar-save.ts
@@ -1,0 +1,64 @@
+import type { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const supa = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+function b64ToBuffer(b64: string) {
+  return Buffer.from(b64, 'base64');
+}
+
+export const handler: Handler = async (event) => {
+  try {
+    const { user_id, name, navatar_id, b64_png } = JSON.parse(event.body || '{}');
+    if (!user_id || !name || !navatar_id || !b64_png) {
+      return { statusCode: 400, body: 'Missing fields' };
+    }
+
+    const path = `u/${user_id}/${navatar_id}.png`;
+    const file = b64ToBuffer(b64_png);
+
+    const up = await supa.storage.from('navatars-user').upload(path, file, {
+      contentType: 'image/png',
+      upsert: true,
+    });
+    if (up.error) return { statusCode: 500, body: up.error.message };
+
+    const { data: pub } = supa.storage.from('navatars-user').getPublicUrl(path);
+    const imgUrl = pub?.publicUrl;
+
+    const { error: insErr } = await supa.from('navatars').upsert({
+      id: navatar_id,
+      slug: navatar_id,
+      name,
+      rarity: 'starter',
+      price_cents: 0,
+      img: imgUrl,
+      tags: ['user'],
+      active: true,
+      created_by: user_id,
+      user_generated: true,
+    });
+    if (insErr) return { statusCode: 500, body: insErr.message };
+
+    await supa.from('owned_navatars').upsert(
+      {
+        user_id,
+        navatar_id,
+      },
+      { onConflict: 'user_id,navatar_id' }
+    );
+
+    const { data: profile } = await supa
+      .from('profiles')
+      .select('navatar_id')
+      .eq('id', user_id)
+      .maybeSingle();
+    if (!profile?.navatar_id) {
+      await supa.from('profiles').update({ navatar_id }).eq('id', user_id);
+    }
+
+    return { statusCode: 200, body: JSON.stringify({ ok: true, img: imgUrl }) };
+  } catch (e: any) {
+    return { statusCode: 500, body: JSON.stringify({ error: e?.message || 'Server error' }) };
+  }
+};

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -45,6 +45,7 @@ export default function NavBar() {
           <NavLink to="/naturversity">Naturversity</NavLink>
           <NavLink to="/naturbank">NaturBank</NavLink>
           <NavLink to="/navatar">Navatar</NavLink>
+          <NavLink to="/create/navatar">Create Navatar</NavLink>
           <NavLink to="/passport">Passport</NavLink>
           <NavLink to="/turian">Turian</NavLink>
         </nav>
@@ -92,6 +93,7 @@ export default function NavBar() {
           <NavLink to="/naturversity">Naturversity</NavLink>
           <NavLink to="/naturbank">NaturBank</NavLink>
           <NavLink to="/navatar">Navatar</NavLink>
+          <NavLink to="/create/navatar">Create Navatar</NavLink>
           <NavLink to="/passport">Passport</NavLink>
           <NavLink to="/turian">Turian</NavLink>
         </div>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -90,6 +90,13 @@ export default function SiteHeader() {
               Navatar
             </NavLink>
             <NavLink
+              to="/create/navatar"
+              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+              onClick={() => setOpen(false)}
+            >
+              Create Navatar
+            </NavLink>
+            <NavLink
               to="/passport"
               className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
               onClick={() => setOpen(false)}

--- a/src/pages/create/navatar.tsx
+++ b/src/pages/create/navatar.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import { useAuth } from '../../lib/auth-context';
+
+const STYLE_PRESETS = [
+  'Leaf spirit with gentle smile, teal-blue palette',
+  'Festival splash creature with water motif',
+  'Zen panda minimal lines, calm expression',
+  'Bamboo buddy, rounded shapes, friendly eyes',
+];
+
+export default function CreateNavatarPage() {
+  const { user } = useAuth();
+  const [prompt, setPrompt] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [images, setImages] = useState<string[] | null>(null);
+  const [choice, setChoice] = useState<number | null>(null);
+  const [name, setName] = useState('');
+
+  async function generate() {
+    setBusy(true);
+    setImages(null);
+    setChoice(null);
+    const r = await fetch('/.netlify/functions/navatar-generate', {
+      method: 'POST',
+      body: JSON.stringify({ prompt: prompt.trim() || 'leaf spirit mascot' }),
+    });
+    const data = await r.json();
+    setImages(data.images || []);
+    setBusy(false);
+  }
+
+  async function save() {
+    if (!user) {
+      alert('Please sign in to save your Navatar');
+      return;
+    }
+    if (choice == null || !images?.[choice]) {
+      alert('Pick one preview');
+      return;
+    }
+    const navatar_id = `u-${user.id.slice(0, 8)}-${Math.random().toString(36).slice(2, 8)}`;
+    const b64 = images[choice];
+    const label = name.trim() || 'My Navatar';
+
+    setBusy(true);
+    const rr = await fetch('/.netlify/functions/navatar-save', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        user_id: user.id,
+        name: label,
+        navatar_id,
+        b64_png: b64,
+      }),
+    });
+    const out = await rr.json();
+    setBusy(false);
+    if (!rr.ok || !out?.ok) {
+      alert(out?.error || 'Failed to save');
+      return;
+    }
+    alert('Saved! You now own this Navatar.');
+    window.location.href = '/navatar';
+  }
+
+  return (
+    <main style={{ maxWidth: 1100, margin: '0 auto', padding: '24px 16px' }}>
+      <h1>Create your Navatar</h1>
+      <p>Describe your vibe — we’ll generate a Thailandia-style avatar.</p>
+
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', margin: '12px 0' }}>
+        {STYLE_PRESETS.map((s) => (
+          <button key={s} onClick={() => setPrompt(s)} className="btn">
+            {s}
+          </button>
+        ))}
+      </div>
+
+      <textarea
+        rows={3}
+        placeholder="e.g., leaf spirit with bamboo crown and ocean aura"
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        style={{ width: '100%', padding: 12, borderRadius: 8, border: '1px solid #e5e7eb' }}
+      />
+      <div style={{ marginTop: 12 }}>
+        <button className="btn btn-primary" onClick={generate} disabled={busy}>
+          {busy ? 'Generating…' : 'Generate 4 previews'}
+        </button>
+      </div>
+
+      {images && (
+        <>
+          <h2 style={{ marginTop: 24 }}>Pick one</h2>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(220px,1fr))',
+              gap: 12,
+            }}
+          >
+            {images.map((b64, i) => (
+              <button
+                type="button"
+                key={i}
+                onClick={() => setChoice(i)}
+                style={{
+                  border: choice === i ? '3px solid #2563eb' : '1px solid #e5e7eb',
+                  borderRadius: 12,
+                  padding: 6,
+                  background: '#fff',
+                }}
+              >
+                <img
+                  src={`data:image/png;base64,${b64}`}
+                  alt={`preview ${i + 1}`}
+                  style={{ width: '100%', borderRadius: 8 }}
+                />
+              </button>
+            ))}
+          </div>
+
+          <div style={{ marginTop: 16, display: 'flex', gap: 12, alignItems: 'center' }}>
+            <input
+              type="text"
+              placeholder="Name your Navatar"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              style={{ flex: 1, padding: 10, border: '1px solid #e5e7eb', borderRadius: 8 }}
+            />
+            <button className="btn btn-primary" onClick={save} disabled={busy || choice == null}>
+              {busy ? 'Saving…' : 'Save & Own'}
+            </button>
+          </div>
+        </>
+      )}
+    </main>
+  );
+}

--- a/src/pages/marketplace/navatar.tsx
+++ b/src/pages/marketplace/navatar.tsx
@@ -30,6 +30,7 @@ export default function NavatarMarketplacePage() {
   return (
     <div style={{ padding: '24px 16px', maxWidth: 1100, margin: '0 auto' }}>
       <h1>Navatar Marketplace</h1>
+      <p><a className="btn" href="/create/navatar">✨ Create your own</a></p>
       <div style={{ display: 'flex', gap: 12, alignItems: 'center', marginBottom: 16 }}>
         <label>Filter:</label>
         <select value={filter} onChange={(e) => setFilter(e.target.value as any)}>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -30,6 +30,7 @@ import BankToken from './pages/naturbank/Token';
 import BankNFTs from './pages/naturbank/NFTs';
 import BankLearn from './pages/naturbank/Learn';
 import NavatarPage from './pages/navatar';
+import CreateNavatarPage from './pages/create/navatar';
 import PassportPage from './pages/passport';
 import ProgressPage from './pages/progress';
 import LoginPage from './pages/Login';
@@ -101,6 +102,7 @@ export const router = createBrowserRouter([
       { path: 'accessibility', element: <Accessibility /> },
       { path: 'about', element: <About /> },
       { path: 'navatar', element: <NavatarPage /> },
+      { path: 'create/navatar', element: <CreateNavatarPage /> },
       { path: 'progress', element: <ProgressPage /> },
       { path: 'passport', element: <PassportPage /> },
       { path: 'auth/callback', element: <AuthCallback /> },


### PR DESCRIPTION
## Summary
- add serverless functions to generate and save Navatars
- create `/create/navatar` page to preview and own generated avatars
- wire up routes and header links for Navatar creation and add marketplace CTA

## Testing
- `npm run typecheck` *(fails: Property 'error' does not exist; Cannot find module 'ethers')*


------
https://chatgpt.com/codex/tasks/task_e_68b10ef65ef48329afec39e0efb13dea