### PR TITLE
Fix Netlify redirects and add service worker cleanup

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,16 +3,29 @@ command = "npm run build"
 publish = "dist"
 functions = "netlify/functions"
 
-# SPA routing: send everything (incl. /auth/callback) to index.html
+# 1) Only the real callback path is handled by the SPA shell
 [[redirects]]
-from = "/auth/*"
+from = "/auth/callback"
 to = "/index.html"
 status = 200
 force = true
 
+# 2) Never rewrite real static assets (important!)
+[[redirects]]
+from = "/assets/*"
+to   = "/assets/:splat"
+status = 200
+
+# Some older builds might have emitted /auth/assets — keep them public too
+[[redirects]]
+from = "/auth/assets/*"
+to   = "/auth/assets/:splat"
+status = 200
+
+# 3) SPA fallback for the rest
 [[redirects]]
 from = "/*"
-to = "/index.html"
+to   = "/index.html"
 status = 200
 force = true
 

--- a/public/kill-sw.html
+++ b/public/kill-sw.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Reset app cache</title>
+  </head>
+  <body>
+    <p>Cleaning up old service workers & caches…</p>
+    <script src="/kill-sw.js" defer></script>
+  </body>
+</html>

--- a/public/kill-sw.js
+++ b/public/kill-sw.js
@@ -1,0 +1,15 @@
+(async () => {
+  try {
+    if ('serviceWorker' in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map(r => r.unregister().catch(() => {})));
+    }
+    if ('caches' in window) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map(k => caches.delete(k).catch(() => {})));
+    }
+    console.log('Service workers and caches cleared');
+  } catch (err) {
+    console.error('SW cleanup failed', err);
+  }
+})();

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,23 +1,16 @@
-import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function AuthCallback() {
-  const navigate = useNavigate()
-
+  const navigate = useNavigate();
   useEffect(() => {
-    // Handle hash tokens from Supabase OAuth
-    const { hash, search } = window.location
-    if (hash && hash.includes('access_token')) {
-      // Store or let your auth layer parse directly; this just verifies then redirects.
-      sessionStorage.setItem('nv-auth-hash', hash)
-      navigate('/', { replace: true })
-    } else if (search && search.includes('code=')) {
-      // PKCE/code flow case
-      navigate('/', { replace: true })
+    const { hash, search } = window.location;
+    if (hash?.includes('access_token') || search?.includes('code=')) {
+      // let your auth layer pick tokens from URL; then go home
+      navigate('/', { replace: true });
     } else {
-      navigate('/', { replace: true })
+      navigate('/', { replace: true });
     }
-  }, [navigate])
-
-  return <div style={{ padding: 24 }}>Signing you in…</div>
+  }, [navigate]);
+  return <div style={{ padding: 24 }}>Signing you in…</div>;
 }


### PR DESCRIPTION
## Summary
- refine Netlify redirects to avoid rewriting asset paths and only handle the auth callback
- add kill-sw runner for clearing service workers and caches
- simplify auth callback page routing logic

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react-swc'; `npm install` returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b31dc4e66c8329b9a60552f57ad07d