### PR TITLE
fix: externalize OAuth callback redirect

### DIFF
--- a/public/auth/callback/index.html
+++ b/public/auth/callback/index.html
@@ -3,16 +3,8 @@
   <meta charset="utf-8" />
   <title>Authenticating…</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script>
-    // Preserve the OAuth fragment and bounce to site root so assets resolve from "/"
-    (function () {
-      var hash = window.location.hash || '';
-      // Use replace() so the interim URL isn’t kept in history
-      window.location.replace('/' + hash);
-    })();
-  </script>
-  <noscript>
-    <meta http-equiv="refresh" content="0;url=/" />
-  </noscript>
+  <!-- use external script so CSP allows it -->
+  <script src="/auth/callback/redirect.js" defer></script>
+  <noscript><meta http-equiv="refresh" content="0;url=/" /></noscript>
   <body>Authenticating…</body>
 </html>

--- a/public/auth/callback/redirect.js
+++ b/public/auth/callback/redirect.js
@@ -1,0 +1,11 @@
+// Bounce to site root while preserving the Supabase OAuth fragment
+(function () {
+  try {
+    var hash = window.location.hash || '';
+    // strip any stray query; Supabase uses the fragment (#)
+    window.location.replace('/' + (hash.startsWith('#') ? hash : ('#' + hash)));
+  } catch (_) {
+    // last resort: go home
+    window.location.replace('/');
+  }
+})();


### PR DESCRIPTION
## Summary
- replace inline OAuth callback script with external redirect
- add redirect.js to safely bounce to root

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'ethers', '@stripe/stripe-js', '@stripe/react-stripe-js'; 'supabase' possibly null)*

------
https://chatgpt.com/codex/tasks/task_e_68b24c0ad0048329bd376ea8f25ae886