### PR TITLE
fix: responsive nav and footer styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import './styles/fixes.css';
 import React, { useEffect, useState } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { router } from './router';

--- a/src/styles/fixes.css
+++ b/src/styles/fixes.css
@@ -1,0 +1,55 @@
+/* === GLOBAL FIXES === */
+
+/* Force brand/logo text consistent */
+.nv-brand, .nv-logo, .nv-footer, footer, .footer a {
+  color: var(--naturverse-blue) !important;
+  text-decoration: none;
+}
+
+/* Footer layout */
+footer, .nv-footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  padding: 20px 10px;
+  font-size: 14px;
+}
+
+/* Prevent stacked dots (reset ul/li) */
+footer ul, .nv-footer ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+footer li {
+  list-style: none;
+}
+
+/* Nav brand always visible */
+.nv-brand {
+  font-weight: 800;
+  font-size: 1.2rem;
+}
+
+/* Mobile nav toggle */
+@media (max-width: 768px) {
+  .nv-navbar {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0 1rem;
+  }
+  .nv-brand {
+    margin-bottom: 8px;
+  }
+  nav ul {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add global fixes stylesheet to enforce Naturverse blue brand color and layout for nav/footer
- import fixes stylesheet in App component for consistent mobile and desktop rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: ENOTEMPTY: directory not empty, rename '/workspace/naturverse-web/node_modules/glob')*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" from src/lib/natur.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b480afc08c8329b9d9b4beb13b10c1