### PR TITLE
Adjust mobile spacing and sizing

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -669,3 +669,46 @@ main,
     padding-right: 12px;
   }
 }
+
+/* ===== Mobile tightening (phones & small tablets) ===== */
+@media (max-width: 768px) {
+  /* Headings & text spacing */
+  h1 { font-size: 1.25rem; line-height: 1.2; margin: 0 0 0.55rem; }
+  h2 { font-size: 1.05rem; line-height: 1.25; margin: 0.9rem 0 0.45rem; }
+  h3 { font-size: 0.95rem; line-height: 1.3;  margin: 0.75rem 0 0.4rem; }
+  p  { margin: 0 0 0.8rem; }
+
+  /* Buttons: scale down a touch */
+  .btn {
+    padding: 10px 14px;
+    font-size: 0.95rem;
+    border-radius: 12px;
+  }
+
+  /* Panels/cards: reduce internal padding so hero block isn’t huge */
+  .panel,
+  .card,
+  .nv-card,
+  .tile {
+    padding: 16px;
+    border-radius: 14px;
+  }
+
+  /* Hero/section containers: trim the big insets if present */
+  .page-hero,
+  .hero,
+  .section-intro {
+    padding: 14px 16px;
+  }
+
+  /* Keep container edges tidy but not cramped */
+  .container { padding: 0 12px; }
+}
+
+/* Ultra-small phones (iPhone SE/mini) */
+@media (max-width: 430px) {
+  h1 { font-size: 1.15rem; margin-bottom: 0.5rem; }
+  h2 { font-size: 1rem;   margin: 0.85rem 0 0.4rem; }
+  .btn { padding: 9px 12px; font-size: 0.9rem; }
+  .panel, .card, .nv-card, .tile { padding: 14px; }
+}


### PR DESCRIPTION
## Summary
- tighten headings, buttons, panels, and containers on mobile
- add ultra-small phone adjustments for headers and buttons

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4f690002483299873fcc09e9bfa2f