### PR TITLE
Load global CSS last

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import './styles/images.css';
 import './components/skeleton.css';
 import NetworkBanner from './components/NetworkBanner';
 import './components/network.css';
+import './styles/global.css';
 import SearchProvider from './search/SearchProvider';
 import CheckoutBanner from './components/CheckoutBanner';
 import ToastHost from '@/components/ToastHost';

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>The Naturverse</title>
     <!-- Naturverse: UI polish -->
     <meta name="theme-color" content="#2F7AE5" />

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,7 +3,6 @@
 @import './styles/passport.css';
 @import './styles/turian.css';
 @import './styles/profile.css';
-@import './styles/global.css';
 @import './styles/layout.css';
 @import './styles/hub.css';
 @import './styles/crumbs.css';


### PR DESCRIPTION
## Summary
- Import global.css after other styles in App to ensure global overrides
- Drop redundant global.css import from styles bundle
- Normalize viewport meta tag formatting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers"; npm install ethers returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b49271cca483299fe26fd54048f876