### PR TITLE
fix: footer social links & centralize config

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Icon from "./Icon";
+import { SOCIALS } from '@/lib/socials';
 
 export default function Footer() {
   return (
@@ -9,12 +10,21 @@ export default function Footer() {
         <a href="mailto:info@thenaturverse.com" aria-label="Email us">
           <Icon name="contact" size={18} />
         </a>
-        <a href="https://twitter.com/naturverse" target="_blank" rel="noopener" aria-label="Twitter">
-          <Icon name="arrow" size={18} />
-        </a>
-        <a href="https://instagram.com/naturverse" target="_blank" rel="noopener" aria-label="Instagram">
-          <Icon name="world" size={18} />
-        </a>
+        <ul className="socials" style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          {SOCIALS.map((s) => (
+            <li key={s.name}>
+              <a
+                href={s.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={s.aria ?? s.name}
+                className="link"
+              >
+                {s.icon ?? <span>{s.name}</span>}
+              </a>
+            </li>
+          ))}
+        </ul>
       </div>
     </footer>
   );

--- a/src/lib/socials.ts
+++ b/src/lib/socials.ts
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react';
+
+export type SocialLink = {
+  name: 'X' | 'Instagram' | 'TikTok' | 'YouTube' | 'Facebook';
+  href: string;
+  icon?: ReactNode; // Footer can supply icons
+  aria?: string;
+};
+
+export const SOCIALS: SocialLink[] = [
+  {
+    name: 'X',
+    href: 'https://x.com/TuriantheDurian',
+    aria: 'Follow us on X',
+  },
+  {
+    name: 'Instagram',
+    href: 'https://instagram.com/turianthedurian',
+    aria: 'Follow us on Instagram',
+  },
+  {
+    name: 'TikTok',
+    href: 'https://tiktok.com/@turian.the.durian',
+    aria: 'Follow us on TikTok',
+  },
+  {
+    name: 'YouTube',
+    href: 'https://youtube.com/@TuriantheDurian',
+    aria: 'Subscribe on YouTube',
+  },
+  {
+    name: 'Facebook',
+    href: 'https://facebook.com/TurianMediaCompany',
+    aria: 'Like us on Facebook',
+  },
+];


### PR DESCRIPTION
## Summary
- add `src/lib/socials.ts` with canonical URLs for X, Instagram, TikTok, YouTube, Facebook
- render social links from config in `Footer`
- remove old `@` handle text and keep accessibility attributes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" in `src/lib/natur.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68b45c96db7c8329b4f9a8a312dec17b