### PR TITLE
Refactor header nav for authenticated users

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,107 +1,18 @@
-'use client';
-
-import { NavLink } from 'react-router-dom';
-import { useState } from 'react';
 import styles from './NavBar.module.css';
 import './NavBar.css';
-import { useAuth } from '@/lib/auth-context';
-import SearchBar from './SearchBar';
-import CartButton from './CartButton';
-import CartDrawer from './CartDrawer';
 
 export default function NavBar() {
-  const { ready, user } = useAuth();
-  const [open, setOpen] = useState(false);
-  const [cartOpen, setCartOpen] = useState(false);
-  const emoji = (user?.user_metadata?.navemoji as string) ?? '🧑';
-
   return (
-    <header className={`${styles.header} nv-nav`}>
-      <div className={`container ${styles.inner}`}>
-        {/* Left brand (logo + wordmark) */}
-          <a
-            href="/"
-            className="flex items-center gap-2"
-            aria-label="The Naturverse home"
-          >
-            <picture>
-              <source srcSet="/favicon.svg" type="image/svg+xml" />
-              <img
-                src="/favicon-64x64.png"
-                alt=""
-                className="nv-logo"
-                width={40}
-                height={40}
-                loading="eager"
-                decoding="async"
-              />
-            </picture>
-
-            <span className="nv-brand text-nv-blue">The Naturverse</span>
-          </a>
-
-        <nav className={`${styles.links} nv-nav__links`} aria-label="Primary">
-          <NavLink to="/worlds">Worlds</NavLink>
-          <NavLink to="/zones">Zones</NavLink>
-          <NavLink to="/marketplace">Marketplace</NavLink>
-          <NavLink to="/wishlist">Wishlist</NavLink>
-          <NavLink to="/naturversity">Naturversity</NavLink>
-          <NavLink to="/naturbank">NaturBank</NavLink>
-          <NavLink to="/navatar">Navatar</NavLink>
-          <NavLink to="/create/navatar">Create Navatar</NavLink>
-          <NavLink to="/passport">Passport</NavLink>
-          <NavLink to="/orders">Orders</NavLink>
-          <NavLink to="/turian">Turian</NavLink>
-        </nav>
-
-        <div style={{ marginLeft: "auto", minWidth: 280 }}>
-          <SearchBar />
-        </div>
-        <div className={styles.right} key={user?.id ?? 'anon'}>
-          {ready && user && (
-            <>
-              <CartButton onClick={() => setCartOpen(true)} />
-              <NavLink to="/profile" aria-label="Profile" className={styles.profileBtn}>
-                {emoji}
-              </NavLink>
-            </>
-          )}
-
-          {/* Mobile hamburger (no blue background) */}
-          <button
-            className="nv-hamburger nav-toggle"
-            aria-label="Open menu"
-            onClick={() => setOpen(true)}
-          >
-            <span className="bar" />
-            <span className="bar" />
-            <span className="bar" />
-          </button>
-        </div>
-      </div>
-
-      <div className={`${styles.mobile} ${open ? styles.open : ''}`} onClick={() => setOpen(false)}>
-        <div className={styles.sheet} onClick={(e) => e.stopPropagation()}>
-          {ready && user && (
-            <NavLink to="/profile" className={styles.mobileProfile}>
-              <span className={styles.mobileEmoji}>{emoji}</span>
-              <span>Profile</span>
-            </NavLink>
-          )}
-          <NavLink to="/worlds">Worlds</NavLink>
-          <NavLink to="/zones">Zones</NavLink>
-          <NavLink to="/marketplace">Marketplace</NavLink>
-          <NavLink to="/wishlist">Wishlist</NavLink>
-          <NavLink to="/naturversity">Naturversity</NavLink>
-          <NavLink to="/naturbank">NaturBank</NavLink>
-          <NavLink to="/navatar">Navatar</NavLink>
-          <NavLink to="/create/navatar">Create Navatar</NavLink>
-          <NavLink to="/passport">Passport</NavLink>
-          <NavLink to="/orders">Orders</NavLink>
-          <NavLink to="/turian">Turian</NavLink>
-        </div>
-      </div>
-    </header>
-    <CartDrawer open={cartOpen} onClose={() => setCartOpen(false)} />
+    <nav className={`${styles.links} nv-desktop-nav`} aria-label="Primary">
+      <a href="/worlds">Worlds</a>
+      <a href="/zones">Zones</a>
+      <a href="/marketplace">Marketplace</a>
+      <a href="/wishlist">Wishlist</a>
+      <a href="/naturversity">Naturversity</a>
+      <a href="/naturbank">NaturBank</a>
+      <a href="/navatar">Navatar</a>
+      <a href="/passport">Passport</a>
+      <a href="/turian">Turian</a>
+    </nav>
   );
 }

--- a/src/components/SiteHeader.css
+++ b/src/components/SiteHeader.css
@@ -1,166 +1,81 @@
-/* layout */
-.nv-site-header {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  background: #ffffff;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
-}
+/* Breakpoints */
+.lg-hidden { display: inline-flex; }
+@media (min-width: 1024px) { .lg-hidden { display: none; } }
 
-.nv-header-inner {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
+.nv-site-header { position: sticky; top: 0; z-index: 50; background: #fff; }
+.nv-header-inner { display:flex; align-items:center; gap:12px; padding:12px 16px; }
+.nv-brand { display:flex; align-items:center; gap:10px; text-decoration:none; }
+.nv-brand-icon { width:40px; height:40px; }
+.nv-brand-name { font-weight:800; color:#2563eb; }
 
-/* brand */
-.nv-brand {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  text-decoration: none;
-}
+.nv-actions { margin-left:auto; display:flex; align-items:center; gap:10px; }
 
-.nv-brand-icon {
-  width: 40px;
-  height: 40px;
-  filter: none; /* keep icon green (no tinting) */
-}
+/* Desktop nav hidden on mobile */
+.nv-desktop-nav { display:none; gap:16px; margin-left:24px; }
+@media (min-width:1024px) { .nv-desktop-nav { display:flex; } }
 
-.nv-brand-name {
-  color: var(--nv-brand, #2563eb);
-  font-weight: 800;
-  font-size: 1.25rem;
-  line-height: 1;
-}
-
-/* desktop nav */
-.nv-desktop-nav {
-  margin-left: 1.5rem;
-  display: none; /* hidden by default; enabled at desktop */
-  gap: 1rem;
-  flex: 1 1 auto;
-}
-
-.nv-desktop-nav a {
-  font-size: 15px;
-  font-weight: 500;
-  color: var(--nv-link, #2563eb);
-  text-decoration: none;
-}
-
-.nv-desktop-nav a:hover,
-.nv-desktop-nav a:focus-visible {
-  text-decoration: underline;
-}
-
-.nv-right {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-left: auto;
-}
-
-/* mobile actions (cart/hamburger) */
-.nv-mobile-actions {
-  margin-left: auto;
-  display: flex;
-  gap: 10px;
-}
-
-/* Icon button reset (no blue pill) */
+/* Icon button reset */
 .nv-icon-btn {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border: 0;
-  background: transparent;
-  padding: 0;
-  border-radius: 8px;
-  cursor: pointer;
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:36px;
+  height:36px;
+  border:0;
+  background:transparent;
+  padding:0;
+  border-radius:8px;
+  cursor:pointer;
 }
-.nv-icon-btn:focus-visible {
-  outline: 2px solid var(--nv-focus, #2563eb);
-  outline-offset: 2px;
+.nv-icon-btn:focus-visible { outline:2px solid var(--nv-focus,#2563eb); outline-offset:2px; }
+
+/* Hamburger bars */
+.nv-hamburger .bar {
+  display:block; width:20px; height:2px; margin:4px 0; background:#2563eb; border-radius:2px;
 }
 
-/* Cart tweaks */
-.nv-cart span[aria-hidden] {
-  font-size: 20px;
-  line-height: 1;
-}
-
-/* Small count badge (only rendered when > 0) */
+/* Cart */
+.nv-cart span[aria-hidden] { font-size:20px; line-height:1; }
 .nv-cart-badge {
-  position: absolute;
-  top: -4px;
-  right: -6px;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 4px;
-  border-radius: 999px;
-  background: var(--nv-badge, #2563eb);
-  color: #fff;
-  font-size: 12px;
-  font-weight: 700;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  position:absolute; top:-4px; right:-6px; min-width:18px; height:18px; padding:0 4px;
+  border-radius:999px; background:#2563eb; color:#fff; font-size:12px; font-weight:700;
+  display:flex; align-items:center; justify-content:center;
 }
 
-/* Avatar */
-.nv-avatar {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 999px;
-  overflow: hidden;
-  background: var(--nv-avatar-bg, #e5e7eb);
-  text-decoration: none;
+/* Mobile menu overlay */
+.nv-mobile-menu { position:fixed; inset:0; display:none; background:rgba(0,0,0,.4); }
+.nv-mobile-menu.open { display:block; }
+.nv-mobile-menu .sheet {
+  position:absolute;
+  right:0;
+  top:0;
+  bottom:0;
+  width:80%;
+  max-width:360px;
+  background:#fff;
+  padding:16px;
+  overflow-y:auto;
+  box-shadow:-4px 0 16px rgba(0,0,0,.15);
+  border-top-left-radius:12px;
+  border-bottom-left-radius:12px;
 }
-.nv-avatar img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-.nv-avatar-initial {
-  font-weight: 800;
-  font-size: 14px;
-  color: #111827;
-}
+.nv-mobile-menu nav a { display:block; padding:12px 4px; font-weight:600; color:#2563eb; text-decoration:none; }
 
-/* responsive rules */
-@media (min-width: 1024px) {
-  .nv-desktop-nav {
-    display: inline-flex;
-  }
-  .nv-mobile-actions {
-    display: none;
-  } /* hide mobile UI on desktop */
-  .nv-brand-icon {
-    width: 48px;
-    height: 48px;
-  }
-  .nv-brand-name {
-    font-size: 1.5rem;
-  }
-}
+/* Avatar size (mobile & desktop) */
+.nv-avatar { display:inline-flex; width:36px; height:36px; border-radius:9999px; overflow:hidden; }
+.nv-avatar img { width:100%; height:100%; object-fit:cover; }
+.nv-avatar-initial { font-weight:800; font-size:14px; color:#111827; }
 
-/* screen-reader only utility */
+/* Screen-reader only utility */
 .nv-sr {
-  position: absolute !important;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+  position:absolute!important;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  white-space:nowrap;
+  border:0;
 }

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import './SiteHeader.css';
 import { useAuth } from '@/lib/auth-context';
 import CartButton from './CartButton';
@@ -8,21 +8,22 @@ import UserAvatar from './UserAvatar';
 import CartDrawer from './CartDrawer';
 
 export default function SiteHeader() {
-  const { ready, user } = useAuth();
-  const isAuthenticated = ready && !!user;
+  const { user } = useAuth();
+  const isAuthenticated = !!user;
+  const [menuOpen, setMenuOpen] = useState(false);
   const [cartOpen, setCartOpen] = useState(false);
 
   return (
     <>
       <header className="nv-site-header" role="banner">
-        <div className="nv-header-inner container">
-          <a className="nv-brand" href="/">
-            {/* Use PNG to avoid CSS fill/fill-rule issues */}
+        <div className="nv-header-inner">
+          {/* Brand */}
+          <a className="nv-brand" href="/" aria-label="The Naturverse">
             <img className="nv-brand-icon" src="/favicon-64x64.png" alt="" />
             <span className="nv-brand-name">The Naturverse</span>
           </a>
 
-          {/* Desktop navigation — auth only */}
+          {/* Desktop nav (auth only) */}
           {isAuthenticated && (
             <nav className="nv-desktop-nav" aria-label="Primary">
               <a href="/worlds">Worlds</a>
@@ -37,28 +38,67 @@ export default function SiteHeader() {
             </nav>
           )}
 
-          <div className="nv-right">
-            {/* Small icon button; badge only when > 0 */}
-            <CartButton onClick={() => setCartOpen(true)} />
-            {isAuthenticated && <UserAvatar />}
-          </div>
+          {/* Right side actions (mobile + desktop) */}
+          <div className="nv-actions">
+            {isAuthenticated && <CartButton onClick={() => setCartOpen(true)} />}
 
-          {/* Mobile-only actions remain as-is (hidden on desktop via CSS) */}
-          <div className="nv-mobile-actions">
+            {isAuthenticated && <UserAvatar />}
+
+            {/* Mobile hamburger (always visible, but only shows menu items if signed in) */}
             <button
-              className="nv-icon-btn"
-              aria-label="Open cart"
-              onClick={() => setCartOpen(true)}
+              type="button"
+              className="nv-icon-btn nv-hamburger lg-hidden"
+              aria-label="Open menu"
+              aria-expanded={menuOpen}
+              aria-controls="nv-mobile-menu"
+              onClick={() => setMenuOpen(true)}
             >
-              <span className="nv-sr">Open cart</span>
-            </button>
-            <button className="nv-icon-btn" aria-label="Open menu" data-menu>
-              <span className="nv-sr">Open menu</span>
-              {'≡'}
+              <span className="bar" />
+              <span className="bar" />
+              <span className="bar" />
             </button>
           </div>
         </div>
+
+        {/* Mobile overlay menu */}
+        <div
+          id="nv-mobile-menu"
+          className={`nv-mobile-menu ${menuOpen ? 'open' : ''}`}
+          role="dialog"
+          aria-modal="true"
+          onClick={() => setMenuOpen(false)}
+        >
+          <div className="sheet" onClick={(e) => e.stopPropagation()}>
+            <button
+              className="nv-icon-btn close"
+              aria-label="Close menu"
+              onClick={() => setMenuOpen(false)}
+            >
+              ×
+            </button>
+
+            {isAuthenticated ? (
+              <nav aria-label="Mobile">
+                <a href="/worlds">Worlds</a>
+                <a href="/zones">Zones</a>
+                <a href="/marketplace">Marketplace</a>
+                <a href="/wishlist">Wishlist</a>
+                <a href="/naturversity">Naturversity</a>
+                <a href="/naturbank">NaturBank</a>
+                <a href="/navatar">Navatar</a>
+                <a href="/passport">Passport</a>
+                <a href="/turian">Turian</a>
+              </nav>
+            ) : (
+              <div className="nv-mobile-loggedout">
+                <a className="cta" href="/login">Sign in</a>
+                <a className="cta secondary" href="/signup">Create account</a>
+              </div>
+            )}
+          </div>
+        </div>
       </header>
+
       <CartDrawer open={cartOpen} onClose={() => setCartOpen(false)} />
     </>
   );


### PR DESCRIPTION
## Summary
- show desktop nav, cart, and profile only when signed in
- use a single mobile hamburger that opens an overlay menu
- drop extra NavBar elements so desktop links only

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5deb281b08329891bcc8f084d8148