### PR TITLE
Fix /auth/callback loop + lock correct Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "dist"

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-/auth/callback  /  302
-/*              /index.html  200
+/auth/callback   /index.html   200
+/*               /index.html   200


### PR DESCRIPTION
## Summary
- Serve Supabase auth callback with the SPA shell
- Specify Netlify build output and command

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react-swc')*

------
https://chatgpt.com/codex/tasks/task_e_68b27c13c190832989f553899fca4415