### PR TITLE
Refine PWA routing and Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,51 +2,29 @@
   command = "npm run build"
   publish = "dist"
 
-# --- Hard fix: when the callback page requests assets under /auth/*,
-#     rewrite them to the real root assets so MIME types are correct.
-
-# service worker helper
 [[redirects]]
-  from = "/auth/registerSW.js"
-  to   = "/registerSW.js"
-  status = 200
-  force = true
-
-# our SW killer utility
-[[redirects]]
-  from = "/auth/kill-sw.js"
-  to   = "/kill-sw.js"
-  status = 200
-  force = true
-
-# any CSS/JS/images accidentally requested under /auth/assets/* -> /assets/*
-[[redirects]]
-  from = "/auth/assets/:splat"
-  to   = "/assets/:splat"
-  status = 200
-  force = true
-
-# the real callback route must be served by the SPA shell
-[[redirects]]
-  from = "/auth/callback"
-  to   = "/index.html"
-  status = 200
-
-# SPA fallback for everything else
-[[redirects]]
+  # Let React handle all SPA routes including /auth/callback
   from = "/*"
-  to   = "/index.html"
+  to = "/index.html"
   status = 200
 
-# --- Headers (relax just enough for callback bootstrap; tighten later)
+[[redirects]]
+  # Explicitly remove kill-sw and registerSW from being served as HTML
+  from = "/kill-sw.js"
+  to = "/404.html"
+  status = 404
+
+[[redirects]]
+  from = "/registerSW.js"
+  to = "/404.html"
+  status = 404
+
 [[headers]]
   for = "/*"
   [headers.values]
-    # allow scripts/styles from ourselves; allow inline styles (Tailwind etc);
-    # allow inline scripts during bootstrap (you can remove 'unsafe-inline' after hashing/noncing)
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https: wss:; font-src 'self' data:; frame-ancestors 'self'; base-uri 'self'; form-action 'self';"
+    # Relax CSP for Supabase OAuth + inline hydration
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https: wss:; font-src 'self' data:; frame-ancestors 'self'; base-uri 'self'; form-action 'self';"
     Referrer-Policy = "strict-origin-when-cross-origin"
     X-Content-Type-Options = "nosniff"
     X-Frame-Options = "SAMEORIGIN"
     X-XSS-Protection = "0"
-

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,18 +15,20 @@ export default defineConfig({
             registerType: 'autoUpdate',
             injectRegister: 'auto',
             workbox: {
-              globPatterns: ['**/*.{js,css,html,svg,png,webp,ico}'],
-              maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
-              // Exclude auth routes from SPA fallback to avoid hash/callback quirks
-              navigateFallbackDenylist: [/^\/auth(\/.*)?$/],
+              globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+              maximumFileSizeToCacheInBytes: 5000000,
+              navigateFallback: '/index.html',
+              // Prevent SW from hijacking auth callback route
+              navigateFallbackDenylist: [/^\/auth\/callback$/],
             },
             manifest: {
               name: 'Naturverse',
               short_name: 'Naturverse',
               theme_color: '#2563eb',
               background_color: '#ffffff',
-              start_url: '.',
+              start_url: '/',
               display: 'standalone',
+              orientation: 'portrait',
               icons: [
                 { src: 'favicon-192x192.png', sizes: '192x192', type: 'image/png' },
                 { src: 'favicon-256x256.png', sizes: '256x256', type: 'image/png' },


### PR DESCRIPTION
## Summary
- Narrow service worker fallback denylist to only the auth callback and add fallback navigation
- Allow SPA routes through Netlify and block service worker helper scripts
- Relax CSP for Supabase and force portrait orientation in manifest

## Testing
- `npm test`
- `npm run typecheck` (fails: Cannot find module 'ethers')


------
https://chatgpt.com/codex/tasks/task_e_68b2f2e9ce6c83298325b0172ef8db2a