### PR TITLE
fix(mobile): proper viewport fit, hide skip link, and scale mobile type/spacing

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>The Naturverse</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>The Naturverse</title>
     <!-- Naturverse: UI polish -->
     <meta name="theme-color" content="#2F7AE5" />
     <meta name="color-scheme" content="light" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,27 @@
 @import './tokens.css';
 
+/* Accessibility: hide skip link until focused */
+.nv-skip {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: -1;
+}
+.nv-skip:focus {
+  left: 12px;
+  top: 12px;
+  width: auto;
+  height: auto;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  z-index: 1000;
+}
+
 /* Page background */
 :root {
   --page-bg: #f8fbff; /* light blue background */
@@ -156,6 +178,14 @@ hr {
   border-color: var(--nv-border);
 }
 
+img,
+svg,
+video,
+canvas {
+  max-width: 100%;
+  height: auto;
+}
+
 /* Headings (no layout change) */
 h1,
 h2,
@@ -165,6 +195,99 @@ h3 {
 .section-title,
 .page-title {
   color: var(--nv-blue-700);
+}
+
+/* ===== Mobile type & spacing scale ===== */
+@media (max-width: 768px) {
+  /* Base font sizing: slightly smaller on mobile */
+  html {
+    font-size: 15px;
+  } /* was effectively bigger via large h1/button scales */
+
+  /* Headings */
+  h1,
+  .section-title,
+  .page-title {
+    /* 28px -> 24–26px on common widths */
+    font-size: clamp(1.5rem, 4.8vw + 0.2rem, 1.7rem);
+    line-height: 1.2;
+    letter-spacing: 0;
+  }
+  h2 {
+    font-size: clamp(1.25rem, 4.2vw + 0.1rem, 1.5rem);
+    line-height: 1.25;
+  }
+  h3 {
+    font-size: clamp(1.1rem, 3.6vw, 1.25rem);
+    line-height: 1.3;
+  }
+
+  /* Hero lead paragraph under the big title */
+  .lead,
+  .headline {
+    font-size: clamp(1rem, 3.4vw, 1.1rem);
+    line-height: 1.5;
+  }
+
+  /* Buttons: reduce padding & shadow a touch */
+  .btn,
+  button.btn,
+  a.btn {
+    padding: 10px 16px;
+    font-size: 1rem;
+    line-height: 1.1;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  }
+
+  /* Search input height and padding */
+  input[type='search'],
+  .search input,
+  .searchbar input {
+    height: 44px;
+    padding: 0 14px;
+    font-size: 0.95rem;
+  }
+
+  /* Container gutters */
+  .container {
+    padding: 0 12px;
+  }
+
+  /* Cards/panels */
+  .card,
+  .panel,
+  .tile,
+  .zone-card,
+  .market-card,
+  .nv-card {
+    border-radius: 14px;
+    padding: 14px 16px;
+  }
+
+  /* Home “Play/Learn/Earn” tiles */
+  .nv-grid,
+  .grid,
+  .cards {
+    gap: 14px;
+  }
+  .home-callouts h3 {
+    margin-bottom: 6px;
+  }
+  .home-callouts p {
+    font-size: 1rem;
+    line-height: 1.45;
+  }
+
+  /* Navbar brand wordmark on mobile */
+  .nv-brand {
+    font-size: clamp(1.125rem, 1.8vw + 0.55rem, 1.35rem);
+    font-weight: 800;
+  }
+  .nv-logo {
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+  }
 }
 
 /* Cards / panels / list tiles */
@@ -609,14 +732,14 @@ main,
   .btn,
   button,
   .button {
-    font-size: 1rem;           /* 16px */
-    padding: 10px 14px;        /* smaller tap-friendly */
+    font-size: 1rem; /* 16px */
+    padding: 10px 14px; /* smaller tap-friendly */
     border-radius: 12px;
   }
 
   /* Search bars / inputs */
-  input[type="search"],
-  input[type="text"],
+  input[type='search'],
+  input[type='text'],
   .search input,
   .searchbar input {
     height: 44px;
@@ -643,4 +766,3 @@ main,
     padding-right: 12px;
   }
 }
-


### PR DESCRIPTION
## Summary
- add `viewport-fit=cover` for immersive iOS layout
- hide `.nv-skip` link offscreen until focused
- adjust font sizing, buttons, and spacing for mobile screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" in src/lib/natur.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d5c2961c8329950726d2708e4cd0