### PR TITLE
Fix Google OAuth callback route

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
 <html lang="en">
     <head>
-      <!-- Make all asset URLs resolve from site root so /auth/* doesn't try /auth/assets/... -->
-      <base href="/" />
-      <meta charset="UTF-8" />
+        <!-- Ensure all relative URLs resolve from site root so /auth/* doesn't try /auth/assets/... -->
+        <base href="/" />
+        <meta charset="UTF-8" />
     <script src="/kill-sw.js?v=2" defer></script>
     <script>
       // Vite replaces %VITE_ENABLE_PWA% at build-time
@@ -167,6 +167,7 @@
         const no  = document.getElementById("nv-install-no");
 
         window.addEventListener("beforeinstallprompt", (e) => {
+          if (location.pathname.startsWith('/auth/')) return; // don't show on OAuth callback
           e.preventDefault();
           deferred = e;
           // Show prompt only on home route (avoid spamming during deep flows)

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,3 @@
-/*    /index.html   200
-/auth/callback    /index.html   200
+/auth/*    /index.html   200
+/*         /index.html   200
 

--- a/public/kill-sw.js
+++ b/public/kill-sw.js
@@ -18,3 +18,10 @@
     }
   } catch (_) { /* no-op */ }
 })();
+
+const showInstall = () => {
+  if (location.pathname.startsWith('/auth/')) return; // don't show on OAuth callback
+  // Install prompt UI handled elsewhere
+};
+
+showInstall();


### PR DESCRIPTION
## Summary
- Route `/auth/*` to SPA shell before catch-all fallback
- Use `<base href="/">` to resolve assets from site root
- Block PWA install prompt on OAuth callback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'ethers' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c54903e48329801efe75436410c9