### PR TITLE
feat: remember return path for Google sign-in

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,13 @@ export async function signInWithGoogle() {
   const sb = getSupabase();
   if (!sb) return { error: new Error('Supabase unavailable in this build') };
 
+  // remember where the user was on this host
+  const returnTo =
+    window.location.pathname +
+    (window.location.search || '') +
+    (window.location.hash || '');
+  localStorage.setItem('returnTo', returnTo);
+
   // Redirect back to current host, works for prod & previews.
   const redirectTo = `${window.location.origin}/auth/callback`;
   return sb.auth.signInWithOAuth({ provider: 'google', options: { redirectTo } });


### PR DESCRIPTION
## Summary
- store current path in localStorage before Google OAuth
- ensure OAuth redirect uses current origin

## Testing
- `npm run typecheck` *(fails: Cannot find module 'ethers', '@stripe/stripe-js', '@stripe/react-stripe-js')*
- `npm install --no-save ethers @stripe/stripe-js @stripe/react-stripe-js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b19387cd1c8329a7ce8ae7788b1b51