### PR TITLE
Normalize header & navigation across breakpoints (fix mobile overlay, desktop links, colors)

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,102 +1,158 @@
-import { useState } from "react";
-import { Link } from "wouter"; // Make sure step 3 is done
-import { useSession } from "@/lib/session"; // whatever you already use
-import CartButton from "@/components/CartButton";
+import { useState, useEffect, useRef } from "react";
+import { Link } from "wouter"; // already in repo
+import { useSession } from "../lib/session"; // or your existing hook
+import CartButton from "./CartButton"; // existing
+import cn from "../utils/cn";
+
+const NAV_LINKS = [
+  { href: "/worlds", label: "Worlds" },
+  { href: "/zones", label: "Zones" },
+  { href: "/marketplace", label: "Marketplace" },
+  { href: "/wishlist", label: "Wishlist" },
+  { href: "/naturversity", label: "Naturversity" },
+  { href: "/naturbank", label: "NaturBank" },
+  { href: "/navatar", label: "Navatar" },
+  { href: "/passport", label: "Passport" },
+  { href: "/turian", label: "Turian" },
+];
 
 export default function SiteHeader() {
-  const { user } = useSession();
-  const isAuthed = !!user;
+  const { user } = useSession(); // truthy when authed
   const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // lock body scroll when menu is open
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  // close on outside click
+  useEffect(() => {
+    function onDown(e: MouseEvent) {
+      if (!open) return;
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    window.addEventListener("mousedown", onDown);
+    return () => window.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  // close on Escape
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const Brand = (
+    <Link href="/" aria-label="The Naturverse home" className="flex items-center gap-2">
+      <span className="text-xl md:text-2xl leading-none">🧚‍♂️</span>
+      <span className="font-extrabold text-blue-600 md:text-xl">The Naturverse</span>
+    </Link>
+  );
 
   return (
-    <header className="sticky top-0 z-40 bg-white/75 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+    <header className="sticky top-0 z-40 bg-white/80 backdrop-blur border-b border-slate-200">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex h-14 items-center justify-between gap-3">
-          {/* Brand */}
-          <Link href="/" className="flex items-center gap-2 shrink-0">
-            <img
-              src="/favicon-32x32.png"
-              alt=""
-              className="h-6 w-6 rounded"
-              loading="eager"
-            />
-            <span className="text-blue-600 font-extrabold tracking-tight">
-              The Naturverse
-            </span>
-          </Link>
+        {/* Row */}
+        <div className="flex h-14 md:h-16 items-center justify-between">
+          {/* Left: Brand */}
+          <div className="flex min-w-0 items-center shrink-0">{Brand}</div>
 
-          {/* Desktop nav (ONLY when authed) */}
-          {isAuthed && (
-            <nav className="hidden lg:flex items-center gap-6 text-[15px]">
-              <Link href="/worlds" className="hover:opacity-80">Worlds</Link>
-              <Link href="/zones" className="hover:opacity-80">Zones</Link>
-              <Link href="/marketplace" className="hover:opacity-80">Marketplace</Link>
-              <Link href="/wishlist" className="hover:opacity-80">Wishlist</Link>
-              <Link href="/naturversity" className="hover:opacity-80">Naturversity</Link>
-              <Link href="/naturbank" className="hover:opacity-80">NaturBank</Link>
-              <Link href="/navatar" className="hover:opacity-80">Navatar</Link>
-              <Link href="/passport" className="hover:opacity-80">Passport</Link>
-              <Link href="/turian" className="hover:opacity-80">Turian</Link>
+          {/* Desktop nav (auth only) */}
+          {user ? (
+            <nav className="hidden lg:flex items-center gap-6 text-sm font-medium">
+              {NAV_LINKS.map((l) => (
+                <Link
+                  key={l.href}
+                  href={l.href}
+                  className="text-blue-600 hover:text-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300 rounded"
+                >
+                  {l.label}
+                </Link>
+              ))}
             </nav>
+          ) : (
+            <div className="hidden lg:block" />
           )}
 
-          {/* Actions */}
+          {/* Right: actions */}
           <div className="flex items-center gap-2">
-            <CartButton />
-
-            {/* Hamburger (mobile / tablet only) */}
+            <CartButton className="focus:outline-none focus:ring-0" />
+            {/* Hamburger (mobile only) */}
             <button
               type="button"
-              aria-label="Open menu"
-              aria-controls="mobile-menu"
+              aria-label={open ? "Close menu" : "Open menu"}
               aria-expanded={open}
-              onClick={() => setOpen(true)}
-              className="inline-flex lg:hidden items-center justify-center h-10 w-10 rounded-md ring-1 ring-black/10"
+              aria-controls="mobile-menu"
+              onClick={() => setOpen((v) => !v)}
+              className="inline-flex lg:hidden items-center justify-center w-11 h-10 rounded-md border border-slate-300 text-blue-600 hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
             >
-              <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M4 7h16M4 12h16M4 17h16" />
-              </svg>
+              {/* cracked hamburger look */}
+              <span className="relative block w-5 h-0.5 bg-blue-600 before:absolute before:inset-x-0 before:-top-2 before:h-0.5 before:bg-blue-600 after:absolute after:inset-x-0 after:top-2 after:h-0.5 after:bg-blue-600" />
             </button>
           </div>
         </div>
       </div>
 
-      {/* Mobile menu overlay */}
-      {open && (
-        <div className="fixed inset-0 z-50" id="mobile-menu">
-          <div
-            className="absolute inset-0 bg-black/30"
-            onClick={() => setOpen(false)}
-            aria-hidden="true"
-          />
-          <div className="absolute inset-x-3 top-3 rounded-2xl bg-white shadow-xl ring-1 ring-black/10">
-            <div className="flex items-center justify-between px-4 py-3">
-              <span className="text-blue-600 font-extrabold">The Naturverse</span>
-              <button
-                aria-label="Close menu"
-                onClick={() => setOpen(false)}
-                className="h-10 w-10 inline-flex items-center justify-center rounded-md ring-1 ring-black/10"
-              >
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth="2">
-                  <path d="M6 6l12 12M18 6l-12 12" />
-                </svg>
-              </button>
-            </div>
-
-            <nav className="px-6 pb-6 pt-2 grid gap-4 text-lg">
-              <Link href="/worlds" onClick={() => setOpen(false)}>Worlds</Link>
-              <Link href="/zones" onClick={() => setOpen(false)}>Zones</Link>
-              <Link href="/marketplace" onClick={() => setOpen(false)}>Marketplace</Link>
-              <Link href="/wishlist" onClick={() => setOpen(false)}>Wishlist</Link>
-              <Link href="/naturversity" onClick={() => setOpen(false)}>Naturversity</Link>
-              <Link href="/naturbank" onClick={() => setOpen(false)}>NaturBank</Link>
-              <Link href="/navatar" onClick={() => setOpen(false)}>Navatar</Link>
-              <Link href="/passport" onClick={() => setOpen(false)}>Passport</Link>
-              <Link href="/turian" onClick={() => setOpen(false)}>Turian</Link>
-            </nav>
+      {/* Mobile overlay menu */}
+      <div
+        className={cn(
+          "lg:hidden fixed inset-0 z-50",
+          open ? "pointer-events-auto" : "pointer-events-none"
+        )}
+        aria-hidden={!open}
+      >
+        {/* Backdrop */}
+        <div
+          className={cn(
+            "absolute inset-0 bg-slate-900/40 transition-opacity",
+            open ? "opacity-100" : "opacity-0"
+          )}
+          onClick={() => setOpen(false)}
+        />
+        {/* Panel */}
+        <div
+          id="mobile-menu"
+          ref={panelRef}
+          className={cn(
+            "absolute left-0 right-0 top-0 mx-4 mt-4 rounded-2xl bg-white shadow-xl overflow-hidden border border-slate-200",
+            "transition-transform duration-200 ease-out",
+            open ? "translate-y-0" : "-translate-y-6"
+          )}
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200">
+            {Brand}
+            <button
+              className="p-2 rounded-md text-blue-600 hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
+              onClick={() => setOpen(false)}
+              aria-label="Close menu"
+            >
+              ✕
+            </button>
           </div>
+          <nav className="px-6 py-4 grid gap-4 text-lg font-semibold">
+            {NAV_LINKS.map((l) => (
+              <Link
+                key={l.href}
+                href={l.href}
+                onClick={() => setOpen(false)}
+                className="text-blue-600 hover:text-blue-700"
+              >
+                {l.label}
+              </Link>
+            ))}
+          </nav>
         </div>
-      )}
+      </div>
     </header>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -324,3 +324,11 @@ footer img {
   height: 28px !important;
   width: auto !important;
 }
+
+/* Prevent default blue focus ring box around cart and icons; keep a11y ring where we add it */
+button:focus { outline: none; }
+a:focus { outline: none; }
+
+/* Ensure the hero/heading doesn’t get unexpected link styles from header spillover */
+.hero a { text-decoration: none; }
+


### PR DESCRIPTION
## Summary
- Revamp `SiteHeader` with unified branding, desktop auth-only navigation, and mobile hamburger/overlay menu using the site's blue palette
- Add global CSS tweaks to suppress default focus outlines and avoid hero link styling conflicts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup could not resolve import "wouter")*


------
https://chatgpt.com/codex/tasks/task_e_68b56bc3ef3c8329984d8a8abe86ad82