### PR TITLE
Fix mobile hero heading alignment (force center on h1/p)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -768,3 +768,19 @@ main,
   /* Keep page edges comfortable */
   .container { padding-left: 12px; padding-right: 12px; }
 }
+/* ===== Naturverse — Force hero heading center (≤430px) ===== */
+@media (max-width: 430px) {
+  /* Target any hero/welcome headline directly */
+  .hero h1,
+  .hero p,
+  .nv-hero h1,
+  .nv-hero p,
+  .welcome-section h1,
+  .welcome-section p,
+  h1.page-title,
+  .page-title + p {
+    text-align: center !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Center hero and welcome headings on screens <=430px by targeting common hero title and subtitle selectors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" from src/lib/natur.ts; attempted to install dependency but received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b50305bc4083299ad1b24d7f0afbdb