### PR TITLE
Add no-store caching headers for service worker files

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -2,5 +2,16 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: same-origin
-  Content-Security-Policy: default-src 'self' https://*.supabase.co https://*.googleapis.com https://accounts.google.com https://apis.google.com 'unsafe-inline' 'unsafe-eval' data: blob:;
+Content-Security-Policy: default-src 'self' https://*.supabase.co https://*.googleapis.com https://accounts.google.com https://apis.google.com 'unsafe-inline' 'unsafe-eval' data: blob:;
 
+/index.html
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+
+/sw.js
+  Cache-Control: no-store
+/register-sw.js
+  Cache-Control: no-store
+/kill-sw.js
+  Cache-Control: no-store


### PR DESCRIPTION
## Summary
- disable caching for index.html so updates always load fresh
- ensure service worker files are never cached

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'ethers' or its corresponding type declarations, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b23f4d5c888329ae0b278042b5016f