### PR TITLE
Fix OAuth callback handling + CSP headers

### DIFF
--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -96,8 +96,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        // Always land on the app shell; no more /auth/callback
-        redirectTo: `${window.location.origin}/`,
+        redirectTo: `${window.location.origin}/auth/callback`,
         queryParams: { prompt: 'select_account' },
       },
     });

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,10 @@
 [build]
   command = "npm run build"
   publish = "dist"
+
+# TEMP: permissive CSP so callback page can run.
+# After things work, we'll tighten this.
+[[headers]]
+  for = "/*"
+  [headers.values]
+  Content-Security-Policy = "default-src 'self' https: http: blob: data: 'unsafe-inline' 'unsafe-eval'; img-src * data: blob:; font-src * data:; connect-src *; frame-src *;"

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
-/*  /index.html  200
+/auth/callback  /index.html  200
+/*              /index.html  200

--- a/src/routes/AuthCallback.tsx
+++ b/src/routes/AuthCallback.tsx
@@ -6,28 +6,24 @@ export default function AuthCallback() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Supabase will consume the hash on page load and populate the session
-    (async () => {
+    const hash = window.location.hash || "";
+    const finish = async () => {
       try {
-        const { data, error } = await supabase.auth.getSession();
-        if (error) {
-          console.error("Auth callback error:", error);
-          navigate("/", { replace: true });
-          return;
-        }
-        if (data?.session) {
-          // logged in – go wherever you prefer
-          navigate("/profile", { replace: true });
-        } else {
-          // no session; bounce home
-          navigate("/", { replace: true });
-        }
+        await supabase.auth.getSession();
       } catch (e) {
-        console.error("Auth callback exception:", e);
-        navigate("/", { replace: true });
+        // no-op; we'll still send users home
+      } finally {
+        window.history.replaceState({}, "", "/");
+        navigate("/profile", { replace: true });
       }
-    })();
+    };
+
+    if (hash.includes("access_token") || hash.includes("provider_token")) {
+      finish();
+    } else {
+      navigate("/", { replace: true });
+    }
   }, [navigate]);
 
-  return <div style={{ padding: 24 }}>Finishing sign-in…</div>;
+  return <p style={{ padding: 24 }}>Finishing sign-in…</p>;
 }


### PR DESCRIPTION
## Summary
- handle Supabase OAuth hash in callback route
- allow callback with permissive CSP headers
- redirect Google OAuth to /auth/callback and ensure Netlify routes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck` (fails: Cannot find module '@stripe/stripe-js' etc.)

------
https://chatgpt.com/codex/tasks/task_e_68b28eb1fd6c83299ea92687eef54364