### PR TITLE
fix stripe deps and add ping function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,8 @@
 
 [functions]
   directory = "netlify/functions"
+  node_bundler = "esbuild"
+  external_node_modules = ["stripe"]
 
 # Do not rewrite real built assets to index.html
 [[redirects]]

--- a/netlify/functions/stripe-ping.ts
+++ b/netlify/functions/stripe-ping.ts
@@ -1,0 +1,11 @@
+import type { Handler } from "@netlify/functions";
+
+// No Stripe import here yet to avoid requiring secrets during build.
+// This is just a smoke test endpoint.
+export const handler: Handler = async () => {
+  return {
+    statusCode: 200,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ok: true, service: "stripe", ts: Date.now() })
+  };
+};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "workbox-window": "^7.1.0",
     "nprogress": "^0.2.0",
     "react-helmet-async": "^2.0.4",
-    "stripe": "^12.20.0",
+    "stripe": "^14.0.0",
+    "@stripe/stripe-js": "^2.4.0",
     "ethers": "^6.13.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- upgrade Stripe SDKs
- configure Netlify to externalize stripe
- add stub stripe ping function

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@stripe%2fstripe-js)*
- `npm run typecheck` *(fails: Property 'error' does not exist on type ...; Cannot find module 'ethers')*


------
https://chatgpt.com/codex/tasks/task_e_68b1121fcf7c83299139e9a8c217e4ba