### PR TITLE
Fix favicon links (all sizes) and add iOS apple-touch icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,19 @@
       content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
     <base href="/" />
-    <link rel="icon" href="/favicon.svg" />
+    <!-- Favicons -->
+    <link rel="icon" type="image/png" sizes="16x16"  href="/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32"  href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="48x48"  href="/favicon-48x48.png">
+    <link rel="icon" type="image/png" sizes="64x64"  href="/favicon-64x64.png">
+    <link rel="icon" type="image/png" sizes="128x128" href="/favicon-128x128.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="256x256" href="/favicon-256x256.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/favicon-512x512.png">
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+    <!-- iOS home screen icon (re-uses existing PNG; no new file) -->
+    <link rel="apple-touch-icon" href="/favicon-192x192.png">
       <title>The Naturverse</title>
     <!-- PWA is removed: no manifest, no apple-web-app-* meta, no service worker registration -->
   </head>


### PR DESCRIPTION
## Summary
- Use explicit `<link rel="icon">` entries for all existing PNG sizes (+ `.ico` and `.svg`)
- Add `<link rel="apple-touch-icon">` pointing to the existing 192×192 PNG (no new files)
- No binary additions; HTML only

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b544abd7b88329a8b454d6a3d6d76c