### PR TITLE
Restore cart & profile in header and fix desktop nav link color

### DIFF
--- a/src/components/SiteHeader.css
+++ b/src/components/SiteHeader.css
@@ -8,12 +8,9 @@
 }
 
 .nv-header-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 12px 20px;
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 1rem;
 }
 
 /* brand */
@@ -31,29 +28,42 @@
 }
 
 .nv-brand-name {
-  font-weight: 800;
+  color: var(--nv-brand, #2563eb);
+  font-weight: 700;
   font-size: 20px;
-  color: #2563eb; /* current brand blue used in headings */
 }
 
 /* desktop nav */
 .nv-desktop-nav {
-  margin-left: 8px;
+  margin-left: 1.5rem;
   display: none; /* hidden by default; enabled at desktop */
-  gap: 22px;
+  gap: 1rem;
+  flex: 1 1 auto;
 }
 
 .nv-desktop-nav a {
   font-size: 15px;
-  font-weight: 600;
-  color: #1f2937;
+  font-weight: 500;
+  color: var(--nv-link, #2563eb);
   text-decoration: none;
 }
 
 .nv-desktop-nav a:hover,
 .nv-desktop-nav a:focus-visible {
-  color: #2563eb;
   text-decoration: underline;
+}
+
+.nv-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: auto;
+}
+
+.nv-profile-link .nv-emoji {
+  font-size: 1.25rem;
+  display: inline-block;
+  line-height: 1;
 }
 
 /* mobile actions (cart/hamburger) */

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -3,14 +3,16 @@
 import React from 'react';
 import './SiteHeader.css';
 import { useAuth } from '@/lib/auth-context';
+import CartButton from './CartButton';
 
 export default function SiteHeader() {
   const { ready, user } = useAuth();
   const isAuthenticated = ready && !!user;
+  const emoji = user?.user_metadata?.navemoji;
 
   return (
     <header className="nv-site-header" role="banner">
-      <div className="nv-header-inner">
+      <div className="nv-header-inner container">
         <a className="nv-brand" href="/">
           {/* Use PNG to avoid CSS fill/fill-rule issues */}
           <img className="nv-brand-icon" src="/favicon-64x64.png" alt="" />
@@ -32,7 +34,17 @@ export default function SiteHeader() {
           </nav>
         )}
 
-        {/* Mobile-only actions kept here, styles already hide on desktop */}
+        {/* Right side actions (cart + profile) */}
+        {isAuthenticated && (
+          <div className="nv-right">
+            <CartButton className="nv-cart-btn" aria-label="Open cart" />
+            <a href="/profile" className="nv-profile-link" aria-label="Open profile">
+              <span className="nv-emoji">{emoji ?? '🙂'}</span>
+            </a>
+          </div>
+        )}
+
+        {/* Mobile-only actions remain as-is (hidden on desktop via CSS) */}
         <div className="nv-mobile-actions">
           <button className="nv-icon-btn" aria-label="Open cart" data-cart>
             <span className="nv-sr">Open cart</span>


### PR DESCRIPTION
## Summary
- restore CartButton and profile link on the right side of the site header for authenticated users
- style desktop nav links with explicit blue color and tweak header layout spacing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5c935dbc88329b91463967c24bc94