### PR TITLE
feat: improve auth and pwa handling

### DIFF
--- a/components/auth/AuthButtons.tsx
+++ b/components/auth/AuthButtons.tsx
@@ -1,11 +1,8 @@
 'use client';
 import { useState } from 'react';
-import { sendMagicLink } from '@/lib/auth';
-import { signInWithGoogle } from '@/lib/auth';
-import { useSupabase } from '@/lib/useSupabase';
+import { sendMagicLink, getSupabase, getOAuthRedirect } from '@/lib/auth';
 
 export default function AuthButtons() {
-  const supabase = useSupabase();
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -13,7 +10,9 @@ export default function AuthButtons() {
   async function handleMagicLink(e: React.FormEvent) {
     e.preventDefault();
     if (!email) return;
-    if (!supabase) {
+    const supabase = getSupabase();
+    const redirectTo = getOAuthRedirect();
+    if (!supabase || !redirectTo) {
       alert('Sign-in is unavailable in this preview. Please use production.');
       return;
     }
@@ -25,7 +24,16 @@ export default function AuthButtons() {
   }
 
   async function signInGoogle() {
-    await signInWithGoogle();
+    const supabase = getSupabase();
+    const redirectTo = getOAuthRedirect();
+    if (!supabase || !redirectTo) {
+      alert('Sign-in is unavailable in this preview. Please use production.');
+      return;
+    }
+    await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo }
+    });
   }
 
   return (

--- a/index.html
+++ b/index.html
@@ -129,23 +129,6 @@
     <script type="module" src="/src/main.tsx"></script>
 
 
-    <!-- Register service worker (gated) -->
-    <script>
-      (function () {
-        if (!("serviceWorker" in navigator)) return;
-        if (!window.__NV_PWA_ENABLED__) {
-          console.info("[PWA] Disabled via VITE_ENABLE_PWA");
-          return;
-        }
-        window.addEventListener("load", () => {
-          navigator.serviceWorker
-            .register("/sw.js")
-            .then(() => console.info("[PWA] service worker registered"))
-            .catch((err) => console.error("[PWA] registration failed", err));
-        });
-      })();
-    </script>
-
     <!-- Install prompt banner (hidden until beforeinstallprompt) -->
     <style>
       #nv-install {

--- a/public/_headers
+++ b/public/_headers
@@ -5,6 +5,11 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=()
+  Content-Security-Policy: default-src 'self';
+    script-src 'self' 'unsafe-inline' plausible.io https://js.stripe.com;
+    connect-src 'self' https://*.supabase.co https://*.supabase.in https://api.stripe.com https://plausible.io;
+    img-src 'self' data: https://*.stripe.com https://*.supabase.co;
+    frame-src https://js.stripe.com https://hooks.stripe.com;
 
 /*.html
   Content-Type: text/html; charset=UTF-8

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -2,12 +2,12 @@
   "name": "Naturverse",
   "short_name": "Naturverse",
   "icons": [
-    { "src": "favicon-192x192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "favicon-512x512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "/favicon-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/favicon-512x512.png", "sizes": "512x512", "type": "image/png" }
   ],
-  "start_url": ".",
+  "start_url": "/",
   "display": "standalone",
-  "theme_color": "#2563eb",
-  "background_color": "#ffffff"
+  "background_color": "#ffffff",
+  "theme_color": "#1e66f5"
 }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,47 +1,67 @@
 import { createClient } from '@supabase/supabase-js';
-import {
-  VITE_SUPABASE_URL,
-  VITE_SUPABASE_ANON_KEY,
-  VITE_ALLOW_PREVIEW_SIGNIN,
-  isPreviewHost,
-  currentOrigin,
-} from './env';
+import { VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_ALLOW_PREVIEW_AUTH } from './env';
+import { getHost, isPreviewHost, isProdHost } from './hosts';
 
-export const supabase = createClient(VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, {
-  auth: { persistSession: true, detectSessionInUrl: true }
-});
+let _client: ReturnType<typeof createClient> | null = null;
 
-export const getSupabase = () => supabase;
+export function getSupabase() {
+  // In previews, allow auth only if explicitly enabled
+  if (isPreviewHost() && !VITE_ALLOW_PREVIEW_AUTH) return null;
 
-// Build a redirect that matches the host we’re actually on (preview or prod)
-const oauthRedirect = () => `${currentOrigin()}/auth/callback`;
+  if (!_client) {
+    if (!VITE_SUPABASE_URL || !VITE_SUPABASE_ANON_KEY) return null;
+    _client = createClient(VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, {
+      auth: {
+        // Build redirect URL dynamically; prod domain only
+        autoRefreshToken: true,
+        persistSession: true,
+        detectSessionInUrl: true,
+      },
+    });
+  }
+  return _client;
+}
+
+export function getOAuthRedirect(): string | undefined {
+  const host = getHost();
+  if (isProdHost(host)) return `https://${host}/auth/callback`;
+  if (isPreviewHost(host) && VITE_ALLOW_PREVIEW_AUTH) return `https://${host}/auth/callback`;
+  return undefined; // previews disabled
+}
 
 export async function signInWithGoogle() {
-  // old behavior was: if (host ends with netlify.app) alert(...); return;
-  // New: respect the kill-switch only.
-  if (isPreviewHost() && !VITE_ALLOW_PREVIEW_SIGNIN) {
-    alert('Sign-in is disabled for previews on this site.');
-    return;
+  const supabase = getSupabase();
+  const redirectTo = getOAuthRedirect();
+  if (!supabase || !redirectTo) {
+    throw new Error('Sign-in is disabled on previews. Please open the production site.');
   }
-  const { error } = await supabase.auth.signInWithOAuth({
+  await supabase.auth.signInWithOAuth({
     provider: 'google',
-    options: { redirectTo: oauthRedirect() }
+    options: { redirectTo },
   });
-  if (error) console.error('[auth] google sign-in error', error);
 }
 
 export async function sendMagicLink(email: string) {
+  const supabase = getSupabase();
+  const redirectTo = getOAuthRedirect();
+  if (!supabase || !redirectTo) {
+    throw new Error('Sign-in is disabled on previews. Please open the production site.');
+  }
   return supabase.auth.signInWithOtp({
     email,
-    options: { emailRedirectTo: oauthRedirect() },
+    options: { emailRedirectTo: redirectTo },
   });
 }
 
 export async function getUser() {
+  const supabase = getSupabase();
+  if (!supabase) return null;
   const { data } = await supabase.auth.getUser();
   return data.user;
 }
 
 export async function signOut() {
+  const supabase = getSupabase();
+  if (!supabase) return;
   await supabase.auth.signOut();
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,11 +1,8 @@
-export const VITE_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
-export const VITE_SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+export const VITE_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+export const VITE_SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
-// Allow previews to sign in (default true)
-export const VITE_ALLOW_PREVIEW_SIGNIN =
-  (import.meta.env.VITE_ALLOW_PREVIEW_SIGNIN ?? 'true').toString().toLowerCase() !== 'false';
+export const STRIPE_PK = import.meta.env.VITE_STRIPE_PK as string | undefined;
 
-// tiny host helpers
-export const isPreviewHost = () => typeof location !== 'undefined' && /\.netlify\.app$/i.test(location.hostname);
-export const currentOrigin = () =>
-  typeof location !== 'undefined' ? location.origin : (globalThis as any)?.ORIGIN ?? '';
+// Optional flags you already set; safe defaults if absent
+export const VITE_ENABLE_PWA = (import.meta.env.VITE_ENABLE_PWA ?? 'true') === 'true';
+export const VITE_ALLOW_PREVIEW_AUTH = (import.meta.env.VITE_ALLOW_PREVIEW_AUTH ?? 'false') === 'true';

--- a/src/lib/hosts.ts
+++ b/src/lib/hosts.ts
@@ -1,0 +1,14 @@
+export function getHost(): string {
+  if (typeof window !== 'undefined') return window.location.host;
+  return process.env.VERCEL_URL || process.env.URL || 'localhost';
+}
+
+export function isPreviewHost(host = getHost()): boolean {
+  // Treat Netlify preview/permalink as preview
+  return /\.netlify\.app$/i.test(host);
+}
+
+export function isProdHost(host = getHost()): boolean {
+  // Your production domains
+  return /^(www\.)?thenaturverse\.com$/i.test(host) || /^naturverse-web\.pages\.dev$/i.test(host);
+}

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,2 +1,5 @@
-export { supabase, getSupabase, signInWithGoogle } from './auth';
+import { getSupabase } from './auth';
 
+export const supabase = getSupabase()!;
+
+export { getSupabase };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,26 +26,11 @@ import './boot/warmup';
 import { Elements } from '@stripe/react-stripe-js';
 import { stripePromise } from '@/lib/stripe';
 import { installGlobalLogCapture } from '@/lib/log';
-
-function unregisterStaleSW() {
-  if (location.hostname.endsWith('.netlify.app') && 'serviceWorker' in navigator) {
-    navigator.serviceWorker.getRegistrations().then((regs) => {
-      regs.forEach((reg) => reg.unregister());
-    });
-  }
-}
+import { registerPWA } from '@/pwa/register-sw';
 
 applyTheme(getTheme());
-unregisterStaleSW();
 installGlobalLogCapture();
-// Skip service worker registration on Netlify preview hosts
-if (location.hostname.endsWith('.netlify.app')) {
-  console.info('[Naturverse] Preview host — skipping SW registration');
-} else {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/sw.js').catch(() => {});
-  }
-}
+registerPWA();
 
 function RootWithPalette({ children }: { children: React.ReactNode }) {
   const [open, setOpen] = useState(false);

--- a/src/pwa/register-sw.ts
+++ b/src/pwa/register-sw.ts
@@ -1,0 +1,20 @@
+import { isPreviewHost } from '@/lib/hosts';
+import { VITE_ENABLE_PWA } from '@/lib/env';
+
+export async function registerPWA() {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
+  if (!VITE_ENABLE_PWA) return;
+
+  if (isPreviewHost()) {
+    // Unregister any stray SW from a prior visit
+    const regs = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(regs.map(r => r.unregister()));
+    return;
+  }
+
+  try {
+    await navigator.serviceWorker.register('/sw.js');
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
- add host helpers and guarded Supabase client with preview-aware redirects
- register service worker only in production and when enabled
- relax CSP and fix PWA manifest icons

## Testing
- `npm run typecheck` *(fails: Cannot find module '@stripe/stripe-js' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b1887d8f108329be0694eb390a3310