### PR TITLE
feat(header): simplify top nav + “More” dropdown

### DIFF
--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -1,18 +1,145 @@
 .header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.75rem 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  backdrop-filter: saturate(140%) blur(6px);
+  background: rgba(255, 255, 255, 0.75);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
 }
 
-.brand a {
-  font-weight: 700;
+.brandRow {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   text-decoration: none;
-  color: inherit;
+}
+
+.logo {
+  width: 28px;
+  height: 28px;
+}
+.brandText {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--text-strong, #1f2937);
 }
 
 .nav {
-  display: flex;
-  flex-wrap: wrap;
+  display: inline-flex;
+  align-items: center;
   gap: 0.75rem;
+  justify-content: center;
+}
+
+.navLink {
+  font-weight: 500;
+  text-decoration: none;
+  padding: 0.4rem 0.5rem;
+  border-radius: 6px;
+}
+.navLink:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.more {
+  position: relative;
+}
+.moreButton {
+  cursor: pointer;
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+}
+.more[open] .moreButton,
+.moreButton:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.moreMenu {
+  position: absolute;
+  right: 0;
+  margin-top: 0.5rem;
+  min-width: 220px;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+  padding: 0.4rem;
+}
+.moreMenu li {
+  list-style: none;
+}
+.moreLink {
+  display: block;
+  padding: 0.5rem 0.6rem;
+  border-radius: 6px;
+  text-decoration: none;
+}
+.moreLink:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.actions {
+  justify-self: end;
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+/* Mobile drawer */
+.hamburger {
+  display: none;
+  justify-self: end;
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.drawerToggler {
+  display: none;
+}
+.drawer {
+  display: none;
+  position: fixed;
+  inset: 0 0 0 35%;
+  background: #fff;
+  padding: 1rem;
+  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.15);
+  z-index: 45;
+}
+.drawer nav {
+  display: grid;
+  gap: 0.25rem;
+  margin-top: 1rem;
+}
+.drawerLink {
+  padding: 0.6rem 0.5rem;
+  border-radius: 6px;
+  text-decoration: none;
+}
+.drawerLink:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+@media (max-width: 980px) {
+  .nav {
+    display: none;
+  }
+  .hamburger {
+    display: inline-flex;
+  }
+}
+.drawerToggler:checked ~ .hamburger {
+  background: rgba(0, 0, 0, 0.06);
+}
+.drawerToggler:checked ~ .drawer {
+  display: block;
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,25 @@
 import { useState, useEffect } from 'react';
 import { useCart } from '../lib/cart';
 import CartDrawer from './CartDrawer';
+import styles from './Header.module.css';
+
+type LinkItem = { label: string; to: string };
+
+const PRIMARY_LINKS: LinkItem[] = [
+  { label: 'Worlds', to: '/worlds' },
+  { label: 'Zones', to: '/zones' },
+  { label: 'Quests', to: '/quests' },
+  { label: 'Marketplace', to: '/marketplace' },
+];
+
+const MORE_LINKS: LinkItem[] = [
+  { label: 'Wishlist', to: '/wishlist' },
+  { label: 'Naturversity', to: '/naturversity' },
+  { label: 'NaturBank', to: '/naturbank' },
+  { label: 'Navatar', to: '/navatar' },
+  { label: 'Passport', to: '/passport' },
+  { label: 'Create Navatar', to: '/create-navatar' },
+];
 
 export default function Header() {
   const { items } = useCart();
@@ -13,18 +32,62 @@ export default function Header() {
   }, []);
 
   return (
-    <header className="site-header">
-      <a href="/">Naturverse</a>
-      <nav>
-        <a href="/worlds">Worlds</a>
-        <a href="/zones">Zones</a>
-        <a href="/marketplace">Marketplace</a>
-      </nav>
-      <button className="cart-btn" onClick={() => setOpen(true)}>
-        🛒 {items.length > 0 && <span className="cart-count">{items.length}</span>}
-      </button>
+    <header className={styles.header}>
+      <div className={styles.brandRow}>
+        {/* left: logo/brand */}
+        <a href="/" className={styles.brand}>
+          <img src="/logo-64.png" alt="Naturverse logo" className={styles.logo} />
+          <span className={styles.brandText}>Naturverse</span>
+        </a>
+
+        {/* center: primary nav */}
+        <nav className={styles.nav}>
+          {PRIMARY_LINKS.map((l) => (
+            <a key={l.to} href={l.to} className={styles.navLink}>
+              {l.label}
+            </a>
+          ))}
+
+          <details className={styles.more} role="list">
+            <summary className={styles.moreButton}>More</summary>
+            <ul className={styles.moreMenu} role="listbox">
+              {MORE_LINKS.map((l) => (
+                <li key={l.to}>
+                  <a href={l.to} className={styles.moreLink}>
+                    {l.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </details>
+        </nav>
+
+        {/* right: search + user/wallet (keep your existing components if any) */}
+        <div className={styles.actions}>
+          {/* keep your search input component here */}
+          {/* keep your connect wallet / auth avatar here */}
+          <button className="cart-btn" onClick={() => setOpen(true)}>
+            🛒 {items.length > 0 && <span className="cart-count">{items.length}</span>}
+          </button>
+        </div>
+
+        {/* mobile hamburger toggles a drawer with ALL links */}
+        <input id="nv-mobile-toggle" type="checkbox" className={styles.drawerToggler} />
+        <label htmlFor="nv-mobile-toggle" className={styles.hamburger} aria-label="Open menu">
+          ☰
+        </label>
+        <aside className={styles.drawer}>
+          <nav>
+            {[...PRIMARY_LINKS, ...MORE_LINKS].map((l) => (
+              <a key={l.to} href={l.to} className={styles.drawerLink}>
+                {l.label}
+              </a>
+            ))}
+          </nav>
+        </aside>
+      </div>
+
       <CartDrawer open={open} onClose={() => setOpen(false)} />
     </header>
   );
 }
-


### PR DESCRIPTION
## Summary
- simplify header navigation to highlight Worlds, Zones, Quests, and Marketplace
- tuck secondary links into a new “More” dropdown and mobile drawer
- reorganize header layout and styling for a cleaner top bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" from src/lib/natur.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b464b69e148329b45ec606be0d0c43