### PR TITLE
Show desktop nav when signed in (remove ready gate + fix CSS)

### DIFF
--- a/src/components/NavBar.module.css
+++ b/src/components/NavBar.module.css
@@ -2,11 +2,10 @@
 .inner { display: flex; align-items: center; gap: 12px; padding: 10px 0; }
 .brand { font-weight: 800; font-size: 20px; text-decoration: none; color: #1f4fd8; }
 
-.links { display: none; gap: 14px; margin-left: 8px; }
+.links { display: none; }
 .links a { text-decoration: none; color: #2d2d2d; }
-@media (min-width: 900px) { .links { display: flex; } }
 
-.right { margin-left: auto; display: flex; align-items: center; gap: 10px; }
+.right { display: none; }
 
 /* Cart & profile share exact rules across breakpoints */
 .cartBtn { display: grid; place-items: center; width: 28px; height: 28px; font-size: 18px; text-decoration: none; }
@@ -22,4 +21,22 @@
 
 .mobileProfile { display: flex; align-items: center; gap: 10px; padding-bottom: 8px; border-bottom: 1px solid #eef2ff; }
 .mobileEmoji { width: 28px; height: 28px; display: grid; place-items: center; border-radius: 50%; background: #e6f0ff; }
+
+@media (min-width: 1024px) {
+  .links {
+    display: flex;
+    gap: 1.25rem;
+    align-items: center;
+  }
+  .right {
+    display: flex;
+    gap: 0.75rem;
+    margin-left: auto;
+    align-items: center;
+  }
+}
+
+@media (min-width: 1024px) {
+  .mobile { display: none; }
+}
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -9,7 +9,7 @@ import SearchBar from './SearchBar';
 import CartButton from './CartButton';
 
 export default function NavBar() {
-  const { ready, user } = useAuth();
+  const { user } = useAuth();
   const [open, setOpen] = useState(false);
   const emoji = (user?.user_metadata?.navemoji as string) ?? '🧑';
 
@@ -38,49 +38,48 @@ export default function NavBar() {
             <span className="nv-brand text-nv-blue">The Naturverse</span>
           </a>
 
-        <nav className={`${styles.links} nv-nav__links`} aria-label="Primary">
-          <NavLink to="/worlds">Worlds</NavLink>
-          <NavLink to="/zones">Zones</NavLink>
-          <NavLink to="/marketplace">Marketplace</NavLink>
-          <NavLink to="/wishlist">Wishlist</NavLink>
-          <NavLink to="/naturversity">Naturversity</NavLink>
-          <NavLink to="/naturbank">NaturBank</NavLink>
-          <NavLink to="/navatar">Navatar</NavLink>
-          <NavLink to="/create/navatar">Create Navatar</NavLink>
-          <NavLink to="/passport">Passport</NavLink>
-          <NavLink to="/orders">Orders</NavLink>
-          <NavLink to="/turian">Turian</NavLink>
-        </nav>
+        {user && (
+          <nav className={`${styles.links} nv-desktop-nav`} aria-label="Primary">
+            <NavLink to="/worlds">Worlds</NavLink>
+            <NavLink to="/zones">Zones</NavLink>
+            <NavLink to="/marketplace">Marketplace</NavLink>
+            <NavLink to="/wishlist">Wishlist</NavLink>
+            <NavLink to="/naturversity">Naturversity</NavLink>
+            <NavLink to="/naturbank">NaturBank</NavLink>
+            <NavLink to="/navatar">Navatar</NavLink>
+            <NavLink to="/create/navatar">Create</NavLink>
+            <NavLink to="/passport">Passport</NavLink>
+            <NavLink to="/turian">Turian</NavLink>
+          </nav>
+        )}
 
         <div style={{ marginLeft: "auto", minWidth: 280 }}>
           <SearchBar />
         </div>
-        <div className={styles.right} key={user?.id ?? 'anon'}>
-          {ready && user && (
-            <>
-              <CartButton className={styles.cartBtn} />
-              <NavLink to="/profile" aria-label="Profile" className={styles.profileBtn}>
-                {emoji}
-              </NavLink>
-            </>
-          )}
+        {user && (
+          <div className={styles.right} key={user?.id ?? 'anon'}>
+            <CartButton className={styles.cartBtn} />
+            <NavLink to="/profile" aria-label="Profile" className={styles.profileBtn}>
+              {emoji}
+            </NavLink>
+          </div>
+        )}
 
-          {/* Mobile hamburger (no blue background) */}
-          <button
-            className="nv-hamburger nav-toggle"
-            aria-label="Open menu"
-            onClick={() => setOpen(true)}
-          >
-            <span className="bar" />
-            <span className="bar" />
-            <span className="bar" />
-          </button>
-        </div>
+        {/* Mobile hamburger (no blue background) */}
+        <button
+          className="nv-hamburger nav-toggle"
+          aria-label="Open menu"
+          onClick={() => setOpen(true)}
+        >
+          <span className="bar" />
+          <span className="bar" />
+          <span className="bar" />
+        </button>
       </div>
 
       <div className={`${styles.mobile} ${open ? styles.open : ''}`} onClick={() => setOpen(false)}>
         <div className={styles.sheet} onClick={(e) => e.stopPropagation()}>
-          {ready && user && (
+          {user && (
             <NavLink to="/profile" className={styles.mobileProfile}>
               <span className={styles.mobileEmoji}>{emoji}</span>
               <span>Profile</span>
@@ -93,9 +92,8 @@ export default function NavBar() {
           <NavLink to="/naturversity">Naturversity</NavLink>
           <NavLink to="/naturbank">NaturBank</NavLink>
           <NavLink to="/navatar">Navatar</NavLink>
-          <NavLink to="/create/navatar">Create Navatar</NavLink>
+          <NavLink to="/create/navatar">Create</NavLink>
           <NavLink to="/passport">Passport</NavLink>
-          <NavLink to="/orders">Orders</NavLink>
           <NavLink to="/turian">Turian</NavLink>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- render desktop links and cart/profile only for authenticated users
- update nav links (rename create navatar to create) and drop orders link
- show desktop nav at ≥1024px and hide mobile overlay on larger screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5c2fb492483299660bea7819252bc