### PR TITLE
Serve a static OAuth callback that stores token and redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,23 +1,13 @@
 [build]
-  command   = "npm run build"
-  publish   = "dist"
+  command = "npm run build"
+  publish = "dist"
 
-# Serve the SPA shell for everything
+# --- Auth callback served as a real static file (no SPA rewrite) ---
 [[redirects]]
   from = "/auth/callback"
-  to   = "/index.html"
+  to   = "/auth/callback.html"
   status = 200
-
-[[redirects]]
-  from = "/auth/*"
-  to   = "/index.html"
-  status = 200
-
-# (safety) assets under /auth/* that some browsers may request
-[[redirects]]
-  from = "/auth/assets/*"
-  to   = "/assets/:splat"
-  status = 200
+  force = true
 
 # Run the SW killer page as-is (no SPA rewrite)
 [[redirects]]
@@ -26,7 +16,13 @@
   status = 200
   force = true
 
-# Basic CSP that won’t block our inline boot + OAuth callback
+# Keep SPA shell for everything else
+[[redirects]]
+  from = "/*"
+  to   = "/index.html"
+  status = 200
+
+# Slim, permissive CSP for the whole app (fine for now)
 [[headers]]
   for = "/*"
   [headers.values]

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,3 @@
-/auth/callback    /index.html    200
-/auth/*           /index.html    200
-/auth/assets/*    /assets/:splat 200
-/kill-sw          /kill-sw.html  200!
-/*                /index.html    200
+/auth/callback   /auth/callback.html   200!
+/kill-sw         /kill-sw.html         200!
+/*               /index.html           200

--- a/public/auth/callback.html
+++ b/public/auth/callback.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'self';"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Signing you in…</title>
+    <style>
+      html,body{height:100%}body{display:flex;align-items:center;justify-content:center;font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Arial}
+      .box{max-width:520px;padding:24px;border:1px solid #e5e7eb;border-radius:12px;box-shadow:0 4px 18px rgba(0,0,0,.06)}
+      .muted{opacity:.7}
+    </style>
+  </head>
+  <body>
+    <div class="box">
+      <div><strong>Naturverse</strong></div>
+      <p class="muted">Completing sign-in…</p>
+      <noscript>Enable JavaScript to continue.</noscript>
+    </div>
+
+    <script>
+      (function () {
+        try {
+          // Parse the fragment (#foo=bar&baz=qux)
+          const frag = (location.hash || '').replace(/^#/, '');
+          const params = new URLSearchParams(frag);
+
+          // Common Supabase fields
+          const access_token  = params.get('access_token');
+          const refresh_token = params.get('refresh_token');
+          const token_type    = params.get('token_type');
+          const expires_in    = params.get('expires_in');
+
+          // Persist for your app to pick up on /
+          if (access_token) {
+            // Keep keys namespaced to avoid collisions
+            localStorage.setItem('nv.sb.access_token',  access_token);
+            if (refresh_token) localStorage.setItem('nv.sb.refresh_token', refresh_token);
+            if (token_type)    localStorage.setItem('nv.sb.token_type',    token_type);
+            if (expires_in)    localStorage.setItem('nv.sb.expires_in',    expires_in);
+
+            // If opener is available (popup flow), notify it
+            try { window.opener && window.opener.postMessage({ nvAuth: 'ok' }, location.origin); } catch (_) {}
+          } else {
+            // Surface something useful for debugging
+            localStorage.setItem('nv.sb.callback_debug', frag || '(no fragment)');
+          }
+        } catch (err) {
+          localStorage.setItem('nv.sb.callback_error', String(err && err.message || err));
+        } finally {
+          // Always end on the app shell
+          location.replace('/');
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/src/components/HeadPreloads.tsx
+++ b/src/components/HeadPreloads.tsx
@@ -16,10 +16,6 @@ export default function HeadPreloads() {
       <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png" />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
       <link rel="shortcut icon" href="/favicon.ico" />
-
-      {/* PWA meta */}
-      <meta name="mobile-web-app-capable" content="yes" />
-      <meta name="apple-mobile-web-app-capable" content="yes" />
     </Helmet>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,27 +3,8 @@ import react from '@vitejs/plugin-react-swc'
 import path from 'path'
 
 export default defineConfig({
-  base: '/',                       // ensures absolute asset URLs
+  base: '/',
   plugins: [react(), splitVendorChunkPlugin()],
   envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   resolve: { alias: { '@': path.resolve(__dirname, './src') } },
-  optimizeDeps: {
-    include: [
-      'react','react-dom','react-router-dom','@supabase/supabase-js','three','react-helmet-async'
-    ],
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: true,
-    // DO NOT externalize app deps: caused unresolved imports in Netlify
-    rollupOptions: {
-      // no external
-      output: {
-        manualChunks(id) {
-          if (id.includes('node_modules')) return 'vendor'
-        },
-      },
-    },
-    commonjsOptions: { include: [/node_modules/] },
-  },
 })


### PR DESCRIPTION
## Summary
- Add `public/auth/callback.html` to parse access tokens, store them in `localStorage`, notify opener, and redirect home
- Update Netlify redirects and headers to serve static auth callback and SPA shell elsewhere
- Strip PWA metadata and remove service worker artifacts; simplify Vite config

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module 'ethers', '@stripe/stripe-js', '@stripe/react-stripe-js')*

------
https://chatgpt.com/codex/tasks/task_e_68b3133361b483298650b8b313710aa8