### PR TITLE
Redirect auth flows to site root

### DIFF
--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -93,11 +93,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
   };
 
   const signInWithGoogle = async () => {
-    const redirectTo = `${location.origin}/auth/callback`;
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo,
+        // land on the site root so assets + CSP are happy
+        redirectTo: `${window.location.origin}/`,
         queryParams: { prompt: 'consent', access_type: 'offline' },
       },
     });

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,5 @@
-# Serve the callback HTML explicitly (so the route works as a page)
- /auth/callback      /auth/callback/index.html   200
+# Hard redirect any auth callback to root
+/auth/callback    /    302!
 
 # SPA fallback for everything else — IMPORTANT: no "!" at the end
- /*                   /index.html                 200
-
+/*                   /index.html                 200

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,11 +18,11 @@ export function getSupabase() {
 export async function signInWithGoogle() {
   if (!supabase) return { data: null, error: new Error('Supabase not configured') };
 
-  const redirectTo = `${location.origin}/auth/callback`;
   return supabase.auth.signInWithOAuth({
     provider: 'google',
     options: {
-      redirectTo,
+      // land on the site root so assets + CSP are happy
+      redirectTo: `${window.location.origin}/`,
       queryParams: { prompt: 'consent', access_type: 'offline' },
     },
   });
@@ -31,7 +31,7 @@ export async function signInWithGoogle() {
 export async function sendMagicLink(email: string) {
   if (!supabase) return { data: null, error: new Error('Supabase not configured') };
 
-  const redirectTo = `${location.origin}/auth/callback`;
+  const redirectTo = `${window.location.origin}/`;
   return supabase.auth.signInWithOtp({
     email,
     options: { emailRedirectTo: redirectTo },

--- a/src/routes/auth/callback.tsx
+++ b/src/routes/auth/callback.tsx
@@ -1,21 +1,5 @@
-import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { supabase } from '@/lib/supabase-client'
+if (typeof window !== 'undefined') window.location.replace('/');
 
 export default function AuthCallback() {
-  const navigate = useNavigate()
-
-  useEffect(() => {
-    // Parse tokens from the hash and set session, then bounce home.
-    // Works for both ? and # token delivery.
-    supabase!
-      .auth
-      .getSession()
-      .finally(() => {
-        // Use replace so /auth/callback never stays in history.
-        window.location.replace('/')
-      })
-  }, [])
-
-  return null
+  return null;
 }


### PR DESCRIPTION
## Summary
- send Google and magic-link auth redirects to the site root
- ensure legacy /auth/callback paths hard redirect to /
- make callback route a client-side no-op

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'ethers' or its corresponding type declarations, etc.)*
- `npx tsc -p client/tsconfig.json --noEmit` *(fails: Cannot find module '@assets/Mango Mike_1754677394025.png', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b250fa7ad083299f943f561cba4475