### PR TITLE
chore: hide skip link until focused

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -86,7 +86,8 @@
     </style>
   </head>
   <body>
-    <a class="nv-skip" href="#main">Skip to content</a>
+    <!-- Accessible skip link (hidden until focused) -->
+    <a class="skip-link" href="#main">Skip to content</a>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
     <!-- This is a replit script which adds a banner on the top of the page when opened in development mode outside the replit environment -->

--- a/src/components/SkipLink.tsx
+++ b/src/components/SkipLink.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 
 /**
  * Keyboard users can press Tab once to reveal this link and jump
@@ -6,7 +6,7 @@ import React from "react";
  */
 export default function SkipLink() {
   return (
-    <a href="#main" className="nv-skip">
+    <a href="#main" className="skip-link">
       Skip to content
     </a>
   );

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <title>The Naturverse</title>
+    <title>The Naturverse</title>
     <!-- Naturverse: UI polish -->
     <meta name="theme-color" content="#2F7AE5" />
     <meta name="color-scheme" content="light" />
@@ -20,7 +20,8 @@
     />
   </head>
   <body>
-    <a class="nv-skip" href="#main">Skip to content</a>
+    <!-- Accessible skip link (hidden until focused) -->
+    <a class="skip-link" href="#main">Skip to content</a>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/styles/a11y.css
+++ b/src/styles/a11y.css
@@ -1,29 +1,8 @@
 /* ===== Accessibility primitives (global, low-risk) ===== */
 
-/* 1) Skip link: hidden until focused */
-.nv-skip {
-  position: absolute;
-  left: 12px;
-  top: 10px;
-  padding: 8px 12px;
-  background: #0b5fff;
-  color: #fff;
-  text-decoration: none;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,.18);
-  transform: translateY(-120%);
-  transition: transform .15s ease;
-  z-index: 1000;
-}
-.nv-skip:focus,
-.nv-skip:focus-visible {
-  transform: translateY(0);
-  outline: none;
-}
-
-/* 2) High-visibility focus ring that respects :focus-visible */
-:where(a, button, [role="button"], input, select, textarea, summary):focus-visible {
-  outline: 3px solid rgba(11,95,255,.6);
+/* High-visibility focus ring that respects :focus-visible */
+:where(a, button, [role='button'], input, select, textarea, summary):focus-visible {
+  outline: 3px solid rgba(11, 95, 255, 0.6);
   outline-offset: 2px;
   border-radius: 8px;
 }
@@ -43,5 +22,10 @@
 
 /* 4) Avoid motion for users who prefer reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  * { animation-duration: .001ms !important; animation-iteration-count: 1 !important; transition-duration: .001ms !important; scroll-behavior: auto !important; }
+  * {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,31 @@
 @import './tokens.css';
 
+/* Visually hide skip link, show on keyboard focus (a11y) */
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+/* When tabbed to, reveal it in a sensible spot */
+.skip-link:focus {
+  left: 12px;
+  top: 12px;
+  width: auto;
+  height: auto;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: #ffffff;
+  border: 2px solid var(--nv-blue-600, #2463eb);
+  color: var(--nv-blue-700, #2d5cff);
+  z-index: 10000;
+  box-shadow: 0 2px 8px rgba(17, 34, 68, 0.15);
+}
+
 /* Page background */
 :root {
   --page-bg: #f8fbff; /* light blue background */
@@ -609,14 +635,14 @@ main,
   .btn,
   button,
   .button {
-    font-size: 1rem;           /* 16px */
-    padding: 10px 14px;        /* smaller tap-friendly */
+    font-size: 1rem; /* 16px */
+    padding: 10px 14px; /* smaller tap-friendly */
     border-radius: 12px;
   }
 
   /* Search bars / inputs */
-  input[type="search"],
-  input[type="text"],
+  input[type='search'],
+  input[type='text'],
   .search input,
   .searchbar input {
     height: 44px;
@@ -643,4 +669,3 @@ main,
     padding-right: 12px;
   }
 }
-


### PR DESCRIPTION
## Summary
- hide `Skip to content` link until keyboard focus
- add global styles for skip link
- remove legacy skip link CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" from src/lib/natur.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d7aef6ac832984435b6428e9755b