### PR TITLE
Fix OAuth callback asset paths, CSP, and mobile viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,9 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <!-- Force all relative links to resolve from the site root -->
     <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta charset="UTF-8" />
-    <!-- Ensure proper mobile scaling -->
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"
-    />
-    <!-- Mobile chrome color (optional) -->
     <meta name="theme-color" content="#0ea5e9" />
     <script>
       // Vite replaces %VITE_ENABLE_PWA% at build-time

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,30 +2,51 @@
   command = "npm run build"
   publish = "dist"
 
-# Serve the SPA for any /auth/* URL (prevents wrong MIME/404 HTML for JS files)
+# --- Hard fix: when the callback page requests assets under /auth/*,
+#     rewrite them to the real root assets so MIME types are correct.
+
+# service worker helper
 [[redirects]]
-  from = "/auth/*"
+  from = "/auth/registerSW.js"
+  to   = "/registerSW.js"
+  status = 200
+  force = true
+
+# our SW killer utility
+[[redirects]]
+  from = "/auth/kill-sw.js"
+  to   = "/kill-sw.js"
+  status = 200
+  force = true
+
+# any CSS/JS/images accidentally requested under /auth/assets/* -> /assets/*
+[[redirects]]
+  from = "/auth/assets/:splat"
+  to   = "/assets/:splat"
+  status = 200
+  force = true
+
+# the real callback route must be served by the SPA shell
+[[redirects]]
+  from = "/auth/callback"
   to   = "/index.html"
   status = 200
 
-# Security headers: allow only what we need for Supabase + Google on the callback
+# SPA fallback for everything else
+[[redirects]]
+  from = "/*"
+  to   = "/index.html"
+  status = 200
+
+# --- Headers (relax just enough for callback bootstrap; tighten later)
 [[headers]]
   for = "/*"
   [headers.values]
-  X-Content-Type-Options = "nosniff"
-  Referrer-Policy = "same-origin"
-  Permissions-Policy = "geolocation=(), microphone=(), camera=()"
-  # Keep default-src tight, but allow Supabase/Google domains we actually use.
-  # We temporarily allow 'unsafe-inline' on script/style to let the callback boot.
-  # Once stable, we can replace inline use with nonces/hashes and remove 'unsafe-inline'.
-  Content-Security-Policy = """
-    default-src 'self' https://*.supabase.co https://*.supabase.in https://apis.google.com;
-    script-src  'self' 'unsafe-inline' 'unsafe-eval' https://*.supabase.co https://*.supabase.in https://apis.google.com;
-    style-src   'self' 'unsafe-inline';
-    img-src     'self' data: https:;
-    font-src    'self' data:;
-    connect-src 'self' https://*.supabase.co https://*.supabase.in https://oauth2.googleapis.com https://accounts.google.com;
-    frame-src   'self' https://*.supabase.co https://accounts.google.com https://*.google.com;
-    base-uri    'self';
-    form-action 'self';
-  """
+    # allow scripts/styles from ourselves; allow inline styles (Tailwind etc);
+    # allow inline scripts during bootstrap (you can remove 'unsafe-inline' after hashing/noncing)
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https: wss:; font-src 'self' data:; frame-ancestors 'self'; base-uri 'self'; form-action 'self';"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "SAMEORIGIN"
+    X-XSS-Protection = "0"
+

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,3 @@
-# Preserve Supabase access token by serving the SPA shell
-# Both rules must return 200 so the SPA renders and reads the hash
-/auth/callback   /index.html   200
-/*               /index.html   200
+/auth/callback  /index.html  200
+/*              /index.html  200
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
             workbox: {
               globPatterns: ['**/*.{js,css,html,svg,png,ico,webp,woff2}'],
               maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+              // don't cache auth pages at all
+              navigateFallbackDenylist: [/^\/auth\/],
             },
             manifest: {
               name: 'Naturverse',


### PR DESCRIPTION
## Summary
- rewrite /auth/* asset requests to real root assets and keep SPA fallback
- apply CSP and security headers for callback bootstrap
- ensure root base URL, mobile viewport meta, and avoid caching auth pages in PWA

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module 'ethers'; npm install returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ec2ae4d08329915487bbbed9becf