### PR TITLE
Auth-gated mobile header with accessible cart modal

### DIFF
--- a/src/components/CartButton.tsx
+++ b/src/components/CartButton.tsx
@@ -1,14 +1,23 @@
 import { useCart } from '@/lib/cart';
+import { useAuth } from '@/lib/auth-context';
 
-export default function CartButton({ onClick }: { onClick: () => void }) {
+export default function CartButton({
+  className = '',
+  onClick,
+}: {
+  className?: string;
+  onClick: () => void;
+}) {
   const { items } = useCart();
+  const { user, ready } = useAuth();
+  if (ready && !user) return null;
   const count = items?.length ?? 0;
 
   return (
     <button
       type="button"
       aria-label="Open cart"
-      className="nv-icon-btn nv-cart"
+      className={`${className} nv-cart`.trim()}
       onClick={onClick}
     >
       <span aria-hidden>🛒</span>

--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -48,11 +48,16 @@ export default function CartDrawer({ open, onClose }: { open: boolean; onClose: 
 
   if (!open) return null;
   return (
-    <div className="cart-drawer">
+    <div
+      className="cart-drawer"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="cart-title"
+    >
       <div className="backdrop" onClick={onClose} />
       <aside className="cart-panel cart-panel--in">
         <header className="cart__hd">
-          <h3>Your cart</h3>
+          <h2 id="cart-title">Your cart</h2>
           <div style={{ display: "flex", gap: 8 }}>
             <button className="link" onClick={shareCart}>
               Quick link
@@ -60,7 +65,7 @@ export default function CartDrawer({ open, onClose }: { open: boolean; onClose: 
             <button className="link" onClick={shareCartShort}>
               Save &amp; share
             </button>
-            <button onClick={onClose} aria-label="Close">
+            <button onClick={onClose} aria-label="Close cart">
               ✕
             </button>
           </div>

--- a/src/components/SiteHeader.css
+++ b/src/components/SiteHeader.css
@@ -8,7 +8,7 @@
 .nv-brand-icon { width:40px; height:40px; }
 .nv-brand-name { font-weight:800; color:#2563eb; }
 
-.nv-actions { margin-left:auto; display:flex; align-items:center; gap:10px; }
+.nv-actions { display:flex; gap:.5rem; margin-left:auto; }
 
 /* Desktop nav hidden on mobile */
 .nv-desktop-nav { display:none; gap:16px; margin-left:24px; }
@@ -17,23 +17,23 @@
 /* Icon button reset */
 .nv-icon-btn {
   position:relative;
+  width:44px;
+  height:44px;
+  border-radius:12px;
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  width:36px;
-  height:36px;
   border:0;
   background:transparent;
+  box-shadow:none;
   padding:0;
-  border-radius:8px;
   cursor:pointer;
 }
-.nv-icon-btn:focus-visible { outline:2px solid var(--nv-focus,#2563eb); outline-offset:2px; }
+.nv-icon-btn:focus-visible { outline:2px solid var(--nv-blue-500); outline-offset:2px; }
 
 /* Hamburger bars */
-.nv-hamburger .bar {
-  display:block; width:20px; height:2px; margin:4px 0; background:#2563eb; border-radius:2px;
-}
+.nv-hamburger .bar { display:block; width:18px; height:2px; border-radius:2px; background:var(--nv-blue-600); }
+.nv-hamburger .bar + .bar { margin-top:4px; }
 
 /* Cart */
 .nv-cart span[aria-hidden] { font-size:20px; line-height:1; }
@@ -62,10 +62,15 @@
 }
 .nv-mobile-menu nav a { display:block; padding:12px 4px; font-weight:600; color:#2563eb; text-decoration:none; }
 
-/* Avatar size (mobile & desktop) */
-.nv-avatar { display:inline-flex; width:36px; height:36px; border-radius:9999px; overflow:hidden; }
+/* hide pills that previously rendered empty */
+.nv-avatar { display:block; width:28px; height:28px; border-radius:999px; background: var(--nv-blue-100); overflow:hidden; }
 .nv-avatar img { width:100%; height:100%; object-fit:cover; }
-.nv-avatar-initial { font-weight:800; font-size:14px; color:#111827; }
+.nv-avatar-initial { font-weight:800; font-size:14px; color:#111827; display:flex; align-items:center; justify-content:center; }
+
+/* desktop hover keeps icon subtle (prevents big blue box) */
+@media (hover:hover) {
+  .nv-icon-btn:hover { background:rgba(0,0,0,0.04); box-shadow:none; }
+}
 
 /* Screen-reader only utility */
 .nv-sr {

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -38,25 +38,29 @@ export default function SiteHeader() {
             </nav>
           )}
 
-          {/* Right side actions (mobile + desktop) */}
+          {/* Right side actions — auth gated */}
           <div className="nv-actions">
-            {isAuthenticated && <CartButton onClick={() => setCartOpen(true)} />}
-
-            {isAuthenticated && <UserAvatar />}
-
-            {/* Mobile hamburger (always visible, but only shows menu items if signed in) */}
-            <button
-              type="button"
-              className="nv-icon-btn nv-hamburger lg-hidden"
-              aria-label="Open menu"
-              aria-expanded={menuOpen}
-              aria-controls="nv-mobile-menu"
-              onClick={() => setMenuOpen(true)}
-            >
-              <span className="bar" />
-              <span className="bar" />
-              <span className="bar" />
-            </button>
+            {isAuthenticated && (
+              <>
+                <CartButton
+                  className="nv-icon-btn"
+                  onClick={() => setCartOpen(true)}
+                />
+                <UserAvatar className="nv-icon-btn" />
+                <button
+                  type="button"
+                  className="nv-icon-btn nv-hamburger lg-hidden nav-toggle"
+                  aria-label="Open menu"
+                  aria-expanded={menuOpen}
+                  aria-controls="nv-mobile-menu"
+                  onClick={() => setMenuOpen(true)}
+                >
+                  <span className="bar" />
+                  <span className="bar" />
+                  <span className="bar" />
+                </button>
+              </>
+            )}
           </div>
         </div>
 

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from '@/lib/auth-context';
 
-export default function UserAvatar() {
+export default function UserAvatar({ className = '' }: { className?: string }) {
   const { user } = useAuth();
   if (!user) return null;
 
@@ -16,7 +16,11 @@ export default function UserAvatar() {
   const initial = name.trim().charAt(0).toUpperCase() || '•';
 
   return (
-    <a href="/profile" className="nv-avatar" aria-label="Profile">
+    <a
+      href="/profile"
+      className={`${className} nv-avatar`.trim()}
+      aria-label="Profile"
+    >
       {src ? (
         <img src={src} alt="" />
       ) : (


### PR DESCRIPTION
## Summary
- Hide cart, profile, and menu actions unless the user is authenticated
- Add auth awareness to `CartButton` and support custom classes
- Improve cart drawer accessibility with dialog semantics

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5e18a5ae4832983b8e8bd75949605