### PR TITLE
Disable PWA, add kill-sw page, and relax CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,43 +3,29 @@
   publish = "dist"
   functions = "netlify/functions"
 
-# IMPORTANT: Do NOT rewrite /auth/*, only the callback document itself.
-# Specific rules must come before the SPA catch-all.
-[[redirects]]
-  from = "/auth/callback"
-  to   = "/index.html"
-  status = 200
-  force  = true
+[build.environment]
+  VITE_ENABLE_PWA = "false"
+  VITE_ALLOW_PREVIEW_AUTH = "false"
+  VITE_ALLOW_PREVIEW_SIGNIN = "false"
 
-# Keep helper utilities served as actual files (no rewrites)
+## SPA fallback for client routes (including OAuth callback)
 [[redirects]]
-  from = "/kill-sw"
-  to   = "/kill-sw.html"
-  status = 200
-  force = true
-
-[[redirects]]
-  from = "/kill-sw.js"
-  to   = "/kill-sw.js"
+  from = "/auth/*"
+  to = "/index.html"
   status = 200
 
-[[redirects]]
-  from = "/registerSW.js"
-  to   = "/registerSW.js"
-  status = 200
-
-# SPA fallback (works for every other client route)
 [[redirects]]
   from = "/*"
-  to   = "/index.html"
+  to = "/index.html"
   status = 200
 
-# Minimal, permissive CSP for now (no inline hashes needed)
-# Remove once everything is stable and you want to lock it down again.
+## Security headers with relaxed CSP to allow Vite’s inline bootstrapping
 [[headers]]
   for = "/*"
   [headers.values]
-  Content-Security-Policy = "default-src 'self'; img-src 'self' data: blob: https:; connect-src 'self' https: wss:; script-src 'self'; style-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'"
-  Referrer-Policy = "strict-origin-when-cross-origin"
-  X-Frame-Options = "SAMEORIGIN"
-  X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "SAMEORIGIN"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    # IMPORTANT: relax CSP while we stabilize OAuth callback and remove inline-block errors.
+    # When everything is stable, we can re-harden this.
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src *; frame-ancestors 'self'; base-uri 'self'; form-action 'self'"

--- a/public/kill-sw.html
+++ b/public/kill-sw.html
@@ -1,11 +1,49 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Kill SW</title>
-    <meta name="robots" content="noindex" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Clear Naturverse Service Workers</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; padding: 24px; line-height: 1.5; }
+      .card { max-width: 680px; margin: 0 auto; border: 1px solid #e5e7eb; border-radius: 12px; padding: 20px; }
+      button { padding: 10px 14px; border-radius: 10px; border: 0; cursor: pointer; }
+    </style>
   </head>
   <body>
-    <script src="/kill-sw.js"></script>
+    <div class="card">
+      <h1>Clear Naturverse Service Workers</h1>
+      <p>This page unregisters all Service Workers and clears old caches. Use it if you see “Install Naturverse?” banners or stale pages.</p>
+      <button id="run">Clear now</button>
+      <pre id="log"></pre>
+    </div>
+    <script>
+      async function clearAll() {
+        const out = [];
+        try {
+          if ('serviceWorker' in navigator) {
+            const regs = await navigator.serviceWorker.getRegistrations();
+            out.push(`Found ${regs.length} service worker(s).`);
+            await Promise.all(regs.map(r => r.unregister().catch(() => {})));
+            out.push('Unregistered all service workers.');
+          }
+          if (self.caches && caches.keys) {
+            const keys = await caches.keys();
+            out.push(`Found ${keys.length} cache key(s): ${keys.join(', ')}`);
+            await Promise.all(keys.map(k => caches.delete(k).catch(() => {})));
+            out.push('Deleted all caches.');
+          }
+          out.push('✅ Done. Reloading…');
+          document.getElementById('log').textContent = out.join('\n');
+          setTimeout(() => location.replace('/'), 800);
+        } catch (e) {
+          out.push('Error: ' + (e && e.message ? e.message : e));
+          document.getElementById('log').textContent = out.join('\n');
+        }
+      }
+      document.getElementById('run').addEventListener('click', clearAll);
+      // auto-run on open
+      clearAll();
+    </script>
   </body>
-</html>
+  </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,48 +1,47 @@
 import { defineConfig, splitVendorChunkPlugin } from 'vite'
 import react from '@vitejs/plugin-react-swc'
-// import { VitePWA } from 'vite-plugin-pwa'   // <- remove PWA for now
 import path from 'path'
 
 export default defineConfig({
-  // Force absolute URLs for built assets, regardless of Netlify "baseRelDir"
+  // Force absolute asset URLs so nested routes like /auth/callback
+  // don’t try to load /auth/assets/* and break MIME type checks.
   base: '/',
-
   plugins: [
     react(),
     splitVendorChunkPlugin(),
-    // PWA disabled until auth/callback is fully stable
-    // ...(process.env.VITE_ENABLE_PWA === 'true' ? [VitePWA({})] : []),
+    // PWA disabled by default. If you ever want it back,
+    // re-enable the plugin behind the env flag.
   ],
-
+  // Keep source maps in prod while we stabilize
+  sourcemap: true,
+  // Avoid accidental externalization that caused “failed to resolve import”
+  build: {
+    rollupOptions: {
+      external: [],
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            if (id.includes('react-router') || id.includes('@supabase') || id.includes('react'))
+              return 'vendor'
+          }
+        }
+      }
+    },
+  },
+  optimizeDeps: {
+    include: [
+      'react',
+      'react-dom',
+      'react-router-dom',
+      '@supabase/supabase-js',
+      'three',
+      'react-helmet-async',
+    ],
+  },
+  envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
-  },
-
-  optimizeDeps: {
-    include: ['react','react-dom','react-router-dom','@supabase/supabase-js','three','react-helmet-async']
-  },
-
-  // keep your existing optimizeDeps/build options…
-  build: {
-    outDir: 'dist',
-    sourcemap: true,
-    assetsDir: 'assets', // explicit
-    rollupOptions: {
-      output: {
-        manualChunks(id: string) {
-          if (id.includes('node_modules')) {
-            if (id.includes('react-router')) return 'vendor-router'
-            if (id.includes('@supabase')) return 'vendor-supabase'
-            if (id.includes('react') || id.includes('react-dom')) return 'vendor-react'
-            return 'vendor'
-          }
-        },
-      },
-      // Never externalize client code accidentally
-      external: [],
-    },
-    commonjsOptions: { include: [/node_modules/] },
   },
 })


### PR DESCRIPTION
## Summary
- Disable PWA plugin and force absolute asset URLs in Vite
- Add standalone `/kill-sw.html` to unregister service workers and clear caches
- Relax Netlify CSP and add SPA fallbacks for `/auth/*`

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module 'ethers' or '@stripe/stripe-js'; dependency install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b32b8e6ee0832982b4d5b822fd8a8d