### PR TITLE
fix(mobile): restore compact mobile layout (typography, spacing, grid, hero) to match main-stable-642

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,11 +1,35 @@
 /* ===== Naturverse Global Fixes ===== */
 
+/* Container + page gutters */
+.page-wrapper,
+.container,
+.container-narrow {
+  max-width: var(--nv-container-max);
+  margin-inline: auto;
+  padding-inline: var(--nv-gutter-sm);
+}
+
+@media (min-width: 768px) {
+  .page-wrapper,
+  .container,
+  .container-narrow {
+    padding-inline: var(--nv-gutter-md);
+  }
+}
+
 /* Center and space homepage buttons */
 .auth-buttons {
-  display: flex;
-  justify-content: center;
-  gap: 1rem; /* space between Create + Google */
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px; /* space between Create + Google */
   margin-bottom: 1.5rem;
+  justify-content: center;
+}
+
+@media (max-width: 390px) {
+  .auth-buttons {
+    grid-template-columns: 1fr; /* stack buttons */
+  }
 }
 
 /* Center Play / Learn / Earn tiles */
@@ -45,11 +69,6 @@
     align-items: center;
     gap: 1rem;
   }
-
-  .auth-buttons {
-    flex-direction: column;
-    gap: 0.75rem;
-  }
 }
 
 @media (min-width: 1600px) {
@@ -62,7 +81,8 @@
 /* ===== Center Welcome Hero ===== */
 .hero {
   text-align: center;
-  margin: 2rem auto;
+  margin: 0 auto;
+  padding-block: clamp(16px, 4vw, 40px);
 }
 
 .hero h1 {

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -4,11 +4,19 @@
   padding: 28px 0 64px; /* a touch more top space */
 }
 
+
 .hero {
-  max-width: 1040px;
+  max-width: var(--nv-container-max);
   margin: 0 auto;
-  padding: 0 20px 16px;
+  padding-block: clamp(16px, 4vw, 40px);
+  padding-inline: var(--nv-gutter-sm);
   text-align: center;
+}
+
+@media (min-width: 768px) {
+  .hero {
+    padding-inline: var(--nv-gutter-md);
+  }
 }
 
 .title {
@@ -25,10 +33,18 @@
   color: var(--nv-blue-700, #1f4ed8); /* blue (not black/grey) */
 }
 
+
 .ctaRow {
-  display: inline-flex;
-  gap: 16px; /* space between buttons */
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px; /* space between buttons */
   margin-top: 8px;
+}
+
+@media (max-width: 390px) {
+  .ctaRow {
+    grid-template-columns: 1fr; /* stack buttons on very small phones */
+  }
 }
 
 .cta {
@@ -79,21 +95,23 @@
   color: var(--nv-blue-700, #1f4ed8); /* blue body text under tiles */
 }
 
+
 .flowWrap {
   max-width: 1040px;
   margin: 28px auto 0;
-  padding: 18px 20px;
+  padding: clamp(12px, 2vw, 18px);
   border-radius: 18px;
   border: 2px dashed rgba(37, 99, 235, 0.25);
   background: rgba(255, 255, 255, 0.55);
 }
+
 
 .flowStep {
   background: #ffffff; /* match tile white */
   border: 2px solid rgba(37, 99, 235, 0.25);
   border-radius: 14px;
   padding: 14px 16px;
-  margin: 0 0 14px;
+  margin: 10px 0;
 }
 
 .flowHead {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,6 +3,9 @@
 /* Page background */
 :root {
   --page-bg: #f8fbff; /* light blue background */
+  --nv-container-max: 1120px;     /* desktop */
+  --nv-gutter-sm: 16px;           /* mobile side padding */
+  --nv-gutter-md: 24px;           /* tablets */
 }
 
 /* ---- Naturverse Navbar Brand ---- */
@@ -96,18 +99,23 @@ a {
   min-height: 100vh;
 }
 
-/* ====== Responsive container & grid reset (like 642) ====== */
-.container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 16px;
+.page-wrapper,
+.container,
+.container-narrow {
+  max-width: var(--nv-container-max);
+  margin-inline: auto;
+  padding-inline: var(--nv-gutter-sm);
+}
+
+@media (min-width: 768px) {
+  .page-wrapper,
+  .container,
+  .container-narrow {
+    padding-inline: var(--nv-gutter-md);
+  }
 }
 
 @media (max-width: 768px) {
-  .container {
-    padding: 0 12px;
-  }
-
   /* any generic grids/cards collapse to single column */
   .grid,
   .cards,
@@ -136,6 +144,106 @@ a {
 
   .site-footer nav li::marker {
     content: '';
+  }
+}
+
+/* Typography sizing with clamp() so mobile isn’t huge */
+h1,
+.title-xl {
+  font-size: clamp(1.75rem, 4.5vw + 0.25rem, 3rem);
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+}
+
+h2,
+.title-lg {
+  font-size: clamp(1.25rem, 2.6vw + 0.25rem, 2rem);
+  line-height: 1.2;
+}
+
+.lead {
+  font-size: clamp(1rem, 1.2vw + 0.75rem, 1.25rem);
+  line-height: 1.5;
+}
+
+/* Hero section spacing */
+.hero,
+.home-hero {
+  padding-block: clamp(16px, 4vw, 40px);
+}
+
+.hero .actions,
+.cta-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+@media (max-width: 390px) {
+  .hero .actions,
+  .cta-row {
+    grid-template-columns: 1fr; /* stack buttons on very small phones */
+  }
+}
+
+/* Cards & panels */
+.card,
+.panel,
+.tile {
+  padding: clamp(12px, 2.2vw, 20px);
+  border-radius: 14px;
+}
+
+.card + .card {
+  margin-top: 12px;
+}
+
+/* Mini-quests grid (1-col on mobile, 2-col on small tablets) */
+.mini-quests,
+.grid-quests,
+.mq-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+@media (min-width: 600px) {
+  .mini-quests,
+  .grid-quests,
+  .mq-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+@media (min-width: 1024px) {
+  .mini-quests,
+  .grid-quests,
+  .mq-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* “1) Create / 2) Pick / 3) Play” steps box spacing */
+.steps-box {
+  padding: clamp(12px, 2vw, 18px);
+}
+.steps-box .step {
+  margin-block: 10px;
+}
+
+/* Search bars and inputs – prevent full-width overflow on mobile */
+.search-bar,
+.input-lg {
+  height: 44px;
+  font-size: 16px; /* avoids iOS zoom */
+}
+
+/* Keep footer exactly as on main; just ensure mobile gutters */
+.site-footer {
+  padding-block: 20px;
+  padding-inline: var(--nv-gutter-sm);
+}
+@media (min-width: 768px) {
+  .site-footer {
+    padding-inline: var(--nv-gutter-md);
   }
 }
 


### PR DESCRIPTION
## Summary
- introduce responsive container tokens and gutters
- clamp mobile typography and streamline hero/actions grid
- tighten Home hero, CTA layout, and steps spacing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers")*

------
https://chatgpt.com/codex/tasks/task_e_68b488e9acc08329a59427dbcc860a81