### PR TITLE
Restore mobile hamburger + fix “ethers” build error

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -32,14 +32,27 @@ export default function SiteHeader() {
   }, [supabase]);
 
   return (
-    <header className={`site-header ${open ? 'open' : ''}`}>
-      <div className="container">
+    <header className={`nv-header site-header ${open ? 'open' : ''}`}>
+      <div className="container nv-header-row">
         <div className="nav-left">
             <Link to="/" className="brand" onClick={() => setOpen(false)}>
               <Img src="/favicon-32x32.png" width="28" height="28" alt="" />
               <span>The Naturverse</span>
             </Link>
-          <nav className="nav nav-links">
+            {/* Mobile menu toggle */}
+            <button
+              className="nv-menu-toggle"
+              aria-label="Open menu"
+              aria-expanded={open ? 'true' : 'false'}
+              aria-controls="nv-main-nav"
+              onClick={() => setOpen(!open)}
+            >
+              {/* simple hamburger — three bars */}
+              <span aria-hidden="true" className="nv-burger">
+                <span></span><span></span><span></span>
+              </span>
+            </button>
+          <nav id="nv-main-nav" className="nav nav-links">
             <NavLink
               to="/worlds"
               className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
@@ -128,15 +141,6 @@ export default function SiteHeader() {
           <ProfileMini />
           <WalletConnect />
           <CartButton />
-          <button
-            className={`nv-menu-btn${open ? ' is-open' : ''}`}
-            aria-label="Open menu"
-            onClick={() => setOpen((v) => !v)}
-          >
-            <span></span>
-            <span></span>
-            <span></span>
-          </button>
         </div>
       </div>
     </header>

--- a/src/components/site-header.css
+++ b/src/components/site-header.css
@@ -64,7 +64,7 @@
   order: 2;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1023px) {
   .nav-links {
     position: fixed;
     inset: 64px 12px auto 12px;

--- a/src/lib/natur.ts
+++ b/src/lib/natur.ts
@@ -1,5 +1,11 @@
-import { Contract, parseUnits, formatUnits } from 'ethers';
 import { connectWallet } from './web3';
+
+let _ethers: any;
+export async function getEthers() {
+  if (_ethers) return _ethers;
+  _ethers = await import('ethers');
+  return _ethers;
+}
 
 const TOKEN = import.meta.env.VITE_NATUR_TOKEN_CONTRACT as string;
 const DECIMALS = Number(import.meta.env.VITE_NATUR_TOKEN_DECIMALS || '18');
@@ -12,6 +18,7 @@ const ERC20_ABI = [
 ];
 
 export async function getNaturBalance(address: string) {
+  const { Contract, formatUnits } = await getEthers();
   const { provider } = await connectWallet(); // ensures chain
   const c = new Contract(TOKEN, ERC20_ABI, provider);
   const raw = await c.balanceOf(address);
@@ -19,7 +26,8 @@ export async function getNaturBalance(address: string) {
 }
 
 export async function buyNavatarWithNatur(navatarId: string, amountNatur: number) {
-  const { address, provider, signer } = await connectWallet();
+  const { Contract, parseUnits } = await getEthers();
+  const { address, signer } = await connectWallet();
   const c = new Contract(TOKEN, ERC20_ABI, signer);
   const amount = parseUnits(String(amountNatur), DECIMALS);
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,6 +29,9 @@ html, body, #root {
   max-inline-size: 100%;
 }
 
+/* guard against accidental horizontal overflow from header controls */
+.nv-container, .nv-header-row { overflow-x: hidden; }
+
 /* If any component used 100vw, make it safe on mobile */
 :where(.uses-viewport-width) {
   inline-size: 100%; /* safer than 100vw — respects padding/borders/scrollbar */
@@ -551,6 +554,8 @@ main,
   text-align: center;
   margin: 0 auto;
   max-width: 64rem;
+  position: relative;
+  z-index: 1;
 }
 .nv-hero h1 {
   color: var(--nv-blue-700);

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -58,25 +58,36 @@
   text-decoration: underline;
 }
 
-/* burger */
-.nv-burger {
+/* ---- Mobile menu toggle ---- */
+.nv-menu-toggle {
   display: inline-flex;
-  width: 38px;
-  height: 34px;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--nv-border);
-  border-radius: 10px;
-  background: #fff;
+  width: 44px;
+  height: 44px;
+  border: 0;
+  background: var(--nv-surface, #fff);
+  border-radius: 12px;
+  box-shadow: var(--nv-shadow, 0 2px 10px rgba(17,34,68,.08));
+  cursor: pointer;
+  z-index: 40;
+  position: relative;
 }
-.nv-burger span {
-  display: block;
-  width: 18px;
-  height: 2px;
-  background: var(--nv-text);
-  margin: 2px 0;
-  border-radius: 2px;
+
+/* three bars */
+.nv-burger { display: inline-block; width: 20px; height: 14px; position: relative; }
+.nv-burger > span {
+  position: absolute; left: 0; right: 0; height: 2px; background: var(--nv-blue-700, #2d5cff);
+  border-radius: 2px; transform-origin: center; transition: transform .2s ease, opacity .2s ease;
 }
+.nv-burger > span:nth-child(1) { top: 0; }
+.nv-burger > span:nth-child(2) { top: 6px; }
+.nv-burger > span:nth-child(3) { bottom: 0; }
+
+/* when open (optional X animation) */
+[aria-expanded="true"] .nv-burger > span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+[aria-expanded="true"] .nv-burger > span:nth-child(2) { opacity: 0; }
+[aria-expanded="true"] .nv-burger > span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
 
 /* drawer */
 .nv-drawer {
@@ -109,16 +120,20 @@
   background: var(--nv-blue-50);
 }
 
-/* responsive */
+/* visibility rules */
 @media (min-width: 1024px) {
+  .nv-menu-toggle { display: none; }
   .nv-nav {
     display: block;
   }
-  .nv-burger,
   .nv-drawer {
     display: none;
   }
 }
+
+/* make sure header never causes sideways scroll */
+.nv-header,
+.nv-header * { max-width: 100%; }
 
 /* safety: hide any legacy top-link list if present */
 header + nav.legacy-top-links {


### PR DESCRIPTION
## Summary
- restore mobile menu toggle with new `.nv-menu-toggle` hamburger and `nv-header` classes
- prevent header/hero overlap and horizontal overflow
- lazy-load `ethers` in Natur library to avoid build failures

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "ethers" due to missing package)*

------
https://chatgpt.com/codex/tasks/task_e_68b527b8a7a48329acc7c76dba35a59c