### PR TITLE
Mobile polish — type, CTAs, and “How it works” cards (safe for web)

### DIFF
--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -166,37 +166,46 @@
   text-decoration: underline;
 }
 
-/* Mobile-only polish */
-@media (max-width: 640px) {
+/* ==== Home hero layout (mobile) ==== */
+@media (max-width: 639.98px) {
+  .page.nv-container,
+  .hero {
+    align-items: center;
+    text-align: center;
+  }
+
   .hero {
     max-width: 640px;         /* prevent over-wide wraps */
     margin: 0 auto;
     padding: var(--nv-space-5) var(--nv-space-4) var(--nv-space-4);
-    text-align: center;
     gap: var(--nv-space-3);
   }
 
   .title {
-    margin: 0 0 var(--nv-space-3);
+    font-size: var(--nv-h1-sm);
+    line-height: var(--nv-lh-tight-sm);
+    margin-bottom: var(--nv-space-xs);
   }
 
   .subtitle {
-    margin: 0 auto var(--nv-space-4);
-    max-width: 36ch;          /* comfortable line length */
+    font-size: var(--nv-body-sm);
+    line-height: var(--nv-lh-body-sm);
+    max-width: 36ch;
+    margin: 0 auto var(--nv-space-sm);
   }
 
   .ctaRow {
-    display: grid;
-    grid-auto-flow: row;
-    gap: var(--nv-space-3);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--nv-space-xs);
+    width: 100%;
     margin: 0 auto var(--nv-space-4);
-    width: min(520px, 100%);
   }
 
-  .cta {
-    width: 100%;
-    padding: 14px 18px;       /* a hair tighter */
-    border-radius: var(--nv-radius-lg);
+  .ctaRow .cta {
+    flex: 1 1 44%;
+    max-width: 260px;
   }
 
   /* Play/Learn/Earn panels spacing */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -854,3 +854,59 @@ main,
     max-width: 100%;
   }
 }
+
+/* ==== Mobile rhythm & CTAs (safe for web) ==== */
+@media (max-width: 639.98px) {
+  /* hero heading + subhead */
+  .nv-hero h1,
+  .nv-hero .title {
+    font-size: var(--nv-h1-sm);
+    line-height: var(--nv-lh-tight-sm);
+    letter-spacing: -0.01em;
+    margin-top: var(--nv-space-md);
+    margin-bottom: var(--nv-space-xs);
+    text-align: center;
+  }
+
+  .nv-hero p,
+  .nv-hero .subtitle {
+    font-size: var(--nv-body-sm);
+    line-height: var(--nv-lh-body-sm);
+    margin: 0 auto var(--nv-space-sm);
+    max-width: 36ch;
+    text-align: center;
+  }
+
+  /* primary CTAs */
+  .btn,
+  .cta,
+  .nv-hero .cta {
+    font-size: 16px;
+    line-height: 1;
+    padding: 14px 18px;     /* down from ~16–20 */
+    border-radius: 14px;
+  }
+
+  /* keep the two CTAs balanced with a small gap */
+  .nv-hero .ctaRow {
+    gap: var(--nv-space-xs);
+  }
+
+  /* dashed “how it works” container */
+  .nv-how {
+    max-width: 640px;
+    margin: var(--nv-space-md) auto;
+    padding: var(--nv-space-sm);
+  }
+  .nv-how .step {
+    padding: var(--nv-space-sm);
+    border-radius: 14px;
+  }
+
+  /* quest cards: nudge spacing so card shadow doesn't cause overflow */
+  .card,
+  .featureCard {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -63,3 +63,23 @@
   --nv-space-4: 16px;
   --nv-space-5: 20px;
 }
+
+/* ==== Mobile type & space (add near the other tokens) ==== */
+:root {
+  /* mobile font sizes */
+  --nv-h1-sm: 32px;    /* was visually ~36–40 */
+  --nv-h2-sm: 22px;
+  --nv-body-sm: 16px;
+
+  /* mobile line-height */
+  --nv-lh-tight-sm: 1.15;
+  --nv-lh-body-sm: 1.45;
+
+  /* mobile spacing (remapped so we can tighten hero) */
+  --nv-space-xxs: 8px;
+  --nv-space-xs: 12px;
+  --nv-space-sm: 16px;
+  --nv-space-md: 20px;
+}
+
+/* keep desktop/tablet as-is via min-width gates elsewhere */


### PR DESCRIPTION
## Summary
- add dedicated mobile font and spacing tokens to support smaller type scale
- tighten mobile hero rhythm and CTA sizing without affecting desktop
- center Home hero layout on small screens and balance CTA row widths

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Rollup failed to resolve import "ethers" from src/lib/natur.ts)


------
https://chatgpt.com/codex/tasks/task_e_68b52544f8b083298fad66f3aaa5205d