### PR TITLE
fix: use prod origin for auth callback

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { hasSupabase, supabase } from './supabaseClient';
 
-const callbackUrl = `${window.location.origin}/auth/callback`;
+const PROD_ORIGIN = 'https://thenaturverse.com';
+const callbackUrl = `${PROD_ORIGIN}/auth/callback`;
 
 export async function signInWithGoogle() {
   if (!hasSupabase()) {


### PR DESCRIPTION
## Summary
- use production site URL for Supabase OAuth redirects

## Testing
- `npm run typecheck` *(fails: Cannot find module '@stripe/stripe-js' and others)*
- `npm install` *(fails: 403 Forbidden fetching @stripe/react-stripe-js)*

------
https://chatgpt.com/codex/tasks/task_e_68b145d4367c832988809547bf1ed7bc