### PR TITLE
Load global styles last and add mobile scale

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,6 @@ import './styles/images.css';
 import './components/skeleton.css';
 import NetworkBanner from './components/NetworkBanner';
 import './components/network.css';
-import './styles/global.css';
 import SearchProvider from './search/SearchProvider';
 import CheckoutBanner from './components/CheckoutBanner';
 import ToastHost from '@/components/ToastHost';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -148,3 +148,8 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 import './styles/overrides.css';
+
+// ⬇️ Keep other site-wide styles above this line
+
+// ✅ Ensure this is LAST so it can override everything else
+import './styles/global.css';

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,60 @@
 @import './tokens.css';
 
+/* === Mobile-first type + spacing sanity === */
+@media (max-width: 768px) {
+  html {
+    /* keep iOS from zooming visual size; subtle downscale */
+    font-size: 15px; /* was ~16px */
+  }
+
+  /* Headings smaller on phones */
+  h1, .page-title, .section-title {
+    /* ~28–36px across common phone widths */
+    font-size: clamp(1.75rem, 5.5vw, 2.25rem);
+    line-height: 1.2;
+    margin: 0 0 0.75rem;
+  }
+
+  h2 {
+    font-size: clamp(1.25rem, 4.2vw, 1.5rem);
+    line-height: 1.25;
+    margin: 0 0 0.5rem;
+  }
+
+  /* Brand wordmark */
+  .nv-brand {
+    font-size: clamp(1.125rem, 3.8vw, 1.375rem);
+    line-height: 1.1;
+  }
+
+  /* Container and cards tighten a bit */
+  .container { padding: 0 12px; }
+  .panel, .card, .nv-card { padding: 16px; }
+
+  /* Big “Create account / Continue” buttons */
+  .btn, .button, button.btn-primary {
+    padding: 10px 14px;
+    font-size: 1rem;
+    line-height: 1.25;
+  }
+
+  /* Play/Learn/Earn panels title size */
+  .tile h3, .panel h3, .card h3 {
+    font-size: clamp(1.1rem, 3.8vw, 1.25rem);
+  }
+
+  /* Search input height & font */
+  input[type="search"], .search input {
+    font-size: 1rem;
+    height: 44px;
+  }
+}
+
+/* DEBUG — remove after verifying */
+@media (max-width: 768px) {
+  body { outline: 2px solid transparent; }
+}
+
 /* Page background */
 :root {
   --page-bg: #f8fbff; /* light blue background */


### PR DESCRIPTION
## Summary
- Import `global.css` after all other site-wide styles to ensure its rules win on load order
- Introduce mobile-first typography/spacing block plus a temporary debug outline in `global.css`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" from src/lib/natur.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a0bde3c8832985d8e91b3404f842