### PR TITLE
Add Apple/Google Pay checkout and cart toasts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-helmet-async": "^2.0.4",
     "stripe": "^14.0.0",
     "@stripe/stripe-js": "^2.4.0",
+    "@stripe/react-stripe-js": "^2.6.0",
     "ethers": "^6.13.2"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import NetworkBanner from './components/NetworkBanner';
 import './components/network.css';
 import SearchProvider from './search/SearchProvider';
 import CheckoutBanner from './components/CheckoutBanner';
+import ToastHost from '@/components/ToastHost';
 
 export default function App() {
   useEffect(() => {
@@ -28,6 +29,7 @@ export default function App() {
   }, []);
   return (
     <SearchProvider>
+      <ToastHost />
       <div id="nv-page">
           {/* Keyboard-accessible jump link (first focusable on the page) */}
           <SkipLink />

--- a/src/components/ToastHost.tsx
+++ b/src/components/ToastHost.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from "react";
+
+type Toast = { id: number; text: string };
+export default function ToastHost() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  useEffect(() => {
+    const add = (e: any) => {
+      const text = e.detail?.text || "Done";
+      const id = Date.now();
+      setToasts((t) => [...t, { id, text }]);
+      setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 2200);
+    };
+    window.addEventListener("nv:toast", add as any);
+    return () => window.removeEventListener("nv:toast", add as any);
+  }, []);
+  return (
+    <div
+      style={{
+        position: "fixed",
+        right: 12,
+        bottom: 12,
+        display: "grid",
+        gap: 8,
+        zIndex: 70,
+      }}
+    >
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          style={{
+            background: "#111827",
+            color: "white",
+            padding: "10px 14px",
+            borderRadius: 10,
+            boxShadow: "0 6px 20px rgba(0,0,0,.25)",
+          }}
+        >
+          {t.text}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -23,14 +23,23 @@ export function addToCart(p: Product, qty = 1) {
   if (i >= 0) cart[i].qty += qty;
   else cart.push({ ...p, qty });
   save(); notify();
+  try {
+    window.dispatchEvent(new CustomEvent('nv:toast', { detail: { text: 'Added to cart' } }));
+  } catch {}
 }
 export function setQty(id: string, qty: number) {
   cart = cart.map(i => i.id === id ? { ...i, qty: Math.max(1, qty) } : i);
   save(); notify();
+  try {
+    window.dispatchEvent(new CustomEvent('nv:toast', { detail: { text: 'Quantity updated' } }));
+  } catch {}
 }
 export function removeFromCart(id: string) {
   cart = cart.filter(i => i.id !== id);
   save(); notify();
+  try {
+    window.dispatchEvent(new CustomEvent('nv:toast', { detail: { text: 'Removed from cart' } }));
+  } catch {}
 }
 export function cartTotalCents() {
   return cart.reduce((s, i) => s + i.price * i.qty, 0);

--- a/src/lib/shop/store.ts
+++ b/src/lib/shop/store.ts
@@ -21,15 +21,27 @@ export function addToCart(id: string, qty = 1) {
   const cart = loadCart();
   const line = cart.find(l => l.id === id);
   if (line) line.qty += qty; else cart.push({ id, qty });
-  write(CK, cart); return cart;
+  write(CK, cart);
+  try {
+    window.dispatchEvent(new CustomEvent('nv:toast', { detail: { text: 'Added to cart' } }));
+  } catch {}
+  return cart;
 }
 export function setQty(id: string, qty: number) {
   let cart = loadCart().map(l => (l.id === id ? { id, qty } : l)).filter(l => l.qty > 0);
-  write(CK, cart); return cart;
+  write(CK, cart);
+  try {
+    window.dispatchEvent(new CustomEvent('nv:toast', { detail: { text: 'Quantity updated' } }));
+  } catch {}
+  return cart;
 }
 export function removeLine(id: string) {
   const cart = loadCart().filter(l => l.id !== id);
-  write(CK, cart); return cart;
+  write(CK, cart);
+  try {
+    window.dispatchEvent(new CustomEvent('nv:toast', { detail: { text: 'Removed from cart' } }));
+  } catch {}
+  return cart;
 }
 export function clearCart() { write(CK, []); }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,6 +23,8 @@ import CommandPalette from './components/CommandPalette';
 import './runtime-logger';
 import { prefetchGlob, prefetchOnHover } from './lib/prefetch';
 import './boot/warmup';
+import { Elements } from '@stripe/react-stripe-js';
+import { stripePromise } from '@/lib/stripe';
 
 function unregisterStaleSW() {
   if (location.hostname.endsWith('.netlify.app') && 'serviceWorker' in navigator) {
@@ -73,29 +75,31 @@ async function bootstrap() {
 
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-      {supabase ? (
-        <AuthProvider initialSession={initialSession}>
+      <Elements stripe={stripePromise}>
+        {supabase ? (
+          <AuthProvider initialSession={initialSession}>
+            <ToastProvider>
+              <BaseAuthProvider>
+                <RootWithPalette>
+                  <AppErrorBoundary>
+                    <App />
+                  </AppErrorBoundary>
+                  <WorldExtras />
+                </RootWithPalette>
+              </BaseAuthProvider>
+            </ToastProvider>
+          </AuthProvider>
+        ) : (
           <ToastProvider>
-            <BaseAuthProvider>
-              <RootWithPalette>
-                <AppErrorBoundary>
-                  <App />
-                </AppErrorBoundary>
-                <WorldExtras />
-              </RootWithPalette>
-            </BaseAuthProvider>
+            <RootWithPalette>
+              <AppErrorBoundary>
+                <App />
+              </AppErrorBoundary>
+              <WorldExtras />
+            </RootWithPalette>
           </ToastProvider>
-        </AuthProvider>
-      ) : (
-        <ToastProvider>
-          <RootWithPalette>
-            <AppErrorBoundary>
-              <App />
-            </AppErrorBoundary>
-            <WorldExtras />
-          </RootWithPalette>
-        </ToastProvider>
-      )}
+        )}
+      </Elements>
     </React.StrictMode>,
   );
 }

--- a/src/pages/checkout.tsx
+++ b/src/pages/checkout.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useCart } from "@/lib/cart";
+import { useStripe, PaymentRequestButtonElement } from "@stripe/react-stripe-js";
+import type {
+  PaymentRequest,
+  PaymentRequestCanMakePaymentResult,
+  PaymentRequestPaymentMethodEvent,
+} from "@stripe/stripe-js";
+import { startCheckout } from "@/lib/checkout";
+
+export default function CheckoutPage() {
+  const { items, setQty, removeFromCart, totalCents } = useCart();
+  const stripe = useStripe();
+  const [pr, setPr] = useState<PaymentRequest | null>(null);
+
+  const amount = useMemo(() => totalCents, [totalCents]);
+  const currency = "usd";
+
+  useEffect(() => {
+    if (!stripe) return;
+    const paymentRequest = stripe.paymentRequest({
+      country: "US",
+      currency,
+      total: { label: "Naturverse", amount },
+      requestPayerName: true,
+      requestPayerEmail: true,
+    });
+      paymentRequest.canMakePayment().then((res: PaymentRequestCanMakePaymentResult | null) => {
+      if (res) setPr(paymentRequest);
+      else setPr(null);
+    });
+  }, [stripe, amount]);
+
+  useEffect(() => {
+    if (!pr) return;
+      pr.on("paymentmethod", async (ev: PaymentRequestPaymentMethodEvent) => {
+      try {
+        const res = await fetch("/.netlify/functions/create-checkout-session", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            items: items.map((i) => ({ id: i.id, qty: i.qty })),
+            customer_email: ev.payerEmail,
+            allow_promotion_codes: true,
+            returnPath: "/checkout",
+          }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const { id } = await res.json();
+        await stripe?.redirectToCheckout({ sessionId: id });
+        ev.complete("success");
+      } catch (e) {
+        ev.complete("fail");
+      }
+    });
+  }, [pr, stripe, items]);
+
+  return (
+    <main className="container" style={{ maxWidth: 760, margin: "40px auto" }}>
+      <h1>Checkout</h1>
+
+      {pr && (
+        <div style={{ margin: "12px 0" }}>
+          <PaymentRequestButtonElement options={{ paymentRequest: pr }} />
+          <div style={{ fontSize: 12, opacity: 0.7, marginTop: 6 }}>
+            Express checkout via Apple Pay / Google Pay when supported.
+          </div>
+        </div>
+      )}
+
+      <ul>
+        {items.map((i) => (
+          <li key={i.id}>
+            <strong>{i.name}</strong> ${(i.price / 100).toFixed(2)} x {i.qty}
+            <button onClick={() => setQty(i.id, i.qty - 1)}>-</button>
+            <button onClick={() => setQty(i.id, i.qty + 1)}>+</button>
+            <button onClick={() => removeFromCart(i.id)}>Remove</button>
+          </li>
+        ))}
+      </ul>
+      <div>Subtotal ${(totalCents / 100).toFixed(2)}</div>
+      <button onClick={() => startCheckout({ items, returnPath: "/checkout" })}>
+        Pay with card
+      </button>
+    </main>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -47,6 +47,7 @@ import PlayQuest from './pages/play/[slug]';
 import SuccessPage from './pages/success';
 import CancelPage from './pages/cancel';
 import OrdersPage from './pages/orders';
+import CheckoutPage from './pages/checkout';
 
 export const router = createBrowserRouter([
   {
@@ -65,6 +66,7 @@ export const router = createBrowserRouter([
       { path: 'play/:quest', element: <PlayQuest /> },
 
       { path: 'marketplace', element: <MarketplacePage /> },
+      { path: 'checkout', element: <CheckoutPage /> },
       { path: 'success', element: <SuccessPage /> },
       { path: 'cancel', element: <CancelPage /> },
       { path: 'quests', element: <QuestsList /> },


### PR DESCRIPTION
## Summary
- integrate Stripe Elements and wallet-friendly checkout page
- show mini toast notifications for cart updates
- wire checkout route and Apple/Google Pay button

## Testing
- `npm install --no-package-lock` (fails: 403 Forbidden)
- `npm test` (fails: Missing script)
- `npm run typecheck` (fails: module resolutions and type errors)

------
https://chatgpt.com/codex/tasks/task_e_68b130b1e7a08329b7661d44b6239e75