### PR TITLE
Ensure global CSS last and add mobile override test

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,22 +6,24 @@ import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
 import { logEvent } from './utils/telemetry';
 import RouteFallback from './routes/RouteFallback';
-import './styles/magic.css';
-// TEMP: disable interactions while we isolate the crash
-// import { initInteractions } from './init/interactions';
-import './init/runtime-logger'; // lightweight global error hooks
-import './styles/footer.css';
 import SkipLink from './components/SkipLink';
-import './styles/a11y.css';
-import './styles/images.css';
-import './components/skeleton.css';
 import NetworkBanner from './components/NetworkBanner';
-import './components/network.css';
-import './styles/global.css';
 import SearchProvider from './search/SearchProvider';
 import CheckoutBanner from './components/CheckoutBanner';
 import ToastHost from '@/components/ToastHost';
 import CartShareLoader from '@/components/CartShareLoader';
+// TEMP: disable interactions while we isolate the crash
+// import { initInteractions } from './init/interactions';
+import './init/runtime-logger'; // lightweight global error hooks
+
+import './styles/magic.css';
+import './styles/footer.css';
+import './styles/a11y.css';
+import './styles/images.css';
+import './components/skeleton.css';
+import './components/network.css';
+// ✅ keep this as the final stylesheet import
+import './styles/global.css';
 
 export default function App() {
   const [path, setPath] = useState(
@@ -40,6 +42,27 @@ export default function App() {
     <SearchProvider>
       <CartShareLoader />
       <ToastHost />
+      {/* TEMP mobile verify: shrink type on <=768px */}
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+@media (max-width:768px){
+  html{ font-size:15px !important; }
+  h1,.page-title,.section-title{
+    font-size: clamp(1.75rem,5.5vw,2.25rem) !important;
+    line-height:1.2 !important;
+    margin: 0 0 .75rem !important;
+  }
+  .btn, .button, button.btn-primary{
+    padding:10px 14px !important;
+    font-size:1rem !important;
+    line-height:1.25 !important;
+  }
+  .container{ padding:0 12px !important; }
+}
+    `,
+        }}
+      />
       <div id="nv-page">
           {/* Keyboard-accessible jump link (first focusable on the page) */}
           <SkipLink />

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
       <title>The Naturverse</title>
     <!-- Naturverse: UI polish -->
     <meta name="theme-color" content="#2F7AE5" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,21 @@
 @import './tokens.css';
 
+@media (max-width: 768px) {
+  html { font-size: 15px; }
+  h1, .page-title, .section-title {
+    font-size: clamp(1.75rem, 5.5vw, 2.25rem);
+    line-height: 1.2;
+    margin: 0 0 0.75rem;
+  }
+  h2 { font-size: clamp(1.25rem, 4.2vw, 1.5rem); line-height: 1.25; }
+  .nv-brand { font-size: clamp(1.125rem, 3.8vw, 1.375rem); line-height: 1.1; }
+  .container { padding: 0 12px; }
+  .panel, .card, .nv-card { padding: 16px; }
+  .btn, .button, button.btn-primary { padding: 10px 14px; font-size: 1rem; line-height: 1.25; }
+  .tile h3, .panel h3, .card h3 { font-size: clamp(1.1rem, 3.8vw, 1.25rem); }
+  input[type="search"], .search input { font-size: 1rem; height: 44px; }
+}
+
 /* Page background */
 :root {
   --page-bg: #f8fbff; /* light blue background */


### PR DESCRIPTION
## Summary
- Move `global.css` import to the end of `App.tsx` and group stylesheet imports
- Add temporary mobile `<style>` block in `App.tsx` to verify smaller fonts and buttons
- Introduce mobile-friendly rules in `src/styles/global.css`
- Update viewport meta tag for safer mobile rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup could not resolve import "ethers" from src/lib/natur.ts; attempted `npm install ethers` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cf46cc088329bc58d9c192b157eb