### PR TITLE
chore: disable PWA and simplify auth redirects

### DIFF
--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -95,11 +95,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const signInWithGoogle = async () => {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
-      options: {
-        // Always land on the homepage after auth (works for Netlify + SPA)
-        redirectTo: `${window.location.origin}/`,
-        queryParams: { prompt: 'consent', access_type: 'offline' },
-      },
+      options: { redirectTo: `${window.location.origin}/` },
     });
     if (error) {
       throw new Error(error.message);
@@ -108,6 +104,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const signOut = async () => {
     const { error } = await supabase.auth.signOut();
+    if (!error) window.location.assign('/');
     return { error };
   };
 

--- a/index.html
+++ b/index.html
@@ -129,34 +129,7 @@
     <script type="module" src="/src/main.tsx"></script>
 
 
-    <!-- Install prompt banner (hidden until beforeinstallprompt) -->
-    <style>
-      #nv-install {
-        position: fixed; left: 12px; right: 12px; bottom: 12px;
-        display: none; gap: 10px; align-items: center; justify-content: space-between;
-        padding: 12px 14px; border-radius: 12px; background: #0b5fff; color: #fff;
-        box-shadow: 0 8px 24px rgba(0,0,0,.2); z-index: 2147483647;
-        font: 600 14px/1.3 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;
-      }
-      #nv-install .nv-actions { display: flex; gap: 8px; }
-      #nv-install button {
-        appearance: none; border: 0; border-radius: 10px; padding: 8px 12px; cursor: pointer;
-        background: #fff; color: #0b5fff; font-weight: 700;
-      }
-      #nv-install button.nv-skip {
-        background: transparent; color: #fff; outline: 2px solid rgba(255,255,255,.6);
-      }
-    </style>
-
-    <div id="nv-install" role="dialog" aria-live="polite" aria-label="Install Naturverse">
-      <span>Install Naturverse?</span>
-      <div class="nv-actions">
-        <button type="button" id="nv-install-yes">Install</button>
-        <button type="button" id="nv-install-no" class="nv-skip">Not now</button>
-      </div>
-    </div>
-
-    <!-- Install banner script disabled while PWA is off -->
+    <!-- Install banner removed while PWA is disabled -->
   <!-- Netlify Forms detection: hidden static form (do not remove) -->
     <form name="contact" netlify netlify-honeypot="bot-field" hidden>
       <input type="text" name="name" />

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,2 @@
-# Send Supabase callback straight to the homepage
-/auth/callback*   /   302
+/*  /index.html  200
 
-# Normal SPA fallback
-/*                /index.html  200

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -43,7 +43,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           await Promise.all(names.map((n) => caches.delete(n)));
         } catch {}
       }
-      window.location.replace('/');
+      window.location.assign('/');
     }
   };
 

--- a/src/components/AuthMenu.tsx
+++ b/src/components/AuthMenu.tsx
@@ -59,6 +59,7 @@ export default function AuthMenu() {
     await supabase.auth.signOut();
     setUser(null);
     setOpen(false);
+    window.location.assign('/');
   }
 
   if (!user) {

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -64,6 +64,7 @@ export default function LoginForm() {
     if (!supabase) return;
     await supabase.auth.signOut();
     setMessage('Signed out.');
+    window.location.assign('/');
   }
 
   if (session) {

--- a/src/components/UserChip.tsx
+++ b/src/components/UserChip.tsx
@@ -58,7 +58,7 @@ export default function UserChip({ email }: { email?: string | null }) {
             onClick={async () => {
               if (!supabase) return;
               await supabase.auth.signOut();
-              window.location.href = '/';
+              window.location.assign('/');
             }}
             className="btn"
             style={menuItem}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -85,7 +85,7 @@ export default function UserMenu() {
             onClick={async () => {
               if (!supabase) return;
               await supabase.auth.signOut();
-              window.location.replace("/");
+              window.location.assign("/");
             }}
           >
             Sign out

--- a/src/components/auth/SessionBadge.tsx
+++ b/src/components/auth/SessionBadge.tsx
@@ -19,7 +19,7 @@ export default function SessionBadge() {
     <div className="nv-session-chip" title={email}>
       <span className="nv-session-dot" />
       <span className="nv-session-email">{email}</span>
-      <button className="nv-session-out" onClick={() => signOut().then(() => location.reload())}>
+      <button className="nv-session-out" onClick={() => signOut()}>
         Sign out
       </button>
     </div>

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -49,6 +49,7 @@ export function AuthProvider({
     if (!supabase) return;
     const { error } = await supabase.auth.signOut();
     if (error) alert(error.message);
+    else window.location.assign('/');
   };
 
   // Stay in sync after first paint

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,10 +4,7 @@ import { supabase } from './supabase-client';
 export async function signInWithGoogle() {
   return supabase.auth.signInWithOAuth({
     provider: 'google',
-    options: {
-      redirectTo: `${window.location.origin}/`,
-      queryParams: { prompt: 'select_account' },
-    },
+    options: { redirectTo: `${window.location.origin}/` },
   });
 }
 
@@ -26,4 +23,5 @@ export async function getUser() {
 
 export async function signOut() {
   await supabase.auth.signOut();
+  window.location.assign('/');
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -34,7 +34,6 @@ import ProgressPage from './pages/progress';
 import LoginPage from './pages/Login';
 import Turian from './routes/turian';
 import ProfilePage from './pages/profile';
-import AuthCallback from './routes/auth/callback';
 import Terms from './pages/Terms';
 import Privacy from './pages/Privacy';
 import Contact from './pages/Contact';
@@ -105,7 +104,6 @@ export const router = createBrowserRouter([
       { path: 'progress', element: <ProgressPage /> },
       { path: 'passport', element: <PassportPage /> },
       { path: 'orders', element: <OrdersPage /> },
-      { path: 'auth/callback', element: <AuthCallback /> },
       { path: 'login', element: <LoginPage /> },
       { path: 'turian', element: <Turian /> },
       { path: 'profile', element: <ProfilePage /> },

--- a/src/routes/auth/callback.tsx
+++ b/src/routes/auth/callback.tsx
@@ -1,5 +1,0 @@
-if (typeof window !== 'undefined') window.location.replace('/');
-
-export default function AuthCallback() {
-  return null;
-}


### PR DESCRIPTION
## Summary
- remove unused auth callback route and Netlify redirect
- drop PWA install banner and related assets
- simplify Google sign-in and sign-out to always redirect to root

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b2657d77b08329864fbcc93326dccc