### PR TITLE
Ensure mobile layout: add/lock viewport meta, iOS-safe caps, and small mobile polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,17 +2,22 @@
 <html lang="en">
   <head>
     <base href="/" />
+    <!-- Ensure proper mobile scaling -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"
+    />
+    <!-- Mobile chrome color (optional) -->
+    <meta name="theme-color" content="#0ea5e9" />
     <!-- Make all relative assets resolve from site root (fixes /auth/callback) -->
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script>
       // Vite replaces %VITE_ENABLE_PWA% at build-time
-      window.__NV_PWA_ENABLED__ = "%VITE_ENABLE_PWA%" === "true";
+      window.__NV_PWA_ENABLED__ = '%VITE_ENABLE_PWA%' === 'true';
     </script>
     <title>Naturverse</title>
     <!-- PWA manifest -->
     <link rel="manifest" href="/manifest.json" />
-    <meta name="theme-color" content="#1e66ff" />
 
     <!-- iOS install hints -->
     <link rel="apple-touch-icon" href="/favicon-192x192.png" />
@@ -51,30 +56,28 @@
 
     <!-- === Naturverse: JSON-LD structured data === -->
     <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "Organization",
-      "name": "Naturverse",
-      "url": "https://thenaturverse.com",
-      "logo": "https://thenaturverse.com/favicon-192x192.png",
-      "sameAs": [
-        "https://thenaturverse.com"
-      ]
-    }
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Naturverse",
+        "url": "https://thenaturverse.com",
+        "logo": "https://thenaturverse.com/favicon-192x192.png",
+        "sameAs": ["https://thenaturverse.com"]
+      }
     </script>
 
     <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "WebSite",
-      "name": "Naturverse",
-      "url": "https://thenaturverse.com",
-      "potentialAction": {
-        "@type": "SearchAction",
-        "target": "https://thenaturverse.com/search?q={query}",
-        "query-input": "required name=query"
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Naturverse",
+        "url": "https://thenaturverse.com",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "https://thenaturverse.com/search?q={query}",
+          "query-input": "required name=query"
+        }
       }
-    }
     </script>
     <!-- === / JSON-LD === -->
 
@@ -100,27 +103,35 @@
         padding: 8px 16px;
         background: #1e63ff; /* Naturverse blue */
         color: #fff;
-        font: 600 14px/1.3 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+        font:
+          600 14px/1.3 system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          Helvetica,
+          Arial,
+          'Apple Color Emoji',
+          'Segoe UI Emoji';
         text-align: center;
-        letter-spacing: .1px;
+        letter-spacing: 0.1px;
       }
       #prod-banner a {
         color: #fff;
         text-decoration: underline;
         text-underline-offset: 2px;
       }
-      #prod-banner[hidden] { display: none; }
+      #prod-banner[hidden] {
+        display: none;
+      }
     </style>
 
-    <div id="prod-banner" hidden>
-      Naturverse is Live ✨ — Welcome explorers!
-    </div>
+    <div id="prod-banner" hidden>Naturverse is Live ✨ — Welcome explorers!</div>
 
     <script>
       // Show the banner only on the homepage.
       try {
-        var isHome = (location.pathname === "/" || location.pathname === "");
-        var el = document.getElementById("prod-banner");
+        var isHome = location.pathname === '/' || location.pathname === '';
+        var el = document.getElementById('prod-banner');
         if (el && isHome) el.hidden = false;
       } catch (_) {}
     </script>
@@ -129,9 +140,8 @@
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
 
-
     <!-- Install banner removed while PWA is disabled -->
-  <!-- Netlify Forms detection: hidden static form (do not remove) -->
+    <!-- Netlify Forms detection: hidden static form (do not remove) -->
     <form name="contact" netlify netlify-honeypot="bot-field" hidden>
       <input type="text" name="name" />
       <input type="email" name="email" />
@@ -142,11 +152,11 @@
       // Progressive enhancement: add lazy+async to any <img> lacking them.
       (function () {
         try {
-          var imgs = document.querySelectorAll("img:not([loading])");
+          var imgs = document.querySelectorAll('img:not([loading])');
           imgs.forEach(function (img) {
             // Do not touch if explicitly eager
-            if (!img.hasAttribute("loading")) img.setAttribute("loading", "lazy");
-            if (!img.hasAttribute("decoding")) img.setAttribute("decoding", "async");
+            if (!img.hasAttribute('loading')) img.setAttribute('loading', 'lazy');
+            if (!img.hasAttribute('decoding')) img.setAttribute('decoding', 'async');
           });
         } catch {}
       })();
@@ -159,35 +169,35 @@
           const isInternal = (a) => a.origin === location.origin && !a.hash;
           const prefetch = (href) => {
             if (!href) return;
-            const link = document.createElement("link");
-            link.rel = "prefetch";
+            const link = document.createElement('link');
+            link.rel = 'prefetch';
             link.href = href;
-            link.as = "document";
+            link.as = 'document';
             document.head.appendChild(link);
           };
 
           // Prefetch when user hovers or touches a link
           document.addEventListener(
-            "mouseover",
+            'mouseover',
             (e) => {
-              const a = e.target && (e.target.closest ? e.target.closest("a") : null);
+              const a = e.target && (e.target.closest ? e.target.closest('a') : null);
               if (a && isInternal(a)) prefetch(a.href);
             },
-            { passive: true }
+            { passive: true },
           );
 
           document.addEventListener(
-            "touchstart",
+            'touchstart',
             (e) => {
-              const a = e.target && (e.target.closest ? e.target.closest("a") : null);
+              const a = e.target && (e.target.closest ? e.target.closest('a') : null);
               if (a && isInternal(a)) prefetch(a.href);
             },
-            { passive: true }
+            { passive: true },
           );
 
           // Idle prefetch of common routes (adjust list if needed)
-          const common = ["/worlds", "/zones", "/marketplace"];
-          if ("requestIdleCallback" in window) {
+          const common = ['/worlds', '/zones', '/marketplace'];
+          if ('requestIdleCallback' in window) {
             requestIdleCallback(() => common.forEach((p) => prefetch(p)));
           } else {
             setTimeout(() => common.forEach((p) => prefetch(p)), 1200);
@@ -209,6 +219,5 @@
         });
       })();
     </script>
-
   </body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,19 +8,22 @@
 /* ---- Naturverse Navbar Brand ---- */
 :root {
   /* tweak these once and all pages follow */
-  --nv-logo-size-sm: 40px;   /* mobile */
-  --nv-logo-size-md: 44px;   /* tablets */
-  --nv-logo-size-lg: 48px;   /* desktop */
+  --nv-logo-size-sm: 40px; /* mobile */
+  --nv-logo-size-md: 44px; /* tablets */
+  --nv-logo-size-lg: 48px; /* desktop */
 }
 
 /* consistent text color token already in your project */
-.text-nv-blue, .nv-brand { color: var(--naturverse-blue) !important; }
+.text-nv-blue,
+.nv-brand {
+  color: var(--naturverse-blue) !important;
+}
 
 .nv-logo {
   width: var(--nv-logo-size-sm);
   height: var(--nv-logo-size-sm);
-  display: block;            /* avoid inline-img baseline gap */
-  flex-shrink: 0;            /* never collapse in tight rows */
+  display: block; /* avoid inline-img baseline gap */
+  flex-shrink: 0; /* never collapse in tight rows */
 }
 
 @media (min-width: 640px) {
@@ -45,21 +48,23 @@
 }
 
 /* ===== Mobile hamburger: lines only, no pill ===== */
-@media (max-width: 768px){
+@media (max-width: 768px) {
   .nv-hamburger {
     background: transparent !important;
     border: 0 !important;
     box-shadow: none !important;
-    padding: 6px 8px;             /* small tap target without the pill */
+    padding: 6px 8px; /* small tap target without the pill */
     border-radius: 0 !important;
   }
-  .nv-hamburger:focus { outline: none; }
+  .nv-hamburger:focus {
+    outline: none;
+  }
   .nv-hamburger .bar {
     display: block;
     width: 24px;
     height: 2px;
     margin: 5px 0;
-    background: #1E40AF;
+    background: #1e40af;
     border-radius: 1px;
   }
 }
@@ -75,13 +80,18 @@
 
 /* Make sure only the lines show */
 .nav-toggle svg {
-  fill: #1E40AF; /* blue lines, match site branding */
+  fill: #1e40af; /* blue lines, match site branding */
   width: 28px;
   height: 28px;
 }
 
 /* Keep titles/links as-is (don’t inherit the rule above) */
-.title, .headline, .lead, a { color: inherit; }
+.title,
+.headline,
+.lead,
+a {
+  color: inherit;
+}
 
 .page-wrapper {
   background-color: var(--page-bg);
@@ -156,7 +166,6 @@ h3 {
   border-color: #fca5a5;
 }
 
-
 /* Inputs & dashed demo areas */
 input,
 select,
@@ -218,14 +227,19 @@ textarea {
 .lang-card {
   display: grid;
   grid-template-columns: 96px 1fr;
-  gap: .75rem;
+  gap: 0.75rem;
   align-items: center;
-  padding: .875rem;
-  border: 1px solid rgba(0,0,0,.1);
+  padding: 0.875rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 14px;
   background: #fff;
 }
-.lang-card img { border-radius: 12px; width:96px; height:96px; object-fit: cover; }
+.lang-card img {
+  border-radius: 12px;
+  width: 96px;
+  height: 96px;
+  object-fit: cover;
+}
 
 /* Language hero */
 .lang-hero {
@@ -245,7 +259,7 @@ textarea {
   display: block;
   margin: 0 auto 1rem auto;
   border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
 /* Buttons */
@@ -253,7 +267,7 @@ textarea {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: .65rem 1.05rem;
+  padding: 0.65rem 1.05rem;
   border: none;
   border-radius: 12px;
   background: #2563eb;
@@ -261,13 +275,27 @@ textarea {
   font-weight: 600;
   text-decoration: none;
 }
-.btn:hover { filter: brightness(0.95); }
-.btn-small { padding: .45rem .7rem; border-radius: 10px; font-size: .9rem; }
+.btn:hover {
+  filter: brightness(0.95);
+}
+.btn-small {
+  padding: 0.45rem 0.7rem;
+  border-radius: 10px;
+  font-size: 0.9rem;
+}
 
 /* Utilities */
-.container { max-width: 1200px; margin: 0 auto; padding: 0 1rem; }
-.stack-md > *+* { margin-top: .75rem; }
-.muted { color: #6b7280; }
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+.stack-md > * + * {
+  margin-top: 0.75rem;
+}
+.muted {
+  color: #6b7280;
+}
 
 /* World map heroes scale nicely and never overflow */
 .world-hero {
@@ -279,8 +307,14 @@ textarea {
 }
 
 /* Card media stays square and crops cleanly */
-.nv-card__media { aspect-ratio: 1 / 1; }
-.nv-card__media img { width: 100%; height: 100%; object-fit: cover; }
+.nv-card__media {
+  aspect-ratio: 1 / 1;
+}
+.nv-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
 
 /* Ensure all product/character cards stay consistent */
 .nv-card,
@@ -299,10 +333,10 @@ textarea {
 }
 
 /* PAGE SCOPED, no cross-bleed */
-[data-page="marketplace"] .product-card,
-[data-page="marketplace"] .mp-card,
-[data-page="wishlist"] .wishlist-card,
-[data-page="wishlist"] .wl-card {
+[data-page='marketplace'] .product-card,
+[data-page='marketplace'] .mp-card,
+[data-page='wishlist'] .wishlist-card,
+[data-page='wishlist'] .wl-card {
   max-width: 320px;
 }
 
@@ -335,7 +369,7 @@ main,
 }
 .nv-hero h1 {
   color: var(--nv-blue-700);
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
 }
 .nv-hero p {
   color: var(--nv-blue-600);
@@ -374,13 +408,13 @@ main,
   margin: 1.25rem auto 0;
   max-width: 64rem;
   display: grid;
-  gap: .625rem;
+  gap: 0.625rem;
 }
 .nv-flow .nv-stepTitle {
   color: var(--nv-blue-700);
   font-weight: 700;
   text-align: center;
-  margin-bottom: .25rem;
+  margin-bottom: 0.25rem;
 }
 .nv-flow .nv-stepBody {
   color: var(--nv-blue-600);
@@ -395,7 +429,7 @@ main,
 }
 
 /* ===== WISHLIST ONLY ===== */
-[data-page="wishlist"] .wl-card,
+[data-page='wishlist'] .wl-card,
 .wishlist-page .wl-card {
   max-width: 320px; /* matches Marketplace card width */
   margin: 0 auto 22px;
@@ -403,7 +437,7 @@ main,
 }
 
 /* image wrapper inside the card */
-[data-page="wishlist"] .wl-card .imageWrap,
+[data-page='wishlist'] .wl-card .imageWrap,
 .wishlist-page .wl-card .imageWrap {
   aspect-ratio: 4 / 3;
   width: 100%;
@@ -416,7 +450,7 @@ main,
 }
 
 /* image itself */
-[data-page="wishlist"] .wl-card img,
+[data-page='wishlist'] .wl-card img,
 .wishlist-page .wl-card img {
   width: 100%;
   height: 100%;
@@ -454,8 +488,58 @@ main,
   cursor: not-allowed;
   opacity: 0.8;
 }
-.orders-list { display: grid; gap: 12px; }
-.order-card { border: 1px solid #e5e7eb; border-radius: 10px; padding: 12px; background: #fff; }
-.order-card .row { display: flex; gap: 12px; align-items: center; justify-content: space-between; }
-.badge { padding: 2px 8px; border-radius: 9999px; font-size: .75rem; background:#eef; }
-.badge.paid { background:#e6ffe9; }
+.orders-list {
+  display: grid;
+  gap: 12px;
+}
+.order-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 12px;
+  background: #fff;
+}
+.order-card .row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+.badge {
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  background: #eef;
+}
+.badge.paid {
+  background: #e6ffe9;
+}
+
+/* Mobile layout polish */
+@media (max-width: 768px) {
+  .nv-container,
+  .container,
+  main {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+  header .nav,
+  .topbar,
+  .menu {
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  header .nav .right,
+  header .nav .links {
+    flex: 1 1 100%;
+  }
+  /* Prevent giant headings from forcing horizontal zoom */
+  h1 {
+    font-size: clamp(1.5rem, 6vw, 2.25rem);
+  }
+  h2 {
+    font-size: clamp(1.25rem, 4.5vw, 1.75rem);
+  }
+  .card-grid {
+    grid-template-columns: 1fr !important;
+  }
+}


### PR DESCRIPTION
## Summary
- lock viewport scale and add theme color for mobile browsers
- tweak CSS for tighter spacing and responsive headings on small screens

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module 'ethers' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e7480c1083298002ec2b402123ac