### PR TITLE
Guard Supabase client for preview builds

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,9 +4,11 @@ import { useUser } from '@supabase/auth-helpers-react';
 import styles from '@/styles/Home.module.css';
 import { sendMagicLink } from '@/lib/auth';
 import { signInWithGoogle } from '@/lib/supabase-client';
+import { useSupabase } from '@/lib/useSupabase';
 
 export default function Home() {
   const user = useUser();
+  const supabase = useSupabase();
 
   const SignedOutCTA = () => (
     <div className="welcome-buttons">
@@ -14,7 +16,11 @@ export default function Home() {
         className="btn btn-primary"
         onClick={async () => {
           const email = prompt('Enter your email to get a magic link:')?.trim();
-          if (email) await sendMagicLink(email);
+          if (!supabase) {
+            alert('Sign-in is unavailable in this preview. Please use production.');
+          } else if (email) {
+            await sendMagicLink(email);
+          }
         }}
       >
         Create account
@@ -22,7 +28,11 @@ export default function Home() {
       <button
         className="btn btn-secondary"
         onClick={async () => {
-          await signInWithGoogle();
+          if (!supabase) {
+            alert('Sign-in is unavailable in this preview. Please use production.');
+          } else {
+            await signInWithGoogle();
+          }
         }}
       >
         Continue with Google
@@ -89,7 +99,11 @@ export default function Home() {
               className="btn btn-primary"
               onClick={async () => {
                 const email = prompt('Enter your email to get a magic link:')?.trim();
-                if (email) await sendMagicLink(email);
+                if (!supabase) {
+                  alert('Sign-in is unavailable in this preview. Please use production.');
+                } else if (email) {
+                  await sendMagicLink(email);
+                }
               }}
             >
               Get started
@@ -97,7 +111,11 @@ export default function Home() {
             <button
               className="btn btn-secondary"
               onClick={async () => {
-                await signInWithGoogle();
+                if (!supabase) {
+                  alert('Sign-in is unavailable in this preview. Please use production.');
+                } else {
+                  await signInWithGoogle();
+                }
               }}
             >
               Continue with Google

--- a/components/auth/AuthButtons.tsx
+++ b/components/auth/AuthButtons.tsx
@@ -2,8 +2,10 @@
 import { useState } from 'react';
 import { sendMagicLink } from '@/lib/auth';
 import { signInWithGoogle } from '@/lib/supabase-client';
+import { useSupabase } from '@/lib/useSupabase';
 
 export default function AuthButtons() {
+  const supabase = useSupabase();
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -11,6 +13,10 @@ export default function AuthButtons() {
   async function handleMagicLink(e: React.FormEvent) {
     e.preventDefault();
     if (!email) return;
+    if (!supabase) {
+      alert('Sign-in is unavailable in this preview. Please use production.');
+      return;
+    }
     setLoading(true);
     const { error } = await sendMagicLink(email);
     setLoading(false);

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -58,7 +58,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   // Email magic link
   const signInWithEmail: AuthCtx['signInWithEmail'] = async (email) => {
-    if (!supabase) return { error: 'no-supabase' };
+    if (!supabase) {
+      alert('Sign-in is unavailable in this preview. Please use production.');
+      return { error: 'no-supabase' };
+    }
     sessionStorage.setItem('post-auth-redirect', window.location.pathname + window.location.search);
     const { error } = await sendMagicLink(email);
     return { error: error?.message };

--- a/src/components/AuthButtons.tsx
+++ b/src/components/AuthButtons.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { sendMagicLink } from '@/lib/auth';
 import { signInWithGoogle } from '@/lib/supabase-client';
+import { useSupabase } from '@/lib/useSupabase';
 
 type Props = {
   cta?: string;           // e.g., "Create account"
@@ -10,11 +11,16 @@ type Props = {
 };
 
 export default function AuthButtons({ cta = "Create account", variant="solid", size="lg", className="" }: Props) {
+  const supabase = useSupabase();
   const [loading, setLoading] = useState<"ml"|"google"|"">("");
 
   const signInWithMagicLink = async () => {
     const email = window.prompt("Enter your email to receive a sign-in link")?.trim();
     if (!email) return;
+    if (!supabase) {
+      alert('Sign-in is unavailable in this preview. Please use production.');
+      return;
+    }
     setLoading("ml");
     sessionStorage.setItem("post-auth-redirect", window.location.pathname + window.location.search);
     const { error } = await sendMagicLink(email);
@@ -24,6 +30,10 @@ export default function AuthButtons({ cta = "Create account", variant="solid", s
   };
 
   const signInGoogle = async () => {
+    if (!supabase) {
+      alert('Sign-in is unavailable in this preview. Please use production.');
+      return;
+    }
     setLoading("google");
     sessionStorage.setItem("post-auth-redirect", window.location.pathname + window.location.search);
     await signInWithGoogle();

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -36,7 +36,11 @@ export default function LoginForm() {
 
   async function handleEmailLogin(e: React.FormEvent) {
     e.preventDefault();
-    if (!email || !supabase) return;
+    if (!email) return;
+    if (!supabase) {
+      alert('Sign-in is unavailable in this preview. Please use production.');
+      return;
+    }
     setStatus('sending');
     setMessage(null);
     try {
@@ -52,7 +56,10 @@ export default function LoginForm() {
   }
 
   async function handleGoogleLogin() {
-    if (!supabase) return;
+    if (!supabase) {
+      alert('Sign-in is unavailable in this preview. Please use production.');
+      return;
+    }
     setStatus('sending');
     setMessage(null);
     try {

--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -2,6 +2,7 @@
    Import and render it where you want later. */
 import { useState } from 'react';
 import { sendMagicLink } from '../../lib/auth';
+import { useSupabase } from '../../lib/useSupabase';
 import './auth.css';
 
 type Props = {
@@ -19,6 +20,7 @@ export default function AuthModal({
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const supabase = useSupabase();
 
   if (!isOpen) return null;
 
@@ -28,6 +30,10 @@ export default function AuthModal({
     setErr(null);
     setMsg(null);
     try {
+      if (!supabase) {
+        alert('Sign-in is unavailable in this preview. Please use production.');
+        return;
+      }
       sessionStorage.setItem('post-auth-redirect', window.location.pathname + window.location.search);
       await sendMagicLink(email.trim());
       setMsg(successMessage);

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -35,6 +35,10 @@ export function AuthProvider({
   const signInWithMagicLink = async () => {
     const email = window.prompt('Enter your email to receive a sign-in link')?.trim();
     if (!email) return;
+    if (!supabase) {
+      alert('Sign-in is unavailable in this preview. Please use production.');
+      return;
+    }
     sessionStorage.setItem('post-auth-redirect', window.location.pathname + window.location.search);
     try {
       await sendMagicLink(email);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -21,17 +21,17 @@ export function buildProdFinishUrl(returnTo?: string) {
 }
 
 export async function sendMagicLink(email: string) {
-  return supabase.auth.signInWithOtp({
+  return supabase!.auth.signInWithOtp({
     email,
     options: { emailRedirectTo: buildProdFinishUrl(currentUrl()) },
   });
 }
 
 export async function getUser() {
-  const { data } = await supabase.auth.getUser();
+  const { data } = await supabase!.auth.getUser();
   return data.user;
 }
 
 export async function signOut() {
-  await supabase.auth.signOut();
+  await supabase!.auth.signOut();
 }

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,22 +1,35 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { buildProdFinishUrl, currentUrl } from './auth';
 
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL!,
-  import.meta.env.VITE_SUPABASE_ANON_KEY!,
-  { auth: { persistSession: true, detectSessionInUrl: true } }
-);
+const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const anon = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+let supabase: SupabaseClient | null = null;
+
+if (url && anon) {
+  supabase = createClient(url, anon, {
+    auth: { persistSession: true, detectSessionInUrl: true },
+  });
+} else {
+  console.warn('[supabase] Missing URL or anon key — auth disabled in this build.');
+}
 
 export function getSupabase() {
   return supabase;
 }
 
 export async function signInWithGoogle() {
+  if (!supabase) {
+    alert('Sign-in is unavailable in this preview. Please use production.');
+    return;
+  }
   // Always finish on prod; include the current page as the return target.
   const redirectTo = buildProdFinishUrl(currentUrl());
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
-    options: { redirectTo }
+    options: { redirectTo },
   });
   if (error) console.error('[auth] google sign-in error:', error);
 }
+
+export { supabase };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,12 +3,14 @@ import { Link } from 'react-router-dom';
 import { sendMagicLink } from '@/lib/auth';
 import { signInWithGoogle } from '@/lib/supabase-client';
 import { useAuth } from '@/lib/auth-context';
+import { useSupabase } from '@/lib/useSupabase';
 import ClickableCard from '@/components/ClickableCard';
 import MiniQuestSection from '../components/miniquests/MiniQuestSection';
 import SearchBox from '../components/SearchBox';
 
 export default function Home() {
   const { user } = useAuth();
+  const supabase = useSupabase();
   const isAuthed = !!user;
 
   return (
@@ -26,7 +28,9 @@ export default function Home() {
               className={styles.cta}
               onClick={async () => {
                 const email = prompt('Enter your email to get a magic link:')?.trim();
-                if (email) {
+                if (!supabase) {
+                  alert('Sign-in is unavailable in this preview. Please use production.');
+                } else if (email) {
                   sessionStorage.setItem(
                     'post-auth-redirect',
                     window.location.pathname + window.location.search,
@@ -41,11 +45,15 @@ export default function Home() {
               type="button"
               className={styles.cta}
               onClick={async () => {
-                sessionStorage.setItem(
-                  'post-auth-redirect',
-                  window.location.pathname + window.location.search,
-                );
-                await signInWithGoogle();
+                if (!supabase) {
+                  alert('Sign-in is unavailable in this preview. Please use production.');
+                } else {
+                  sessionStorage.setItem(
+                    'post-auth-redirect',
+                    window.location.pathname + window.location.search,
+                  );
+                  await signInWithGoogle();
+                }
               }}
             >
               Continue with Google


### PR DESCRIPTION
## Summary
- Avoid creating Supabase client when env vars are missing
- Alert users that sign-in is unavailable when Supabase is not configured
- Guard sign-in flows across pages and components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module '@stripe/stripe-js' or its corresponding type declarations, ethers, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b16ffa4268832985f0b5ec78fa17b9