### PR TITLE
fix(mobile+brand): restore mobile layout & set brand to “The Naturverse”

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     />
     <base href="/" />
     <link rel="icon" href="/favicon.svg" />
-    <title>Naturverse</title>
+      <title>The Naturverse</title>
     <!-- PWA is removed: no manifest, no apple-web-app-* meta, no service worker registration -->
   </head>
   <body>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,7 +14,7 @@ export default function Header() {
 
   return (
     <header className="site-header">
-      <a href="/">Naturverse</a>
+        <a href="/">The Naturverse</a>
       <nav>
         <a href="/worlds">Worlds</a>
         <a href="/zones">Zones</a>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -17,26 +17,26 @@ export default function NavBar() {
     <header className={`${styles.header} nv-nav`}>
       <div className={`container ${styles.inner}`}>
         {/* Left brand (logo + wordmark) */}
-        <a
-          href="/"
-          className="flex items-center gap-2"
-          aria-label="Naturverse home"
-        >
-          <picture>
-            <source srcSet="/favicon.svg" type="image/svg+xml" />
-            <img
-              src="/favicon-64x64.png"
-              alt="Naturverse"
-              className="nv-logo"
-              width={40}
-              height={40}
-              loading="eager"
-              decoding="async"
-            />
-          </picture>
+          <a
+            href="/"
+            className="flex items-center gap-2"
+            aria-label="The Naturverse home"
+          >
+            <picture>
+              <source srcSet="/favicon.svg" type="image/svg+xml" />
+              <img
+                src="/favicon-64x64.png"
+                alt=""
+                className="nv-logo"
+                width={40}
+                height={40}
+                loading="eager"
+                decoding="async"
+              />
+            </picture>
 
-          <span className="nv-brand text-nv-blue">Naturverse</span>
-        </a>
+            <span className="nv-brand text-nv-blue">The Naturverse</span>
+          </a>
 
         <nav className={`${styles.links} nv-nav__links`} aria-label="Primary">
           <NavLink to="/worlds">Worlds</NavLink>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -35,10 +35,10 @@ export default function SiteHeader() {
     <header className={`site-header ${open ? 'open' : ''}`}>
       <div className="container">
         <div className="nav-left">
-          <Link to="/" className="brand" onClick={() => setOpen(false)}>
-            <Img src="/favicon-32x32.png" width="28" height="28" alt="Naturverse" />
-            <span>Naturverse</span>
-          </Link>
+            <Link to="/" className="brand" onClick={() => setOpen(false)}>
+              <Img src="/favicon-32x32.png" width="28" height="28" alt="" />
+              <span>The Naturverse</span>
+            </Link>
           <nav className="nav nav-links">
             <NavLink
               to="/worlds"

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Naturverse</title>
+      <title>The Naturverse</title>
     <!-- Naturverse: UI polish -->
     <meta name="theme-color" content="#2F7AE5" />
     <meta name="color-scheme" content="light" />

--- a/src/pages/_meta.ts
+++ b/src/pages/_meta.ts
@@ -1,3 +1,3 @@
 export const setTitle = (t: string) => {
-  if (typeof document !== "undefined") document.title = t ? `${t} · Naturverse` : "Naturverse";
+  if (typeof document !== "undefined") document.title = t ? `${t} · The Naturverse` : "The Naturverse";
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,7 +2,7 @@
 
 /* Page background */
 :root {
-  --page-bg: #f8fbff; /* light blue background used across pages */
+  --page-bg: #f8fbff; /* light blue background */
 }
 
 /* ---- Naturverse Navbar Brand ---- */
@@ -13,7 +13,7 @@
   --nv-logo-size-lg: 48px; /* desktop */
 }
 
-/* consistent text color token already in your project */
+/* consistent text color token already in your theme */
 .text-nv-blue,
 .nv-brand {
   color: var(--naturverse-blue) !important;
@@ -22,8 +22,8 @@
 .nv-logo {
   width: var(--nv-logo-size-sm);
   height: var(--nv-logo-size-sm);
-  display: block; /* avoid inline-img baseline gap */
-  flex-shrink: 0; /* never collapse in tight rows */
+  display: block; /* avoid inline-img baseline gaps */
+  flex-shrink: 0; /* never collapse in tight flex rows */
 }
 
 @media (min-width: 640px) {
@@ -47,13 +47,13 @@
   line-height: 1;
 }
 
-/* ===== Mobile hamburger: lines only, no pill ===== */
+/* ====== Mobile hamburger: lines only, no pill ====== */
 @media (max-width: 768px) {
   .nv-hamburger {
     background: transparent !important;
     border: 0 !important;
     box-shadow: none !important;
-    padding: 6px 8px; /* small tap target without the pill */
+    padding: 6px 8px; /* small tap target without visual pill */
     border-radius: 0 !important;
   }
   .nv-hamburger:focus {
@@ -69,7 +69,7 @@
   }
 }
 
-/* Remove blue background box on mobile nav (hamburger menu) */
+/* Fallback for older toggle markup (safe to keep) */
 .nav-toggle,
 .nav-toggle button,
 .nav-toggle svg {
@@ -77,10 +77,8 @@
   border: none !important;
   box-shadow: none !important;
 }
-
-/* Make sure only the lines show */
 .nav-toggle svg {
-  fill: #1e40af; /* blue lines, match site branding */
+  fill: #1e40af;
   width: 28px;
   height: 28px;
 }
@@ -96,6 +94,49 @@ a {
 .page-wrapper {
   background-color: var(--page-bg);
   min-height: 100vh;
+}
+
+/* ====== Responsive container & grid reset (like 642) ====== */
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 0 12px;
+  }
+
+  /* any generic grids/cards collapse to single column */
+  .grid,
+  .cards,
+  .nv-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  /* hide wide nav links on mobile; use hamburger/menu */
+  .nv-nav-links {
+    display: none;
+  }
+
+  /* footer: single wrapped row with spacing, no bullets */
+  .site-footer nav ul,
+  .nv-footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    justify-content: center;
+  }
+
+  .site-footer nav li::marker {
+    content: '';
+  }
 }
 
 /* Base */


### PR DESCRIPTION
## Summary
- Re-enable mobile breakpoints (≤768px) for container, grids, spacing.
- Make footer links wrap neatly in a single row on mobile (no bullet stack).
- Keep hamburger clean (no blue box) and hide desktop nav links on small screens.
- Update brand copy from “Naturverse” → “The Naturverse” in header and fallback <title>.

## Acceptance
- iPhone Safari: home renders like main-stable-642; footer links wrap in one row; brand reads “The Naturverse”.
- Desktop layout unchanged.

------
https://chatgpt.com/codex/tasks/task_e_68b485d8aa5883299d369131ed040d4b