### PR TITLE
Fix mobile menu layering and favicon links

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,16 @@
     />
     <base href="/" />
     <!-- Favicons -->
-    <link rel="icon" type="image/png" sizes="16x16"  href="/favicon-16x16.png">
-    <link rel="icon" type="image/png" sizes="32x32"  href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="48x48"  href="/favicon-48x48.png">
-    <link rel="icon" type="image/png" sizes="64x64"  href="/favicon-64x64.png">
-    <link rel="icon" type="image/png" sizes="128x128" href="/favicon-128x128.png">
-    <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192x192.png">
-    <link rel="icon" type="image/png" sizes="256x256" href="/favicon-256x256.png">
-    <link rel="icon" type="image/png" sizes="512x512" href="/favicon-512x512.png">
-    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-16x16.png" sizes="16x16" type="image/png">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="/favicon-48x48.png" sizes="48x48" type="image/png">
+    <link rel="icon" href="/favicon-64x64.png" sizes="64x64" type="image/png">
+    <link rel="icon" href="/favicon-128x128.png" sizes="128x128" type="image/png">
+    <link rel="icon" href="/favicon-192x192.png" sizes="192x192" type="image/png">
+    <link rel="icon" href="/favicon-256x256.png" sizes="256x256" type="image/png">
+    <link rel="icon" href="/favicon-512x512.png" sizes="512x512" type="image/png">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+    <link rel="shortcut icon" href="/favicon.ico">
     <!-- iOS home screen icon (re-uses existing PNG; no new file) -->
     <link rel="apple-touch-icon" href="/favicon-192x192.png">
       <title>The Naturverse</title>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,15 +1,34 @@
 import { useSession } from '@/lib/session';
 import { Link } from 'wouter';
+import { useEffect, useState } from 'react';
 import './site-header.css';
 
 export default function SiteHeader() {
   const { user } = useSession(); // truthy when logged in
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('menu-open', open);
+    document.body.classList.toggle('menu-open', open);
+    return () => {
+      document.documentElement.classList.remove('menu-open');
+      document.body.classList.remove('menu-open');
+    };
+  }, [open]);
 
   return (
     <header className="nv-header" role="banner">
       <div className="nv-header__inner">
         <Link href="/" className="nv-brand" aria-label="The Naturverse home">
-          <img className="nv-brand__mark" src="/favicon-32x32.png" alt="" />
+          <img
+            className="nv-brand__mark"
+            src="/favicon-32x32.png"
+            width={20}
+            height={20}
+            alt=""
+            loading="eager"
+            decoding="async"
+          />
           <span className="nv-brand__text">The Naturverse</span>
         </Link>
 
@@ -38,17 +57,42 @@ export default function SiteHeader() {
           </nav>
         )}
 
-        {/* Mobile hamburger – unchanged behavior */}
+        {/* Mobile hamburger */}
         <button
           className="nv-menu-btn"
-          aria-haspopup="menu"
-          aria-controls="mobile-menu"
-          aria-expanded="false"
+          aria-label="Menu"
+          aria-expanded={open}
+          onClick={() => setOpen(!open)}
         >
           <span className="nv-menu-btn__lines" aria-hidden="true" />
           <span className="sr-only">Menu</span>
         </button>
       </div>
+
+      {/* Mobile menu */}
+      <div className="nv-menu-backdrop" onClick={() => setOpen(false)} />
+      <aside className="nv-menu-panel" role="dialog" aria-modal="true">
+        <button
+          className="nv-menu-close"
+          aria-label="Close"
+          onClick={() => setOpen(false)}
+        >
+          &times;
+        </button>
+        {user && (
+          <nav className="nv-nav nv-nav--mobile" aria-label="Primary">
+            <Link href="/worlds">Worlds</Link>
+            <Link href="/zones">Zones</Link>
+            <Link href="/marketplace">Marketplace</Link>
+            <Link href="/wishlist">Wishlist</Link>
+            <Link href="/naturversity">Naturversity</Link>
+            <Link href="/naturbank">NaturBank</Link>
+            <Link href="/navatar">Navatar</Link>
+            <Link href="/passport">Passport</Link>
+            <Link href="/turian">Turian</Link>
+          </nav>
+        )}
+      </aside>
     </header>
   );
 }

--- a/src/components/site-header.css
+++ b/src/components/site-header.css
@@ -22,8 +22,8 @@
   text-decoration: none;
 }
 .nv-brand__mark {
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
   border-radius: 6px; /* subtle softness */
 }
 .nv-brand__text {
@@ -92,5 +92,68 @@
     linear-gradient(currentColor 2px, transparent 0) 0 100%/100% 2px;
   background-repeat: no-repeat;
   color: var(--brand-600);
+}
+
+/* Mobile menu overlay */
+.nv-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 22, 48, 0.28);
+  backdrop-filter: saturate(140%) blur(2px);
+  -webkit-backdrop-filter: saturate(140%) blur(2px);
+  z-index: 90;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms ease;
+}
+
+.nv-menu-panel {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  margin: 0 auto;
+  max-width: 720px;
+  border-radius: 16px;
+  background: #fff;
+  z-index: 100;
+  transform: translateY(-16px);
+  opacity: 0;
+  pointer-events: none;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+  transition: transform 160ms ease, opacity 160ms ease;
+}
+
+.menu-open .nv-menu-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.menu-open .nv-menu-panel {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+html.menu-open,
+body.menu-open {
+  overflow: hidden;
+  touch-action: none;
+}
+
+.nv-nav--mobile {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  gap: 0.75rem;
+}
+
+.nv-menu-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  background: transparent;
+  border: 0;
+  font-size: 1.5rem;
 }
 


### PR DESCRIPTION
## Summary
- ensure header brand icon and mobile menu overlay render above page content
- restore comprehensive favicon links for browser tab icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "wouter"; npm install failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b54ecb6ed483299dad3cf1d6df3dd7