### PR TITLE
Reset to 642 baseline: remove PWA, fix auth + mobile, clean redirects

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,19 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, viewport-fit=cover"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Naturverse</title>
-
-    <!-- NO manifest, NO apple-mobile-web-app-capable, NO worker/register -->
-    <!-- Vite will replace this with /assets/... because base='/' -->
-    <script type="module" src="/src/main.tsx"></script>
   </head>
   <body>
     <div id="root"></div>
-
-    <!-- NO inline PWA banners or install prompts -->
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,19 +1,34 @@
 [build]
   command = "npm run build"
   publish = "dist"
+  functions = "netlify/functions"
 
-# Auth callback must render the SPA shell (index.html)
+# *** IMPORTANT ***
+# Do NOT set Content-Security-Policy headers here.
+# We’re removing previous CSP overrides that blocked all inline and external scripts.
+
+# Serve the static SW killer HTML (no SPA catch)
+[[redirects]]
+  from = "/kill-sw"
+  to = "/kill-sw.html"
+  status = 200
+  force = true
+
+# Auth callback must load the SPA shell (so client JS can handle the token)
 [[redirects]]
   from = "/auth/callback"
   to = "/index.html"
   status = 200
   force = true
 
-# Generic SPA fallback (does NOT catch /assets/*)
+# Ensure static assets are never eaten by SPA
+[[redirects]]
+  from = "/assets/*"
+  to = "/assets/:splat"
+  status = 200
+
+# SPA catch-all (last)
 [[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200
-
-# No CSP while we stabilize (prevents inline/style/script blocks)
-# (Intentionally omit any headers setting Content-Security-Policy)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^20.14.11",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.3.0",
+    "@vitejs/plugin-react-swc": "^3.5.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
     "vite": "^5.4.2",

--- a/public/kill-sw.html
+++ b/public/kill-sw.html
@@ -1,20 +1,12 @@
-<!doctype html><meta charset="utf-8"/>
-<title>Reset Naturverse</title>
-<script>
-(async () => {
-  try {
-    if ('serviceWorker' in navigator) {
-      const regs = await navigator.serviceWorker.getRegistrations();
-      await Promise.all(regs.map(r => r.unregister().catch(() => {})));
-    }
-    if (self.caches) {
-      const keys = await caches.keys();
-      await Promise.all(keys.map(k => caches.delete(k).catch(() => {})));
-    }
-    sessionStorage.clear(); localStorage.clear();
-  } finally {
-    location.href = '/';
-  }
-})();
-</script>
-<p>Resetting…</p>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kill Service Workers</title>
+  </head>
+  <body>
+    <p>Clearing service workers and caches…</p>
+    <script src="/kill-sw.js"></script>
+  </body>
+</html>

--- a/public/kill-sw.js
+++ b/public/kill-sw.js
@@ -1,0 +1,13 @@
+;(async () => {
+  try {
+    if ('serviceWorker' in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(regs.map(r => r.unregister().catch(() => {})))
+    }
+    if (self.caches) {
+      const keys = await caches.keys()
+      await Promise.all(keys.map(k => caches.delete(k).catch(() => {})))
+    }
+  } catch {}
+  location.replace('/')
+})()

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,18 +1,17 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js'
 
 export const supabase = createClient(
   import.meta.env.VITE_SUPABASE_URL!,
-  import.meta.env.VITE_SUPABASE_ANON_KEY!,
-  {
-    auth: {
-      persistSession: true,
-      autoRefreshToken: true,
-      detectSessionInUrl: true,
-      flowType: 'pkce',
-    },
-  },
-);
+  import.meta.env.VITE_SUPABASE_ANON_KEY!
+)
 
 export function getSupabase() {
-  return supabase;
+  return supabase
+}
+
+// Handle /auth/callback with hash tokens (implicit flow)
+export async function handleAuthCallback() {
+  if (location.pathname !== '/auth/callback') return
+  await supabase.auth.getSessionFromUrl({ storeSession: true }).catch(() => {})
+  history.replaceState({}, '', '/')
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,7 +17,7 @@ import './styles/theme.css';
 import './styles/cart.css';
 import { applyTheme, getTheme } from './lib/theme';
 import ToastProvider from './components/Toast';
-import { getSupabase } from '@/lib/supabase-client';
+import { getSupabase, handleAuthCallback } from '@/lib/supabase-client';
 import WorldExtras from './components/WorldExtras';
 import CommandPalette from './components/CommandPalette';
 import { router } from './router';
@@ -67,6 +67,7 @@ function RootWithPalette({ children }: { children: React.ReactNode }) {
 }
 
 async function bootstrap() {
+  await handleAuthCallback();
   const supabase = getSupabase();
   const { data } = supabase ? await supabase.auth.getSession() : { data: { session: null } };
   const initialSession = data.session ?? null;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,9 @@
 import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import path from 'path'
+import react from '@vitejs/plugin-react-swc'
 
-// IMPORTANT: absolute root so built assets are /assets/... even on /auth/callback
 export default defineConfig({
   base: '/',
   plugins: [react()],
-  resolve: { alias: { '@': path.resolve(__dirname, './src') } },
-  envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
-  build: {
-    sourcemap: false,
-    outDir: 'dist',
-  },
+  build: { outDir: 'dist' },
+  server: { port: 5173 }
 })


### PR DESCRIPTION
## Summary
- remove PWA service worker and install banner, keeping a minimal HTML shell
- streamline Netlify redirects so static assets and `/auth/callback` resolve correctly
- add Supabase auth callback handler and utility to clear existing service workers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react-swc')*

------
https://chatgpt.com/codex/tasks/task_e_68b37d6490788329b762ec1efef3bfe5