### PR TITLE
Navatar Marketplace — List & Sell (Stripe + $NATUR, fees & royalties)

### DIFF
--- a/netlify/functions/listing-buy-natur-verify.ts
+++ b/netlify/functions/listing-buy-natur-verify.ts
@@ -1,0 +1,110 @@
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+import { ethers } from 'ethers';
+
+const supa = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const RPC = process.env.NATUR_RPC_URL!;
+const TOKEN = process.env.VITE_NATUR_TOKEN_CONTRACT!;
+const TREASURY = process.env.VITE_NATUR_TREASURY!;
+const DECIMALS = Number(process.env.VITE_NATUR_TOKEN_DECIMALS || '18');
+const ERC20_ABI = ['event Transfer(address indexed from, address indexed to, uint256 value)'];
+
+export const handler: Handler = async (event) => {
+  try {
+    const { listing_id, buyer_user_id, tx_hashes = [] } = JSON.parse(event.body || '{}');
+    if (!listing_id || !buyer_user_id || !Array.isArray(tx_hashes) || tx_hashes.length === 0) return resp(400, 'Missing inputs');
+
+    const { data: listing } = await supa
+      .from('navatar_listings')
+      .select('*')
+      .eq('id', listing_id)
+      .maybeSingle();
+    if (!listing || listing.status !== 'active') return resp(400, 'Listing unavailable');
+    if (listing.currency !== 'natur' || !listing.price_natur) return resp(400, 'Not a NATUR listing');
+
+    const { data: sellerProfile } = await supa
+      .from('profiles')
+      .select('wallet_address')
+      .eq('id', listing.seller_user_id)
+      .maybeSingle();
+    const { data: nav } = await supa
+      .from('navatars')
+      .select('created_by')
+      .eq('id', listing.navatar_id)
+      .maybeSingle();
+    const { data: creatorProfile } = nav?.created_by
+      ? await supa
+          .from('profiles')
+          .select('wallet_address')
+          .eq('id', nav.created_by)
+          .maybeSingle()
+      : { data: null as any };
+
+    const gross = Number(listing.price_natur);
+    const fee = Math.round(gross * (listing.fee_bps / 10000) * 1e6) / 1e6;
+    const royalty = Math.round(gross * (listing.royalty_bps / 10000) * 1e6) / 1e6;
+    const seller = Math.max(0, Math.round((gross - fee - royalty) * 1e6) / 1e6);
+
+    const provider = new ethers.JsonRpcProvider(RPC);
+    const iface = new ethers.Interface(ERC20_ABI);
+
+    let seenSeller = false;
+    let seenFeeRoy = false;
+    const needSellerTo = (sellerProfile?.wallet_address || '').toLowerCase();
+    const needTreasury = TREASURY.toLowerCase();
+
+    for (const h of tx_hashes) {
+      const receipt = await provider.getTransactionReceipt(h);
+      if (!receipt || receipt.status !== 1) continue;
+      for (const log of receipt.logs) {
+        if ((log.address || '').toLowerCase() !== TOKEN.toLowerCase()) continue;
+        try {
+          const parsed = iface.parseLog({ topics: log.topics, data: log.data });
+          const to = (parsed.args[1] as string).toLowerCase();
+          const val = parsed.args[2] as bigint;
+          if (needSellerTo && to === needSellerTo && Number(ethers.formatUnits(val, DECIMALS)) + 1e-12 >= seller) {
+            seenSeller = true;
+          }
+          if (to === needTreasury && Number(ethers.formatUnits(val, DECIMALS)) + 1e-12 >= (fee + (creatorProfile?.wallet_address ? 0 : royalty))) {
+            seenFeeRoy = true;
+          }
+        } catch {}
+      }
+    }
+
+    if (!(seenSeller && seenFeeRoy)) return resp(400, 'Required NATUR transfers not detected');
+
+    await supa.from('navatar_sales').insert({
+      listing_id,
+      buyer_user_id,
+      method: 'natur',
+      gross_amount: gross,
+      fee_amount: fee,
+      royalty_amount: royalty,
+      seller_proceeds: seller,
+      tx_hashes,
+    });
+
+    await supa
+      .from('owned_navatars')
+      .delete()
+      .eq('user_id', listing.seller_user_id)
+      .eq('navatar_id', listing.navatar_id);
+    await supa
+      .from('owned_navatars')
+      .upsert({ user_id: buyer_user_id, navatar_id: listing.navatar_id });
+
+    await supa
+      .from('navatar_listings')
+      .update({ status: 'sold', sold_at: new Date().toISOString() })
+      .eq('id', listing_id);
+
+    return resp(200, { ok: true });
+  } catch (e: any) {
+    return resp(500, e?.message || 'Server error');
+  }
+};
+
+function resp(code: number, body: any) {
+  return { statusCode: code, body: typeof body === 'string' ? body : JSON.stringify(body) };
+}

--- a/netlify/functions/listing-buy-stripe.ts
+++ b/netlify/functions/listing-buy-stripe.ts
@@ -1,0 +1,51 @@
+import { Handler } from '@netlify/functions';
+import Stripe from 'stripe';
+import { createClient } from '@supabase/supabase-js';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2022-11-15' });
+
+export const handler: Handler = async (event) => {
+  try {
+    const { listing_id, buyer_user_id } = JSON.parse(event.body || '{}');
+    if (!listing_id || !buyer_user_id) return resp(400, 'Missing');
+
+    const admin = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+    const { data: listing } = await admin
+      .from('navatar_listings')
+      .select('*')
+      .eq('id', listing_id)
+      .maybeSingle();
+    if (!listing || listing.status !== 'active') return resp(400, 'Listing unavailable');
+    if (listing.currency !== 'usd' || !listing.price_cents) return resp(400, 'Listing is not Stripe/USD');
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            unit_amount: listing.price_cents,
+            product_data: { name: `Navatar #${listing.navatar_id}` },
+          },
+          quantity: 1,
+        },
+      ],
+      success_url: `${process.env.SITE_URL}/marketplace/navatar?purchase=success`,
+      cancel_url: `${process.env.SITE_URL}/marketplace/navatar?purchase=cancel`,
+      metadata: {
+        type: 'navatar_listing',
+        listing_id,
+        buyer_user_id,
+      },
+    });
+
+    return resp(200, { url: session.url });
+  } catch (e: any) {
+    return resp(500, e?.message || 'Server error');
+  }
+};
+
+function resp(code: number, body: any) {
+  return { statusCode: code, body: typeof body === 'string' ? body : JSON.stringify(body) };
+}

--- a/netlify/functions/listing-cancel.ts
+++ b/netlify/functions/listing-cancel.ts
@@ -1,0 +1,33 @@
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const supa = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+export const handler: Handler = async (event) => {
+  try {
+    const { seller_user_id, listing_id } = JSON.parse(event.body || '{}');
+    if (!seller_user_id || !listing_id) return resp(400, 'Missing');
+
+    const { data: listing } = await supa
+      .from('navatar_listings')
+      .select('*')
+      .eq('id', listing_id)
+      .maybeSingle();
+    if (!listing) return resp(404, 'Listing not found');
+    if (listing.seller_user_id !== seller_user_id) return resp(403, 'Not your listing');
+    if (listing.status !== 'active') return resp(400, 'Listing not active');
+
+    const { error } = await supa
+      .from('navatar_listings')
+      .update({ status: 'cancelled' })
+      .eq('id', listing_id);
+    if (error) return resp(500, error.message);
+    return resp(200, { ok: true });
+  } catch (e: any) {
+    return resp(500, e?.message || 'Server error');
+  }
+};
+
+function resp(code: number, body: any) {
+  return { statusCode: code, body: typeof body === 'string' ? body : JSON.stringify(body) };
+}

--- a/netlify/functions/listing-create.ts
+++ b/netlify/functions/listing-create.ts
@@ -1,0 +1,44 @@
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const supa = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+export const handler: Handler = async (event) => {
+  try {
+    const { seller_user_id, navatar_id, currency, price_cents, price_natur, fee_bps = 1000, royalty_bps = 500 } = JSON.parse(event.body || '{}');
+    if (!seller_user_id || !navatar_id || !currency) return resp(400, 'Missing fields');
+    if (currency === 'usd' && (!Number.isInteger(price_cents) || price_cents <= 0)) return resp(400, 'Invalid price_cents');
+    if (currency === 'natur' && (!price_natur || Number(price_natur) <= 0)) return resp(400, 'Invalid price_natur');
+
+    const { data: own } = await supa
+      .from('owned_navatars')
+      .select('user_id')
+      .eq('user_id', seller_user_id)
+      .eq('navatar_id', navatar_id)
+      .maybeSingle();
+    if (!own) return resp(400, 'Seller does not own this Navatar');
+
+    const { data, error } = await supa
+      .from('navatar_listings')
+      .insert({
+        seller_user_id,
+        navatar_id,
+        currency,
+        price_cents: price_cents ?? null,
+        price_natur: price_natur ?? null,
+        fee_bps,
+        royalty_bps,
+        status: 'active',
+      })
+      .select()
+      .single();
+    if (error) return resp(500, error.message);
+    return resp(200, { ok: true, listing: data });
+  } catch (e: any) {
+    return resp(500, e?.message || 'Server error');
+  }
+};
+
+function resp(code: number, body: any) {
+  return { statusCode: code, body: typeof body === 'string' ? body : JSON.stringify(body) };
+}

--- a/netlify/functions/stripe-webhook.ts
+++ b/netlify/functions/stripe-webhook.ts
@@ -11,17 +11,59 @@ export const handler: Handler = async (event) => {
     const evt = stripe.webhooks.constructEvent(event.body!, sig!, process.env.STRIPE_WEBHOOK_SECRET!);
     if (evt.type === 'checkout.session.completed') {
       const session = evt.data.object as any;
-      const { user_id, navatar_id } = session.metadata;
-      await supabase.from('navatar_purchases').insert([
-        {
-          user_id,
-          navatar_id,
-          method: 'stripe',
-          amount: session.amount_total / 100,
-        },
-      ]);
-      // auto-mark navatar as owned
-      await supabase.from('profiles').update({ navatar_id }).eq('id', user_id);
+      if (session.metadata?.type === 'navatar_listing') {
+        const listing_id = session.metadata.listing_id;
+        const buyer_user_id = session.metadata.buyer_user_id;
+        const admin = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+
+        const { data: listing } = await admin
+          .from('navatar_listings')
+          .select('*')
+          .eq('id', listing_id)
+          .maybeSingle();
+        if (listing && listing.status === 'active') {
+          const gross = Number(session.amount_total) / 100;
+          const fee = Math.round(gross * (listing.fee_bps / 10000) * 100) / 100;
+          const royalty = Math.round(gross * (listing.royalty_bps / 10000) * 100) / 100;
+          const seller = Math.max(0, Math.round((gross - fee - royalty) * 100) / 100);
+
+          await admin.from('navatar_sales').insert({
+            listing_id,
+            buyer_user_id,
+            method: 'stripe',
+            gross_amount: gross,
+            fee_amount: fee,
+            royalty_amount: royalty,
+            seller_proceeds: seller,
+            tx_hashes: [],
+          });
+
+          await admin
+            .from('owned_navatars')
+            .delete()
+            .eq('user_id', listing.seller_user_id)
+            .eq('navatar_id', listing.navatar_id);
+          await admin
+            .from('owned_navatars')
+            .upsert({ user_id: buyer_user_id, navatar_id: listing.navatar_id });
+
+          await admin
+            .from('navatar_listings')
+            .update({ status: 'sold', sold_at: new Date().toISOString() })
+            .eq('id', listing_id);
+        }
+      } else {
+        const { user_id, navatar_id } = session.metadata;
+        await supabase.from('navatar_purchases').insert([
+          {
+            user_id,
+            navatar_id,
+            method: 'stripe',
+            amount: session.amount_total / 100,
+          },
+        ]);
+        await supabase.from('profiles').update({ navatar_id }).eq('id', user_id);
+      }
     }
     return { statusCode: 200, body: 'ok' };
   } catch (e) {

--- a/src/components/ListNavatarModal.tsx
+++ b/src/components/ListNavatarModal.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+
+export default function ListNavatarModal({ navatarId, sellerUserId, onClose, onListed }:{
+  navatarId: string; sellerUserId: string; onClose: ()=>void; onListed: ()=>void;
+}) {
+  const [currency, setCurrency] = useState<'usd'|'natur'>('usd');
+  const [usd, setUsd] = useState<number>(4.99);
+  const [natur, setNatur] = useState<number>(100);
+  const [busy, setBusy] = useState(false);
+
+  async function submit() {
+    setBusy(true);
+    const body: any = { seller_user_id: sellerUserId, navatar_id: navatarId, currency };
+    if (currency === 'usd') body.price_cents = Math.round(usd * 100);
+    else body.price_natur = natur;
+    const r = await fetch('/.netlify/functions/listing-create', { method: 'POST', body: JSON.stringify(body) });
+    setBusy(false);
+    if (!r.ok) {
+      alert(await r.text());
+      return;
+    }
+    onListed();
+    onClose();
+  }
+
+  return (
+    <div className="modal">
+      <div className="modal__card">
+        <h3>List Navatar for sale</h3>
+        <label>
+          Currency:
+          <select value={currency} onChange={(e) => setCurrency(e.target.value as any)}>
+            <option value="usd">USD (Stripe)</option>
+            <option value="natur">$NATUR</option>
+          </select>
+        </label>
+        {currency === 'usd' ? (
+          <label>
+            Price (USD):
+            <input type="number" step="0.01" value={usd} onChange={(e) => setUsd(Number(e.target.value))} />
+          </label>
+        ) : (
+          <label>
+            Price ($NATUR):
+            <input type="number" step="1" value={natur} onChange={(e) => setNatur(Number(e.target.value))} />
+          </label>
+        )}
+        <div className="modal__actions">
+          <button onClick={onClose}>Cancel</button>
+          <button onClick={submit} disabled={busy}>
+            {busy ? 'Listing…' : 'List for sale'}
+          </button>
+        </div>
+      </div>
+      <style>{`
+        .modal{position:fixed;inset:0;background:rgba(0,0,0,.4);display:grid;place-items:center;z-index:50}
+        .modal__card{background:#fff;border-radius:12px;padding:16px;min-width:320px;max-width:420px}
+        .modal__actions{display:flex;gap:8px;justify-content:flex-end;margin-top:12px}
+      `}</style>
+    </div>
+  );
+}

--- a/src/pages/marketplace/navatar.tsx
+++ b/src/pages/marketplace/navatar.tsx
@@ -2,17 +2,40 @@ import React, { useEffect, useState } from 'react';
 import { listAll, getOwned, own, getActive, setActive } from '../../lib/navatar';
 import type { Navatar, Rarity } from '../../data/navatars';
 import NavatarCard from '../../components/NavatarCard';
+import { connectWallet } from '../../lib/web3';
+import { Contract, parseUnits } from 'ethers';
+
+type Listing = {
+  id: string;
+  navatar_id: string;
+  currency: 'usd' | 'natur';
+  price_cents?: number | null;
+  price_natur?: number | null;
+  seller_user_id: string;
+  fee_bps?: number;
+  royalty_bps?: number;
+};
 
 export default function NavatarMarketplacePage() {
   const [all, setAll] = useState<Navatar[]>([]);
   const [owned, setOwned] = useState<string[]>([]);
   const [active, setActiveId] = useState<string | null>(null);
   const [filter, setFilter] = useState<Rarity | 'all'>('all');
+  const [listings, setListings] = useState<Listing[]>([]);
 
   useEffect(() => {
     listAll().then(setAll);
     getOwned().then(setOwned);
     getActive().then(setActiveId);
+    fetch(`${import.meta.env.VITE_SUPABASE_URL}/rest/v1/navatar_listings?select=*`, {
+      headers: {
+        apikey: import.meta.env.VITE_SUPABASE_ANON_KEY!,
+        Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY!}`,
+      },
+    })
+      .then((r) => r.json())
+      .then(setListings)
+      .catch(() => setListings([]));
   }, []);
 
   const filtered = all.filter((a) => (filter === 'all' ? true : a.rarity === filter));
@@ -25,6 +48,76 @@ export default function NavatarMarketplacePage() {
   async function onUse(id: string) {
     await setActive(id);
     setActiveId(await getActive());
+  }
+
+  async function buyStripe(listingId: string) {
+    const buyer = (window as any).user?.id;
+    if (!buyer) {
+      alert('Sign in to buy');
+      return;
+    }
+    const r = await fetch('/.netlify/functions/listing-buy-stripe', {
+      method: 'POST',
+      body: JSON.stringify({ listing_id: listingId, buyer_user_id: buyer }),
+    });
+    const j = await r.json();
+    if (j?.url) window.location.href = j.url;
+    else alert('Failed to start checkout');
+  }
+
+  async function buyNatur(listingId: string, amountNatur: number) {
+    const buyer = (window as any).user?.id;
+    if (!buyer) {
+      alert('Sign in to buy');
+      return;
+    }
+    const rsp = await fetch(
+      `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/navatar_listings?select=*,navatars(created_by)&id=eq.${listingId}`,
+      {
+        headers: {
+          apikey: import.meta.env.VITE_SUPABASE_ANON_KEY!,
+          Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY!}`,
+        },
+      },
+    );
+    const [l] = await rsp.json();
+    if (!l) return alert('Listing unavailable');
+    const sellerRes = await fetch(
+      `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/profiles?select=wallet_address&id=eq.${l.seller_user_id}`,
+      {
+        headers: {
+          apikey: import.meta.env.VITE_SUPABASE_ANON_KEY!,
+          Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY!}`,
+        },
+      },
+    );
+    const [seller] = await sellerRes.json();
+    const sellerWallet = seller?.wallet_address;
+    if (!sellerWallet) return alert('Seller has no wallet set');
+
+    const fee = Math.round(amountNatur * (l.fee_bps / 10000) * 1e6) / 1e6;
+    const royalty = Math.round(amountNatur * (l.royalty_bps / 10000) * 1e6) / 1e6;
+    const sellerAmt = Math.max(0, Math.round((amountNatur - fee - royalty) * 1e6) / 1e6);
+
+    const { signer } = (await connectWallet()) as any;
+    const token = new Contract(import.meta.env.VITE_NATUR_TOKEN_CONTRACT!, ['function transfer(address to, uint256 amount) returns (bool)'], signer);
+    const dec = Number(import.meta.env.VITE_NATUR_TOKEN_DECIMALS || '18');
+
+    const tx1 = await token.transfer(sellerWallet, parseUnits(String(sellerAmt), dec));
+    const r1 = await tx1.wait();
+    const tx2 = await token.transfer(import.meta.env.VITE_NATUR_TREASURY!, parseUnits(String(fee + royalty), dec));
+    const r2 = await tx2.wait();
+
+    const vr = await fetch('/.netlify/functions/listing-buy-natur-verify', {
+      method: 'POST',
+      body: JSON.stringify({ listing_id: listingId, buyer_user_id: buyer, tx_hashes: [r1?.hash || tx1.hash, r2?.hash || tx2.hash] }),
+    });
+    if (vr.ok) {
+      alert('Purchased ✓');
+      location.reload();
+    } else {
+      alert(await vr.text());
+    }
   }
 
   return (
@@ -52,6 +145,32 @@ export default function NavatarMarketplacePage() {
             onUse={onUse}
           />
         ))}
+      </div>
+
+      <h2 style={{ marginTop: 24 }}>Player Listings</h2>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, 240px)', gap: 16 }}>
+        {listings.map((l) => {
+          const nav = all.find((n) => n.id === l.navatar_id);
+          if (!nav) return null;
+          return (
+            <div key={l.id} className="card">
+              <img src={nav.img} width={200} height={200} alt={nav.name} />
+              <div style={{ fontWeight: 700 }}>{nav.name}</div>
+              <div className="muted">
+                {l.currency === 'usd'
+                  ? `$ ${(l.price_cents! / 100).toFixed(2)}`
+                  : `${l.price_natur} $NATUR`}
+              </div>
+              {l.currency === 'usd' ? (
+                <button onClick={() => buyStripe(l.id)}>Buy with card</button>
+              ) : (
+                <button onClick={() => buyNatur(l.id, l.price_natur!)}>
+                  Pay {l.price_natur} $NATUR
+                </button>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/pages/navatar.tsx
+++ b/src/pages/navatar.tsx
@@ -2,11 +2,15 @@ import React, { useEffect, useState } from 'react';
 import { listAll, getOwned, getActive, setActive } from '../lib/navatar';
 import { Navatar } from '../data/navatars';
 import NavatarCard from '../components/NavatarCard';
+import ListNavatarModal from '../components/ListNavatarModal';
+import { useAuth } from '../lib/auth-context';
 
 export default function YourNavatarPage() {
   const [all, setAll] = useState<Navatar[]>([]);
   const [owned, setOwned] = useState<string[]>([]);
   const [active, setActiveId] = useState<string | null>(null);
+  const { user } = useAuth();
+  const [listingFor, setListingFor] = useState<string | undefined>();
 
   useEffect(() => {
     listAll().then(setAll);
@@ -32,16 +36,33 @@ export default function YourNavatarPage() {
       ) : (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, 240px)', gap: 16 }}>
           {mine.map((n) => (
-            <NavatarCard
-              key={n.id}
-              nav={n}
-              owned={true}
-              activeId={active}
-              onGet={() => {}}
-              onUse={onUse}
-            />
+            <div key={n.id} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <NavatarCard
+                nav={n}
+                owned={true}
+                activeId={active}
+                onGet={() => {}}
+                onUse={onUse}
+              />
+              {user && (
+                <button
+                  onClick={() => setListingFor(n.id)}
+                  style={{ padding: '6px 10px', borderRadius: 8 }}
+                >
+                  List for sale
+                </button>
+              )}
+            </div>
           ))}
         </div>
+      )}
+      {listingFor && user && (
+        <ListNavatarModal
+          navatarId={listingFor}
+          sellerUserId={user.id}
+          onClose={() => setListingFor(undefined)}
+          onListed={async () => {}}
+        />
       )}
     </div>
   );

--- a/supabase/migrations/2026-01-03_navatar_marketplace.sql
+++ b/supabase/migrations/2026-01-03_navatar_marketplace.sql
@@ -1,0 +1,42 @@
+-- Navatar listings
+create table if not exists public.navatar_listings (
+  id uuid primary key default gen_random_uuid(),
+  navatar_id text not null references public.navatars(id) on delete cascade,
+  seller_user_id uuid not null references auth.users(id) on delete cascade,
+  currency text not null check (currency in ('usd','natur')),
+  price_cents integer,
+  price_natur numeric,
+  fee_bps integer not null default 1000,
+  royalty_bps integer not null default 500,
+  status text not null check (status in ('active','sold','cancelled')) default 'active',
+  created_at timestamptz default now(),
+  sold_at timestamptz
+);
+
+alter table public.navatar_listings enable row level security;
+create policy "read active listings"
+  on public.navatar_listings for select
+  to anon, authenticated
+  using (status = 'active');
+create policy "seller manage own listings"
+  on public.navatar_listings for update using (auth.uid() = seller_user_id) with check (auth.uid() = seller_user_id);
+create policy "seller insert listing"
+  on public.navatar_listings for insert with check (auth.uid() = seller_user_id);
+
+-- Sales ledger
+create table if not exists public.navatar_sales (
+  id uuid primary key default gen_random_uuid(),
+  listing_id uuid not null references public.navatar_listings(id) on delete cascade,
+  buyer_user_id uuid,
+  method text not null check (method in ('stripe','natur')),
+  gross_amount numeric not null,
+  fee_amount numeric not null,
+  royalty_amount numeric not null,
+  seller_proceeds numeric not null,
+  tx_hashes text[] default '{}',
+  created_at timestamptz default now()
+);
+
+alter table public.navatar_sales enable row level security;
+create policy "read sales public"
+  on public.navatar_sales for select using (true);


### PR DESCRIPTION
## Summary
- add Supabase tables and policies for navatar listings and sales
- create Netlify functions for listing creation, cancelation, and purchases via Stripe or $NATUR
- extend Stripe webhook and expose UI to list Navatars and buy player listings

## Testing
- `npm run typecheck` *(fails: Cannot find module 'ethers' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b110fd2de4832988f95bcea29490a5