### PR TITLE
Revamp site header and mobile menu

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,54 +1,105 @@
+import { useState, useEffect, useRef } from 'react';
 import { useSession } from '@/lib/session';
 import { Link } from 'wouter';
 import './site-header.css';
 
 export default function SiteHeader() {
   const { user } = useSession(); // truthy when logged in
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  // close on escape / outside click
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    function onClick(e: MouseEvent) {
+      if (
+        open &&
+        panelRef.current &&
+        !panelRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onClick);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onClick);
+    };
+  }, [open]);
+
+  // lock body scroll when open
+  useEffect(() => {
+    const { body } = document;
+    if (!body) return;
+    const prev = body.style.overflow;
+    body.style.overflow = open ? 'hidden' : prev || '';
+    return () => {
+      body.style.overflow = prev || '';
+    };
+  }, [open]);
+
+  const navLinks = (
+    <nav className="nv-nav-links">
+      <Link href="/worlds">Worlds</Link>
+      <Link href="/zones">Zones</Link>
+      <Link href="/marketplace">Marketplace</Link>
+      <Link href="/wishlist">Wishlist</Link>
+      <Link href="/naturversity">Naturversity</Link>
+      <Link href="/naturbank">NaturBank</Link>
+      <Link href="/navatar">Navatar</Link>
+      <Link href="/passport">Passport</Link>
+      <Link href="/turian">Turian</Link>
+    </nav>
+  );
 
   return (
-    <header className="nv-header" role="banner">
-      <div className="nv-header__inner">
-        <Link href="/" className="nv-brand" aria-label="The Naturverse home">
-          <img className="nv-brand__mark" src="/favicon-32x32.png" alt="" />
-          <span className="nv-brand__text">The Naturverse</span>
+    <header className="nv-header">
+      <div className="nv-header-inner">
+        <Link href="/" className="nv-brand">
+          <img
+            src="/favicon-32x32.png"
+            alt=""
+            width="24"
+            height="24"
+            className="nv-brand-icon"
+          />
+          <span className="nv-brand-text">The Naturverse</span>
         </Link>
 
-        {/* Search is always visible, but size is clamped in CSS */}
-        <div className="nv-search">
-          <input
-            className="nv-search__input"
-            type="search"
-            placeholder="Search worlds, zones, marketplace, quests"
-            aria-label="Search"
-          />
-        </div>
+        {/* Desktop nav: only when logged-in */}
+        {user ? <div className="nv-desktop-only">{navLinks}</div> : <div />}
 
-        {/* Desktop links visible only when authenticated */}
-        {user && (
-          <nav className="nv-nav nv-nav--desktop" aria-label="Primary">
-            <Link href="/worlds">Worlds</Link>
-            <Link href="/zones">Zones</Link>
-            <Link href="/marketplace">Marketplace</Link>
-            <Link href="/wishlist">Wishlist</Link>
-            <Link href="/naturversity">Naturversity</Link>
-            <Link href="/naturbank">NaturBank</Link>
-            <Link href="/navatar">Navatar</Link>
-            <Link href="/passport">Passport</Link>
-            <Link href="/turian">Turian</Link>
-          </nav>
-        )}
-
-        {/* Mobile hamburger – unchanged behavior */}
+        {/* Mobile actions */}
         <button
-          className="nv-menu-btn"
-          aria-haspopup="menu"
-          aria-controls="mobile-menu"
-          aria-expanded="false"
+          className="nv-hamburger"
+          aria-label="Menu"
+          aria-expanded={open}
+          onClick={() => setOpen(true)}
         >
-          <span className="nv-menu-btn__lines" aria-hidden="true" />
-          <span className="sr-only">Menu</span>
+          <span />
+          <span />
+          <span />
         </button>
       </div>
+
+      {/* Mobile menu overlay */}
+      {open && (
+        <div className="nv-menu-overlay" role="dialog" aria-modal="true">
+          <div className="nv-menu-panel" ref={panelRef}>
+            <button
+              className="nv-close"
+              aria-label="Close"
+              onClick={() => setOpen(false)}
+            >
+              ×
+            </button>
+            {navLinks}
+          </div>
+        </div>
+      )}
     </header>
   );
 }

--- a/src/components/site-header.css
+++ b/src/components/site-header.css
@@ -1,96 +1,124 @@
-/* src/components/site-header.css */
-
+/* layout */
 .nv-header {
-  position: relative;
-  z-index: 20;
-  background: var(--surface);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: #fff;
 }
-
-.nv-header__inner {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
+.nv-header-inner {
+  display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  gap: 12px;
+  padding: 12px 16px;
 }
 
-/* Brand with favicon */
+/* brand */
 .nv-brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
+  font-weight: 800;
+  color: #2d5bf5; /* existing blue */
   text-decoration: none;
 }
-.nv-brand__mark {
-  width: 24px;
-  height: 24px;
-  border-radius: 6px; /* subtle softness */
-}
-.nv-brand__text {
-  font-weight: 800;
-  color: var(--brand-700);
+.nv-brand-icon {
+  border-radius: 4px;
+  display: block;
 }
 
-/* Search sizing (consistent across breakpoints) */
-.nv-search {
-  display: flex;
-  justify-content: center;
-}
-.nv-search__input {
-  width: 100%;
-  max-width: 420px;            /* desktop clamp */
-  min-width: 0;
-  height: 40px;
-  padding: 0 0.875rem;
-  border-radius: 999px;
-  border: 1px solid var(--line-200);
-  background: var(--surface-raise);
-}
-
-/* Mobile first clamp */
-@media (max-width: 640px) {
-  .nv-header__inner {
-    grid-template-columns: auto 1fr auto;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-  }
-  .nv-brand__mark { width: 20px; height: 20px; }
-  .nv-search__input {
-    max-width: 300px;          /* smaller on phones */
-    height: 36px;
-    font-size: 0.95rem;
-  }
-}
-
-/* Desktop nav; presence controlled by TSX via session */
-.nv-nav--desktop {
+/* desktop nav (auth only) */
+.nv-desktop-only {
   display: none;
+  margin-left: 12px;
 }
 @media (min-width: 1024px) {
-  .nv-nav--desktop {
-    display: inline-flex;
-    gap: 1rem;
-    align-items: center;
+  .nv-desktop-only {
+    display: block;
   }
-  .nv-menu-btn { display: none; }   /* hide hamburger on large screens */
+  .nv-nav-links a {
+    margin-right: 18px;
+    font-weight: 600;
+    color: #2d5bf5;
+    text-decoration: none;
+  }
+  .nv-nav-links a:hover {
+    text-decoration: underline;
+  }
 }
 
-/* Hamburger */
-.nv-menu-btn {
-  appearance: none;
-  border: 0;
+/* hamburger */
+.nv-hamburger {
+  margin-left: auto;
+  width: 36px;
+  height: 28px;
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: space-between;
   background: transparent;
-  padding: 0.25rem 0.5rem;
+  border: 0;
+  padding: 2px;
+  cursor: pointer;
 }
-.nv-menu-btn__lines {
-  display: inline-block;
-  width: 22px;
-  height: 16px;
-  background:
-    linear-gradient(currentColor 2px, transparent 0) 0 0/100% 2px,
-    linear-gradient(currentColor 2px, transparent 0) 0 50%/100% 2px,
-    linear-gradient(currentColor 2px, transparent 0) 0 100%/100% 2px;
-  background-repeat: no-repeat;
-  color: var(--brand-600);
+.nv-hamburger span {
+  height: 3px;
+  border-radius: 2px;
+  background: #2d5bf5;
+  display: block;
+}
+
+/* overlay */
+.nv-menu-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;               /* always on top */
+  background: rgba(0, 0, 0, 0.35); /* backdrop */
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 16px;
+}
+.nv-menu-panel {
+  width: min(560px, 92vw);
+  margin-top: 12px;
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+  padding: 24px 20px 28px;
+}
+.nv-menu-panel .nv-nav-links {
+  display: grid;
+  gap: 14px;
+  text-align: center;
+}
+.nv-menu-panel .nv-nav-links a {
+  font-size: 20px;
+  font-weight: 800;
+  color: #2d5bf5;
+  text-decoration: none;
+}
+.nv-menu-panel .nv-nav-links a:hover {
+  text-decoration: underline;
+}
+
+/* close button */
+.nv-close {
+  position: absolute;
+  top: 10px;
+  right: 14px;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  border: 0;
+  background: #eef3ff;
+  color: #2d5bf5;
+  font-size: 22px;
+  cursor: pointer;
+}
+
+/* hide hamburger on wide screens where desktop nav shows */
+@media (min-width: 1024px) {
+  .nv-hamburger {
+    display: none;
+  }
 }
 


### PR DESCRIPTION
## Summary
- replace header component with brand icon and auth-gated nav
- streamline header styles and add mobile menu overlay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "wouter"; `npm install` returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b55131fc5c832993c0431b37ad689c