### PR TITLE
Guard SW on auth callback

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <base href="/" />
+    <!-- Force root-relative asset paths -->
     <meta charset="UTF-8" />
     <script src="/kill-sw.js?v=2" defer></script>
     <script>

--- a/src/pwa/register-sw.ts
+++ b/src/pwa/register-sw.ts
@@ -1,21 +1,19 @@
 import { IS_NETLIFY_PREVIEW } from '@/lib/env';
 
 export function registerPWA() {
-  // Avoid registering on the auth callback route to prevent PWA prompts
-  if (location.pathname === '/auth/callback') return;
-  if (!('serviceWorker' in navigator)) return;
+  if ('serviceWorker' in navigator && location.pathname !== '/auth/callback') {
+    // Don’t register on Netlify previews; do unregister if one exists.
+    if (IS_NETLIFY_PREVIEW) {
+      navigator.serviceWorker.getRegistrations?.().then((regs) =>
+        regs.forEach((r) => r.unregister())
+      );
+      return;
+    }
 
-  // Don’t register on Netlify previews; do unregister if one exists.
-  if (IS_NETLIFY_PREVIEW) {
-    navigator.serviceWorker.getRegistrations?.().then((regs) =>
-      regs.forEach((r) => r.unregister())
-    );
-    return;
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/sw.js').catch((e) =>
+        console.warn('[naturverse] SW register failed', e)
+      );
+    });
   }
-
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch((e) =>
-      console.warn('[naturverse] SW register failed', e)
-    );
-  });
 }


### PR DESCRIPTION
## Summary
- skip service worker registration on /auth/callback
- document base tag to clarify root-relative asset paths
- confirm SPA fallback and Vite base configuration remain in place

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react-swc')*

------
https://chatgpt.com/codex/tasks/task_e_68b1b4558f548329acedf4b3aa96266b