### PR TITLE
Restore signed-in nav, right-size search, bring back mobile hamburger, and lazy-load ethers

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+import './mobile-menu.css';
+
+export default function MobileMenu({ open, onClose }: { open: boolean; onClose: () => void; }) {
+  if (!open) return null;
+  return (
+    <div className="overlay" role="dialog" aria-modal="true">
+      <div className="sheet">
+        <button className="close" aria-label="Close" onClick={onClose}>×</button>
+        <nav className="links">
+          <Link to="/worlds">Worlds</Link>
+          <Link to="/zones">Zones</Link>
+          <Link to="/marketplace">Marketplace</Link>
+          <Link to="/wishlist">Wishlist</Link>
+          <Link to="/naturversity">Naturversity</Link>
+          <Link to="/naturbank">NaturBank</Link>
+          <Link to="/navatar">Navatar</Link>
+          <Link to="/passport">Passport</Link>
+          <Link to="/turian">Turian</Link>
+        </nav>
+      </div>
+      <div className="backdrop" onClick={onClose} />
+    </div>
+  );
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,144 +1,84 @@
-import { Link, NavLink } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import type { User } from '@supabase/supabase-js';
 import './site-header.css';
 import Img from './Img';
-import AuthButton from './AuthButton';
 import CartButton from './CartButton';
 import SearchBar from './SearchBar';
+import MobileMenu from './MobileMenu';
 import { useSupabase } from '@/lib/useSupabase';
-import WalletConnect from './WalletConnect';
-import ProfileMini from './ProfileMini';
 
 export default function SiteHeader() {
   const supabase = useSupabase();
-  const [open, setOpen] = useState(false);
   const [user, setUser] = useState<User | null>(null);
+  const [status, setStatus] = useState<'loading' | 'authenticated' | 'unauthenticated'>('loading');
 
   useEffect(() => {
-    let mounted = true;
     if (!supabase) return;
     supabase.auth.getSession().then(({ data }) => {
-      if (!mounted) return;
       setUser(data.session?.user ?? null);
+      setStatus(data.session?.user ? 'authenticated' : 'unauthenticated');
     });
     const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
       setUser(session?.user ?? null);
+      setStatus(session?.user ? 'authenticated' : 'unauthenticated');
     });
-    return () => {
-      mounted = false;
-      sub.subscription.unsubscribe();
-    };
+    return () => { sub.subscription.unsubscribe(); };
   }, [supabase]);
 
+  const isAuthed = status === 'authenticated' && !!user;
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    if (menuOpen) document.body.style.overflow = 'hidden';
+    else document.body.style.overflow = '';
+    return () => { document.body.style.overflow = ''; };
+  }, [menuOpen]);
+
   return (
-    <header className={`site-header ${open ? 'open' : ''}`}>
-      <div className="container">
-        <div className="nav-left">
-            <Link to="/" className="brand" onClick={() => setOpen(false)}>
-              <Img src="/favicon-32x32.png" width="28" height="28" alt="" />
-              <span>The Naturverse</span>
-            </Link>
-          <nav className="nav nav-links">
-            <NavLink
-              to="/worlds"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              Worlds
-            </NavLink>
-            <NavLink
-              to="/zones"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              Zones
-            </NavLink>
-              <NavLink
-                to="/quests"
-                className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-                onClick={() => setOpen(false)}
-              >
-                Quests
-              </NavLink>
-            <NavLink
-              to="/marketplace"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              Marketplace
-            </NavLink>
-            <NavLink
-              to="/wishlist"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              Wishlist
-            </NavLink>
-            <NavLink
-              to="/naturversity"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              Naturversity
-            </NavLink>
-            <NavLink
-              to="/naturbank"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              NaturBank
-            </NavLink>
-            {/* Navatar is always enabled */}
-            <NavLink
-              to="/navatar"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              Navatar
-            </NavLink>
-            <NavLink
-              to="/create/navatar"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              Create Navatar
-            </NavLink>
-            <NavLink
-              to="/passport"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              Passport
-            </NavLink>
-            <NavLink
-              to="/turian"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              Turian
-            </NavLink>
-          </nav>
+    <header className="site-header">
+      <div className="row">
+        <Link to="/" className="brand">
+          <Img src="/favicon-32x32.png" width="28" height="28" alt="" />
+          <span>The Naturverse</span>
+        </Link>
+        <div className="searchWrap">
+          <SearchBar />
         </div>
-        <div className="nav-right">
-          <div style={{ minWidth: 280 }}>
-            <SearchBar />
-          </div>
-          <AuthButton />
-          <ProfileMini />
-          <WalletConnect />
+        <div className="actions">
+          {isAuthed && (
+            <button
+              aria-label="Menu"
+              aria-expanded={menuOpen}
+              onClick={() => setMenuOpen((v) => !v)}
+              className="hamburger"
+            >
+              <span></span>
+              <span></span>
+              <span></span>
+            </button>
+          )}
           <CartButton />
-          <button
-            className={`nv-menu-btn${open ? ' is-open' : ''}`}
-            aria-label="Open menu"
-            onClick={() => setOpen((v) => !v)}
-          >
-            <span></span>
-            <span></span>
-            <span></span>
-          </button>
         </div>
       </div>
+
+      {isAuthed && (
+        <nav className="desktopNav">
+          <Link to="/worlds">Worlds</Link>
+          <Link to="/zones">Zones</Link>
+          <Link to="/marketplace">Marketplace</Link>
+          <Link to="/wishlist">Wishlist</Link>
+          <Link to="/naturversity">Naturversity</Link>
+          <Link to="/naturbank">NaturBank</Link>
+          <Link to="/navatar">Navatar</Link>
+          <Link to="/passport">Passport</Link>
+          <Link to="/turian">Turian</Link>
+        </nav>
+      )}
+
+      {isAuthed && (
+        <MobileMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
+      )}
     </header>
   );
 }

--- a/src/components/mobile-menu.css
+++ b/src/components/mobile-menu.css
@@ -1,0 +1,22 @@
+.overlay { position: fixed; inset: 0; z-index: var(--z-menu, 40); }
+.backdrop { position: absolute; inset: 0; background: rgba(20,22,25,.35); }
+.sheet {
+  position: absolute;
+  top: 8px; left: 8px; right: 8px;
+  background: white;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.12);
+}
+.close {
+  position: absolute; top: 10px; right: 12px;
+  background: #2563eb; color: white;
+  border: 0; border-radius: 8px; width: 32px; height: 32px;
+}
+.links {
+  display: grid; gap: 12px;
+  padding: 20px 8px 8px;
+  text-align: center;
+  font-weight: 700;
+}
+.links a { text-decoration: none; color: #1a4d9c; }

--- a/src/components/site-header.css
+++ b/src/components/site-header.css
@@ -1,91 +1,71 @@
 .site-header {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  width: 100%;
-  background: #fff;
-  border-bottom: 1px solid #e5e7eb;
+  position: relative;
+  z-index: 10;
+  margin: 16px 0 8px;
 }
-
-.site-header .container {
-  display: flex;
+.row {
+  display: grid;
   align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  row-gap: 8px;
-  padding: 0.75rem 0;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
 }
-
-.nav-left {
-  display: flex;
+.brand {
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
-  min-width: 0;
-}
-
-.site-header .brand {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
   font-weight: 800;
-  color: var(--ink);
   text-decoration: none;
+  color: inherit;
 }
-
-.nav-links {
+.searchWrap {
   display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+  justify-content: center;
+}
+.searchWrap .nv-search {
+  width: clamp(220px, 45vw, 560px);
+  max-width: 100%;
+}
+.searchWrap .nv-search__input {
+  height: 44px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid #d0d4d8;
+  box-shadow: inset 0 1px 0 rgba(0,0,0,.04);
+}
+.actions {
+  display: inline-flex;
   align-items: center;
+  gap: 8px;
 }
-
-.nav-links a { 
-  color: var(--nv-blue-700);
-  text-decoration: none;
-  font-weight: 600;
-  opacity: 0.9;
+.hamburger {
+  inline-size: 28px;
+  block-size: 22px;
+  display: grid;
+  align-items: center;
+  justify-items: stretch;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  z-index: 25;
 }
-.nav-links .disabledLink {
-  opacity: 0.55;
-  pointer-events: none;
-  cursor: default;
+.hamburger span {
+  display: block;
+  height: 2px;
+  border-radius: 2px;
+  background: #1a4d9c;
+  box-shadow: 0 1px 0 rgba(0,0,0,.06);
 }
-
-.nav-links a.active {
-  color: var(--nv-blue-700);
-}
-
-.nav-right {
+.desktopNav {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  flex: 0 0 auto;
-  margin-left: auto;
-  order: 2;
+  gap: 16px;
+  margin-top: 8px;
 }
-
 @media (max-width: 768px) {
-  .nav-links {
-    position: fixed;
-    inset: 64px 12px auto 12px;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    background: #fff;
-    border: 1px solid var(--nv-border);
-    border-radius: 14px;
-    padding: 12px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
-    transform: translateY(-16px);
-    opacity: 0;
-    pointer-events: none;
-    transition: 0.15s ease;
-  }
-
-  .site-header.open .nav-links {
-    transform: translateY(0);
-    opacity: 1;
-    pointer-events: auto;
-  }
+  .row { grid-template-columns: auto 1fr auto; }
+  .searchWrap .nv-search { width: clamp(180px, 60vw, 320px); }
+  .desktopNav { display: none; }
 }
-
+:root {
+  --z-cart: 30;
+  --z-menu: 40;
+}

--- a/src/lib/getEthers.ts
+++ b/src/lib/getEthers.ts
@@ -1,0 +1,21 @@
+let ethersPromise: Promise<typeof import("ethers")> | null = null;
+
+/** Load ethers only on the client when needed. */
+export async function getEthers() {
+  if (typeof window === "undefined") {
+    throw new Error("Wallet features require a browser environment.");
+  }
+  if (!ethersPromise) {
+    const moduleName = 'ethers';
+    // dynamic import so bundlers do not try to include ethers during build
+    // @vite-ignore
+    ethersPromise = import(moduleName);
+  }
+  return ethersPromise;
+}
+
+/** Convenience helper to create a BrowserProvider from window.ethereum */
+export async function createProvider() {
+  const { BrowserProvider } = await getEthers();
+  return new BrowserProvider((window as any).ethereum);
+}

--- a/src/lib/natur.ts
+++ b/src/lib/natur.ts
@@ -1,4 +1,5 @@
-import { Contract, parseUnits, formatUnits } from 'ethers';
+import type { Contract } from 'ethers';
+import { getEthers } from './getEthers';
 import { connectWallet } from './web3';
 
 const TOKEN = import.meta.env.VITE_NATUR_TOKEN_CONTRACT as string;
@@ -13,6 +14,7 @@ const ERC20_ABI = [
 
 export async function getNaturBalance(address: string) {
   const { provider } = await connectWallet(); // ensures chain
+  const { Contract, formatUnits } = await getEthers();
   const c = new Contract(TOKEN, ERC20_ABI, provider);
   const raw = await c.balanceOf(address);
   return { raw, formatted: formatUnits(raw, DECIMALS) };
@@ -20,6 +22,7 @@ export async function getNaturBalance(address: string) {
 
 export async function buyNavatarWithNatur(navatarId: string, amountNatur: number) {
   const { address, provider, signer } = await connectWallet();
+  const { Contract, parseUnits } = await getEthers();
   const c = new Contract(TOKEN, ERC20_ABI, signer);
   const amount = parseUnits(String(amountNatur), DECIMALS);
 

--- a/src/lib/web3.ts
+++ b/src/lib/web3.ts
@@ -1,4 +1,5 @@
-import { BrowserProvider, Eip1193Provider, JsonRpcSigner } from 'ethers';
+import type { BrowserProvider, Eip1193Provider, JsonRpcSigner } from 'ethers';
+import { getEthers } from './getEthers';
 
 const CHAIN_ID = Number(import.meta.env.VITE_NATUR_CHAIN_ID || '80002');
 const CHAIN_HEX = '0x' + CHAIN_ID.toString(16);
@@ -14,6 +15,7 @@ export async function getInjected(): Promise<Eip1193Provider | null> {
 export async function connectWallet(): Promise<{ address: string; provider: BrowserProvider; signer: JsonRpcSigner }> {
   const injected = await getInjected();
   if (!injected) throw new Error('No wallet found. Please install MetaMask.');
+  const { BrowserProvider } = await getEthers();
   const provider = new BrowserProvider(injected);
   const accounts = await injected.request({ method: 'eth_requestAccounts' });
   const address = accounts[0];


### PR DESCRIPTION
## Summary
- show desktop navigation and mobile hamburger only for authenticated users
- clamp search bar width and overlay mobile menu with portal styling
- lazy-load ethers on demand to avoid build-time bundling issues

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b53799cf2483298fd72cf9b9376e09