### PR TITLE
Scale all headings for mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -669,3 +669,31 @@ main,
     padding-right: 12px;
   }
 }
+/* Scale down headings site-wide on mobile */
+@media (max-width: 768px) {
+  h1 {
+    font-size: clamp(1.3rem, 5vw + 0.2rem, 1.7rem);
+  }
+
+  h2 {
+    font-size: clamp(1.2rem, 4.5vw + 0.2rem, 1.5rem);
+  }
+
+  h3 {
+    font-size: clamp(1.1rem, 4vw + 0.2rem, 1.3rem);
+  }
+}
+
+@media (max-width: 430px) {
+  h1 {
+    font-size: 1.25rem;
+  }
+
+  h2 {
+    font-size: 1.1rem;
+  }
+
+  h3 {
+    font-size: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Scale site-wide heading sizes on mobile
- Tweak font sizes for tiny screens to keep titles legible

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Rollup failed to resolve import "ethers")

------
https://chatgpt.com/codex/tasks/task_e_68b4f3a0a4b08329ae58dafced45df8b