### PR TITLE
Add service worker reset page

### DIFF
--- a/public/kill-sw.html
+++ b/public/kill-sw.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Kill SW</title></head>
+  <body>
+    <p>Removing service workers & caches…</p>
+    <script src="/kill-sw.js"></script>
+    <script>
+      // Let the user know it finished (if no auto-reload happened)
+      setTimeout(() => {
+        document.body.insertAdjacentHTML('beforeend','<p>Done. If the page didn’t reload, refresh once.</p>');
+      }, 1500);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add a `kill-sw.html` page that loads `kill-sw.js` to remove service workers and caches

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module 'ethers' or its corresponding type declarations, Cannot find module '@stripe/stripe-js' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fd7733d883298da101a3e42a475b