### PR TITLE
chore: remove stripe import from main entry

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,8 +24,6 @@ import { router } from './router';
 import './runtime-logger';
 import { prefetchGlob, prefetchOnHover } from './lib/prefetch';
 import './boot/warmup';
-import { Elements } from '@stripe/react-stripe-js';
-import { stripePromise } from '@/lib/stripe';
 import { installGlobalLogCapture } from '@/lib/log';
 
 applyTheme(getTheme());
@@ -97,31 +95,29 @@ async function bootstrap() {
 
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-      <Elements stripe={stripePromise}>
-        {supabase ? (
-          <AuthProvider initialSession={initialSession}>
-            <ToastProvider>
-              <BaseAuthProvider>
-                <RootWithPalette>
-                  <AppErrorBoundary>
-                    <App />
-                  </AppErrorBoundary>
-                  <WorldExtras />
-                </RootWithPalette>
-              </BaseAuthProvider>
-            </ToastProvider>
-          </AuthProvider>
-        ) : (
+      {supabase ? (
+        <AuthProvider initialSession={initialSession}>
           <ToastProvider>
-            <RootWithPalette>
-              <AppErrorBoundary>
-                <App />
-              </AppErrorBoundary>
-              <WorldExtras />
-            </RootWithPalette>
+            <BaseAuthProvider>
+              <RootWithPalette>
+                <AppErrorBoundary>
+                  <App />
+                </AppErrorBoundary>
+                <WorldExtras />
+              </RootWithPalette>
+            </BaseAuthProvider>
           </ToastProvider>
-        )}
-      </Elements>
+        </AuthProvider>
+      ) : (
+        <ToastProvider>
+          <RootWithPalette>
+            <AppErrorBoundary>
+              <App />
+            </AppErrorBoundary>
+            <WorldExtras />
+          </RootWithPalette>
+        </ToastProvider>
+      )}
     </React.StrictMode>,
   );
 }


### PR DESCRIPTION
## Summary
- remove Stripe Elements wrapper and related imports from main entry

## Testing
- `npm test` *(fails: missing script `test`)*
- `npm run build` *(fails: Rollup failed to resolve import "@stripe/react-stripe-js" from "src/pages/checkout.tsx"; also cannot install Stripe packages: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4050e12d08329bdf5809ddfba844f