### PR TITLE
Ensure root-relative asset URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <base href="/" />
     <meta charset="UTF-8" />
     <script src="/kill-sw.js?v=2" defer></script>
     <script>

--- a/src/pwa/register-sw.ts
+++ b/src/pwa/register-sw.ts
@@ -1,6 +1,7 @@
 import { IS_NETLIFY_PREVIEW } from '@/lib/env';
 
 export function registerPWA() {
+  // Avoid registering on the auth callback route to prevent PWA prompts
   if (location.pathname === '/auth/callback') return;
   if (!('serviceWorker' in navigator)) return;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,8 +60,8 @@ export default defineConfig({
       ],
     }),
   ],
-  // Use a relative base so assets resolve on Netlify permalinks and production
-  base: './',
+  // Use a root base so assets resolve from the site root
+  base: '/',
   envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- force asset URLs to resolve from root via `<base href="/" />`
- lock Vite's `base` option to `/` for absolute asset paths
- clarify service worker registration skip on `/auth/callback`

## Testing
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react-swc')*
- `npm run typecheck` *(fails: Cannot find module 'ethers' and other typings)*

------
https://chatgpt.com/codex/tasks/task_e_68b1acb856008329b882ad0ea3266801