### PR TITLE
Fix Google OAuth callback

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -19,3 +19,6 @@ Content-Security-Policy: default-src 'self' https://*.supabase.co https://*.goog
 /kill-sw.js
   Cache-Control: no-store
 
+/auth/callback/*
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'
+  X-Robots-Tag: noindex

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,4 @@
+/auth/callback    /auth/callback/index.html   200
 # Force SPA fallback for the Supabase OAuth callback
 /auth/*    /index.html   200
 

--- a/public/auth/callback/index.html
+++ b/public/auth/callback/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="noindex" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Signing you in…</title>
+  </head>
+  <body>
+    <noscript>Signing you in…</noscript>
+    <script src="/auth/callback/redirect.js" defer></script>
+  </body>
+</html>

--- a/public/auth/callback/redirect.js
+++ b/public/auth/callback/redirect.js
@@ -1,0 +1,10 @@
+// Forward Supabase's hash tokens from /auth/callback → / (SPA shell).
+// Example: /auth/callback#access_token=...  ->  /#access_token=...
+(function () {
+  try {
+    var hash = window.location.hash || '';
+    window.location.replace('/' + (hash || ''));
+  } catch (_) {
+    window.location.replace('/');
+  }
+})();


### PR DESCRIPTION
## Summary
- serve `/auth/callback` as a static page that redirects while preserving hash tokens
- restrict callback page CSP to self-hosted scripts/styles and disallow indexing
- add Netlify redirect for `/auth/callback` to ensure static file is served

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b24696d6248329aafdbde48bb6b1df