### PR TITLE
Restore normal mobile scrolling and fix overflow

### DIFF
--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -6,7 +6,10 @@
 }
 
 .hero {
+  margin: 0 auto;
   text-align: center;
+  width: 100%;
+  max-width: 100%;
   padding: var(--space-6) 0 var(--space-5);
 }
 
@@ -27,9 +30,11 @@
 
 .ctaRow {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
-  align-items: stretch;
-  gap: var(--space-4);
+  gap: 12px;
+  width: 100%;
+  max-width: 100%;
   margin: 0 0 var(--space-5);
 }
 
@@ -77,6 +82,14 @@
   .subtitle { max-width: 30ch; }
   .ctaRow { gap: var(--space-3); }
   .cta { flex: 1; min-width: auto; padding: 12px 14px; }
+}
+
+@media (max-width: 640px) {
+  .ctaRow > * {
+    flex: 1 1 160px;
+    min-width: 140px;
+    max-width: 100%;
+  }
 }
 
 .featureGrid {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,9 +1,14 @@
 @import './tokens.css';
 
+/* ========== Safe global reset (no scrolling locks) ========== */
 html {
+  box-sizing: border-box;
+  /* keep your existing viewport meta in index.html as-is */
   font-size: 16px;
   -webkit-text-size-adjust: 100%;
 }
+*, *::before, *::after { box-sizing: inherit; }
+
 @media (max-width: 480px) {
   html { font-size: 15px; }
 }
@@ -12,7 +17,35 @@ body {
   margin: 0;
   color: var(--nv-text, #1f2937);
   background: var(--page-bg, #f8fbff);
-  overflow-x: hidden;
+}
+
+/* Media never pushes wider than screen */
+img, svg, video, canvas, iframe {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* Prevent accidental 100vw overflows from components,
+   but DO NOT block vertical scroll or pinch */
+main, section, header, footer {
+  overflow-x: clip;               /* stops side-scroll, preserves y-scroll */
+}
+
+/* Utility: containers never exceed viewport width */
+.nv-container, .nv-home, .nv-hero, .nv-section {
+  width: 100%;
+  max-width: 100%;
+}
+
+/* Buttons/inputs don’t overflow due to long text */
+button, input, select {
+  max-width: 100%;
+}
+
+/* OPTIONAL (leave on): helps if a nested element uses 100vw */
+:root {
+  /* your existing tokens stay */
 }
 
 h1, h2, h3 {
@@ -751,4 +784,17 @@ main,
 
   /* Keep page edges comfortable */
   .container { padding-left: 12px; padding-right: 12px; }
+}
+
+/* ---------- Mobile-specific tightening ---------- */
+@media (max-width: 640px) {
+  /* Kill any stray margins that can create horizontal overflow */
+  .nv-hero, .nv-section, .featureGrid, .nv-home-tools {
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 16px;
+    padding-right: 16px;
+    width: 100%;
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- remove global overflow locks and clip horizontal scroll only on layout containers
- keep media, inputs, and containers within viewport width
- tweak Home hero and CTA layout to wrap without horizontal overflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" from src/lib/natur.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b51bc775f88329a3562afc99314f05