### PR TITLE
fix/mobile-viewport-scale

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <meta name="HandheldFriendly" content="true" />
+    <meta name="MobileOptimized" content="width" />
+    <style>
+      /* Prevent Safari from zooming text */
+      html, body {
+        -webkit-text-size-adjust: 100%;
+      }
+    </style>
       <title>The Naturverse</title>
     <!-- Naturverse: UI polish -->
     <meta name="theme-color" content="#2F7AE5" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -100,21 +100,28 @@ a {
 .container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 16px;
+  padding: 0 16px; /* add mobile padding */
 }
 
 @media (max-width: 768px) {
-  .container {
-    padding: 0 12px;
+  html {
+    font-size: 14px; /* scale down all rem-based text */
   }
-
-  /* any generic grids/cards collapse to single column */
-  .grid,
+  body {
+    line-height: 1.4;
+  }
+  .container {
+    padding: 0 8px;
+  }
   .cards,
   .nv-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 16px;
+    grid-template-columns: 1fr; /* stack cards in one column */
+    gap: 12px;
+  }
+  .card,
+  .panel,
+  .tile {
+    padding: 12px;
   }
 
   /* hide wide nav links on mobile; use hamburger/menu */


### PR DESCRIPTION
## Summary
- prevent Safari text zoom with `-webkit-text-size-adjust`
- tweak mobile viewport meta tags for improved handheld behavior
- adjust global container and typography for smaller screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" from src/lib/natur.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d156fc408329bd459f71a0cbb23f