### PR TITLE
Apply mobile viewport + typography scale (fix oversized UI on iPhone)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <!-- Viewport: prevent iOS auto-zoom & fit safe areas -->
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1"
+      />
       <title>The Naturverse</title>
     <!-- Naturverse: UI polish -->
     <meta name="theme-color" content="#2F7AE5" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,53 @@
 @import './tokens.css';
 
+/* ===== Mobile base scale =================================================== */
+
+/* Base: leave desktop/tablet alone; tune only phones */
+@media (max-width: 768px) {
+  /* Lower the root font-size so rem-based headings/buttons scale down globally */
+  html { font-size: 87.5%; } /* 14px base */
+
+  /* Tighten container padding slightly (you already do 12px; keep consistent) */
+  .container { padding-left: 12px; padding-right: 12px; }
+
+  /* Headings: keep hierarchy but reduce bulk */
+  h1, .page-title, .section-title { font-size: 1.75rem; line-height: 1.2; }
+  h2 { font-size: 1.375rem; line-height: 1.3; }
+  h3 { font-size: 1.125rem; line-height: 1.35; }
+
+  /* Hero lead paragraph */
+  .lead { font-size: 1rem; line-height: 1.55; }
+
+  /* Primary buttons: slightly smaller tap target but still >44px high */
+  .btn,
+  button.btn {
+    padding: 10px 16px;
+    font-size: 1rem;
+    line-height: 1.25;
+    border-radius: 14px;
+  }
+
+  /* Cards/panels: reduce internal whitespace & headline size */
+  .card, .panel, .tile, .zone-card, .market-card, .nv-card {
+    padding: 14px;
+  }
+  .card h2, .panel h2, .tile h2 { font-size: 1.25rem; }
+
+  /* Brand/logo already uses --nv-logo-size-sm; no change to variables needed */
+}
+
+/* Ultra-small devices: nudge one more step down */
+@media (max-width: 400px) {
+  html { font-size: 81.25%; } /* 13px base */
+
+  h1, .page-title, .section-title { font-size: 1.6rem; }
+  h2 { font-size: 1.25rem; }
+  h3 { font-size: 1.05rem; }
+
+  .btn, button.btn { padding: 9px 14px; font-size: 0.95rem; }
+  .card, .panel, .tile, .zone-card, .market-card, .nv-card { padding: 12px; }
+}
+
 /* Page background */
 :root {
   --page-bg: #f8fbff; /* light blue background */


### PR DESCRIPTION
## Summary
- normalize viewport meta tag to prevent iOS auto-zoom and fit safe areas
- scale down fonts and spacing on mobile and ultra-small devices

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" from src/lib/natur.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b49eef05088329b95f0b84c4ea6e48