### PR TITLE
feat: polish header and mobile layouts

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,82 +1,93 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import SearchBar from './SearchBar';
 import './site-header.css';
 
 export default function SiteHeader() {
-  const [open, setOpen] = useState(false);
-  const sheetRef = useRef<HTMLDivElement>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
 
-  // lock body scroll when sheet is open
+  // lock body scroll when open
   useEffect(() => {
-    const { body } = document;
-    const prev = body.style.overflow;
-    if (open) body.style.overflow = 'hidden';
-    else body.style.overflow = prev || '';
-    return () => (body.style.overflow = prev || '');
-  }, [open]);
+    if (!menuOpen) return;
+    const original = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = original; };
+  }, [menuOpen]);
 
   // close on Escape
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
+      if (e.key === 'Escape') setMenuOpen(false);
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  // close when clicking outside the sheet
-  useEffect(() => {
-    const onClick = (e: MouseEvent) => {
-      if (!open) return;
-      if (sheetRef.current && !sheetRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('click', onClick);
-    return () => document.removeEventListener('click', onClick);
-  }, [open]);
-
   return (
-    <header className="nv-header">
-      <div className="nv-header__row">
+    <>
+      <header className="siteHeader">
         <Link to="/" className="nv-brand">
           <img className="nv-logo" src="/logo.svg" alt="" aria-hidden="true" />
           <span className="nv-brand__text">The Naturverse</span>
         </Link>
-
+        <div className="search">
+          <SearchBar />
+        </div>
         <button
-          className={`nv-burger ${open ? 'nv-burger--open' : ''}`}
+          className={`hamburger ${menuOpen ? 'hamburger--open' : ''}`}
           aria-label="Open menu"
           aria-controls="mobile-menu"
-          aria-expanded={open}
-          onClick={(e) => {
-            e.stopPropagation();
-            setOpen((v) => !v);
-          }}
+          aria-expanded={menuOpen}
+          onClick={() => setMenuOpen((v) => !v)}
         >
           <span aria-hidden="true" />
         </button>
-      </div>
+      </header>
 
-      {/* slide-down sheet */}
-      <div
-        id="mobile-menu"
-        ref={sheetRef}
-        className={`nv-sheet ${open ? 'is-open' : ''}`}
-        role="menu"
-      >
-        <nav className="nv-sheet__nav">
-          <Link to="/worlds" role="menuitem" onClick={() => setOpen(false)}>Worlds</Link>
-          <Link to="/zones" role="menuitem" onClick={() => setOpen(false)}>Zones</Link>
-          <Link to="/marketplace" role="menuitem" onClick={() => setOpen(false)}>Marketplace</Link>
-          <Link to="/wishlist" role="menuitem" onClick={() => setOpen(false)}>Wishlist</Link>
-          <Link to="/naturversity" role="menuitem" onClick={() => setOpen(false)}>Naturversity</Link>
-          <Link to="/naturbank" role="menuitem" onClick={() => setOpen(false)}>NaturBank</Link>
-          <Link to="/navatar" role="menuitem" onClick={() => setOpen(false)}>Navatar</Link>
-          <Link to="/passport" role="menuitem" onClick={() => setOpen(false)}>Passport</Link>
-          <Link to="/turian" role="menuitem" onClick={() => setOpen(false)}>Turian</Link>
-        </nav>
-      </div>
-    </header>
+      {menuOpen && (
+        <>
+          <div className="mmenuBackdrop" onClick={() => setMenuOpen(false)} />
+          <div className="mmenuPanel" id="mobile-menu" role="menu">
+            <button
+              className="mmenuClose"
+              onClick={() => setMenuOpen(false)}
+              aria-label="Close menu"
+            >
+              ✕
+            </button>
+            <nav>
+              <Link to="/worlds" role="menuitem" onClick={() => setMenuOpen(false)}>
+                Worlds
+              </Link>
+              <Link to="/zones" role="menuitem" onClick={() => setMenuOpen(false)}>
+                Zones
+              </Link>
+              <Link to="/marketplace" role="menuitem" onClick={() => setMenuOpen(false)}>
+                Marketplace
+              </Link>
+              <Link to="/wishlist" role="menuitem" onClick={() => setMenuOpen(false)}>
+                Wishlist
+              </Link>
+              <Link to="/naturversity" role="menuitem" onClick={() => setMenuOpen(false)}>
+                Naturversity
+              </Link>
+              <Link to="/naturbank" role="menuitem" onClick={() => setMenuOpen(false)}>
+                NaturBank
+              </Link>
+              <Link to="/navatar" role="menuitem" onClick={() => setMenuOpen(false)}>
+                Navatar
+              </Link>
+              <Link to="/passport" role="menuitem" onClick={() => setMenuOpen(false)}>
+                Passport
+              </Link>
+              <Link to="/turian" role="menuitem" onClick={() => setMenuOpen(false)}>
+                Turian
+              </Link>
+            </nav>
+          </div>
+        </>
+      )}
+    </>
   );
 }
+

--- a/src/components/site-header.css
+++ b/src/components/site-header.css
@@ -1,23 +1,21 @@
-/* Header sizing tokens (mobile-first) */
 :root {
-  --nv-header-h: 64px;
-  --nv-sheet-radius: 16px;
+  --hdr-h-pad: 12px;
+  --search-max: 560px;   /* desktop clamp */
+  --search-min: 220px;
+  --tap: 44px;           /* min tap target */
 }
 
-/* layout */
-.nv-header {
+/* header row */
+.siteHeader {
   position: sticky;
   top: 0;
   z-index: 40;
   background: var(--page-bg, #f8fbff);
-}
-.nv-header__row {
-  height: var(--nv-header-h);
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
-  padding: 8px 16px;
+  padding: 10px var(--hdr-h-pad);
   border-bottom: 1px solid rgba(34, 62, 120, .08);
   backdrop-filter: saturate(140%) blur(6px);
 }
@@ -31,21 +29,50 @@
 }
 .nv-brand__text { font-weight: 800; color: var(--naturverse-blue, #2d5cff); }
 
-/* "cracked" hamburger */
-.nv-burger {
-  --w: 26px;
-  --h: 20px;
-  width: var(--w);
-  height: var(--h);
+/* search input wrapper */
+.siteHeader .search {
+  width: min(100%, var(--search-max));
+  min-width: var(--search-min);
+}
+
+/* actual input */
+.siteHeader .search input {
+  height: 40px;
+  font-size: 16px;       /* iOS no-zoom */
+  line-height: 1.1;
+  padding: 10px 14px;
+  border-radius: 999px;
+}
+
+/* mobile clamps */
+@media (max-width: 640px) {
+  .siteHeader {
+    grid-template-columns: auto 1fr auto;
+    gap: 8px;
+    padding: 8px var(--hdr-h-pad);
+  }
+  .siteHeader .search { width: 72vw; }
+  .siteHeader .search input { height: 38px; }
+}
+
+/* hamburger */
+.hamburger {
+  width: var(--tap);
+  height: var(--tap);
+  display: inline-grid;
+  place-items: center;
+  border-radius: 10px;
+  outline-offset: 3px;
+  z-index: 60;            /* above hero */
   position: relative;
   border: 0;
   background: transparent;
   padding: 0;
   cursor: pointer;
 }
-.nv-burger span,
-.nv-burger::before,
-.nv-burger::after {
+.hamburger span,
+.hamburger::before,
+.hamburger::after {
   content: '';
   position: absolute;
   left: 0; right: 0;
@@ -54,52 +81,38 @@
   border-radius: 3px;
   transition: transform .25s ease, opacity .2s ease, width .25s ease;
 }
-.nv-burger span { top: 50%; transform: translateY(-50%); width: 100%; }
-.nv-burger::before { top: 0; width: 100%; }
-.nv-burger::after  { bottom: 0; width: 100%; }
+.hamburger span { top: 50%; transform: translateY(-50%); width: 100%; }
+.hamburger::before { top: 0; width: 100%; }
+.hamburger::after  { bottom: 0; width: 100%; }
+.hamburger--open span { width: 0; opacity: 0; }
+.hamburger--open::before { transform: translateY(9px) rotate(45deg); }
+.hamburger--open::after  { transform: translateY(-9px) rotate(-45deg); }
 
-/* crack effect on middle when opening (splits from center) */
-.nv-burger--open span {
-  width: 0; opacity: 0;
-}
-.nv-burger--open::before {
-  transform: translateY(9px) rotate(45deg);
-}
-.nv-burger--open::after {
-  transform: translateY(-9px) rotate(-45deg);
+/* overlay */
+.mmenuBackdrop {
+  position: fixed; inset: 0;
+  background: rgba(20,24,40,.45);
+  backdrop-filter: saturate(120%) blur(6px);
+  z-index: 70;
 }
 
-/* slide-down sheet under header */
-.nv-sheet {
-  position: absolute;
-  inset: calc(var(--nv-header-h)) 8px auto 8px;
-  background: #fff;
-  border-radius: var(--nv-sheet-radius);
-  border: 1px solid rgba(34, 62, 120, .12);
-  box-shadow: 0 6px 28px rgba(17, 34, 68, .14);
-  transform-origin: top center;
-  transform: translateY(-8px) scale(.98);
-  opacity: 0;
-  pointer-events: none;
-  transition: transform .22s ease, opacity .22s ease;
+.mmenuPanel {
+  position: fixed; inset: env(safe-area-inset-top) 10px auto 10px;
+  left: 12px; right: 12px; top: 10px;
+  background: var(--surface-1,#fff);
+  border-radius: 16px;
+  padding: 14px 10px 18px;
+  z-index: 80;
+  max-height: calc(100dvh - 28px - env(safe-area-inset-bottom));
+  overflow: auto;
 }
-.nv-sheet.is-open {
-  transform: translateY(0) scale(1);
-  opacity: 1;
-  pointer-events: auto;
+
+.mmenuClose {
+  position: absolute; right: 10px; top: 10px;
+  width: 36px; height: 36px; border-radius: 10px;
 }
-.nv-sheet__nav {
-  display: grid;
-  gap: 14px;
-  padding: 16px 20px;
-  text-align: center;
-}
-.nv-sheet__nav a {
-  font-weight: 700;
-  color: var(--naturverse-blue, #2d5cff);
-  text-decoration: none;
-}
-@media (min-width: 768px) {
-  .nv-burger { display: none; }
-  .nv-sheet { display: none; }
-}
+
+/* desktop nav visibility rules */
+.headerLinks--signedOut { display: none; }
+.headerLinks--signedIn  { display: flex; gap: 14px; }
+

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -84,11 +84,8 @@
 }
 
 @media (max-width: 640px) {
-  .ctaRow > * {
-    flex: 1 1 160px;
-    min-width: 140px;
-    max-width: 100%;
-  }
+  .ctaRow { gap: 10px; flex-wrap: wrap; }
+  .ctaRow .cta { width: 100%; max-width: 420px; }
 }
 
 .featureGrid {

--- a/src/styles/cart.css
+++ b/src/styles/cart.css
@@ -161,6 +161,7 @@
   position: fixed;
   inset: 0;
   pointer-events: none;
+  z-index: 90;
 }
 .cart-drawer .scrim {
   position: absolute;
@@ -181,6 +182,7 @@
   display: flex;
   flex-direction: column;
   transition: 0.25s;
+  padding-bottom: calc(20px + env(safe-area-inset-bottom));
 }
 .cart-drawer.open {
   pointer-events: auto;
@@ -309,7 +311,7 @@
   text-align: center;
 }
 
-.cart-drawer { position: fixed; inset: 0; z-index: 60; display:flex; }
+.cart-drawer { position: fixed; inset: 0; z-index: 90; display:flex; }
 .cart-drawer .backdrop { flex:1; background: rgba(0,0,0,.25); animation: fadeIn .25s ease; }
 .cart-panel {
   width: 380px; max-width: 100vw; height: 100%; background: #fff;
@@ -317,6 +319,7 @@
   transform: translateX(420px);
   /* springy slide */
   transition: transform .36s cubic-bezier(.2,.8,.2,1.2);
+  padding-bottom: calc(20px + env(safe-area-inset-bottom));
 }
 .cart-panel--in { transform: translateX(0); }
 @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -80,20 +80,16 @@ h1, h2, h3 {
   letter-spacing: -0.01em;
   color: var(--nv-blue-700);
 }
-h1 { font-size: var(--nv-h1); line-height: 1.15; }
+.h1, h1 {
+  font-size: clamp(28px, 6vw, 40px);
+  line-height: 1.12;
+  letter-spacing: -0.01em;
+}
 h2 { font-size: var(--nv-h2); line-height: 1.2; }
 p  { line-height: 1.6; }
 
 /* iPhone & small screens only */
 @media (max-width: 640px) {
-  /* Saner type scaling on first paint */
-  h1 {
-    /* ~28–34px depending on width */
-    font-size: clamp(28px, 6vw, 34px);
-    line-height: 1.15;
-    letter-spacing: 0;
-  }
-
   .nv-subtitle, p.nv-subtitle {
     /* ~15–18px */
     font-size: clamp(15px, 3.7vw, 18px);


### PR DESCRIPTION
## Summary
- add responsive header search with consistent tap targets
- lock body scroll and add backdrop for mobile menu
- refine hero headings, CTA spacing, and cart drawer safe areas

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b53bbe0e148329b280e7d5e6b5c10f