### PR TITLE
feat(nav+footer): polish nav, add footer links and contact stub

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -2,9 +2,11 @@ import React, { useEffect } from "react";
 import { useCart } from "@/lib/cart";
 import { getShareLink } from "@/lib/cartShare";
 import { PRODUCT_IMG } from "@/data/productImages";
+import { useAuth } from "@/lib/auth-context";
 
 export default function CartDrawer({ open, onClose }: { open: boolean; onClose: () => void }) {
   const { items, setQty, removeFromCart, clearCart, totalCents } = useCart();
+  const { user } = useAuth();
 
   // close on ESC
   useEffect(() => {
@@ -46,10 +48,10 @@ export default function CartDrawer({ open, onClose }: { open: boolean; onClose: 
     );
   }
 
-  if (!open) return null;
+  if (!open || !user) return null;
   return (
     <div
-      className="cart-drawer"
+      className="cart-drawer pointer-events-auto z-50"
       role="dialog"
       aria-modal="true"
       aria-labelledby="cart-title"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,52 +1,70 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { SOCIALS } from '@/lib/socials';
 
 export default function Footer() {
   const year = new Date().getFullYear();
 
   return (
-    <footer
-      role="contentinfo"
-      style={{
-        marginTop: '4rem',
-        padding: '1.25rem 0',
-        borderTop: '1px solid var(--border, #e5e7eb)',
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          gap: '1rem',
-          flexWrap: 'wrap',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-        }}
-      >
-        <div style={{ opacity: 0.9 }}>© {year} Turian Media Company</div>
-
-        <nav aria-label="Legal" style={{ display: 'flex', gap: '.75rem', flexWrap: 'wrap' }}>
-          <Link to="/terms" className="link">Terms</Link>
-          <span aria-hidden>·</span>
-          <Link to="/privacy" className="link">Privacy</Link>
-          <span aria-hidden>·</span>
-          <Link to="/contact" className="link">Contact</Link>
-        </nav>
-
-        <nav aria-label="Social media" style={{ display: 'flex', gap: '.75rem', flexWrap: 'wrap' }}>
-          {SOCIALS.map((s) => (
+    <footer role="contentinfo" className="border-t bg-neutral-50">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="space-y-2 text-sm text-neutral-600">
+            <p className="text-neutral-900 font-semibold">Naturverse</p>
+            <p>Where learning becomes adventure.</p>
+            <p>© {year} Turian Media Company</p>
+          </div>
+          <div className="space-y-2 text-sm text-neutral-600">
+            <p className="text-neutral-900 font-semibold">Company</p>
+            <Link to="/about" className="hover:text-neutral-900 transition-colors">
+              About
+            </Link>
+            <Link to="/contact" className="hover:text-neutral-900 transition-colors">
+              Contact
+            </Link>
             <a
-              key={s.name}
-              href={s.href}
+              href="mailto:turianmediacompany@gmail.com"
+              className="hover:text-neutral-900 transition-colors"
+            >
+              Email
+            </a>
+          </div>
+          <div className="space-y-2 text-sm text-neutral-600">
+            <p className="text-neutral-900 font-semibold">Legal</p>
+            <Link to="/privacy" className="hover:text-neutral-900 transition-colors">
+              Privacy Policy
+            </Link>
+            <Link to="/terms" className="hover:text-neutral-900 transition-colors">
+              Terms of Service
+            </Link>
+          </div>
+          <div className="space-y-2 text-sm text-neutral-600">
+            <p className="text-neutral-900 font-semibold">Follow</p>
+            <a
+              href="https://x.com/TuriantheDurian"
               target="_blank"
               rel="noopener noreferrer"
-              className="link"
-              aria-label={s.name}
+              className="hover:text-neutral-900 transition-colors"
             >
-              {s.name}
+              X
             </a>
-          ))}
-        </nav>
+            <a
+              href="https://instagram.com/turianthedurian"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-neutral-900 transition-colors"
+            >
+              Instagram
+            </a>
+            <a
+              href="https://facebook.com/TurianMediaCompany"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-neutral-900 transition-colors"
+            >
+              Facebook
+            </a>
+          </div>
+        </div>
       </div>
     </footer>
   );

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import CartButton from './CartButton';
+import UserAvatar from './UserAvatar';
+import { useAuth } from '@/lib/auth-context';
+
+export default function MobileNav({
+  open,
+  onClose,
+  onCartOpen,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCartOpen: () => void;
+}) {
+  const { user } = useAuth();
+
+  return (
+    <div
+      id="nv-mobile-menu"
+      className={`nv-mobile-menu ${open ? 'open' : ''}`}
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div className="sheet pointer-events-auto z-50" onClick={(e) => e.stopPropagation()}>
+        <button
+          className="nv-icon-btn close hover:opacity-80 transition-opacity"
+          aria-label="Close menu"
+          onClick={onClose}
+        >
+          ×
+        </button>
+
+        <nav
+          aria-label="Mobile"
+          className="flex flex-col gap-3 px-4 py-4 pb-[env(safe-area-inset-bottom)]"
+        >
+          <a href="/worlds" onClick={onClose} className="hover:opacity-80 transition-opacity">
+            Worlds
+          </a>
+          <a href="/zones" onClick={onClose} className="hover:opacity-80 transition-opacity">
+            Zones
+          </a>
+          <a href="/marketplace" onClick={onClose} className="hover:opacity-80 transition-opacity">
+            Marketplace
+          </a>
+          <a href="/wishlist" onClick={onClose} className="hover:opacity-80 transition-opacity">
+            Wishlist
+          </a>
+          <a href="/naturversity" onClick={onClose} className="hover:opacity-80 transition-opacity">
+            Naturversity
+          </a>
+          <a href="/naturbank" onClick={onClose} className="hover:opacity-80 transition-opacity">
+            NaturBank
+          </a>
+          <a href="/navatar" onClick={onClose} className="hover:opacity-80 transition-opacity">
+            Navatar
+          </a>
+          <a href="/passport" onClick={onClose} className="hover:opacity-80 transition-opacity">
+            Passport
+          </a>
+          <a href="/turian" onClick={onClose} className="hover:opacity-80 transition-opacity">
+            Turian
+          </a>
+
+          {user ? (
+            <div className="flex items-center gap-3 mt-4">
+              <CartButton
+                className="nv-icon-btn hover:opacity-80 transition-opacity"
+                onClick={() => {
+                  onCartOpen();
+                  onClose();
+                }}
+              />
+              <UserAvatar className="nv-icon-btn hover:opacity-80 transition-opacity" />
+            </div>
+          ) : null}
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SiteHeader.css
+++ b/src/components/SiteHeader.css
@@ -6,9 +6,9 @@
 .nv-header-inner { display:flex; align-items:center; gap:12px; padding:12px 16px; }
 .nv-brand { display:flex; align-items:center; gap:10px; text-decoration:none; }
 .nv-brand-icon { width:40px; height:40px; }
-.nv-brand-name { font-weight:800; color:#2563eb; }
+.nv-brand-name { font-weight:800; color:#3b82f6; }
 
-.nv-actions { display:flex; gap:.5rem; margin-left:auto; }
+.nv-actions { margin-left:auto; }
 
 /* Desktop nav hidden on mobile */
 .nv-desktop-nav { display:none; gap:16px; margin-left:24px; }
@@ -32,14 +32,14 @@
 .nv-icon-btn:focus-visible { outline:2px solid var(--nv-blue-500); outline-offset:2px; }
 
 /* Hamburger bars */
-.nv-hamburger .bar { display:block; width:18px; height:2px; border-radius:2px; background:var(--nv-blue-600); }
+.nv-hamburger .bar { display:block; width:18px; height:2px; border-radius:2px; background:var(--nv-blue-500); }
 .nv-hamburger .bar + .bar { margin-top:4px; }
 
 /* Cart */
 .nv-cart span[aria-hidden] { font-size:20px; line-height:1; }
 .nv-cart-badge {
   position:absolute; top:-4px; right:-6px; min-width:18px; height:18px; padding:0 4px;
-  border-radius:999px; background:#2563eb; color:#fff; font-size:12px; font-weight:700;
+  border-radius:999px; background:#3b82f6; color:#fff; font-size:12px; font-weight:700;
   display:flex; align-items:center; justify-content:center;
 }
 
@@ -60,7 +60,7 @@
   border-top-left-radius:12px;
   border-bottom-left-radius:12px;
 }
-.nv-mobile-menu nav a { display:block; padding:12px 4px; font-weight:600; color:#2563eb; text-decoration:none; }
+.nv-mobile-menu nav a { display:block; padding:12px 4px; font-weight:600; color:#3b82f6; text-decoration:none; }
 
 /* hide pills that previously rendered empty */
 .nv-avatar { display:block; width:28px; height:28px; border-radius:999px; background: var(--nv-blue-100); overflow:hidden; }

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -6,97 +6,105 @@ import { useAuth } from '@/lib/auth-context';
 import CartButton from './CartButton';
 import UserAvatar from './UserAvatar';
 import CartDrawer from './CartDrawer';
+import MobileNav from './MobileNav';
 
 export default function SiteHeader() {
-  const { user, ready } = useAuth();
-  if (!ready || !user) return null;
+  const { user } = useAuth();
+  const isAuthed = !!user;
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [cartOpen, setCartOpen] = useState(false);
 
   return (
     <>
-      <header className="nv-site-header" role="banner">
+      <header
+        className="nv-site-header sticky top-0 z-40 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b"
+        role="banner"
+      >
         <div className="nv-header-inner">
           {/* Brand */}
-          <a className="nv-brand" href="/" aria-label="The Naturverse">
+          <a
+            className="nv-brand shrink-0 hover:opacity-80 transition-opacity"
+            href="/"
+            aria-label="The Naturverse"
+          >
             <img className="nv-brand-icon" src="/favicon-64x64.png" alt="" />
             <span className="nv-brand-name">The Naturverse</span>
           </a>
 
-          {/* Desktop nav (auth only) */}
-          {
-            <nav className="nv-desktop-nav" aria-label="Primary">
-              <a href="/worlds">Worlds</a>
-              <a href="/zones">Zones</a>
-              <a href="/marketplace">Marketplace</a>
-              <a href="/wishlist">Wishlist</a>
-              <a href="/naturversity">Naturversity</a>
-              <a href="/naturbank">NaturBank</a>
-              <a href="/navatar">Navatar</a>
-              <a href="/passport">Passport</a>
-              <a href="/turian">Turian</a>
-            </nav>
-          }
+          {isAuthed ? (
+            <>
+              {/* Desktop nav */}
+              <nav className="nv-desktop-nav hidden md:flex items-center gap-6" aria-label="Primary">
+                <a href="/worlds" className="hover:opacity-80 transition-opacity">
+                  Worlds
+                </a>
+                <a href="/zones" className="hover:opacity-80 transition-opacity">
+                  Zones
+                </a>
+                <a href="/marketplace" className="hover:opacity-80 transition-opacity">
+                  Marketplace
+                </a>
+                <a href="/wishlist" className="hover:opacity-80 transition-opacity">
+                  Wishlist
+                </a>
+                <a href="/naturversity" className="hover:opacity-80 transition-opacity">
+                  Naturversity
+                </a>
+                <a href="/naturbank" className="hover:opacity-80 transition-opacity">
+                  NaturBank
+                </a>
+                <a href="/navatar" className="hover:opacity-80 transition-opacity">
+                  Navatar
+                </a>
+                <a href="/passport" className="hover:opacity-80 transition-opacity">
+                  Passport
+                </a>
+                <a href="/turian" className="hover:opacity-80 transition-opacity">
+                  Turian
+                </a>
+              </nav>
 
-          {/* Right side actions */}
-          <div className="nv-actions">
-            <CartButton
-              className="nv-icon-btn"
-              onClick={() => {
-                setCartOpen(true);
-                setMenuOpen(false);
-              }}
-            />
-            <UserAvatar className="nv-icon-btn" />
-            <button
-              type="button"
-              className="nv-icon-btn nv-hamburger lg-hidden nav-toggle"
-              aria-label="Open menu"
-              aria-expanded={menuOpen}
-              aria-controls="nv-mobile-menu"
-              onClick={() => setMenuOpen(true)}
-            >
-              <span className="bar" />
-              <span className="bar" />
-              <span className="bar" />
-            </button>
-          </div>
-        </div>
+              {/* Right side actions */}
+              <div className="nv-actions hidden md:flex items-center gap-3 md:gap-4">
+                <CartButton
+                  className="nv-icon-btn hover:opacity-80 transition-opacity"
+                  onClick={() => {
+                    setCartOpen(true);
+                    setMenuOpen(false);
+                  }}
+                />
+                <UserAvatar className="nv-icon-btn hover:opacity-80 transition-opacity" />
+              </div>
 
-        {/* Mobile overlay menu */}
-        <div
-          id="nv-mobile-menu"
-          className={`nv-mobile-menu ${menuOpen ? 'open' : ''}`}
-          role="dialog"
-          aria-modal="true"
-          onClick={() => setMenuOpen(false)}
-        >
-          <div className="sheet" onClick={(e) => e.stopPropagation()}>
-            <button
-              className="nv-icon-btn close"
-              aria-label="Close menu"
-              onClick={() => setMenuOpen(false)}
-            >
-              ×
-            </button>
-
-            <nav aria-label="Mobile">
-              <a href="/worlds">Worlds</a>
-              <a href="/zones">Zones</a>
-              <a href="/marketplace">Marketplace</a>
-              <a href="/wishlist">Wishlist</a>
-              <a href="/naturversity">Naturversity</a>
-              <a href="/naturbank">NaturBank</a>
-              <a href="/navatar">Navatar</a>
-              <a href="/passport">Passport</a>
-              <a href="/turian">Turian</a>
-            </nav>
-          </div>
+              {/* Mobile menu toggle */}
+              <button
+                type="button"
+                className="nv-icon-btn nv-hamburger md:hidden nav-toggle hover:opacity-80 transition-opacity"
+                aria-label="Open menu"
+                aria-expanded={menuOpen}
+                aria-controls="nv-mobile-menu"
+                onClick={() => setMenuOpen(true)}
+              >
+                <span className="bar" />
+                <span className="bar" />
+                <span className="bar" />
+              </button>
+            </>
+          ) : null}
         </div>
       </header>
 
-      <CartDrawer open={cartOpen} onClose={() => setCartOpen(false)} />
+      {isAuthed ? (
+        <>
+          <MobileNav
+            open={menuOpen}
+            onClose={() => setMenuOpen(false)}
+            onCartOpen={() => setCartOpen(true)}
+          />
+          <CartDrawer open={cartOpen} onClose={() => setCartOpen(false)} />
+        </>
+      ) : null}
     </>
   );
 }

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,140 +1,16 @@
 import React from "react";
 
-function encode(data: Record<string, string>) {
-  return Object.keys(data)
-    .map((k) => encodeURIComponent(k) + "=" + encodeURIComponent(data[k] ?? ""))
-    .join("&");
-}
-
 export default function Contact() {
-  const [state, setState] = React.useState<{ sending?: boolean; error?: string | null }>({});
-
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setState({ sending: true, error: null });
-
-    const form = e.currentTarget;
-    const formData = new FormData(form);
-    // Netlify needs the "form-name" field to match the hidden static form
-    formData.set("form-name", "contact");
-
-    try {
-      await fetch("/", {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: encode(Object.fromEntries(formData as any)),
-      });
-      // On success, route to success page
-      window.location.assign("/contact/success");
-    } catch (err: any) {
-      setState({ sending: false, error: err?.message || "Failed to send. Please try again." });
-    }
-  }
-
   return (
     <main style={{ maxWidth: 900, margin: "24px auto", padding: "0 20px" }}>
       <h1>Contact</h1>
-      <p>Have a question or idea for Naturverse? Send us a message.</p>
-
-      <form
-        name="contact"
-        method="POST"
-        data-netlify="true"
-        data-netlify-honeypot="bot-field"
-        action="/contact/success"
-        onSubmit={handleSubmit}
-        style={{ marginTop: 16, display: "grid", gap: 12, maxWidth: 640 }}
-      >
-        {/* Honeypot field for bots */}
-        <input type="hidden" name="form-name" value="contact" />
-        <div style={{ display: "none" }}>
-          <label>
-            Don’t fill this out: <input name="bot-field" />
-          </label>
-        </div>
-
-        <label style={{ display: "grid", gap: 6 }}>
-          <span>Name</span>
-          <input
-            name="name"
-            type="text"
-            required
-            placeholder="Your name"
-            autoComplete="name"
-            style={input}
-          />
-        </label>
-
-        <label style={{ display: "grid", gap: 6 }}>
-          <span>Email</span>
-          <input
-            name="email"
-            type="email"
-            required
-            placeholder="you@example.com"
-            autoComplete="email"
-            style={input}
-          />
-        </label>
-
-        <label style={{ display: "grid", gap: 6 }}>
-          <span>Message</span>
-          <textarea
-            name="message"
-            required
-            placeholder="How can we help?"
-            rows={6}
-            style={textarea}
-          />
-        </label>
-
-        {state.error && (
-          <p role="alert" style={{ color: "#b00020", margin: 0 }}>
-            {state.error}
-          </p>
-        )}
-
-        <div style={{ display: "flex", gap: 8 }}>
-          <button type="submit" disabled={state.sending} style={btnPrimary}>
-            {state.sending ? "Sending…" : "Send message"}
-          </button>
-          <button type="reset" disabled={state.sending} style={btnGhost}>
-            Reset
-          </button>
-        </div>
-
-        <p style={{ fontSize: 12, opacity: 0.7 }}>
-          By submitting, you agree to our <a href="/privacy">Privacy Policy</a>.
-        </p>
-      </form>
+      <p>
+        Email us at {" "}
+        <a href="mailto:turianmediacompany@gmail.com">
+          turianmediacompany@gmail.com
+        </a>
+        .
+      </p>
     </main>
   );
 }
-
-const input: React.CSSProperties = {
-  border: "1px solid #E5E7EB",
-  borderRadius: 10,
-  padding: "10px 12px",
-  font: "16px system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial",
-};
-
-const textarea = { ...input, resize: "vertical" } as React.CSSProperties;
-
-const btnPrimary: React.CSSProperties = {
-  appearance: "none",
-  border: "none",
-  borderRadius: 10,
-  padding: "10px 14px",
-  background: "#1e63ff",
-  color: "#fff",
-  fontWeight: 700,
-  cursor: "pointer",
-};
-
-const btnGhost: React.CSSProperties = {
-  ...btnPrimary,
-  background: "transparent",
-  color: "#1e63ff",
-  border: "2px solid #1e63ff",
-};
-

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,6 +4,22 @@
   --naturverse-blue: #2e6bff;
 }
 
+:where(a,button,[role="button"],input,select,textarea):focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(16 185 129 / 40%);
+}
+
+.btn-tap {
+  min-height: 44px;
+  min-width: 44px;
+}
+
+a,
+button {
+  cursor: pointer;
+  transition: opacity 0.15s ease, color 0.15s ease, background-color 0.15s ease;
+}
+
 /* ================================
    NaturBank — color + layout fix
    Scope: any root with .naturbank-page OR [data-page="naturbank"]


### PR DESCRIPTION
## Summary
- gate nav/actions behind auth and add dedicated MobileNav with profile and cart
- update footer with real routes, email link and socials
- add global focus ring and contact page stub

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6225828508329b501b816406be6c4