### PR TITLE
Mobile polish — tighter hero & card spacing

### DIFF
--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -165,3 +165,55 @@
 .flowLink:hover {
   text-decoration: underline;
 }
+
+/* Mobile-only polish */
+@media (max-width: 640px) {
+  .hero {
+    max-width: 640px;         /* prevent over-wide wraps */
+    margin: 0 auto;
+    padding: var(--nv-space-5) var(--nv-space-4) var(--nv-space-4);
+    text-align: center;
+    gap: var(--nv-space-3);
+  }
+
+  .title {
+    margin: 0 0 var(--nv-space-3);
+  }
+
+  .subtitle {
+    margin: 0 auto var(--nv-space-4);
+    max-width: 36ch;          /* comfortable line length */
+  }
+
+  .ctaRow {
+    display: grid;
+    grid-auto-flow: row;
+    gap: var(--nv-space-3);
+    margin: 0 auto var(--nv-space-4);
+    width: min(520px, 100%);
+  }
+
+  .cta {
+    width: 100%;
+    padding: 14px 18px;       /* a hair tighter */
+    border-radius: var(--nv-radius-lg);
+  }
+
+  /* Play/Learn/Earn panels spacing */
+  .featureGrid {
+    gap: var(--nv-space-4);
+    margin-top: var(--nv-space-4);
+    padding: 0 var(--nv-space-4);
+  }
+
+  .featureCard {
+    padding: var(--nv-space-4);
+    border-radius: var(--nv-radius-md);
+  }
+
+  /* Mini-quests container */
+  .miniQuests {
+    padding: 0 var(--nv-space-4) var(--nv-space-5);
+    gap: var(--nv-space-4);
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -18,6 +18,11 @@ html, body {
   box-sizing: inherit;
 }
 
+/* Prevent any stray horizontal scroll (extra safety) */
+html, body, #root {
+  overflow-x: hidden;
+}
+
 /* Any full-width wrappers should never exceed the viewport */
 .nv-container, .nv-content, main, #root {
   inline-size: 100%;    /* logical width */
@@ -78,6 +83,34 @@ h1, h2, h3 {
 h1 { font-size: var(--nv-h1); line-height: 1.15; }
 h2 { font-size: var(--nv-h2); line-height: 1.2; }
 p  { line-height: 1.6; }
+
+/* iPhone & small screens only */
+@media (max-width: 640px) {
+  /* Saner type scaling on first paint */
+  h1 {
+    /* ~28–34px depending on width */
+    font-size: clamp(28px, 6vw, 34px);
+    line-height: 1.15;
+    letter-spacing: 0;
+  }
+
+  .nv-subtitle, p.nv-subtitle {
+    /* ~15–18px */
+    font-size: clamp(15px, 3.7vw, 18px);
+    line-height: 1.4;
+  }
+
+  /* Generic “panel/card” polish used across sections */
+  .nv-panel, .card, .featureCard {
+    border-radius: var(--nv-radius-md);
+    padding: var(--nv-space-4);
+  }
+
+  /* Soften big panels (Play/Learn/Earn) */
+  .nv-panel.nv-large {
+    padding: calc(var(--nv-space-4) + 2px) var(--nv-space-5);
+  }
+}
 
 /* A light, consistent page container used by Home.tsx via `nv-container` */
 .nv-container {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -53,3 +53,13 @@
   --nv-accent-contrast: var(--nv-text-on-accent);
   --nv-focus: 0 0 0 3px rgba(74, 135, 255, 0.35); /* focus ring */
 }
+
+/* --- Mobile polish tokens --- */
+:root {
+  --nv-radius-md: 14px;        /* card radius */
+  --nv-radius-lg: 18px;        /* hero pills radius */
+  --nv-space-2: 8px;
+  --nv-space-3: 12px;
+  --nv-space-4: 16px;
+  --nv-space-5: 20px;
+}


### PR DESCRIPTION
## Summary
- add mobile spacing and radius tokens
- hide horizontal overflow and tweak mobile typography and panels
- tighten mobile hero and card layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" from src/lib/natur.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b522c4f15c8329a26afadc38e4debf