### PR TITLE
Fix mobile overflow & width locking

### DIFF
--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -6,8 +6,11 @@
 }
 
 .hero {
+  padding: var(--nv-space-md) var(--nv-space-sm);
+  margin: 0 auto;
   text-align: center;
-  padding: var(--space-6) 0 var(--space-5);
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 .title {
@@ -27,10 +30,11 @@
 
 .ctaRow {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
-  align-items: stretch;
-  gap: var(--space-4);
-  margin: 0 0 var(--space-5);
+  gap: var(--nv-space-sm);
+  width: 100%;
+  max-width: 100%;
 }
 
 .cta {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,13 @@
 @import './tokens.css';
 
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden; /* Prevent horizontal scroll */
+}
+
 html {
   font-size: 16px;
   -webkit-text-size-adjust: 100%;
@@ -9,10 +17,13 @@ html {
 }
 
 body {
-  margin: 0;
   color: var(--nv-text, #1f2937);
   background: var(--page-bg, #f8fbff);
-  overflow-x: hidden;
+}
+
+main, section, header, footer, div {
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 h1, h2, h3 {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -7,6 +7,10 @@
   --space-4: 16px;
   --space-5: 20px;
   --space-6: 24px;
+  --nv-space-xs: 4px;
+  --nv-space-sm: 8px;
+  --nv-space-md: 16px;
+  --nv-space-lg: 24px;
   --radius-lg: 16px;
   --shadow-soft: 0 2px 8px rgba(17, 34, 68, 0.08);
 


### PR DESCRIPTION
## Summary
- Prevent horizontal scrolling on mobile by constraining html/body and common containers to the viewport
- Introduce nv-space spacing tokens and apply them to Home hero and CTA row

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" from src/lib/natur.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b515fe84488329959a0c78e450a511