### PR TITLE
Reset to stable SPA without PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,16 +1,20 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <!-- base MUST be the first real tag so /auth/callback resolves assets from / -->
-    <base href="/" />
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <title>Naturverse</title>
-    <link rel="icon" href="/favicon-192x192.png" />
-    <!-- Removed PWA and install-banner meta for now -->
+
+    <!-- NO manifest, NO apple-mobile-web-app-capable, NO worker/register -->
+    <!-- Vite will replace this with /assets/... because base='/' -->
+    <script type="module" src="/src/main.tsx"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+
+    <!-- NO inline PWA banners or install prompts -->
   </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,27 +1,19 @@
 [build]
   command = "npm run build"
   publish = "dist"
-  functions = "netlify/functions"
 
-# Serve a real static page for SW cleanup (must be above catch-all)
-[[redirects]]
-  from = "/kill-sw"
-  to = "/kill-sw.html"
-  status = 200
-  force = true
-
-# Auth callback should return the SPA shell so the app handles the hash
+# Auth callback must render the SPA shell (index.html)
 [[redirects]]
   from = "/auth/callback"
   to = "/index.html"
   status = 200
   force = true
 
-# Catch-all SPA
+# Generic SPA fallback (does NOT catch /assets/*)
 [[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200
 
-# ❗️No CSP while we stabilize (it was blocking inline boot + Stripe)
-# If you see a CSP header after this change, a /public/_headers file is overriding it.
+# No CSP while we stabilize (prevents inline/style/script blocks)
+# (Intentionally omit any headers setting Content-Security-Policy)

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "build:galleries": "node scripts/build-kingdom-gallery.js",
-    "build": "npm run build:galleries && vite build",
     "dev": "vite",
-    "preview": "vite preview"
+    "build": "vite build",
+    "preview": "vite preview",
+    "clean": "rimraf dist || rm -rf dist"
   },
   "dependencies": {
     "@vercel/og": "^0.8.2",
@@ -29,10 +29,11 @@
     "@types/node": "^20.14.11",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react-swc": "^3.7.1",
+    "@vitejs/plugin-react": "^4.3.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "rimraf": "^5.0.0"
   },
   "overrides": {
     "react-helmet-async": "^2.0.4"

--- a/public/kill-sw.html
+++ b/public/kill-sw.html
@@ -1,26 +1,20 @@
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>Reset app cache</title>
-  </head>
-  <body>
-    <pre>Clearing service workers & caches…</pre>
-    <script>
-      (async () => {
-        try {
-          if ('serviceWorker' in navigator) {
-            const regs = await navigator.serviceWorker.getRegistrations();
-            await Promise.all(regs.map(r => r.unregister().catch(() => {})));
-          }
-          if (window.caches && caches.keys) {
-            const keys = await caches.keys();
-            await Promise.all(keys.map(k => caches.delete(k).catch(() => {})));
-          }
-        } catch {}
-        setTimeout(() => (location.href = '/'), 300);
-      })();
-    </script>
-  </body>
-</html>
+<!doctype html><meta charset="utf-8"/>
+<title>Reset Naturverse</title>
+<script>
+(async () => {
+  try {
+    if ('serviceWorker' in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map(r => r.unregister().catch(() => {})));
+    }
+    if (self.caches) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map(k => caches.delete(k).catch(() => {})));
+    }
+    sessionStorage.clear(); localStorage.clear();
+  } finally {
+    location.href = '/';
+  }
+})();
+</script>
+<p>Resetting…</p>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,15 @@
-import { defineConfig, splitVendorChunkPlugin } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 import path from 'path'
 
+// IMPORTANT: absolute root so built assets are /assets/... even on /auth/callback
 export default defineConfig({
-  base: '/',                               // 🔒 absolute asset URLs (fixes /auth/assets/…)
-  plugins: [react(), splitVendorChunkPlugin()],
+  base: '/',
+  plugins: [react()],
   resolve: { alias: { '@': path.resolve(__dirname, './src') } },
   envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   build: {
+    sourcemap: false,
     outDir: 'dist',
-    sourcemap: true,
-    rollupOptions: { },
-    commonjsOptions: { include: [/node_modules/] },
   },
 })


### PR DESCRIPTION
## Summary
- Strip PWA bits and service worker for a plain SPA experience
- Ensure absolute asset URLs and add cache-reset page
- Simplify Netlify redirects for `/auth/callback` and generic SPA fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "@stripe/react-stripe-js")*

------
https://chatgpt.com/codex/tasks/task_e_68b338b3d84c8329895990940ca8ad46