### PR TITLE
Mobile viewport + typography scale

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,22 +6,25 @@ import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
 import { logEvent } from './utils/telemetry';
 import RouteFallback from './routes/RouteFallback';
-import './styles/magic.css';
 // TEMP: disable interactions while we isolate the crash
 // import { initInteractions } from './init/interactions';
-import './init/runtime-logger'; // lightweight global error hooks
-import './styles/footer.css';
 import SkipLink from './components/SkipLink';
-import './styles/a11y.css';
-import './styles/images.css';
-import './components/skeleton.css';
 import NetworkBanner from './components/NetworkBanner';
-import './components/network.css';
-import './styles/global.css';
 import SearchProvider from './search/SearchProvider';
 import CheckoutBanner from './components/CheckoutBanner';
 import ToastHost from '@/components/ToastHost';
 import CartShareLoader from '@/components/CartShareLoader';
+import './init/runtime-logger'; // lightweight global error hooks
+
+import './styles/magic.css';
+import './styles/footer.css';
+import './styles/a11y.css';
+import './styles/images.css';
+import './components/skeleton.css';
+import './components/network.css';
+
+// ⬇️ keep this LAST so it overrides everything above
+import './styles/global.css';
 
 export default function App() {
   const [path, setPath] = useState(

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1, viewport-fit=cover" />
       <title>The Naturverse</title>
     <!-- Naturverse: UI polish -->
     <meta name="theme-color" content="#2F7AE5" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -69,6 +69,7 @@
   }
 }
 
+
 /* Fallback for older toggle markup (safe to keep) */
 .nav-toggle,
 .nav-toggle button,
@@ -641,6 +642,58 @@ main,
   .container {
     padding-left: 12px;
     padding-right: 12px;
+  }
+}
+
+/* ====== Compact mobile scale (phones ≤ 480px) ====== */
+@media (max-width: 480px) {
+  /* Typography */
+  html { font-size: 16px; } /* anchor the scale */
+  h1 {
+    /* big hero headline */
+    font-size: clamp(1.6rem, 6vw + 0.2rem, 2.1rem);
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+  }
+  h2 {
+    font-size: clamp(1.25rem, 4.5vw + 0.1rem, 1.6rem);
+    line-height: 1.25;
+  }
+  .lead, .headline {
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+
+  /* Containers & cards */
+  .container { padding: 0 12px; }
+  .card, .panel, .tile, .zone-card, .market-card, .nv-card {
+    padding: 14px;
+    border-radius: 12px;
+  }
+
+  /* Buttons */
+  .btn,
+  button.primary,
+  .cta,
+  .nv-cta {
+    font-size: 1rem;
+    padding: 10px 14px;
+    border-radius: 10px;
+  }
+
+  /* “Play / Learn / Earn” tiles */
+  .section-title, .page-title { margin-bottom: 8px; }
+  .nv-grid { gap: 12px; }
+
+  /* Search input + top spacing */
+  .search-bar, .search, .search input {
+    height: 44px;
+    font-size: 1rem;
+  }
+  .hero, .nv-hero, .welcome, .page-hero {
+    margin-top: 8px;
+    margin-bottom: 12px;
+    padding: 14px;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure global styles override component CSS by importing `global.css` last in `App.tsx`
- correct mobile viewport settings with `initial-scale=1, viewport-fit=cover`
- introduce compact mobile typography and spacing scale for screens ≤480px

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers")*

------
https://chatgpt.com/codex/tasks/task_e_68b49a81335083299341988a0a48828d