### PR TITLE
feat(nav+footer): gate entire header by auth; restore full footer with socials

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -2,8 +2,10 @@ import React, { useEffect } from "react";
 import { useCart } from "@/lib/cart";
 import { getShareLink } from "@/lib/cartShare";
 import { PRODUCT_IMG } from "@/data/productImages";
+import { useAuth } from "@/lib/auth-context";
 
 export default function CartDrawer({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { user, ready } = useAuth();
   const { items, setQty, removeFromCart, clearCart, totalCents } = useCart();
 
   // close on ESC
@@ -46,7 +48,7 @@ export default function CartDrawer({ open, onClose }: { open: boolean; onClose: 
     );
   }
 
-  if (!open) return null;
+  if (!ready || !user || !open) return null;
   return (
     <div
       className="cart-drawer"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,52 +1,108 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { SOCIALS } from '@/lib/socials';
 
 export default function Footer() {
-  const year = new Date().getFullYear();
-
   return (
-    <footer
-      role="contentinfo"
-      style={{
-        marginTop: '4rem',
-        padding: '1.25rem 0',
-        borderTop: '1px solid var(--border, #e5e7eb)',
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          gap: '1rem',
-          flexWrap: 'wrap',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-        }}
-      >
-        <div style={{ opacity: 0.9 }}>© {year} Turian Media Company</div>
-
-        <nav aria-label="Legal" style={{ display: 'flex', gap: '.75rem', flexWrap: 'wrap' }}>
-          <Link to="/terms" className="link">Terms</Link>
-          <span aria-hidden>·</span>
-          <Link to="/privacy" className="link">Privacy</Link>
-          <span aria-hidden>·</span>
-          <Link to="/contact" className="link">Contact</Link>
-        </nav>
-
-        <nav aria-label="Social media" style={{ display: 'flex', gap: '.75rem', flexWrap: 'wrap' }}>
-          {SOCIALS.map((s) => (
-            <a
-              key={s.name}
-              href={s.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="link"
-              aria-label={s.name}
-            >
-              {s.name}
-            </a>
-          ))}
-        </nav>
+    <footer className="border-t bg-neutral-50" role="contentinfo">
+      <div className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          <div>
+            <h2 className="text-sm font-semibold text-neutral-900">Company</h2>
+            <ul className="mt-3 space-y-2 text-sm text-neutral-600">
+              <li>
+                <Link to="/about" className="hover:text-neutral-900 transition-colors">
+                  About
+                </Link>
+              </li>
+              <li>
+                <Link to="/contact" className="hover:text-neutral-900 transition-colors">
+                  Contact
+                </Link>
+              </li>
+              <li>
+                <a
+                  href="mailto:turianmediacompany@gmail.com"
+                  className="hover:text-neutral-900 transition-colors"
+                >
+                  Email
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h2 className="text-sm font-semibold text-neutral-900">Legal</h2>
+            <ul className="mt-3 space-y-2 text-sm text-neutral-600">
+              <li>
+                <Link to="/privacy" className="hover:text-neutral-900 transition-colors">
+                  Privacy Policy
+                </Link>
+              </li>
+              <li>
+                <Link to="/terms" className="hover:text-neutral-900 transition-colors">
+                  Terms of Service
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h2 className="text-sm font-semibold text-neutral-900">Follow</h2>
+            <ul className="mt-3 space-y-2 text-sm text-neutral-600">
+              <li>
+                <a
+                  href="https://x.com/TuriantheDurian"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-neutral-900 transition-colors"
+                >
+                  X
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://instagram.com/TuriantheDurian"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-neutral-900 transition-colors"
+                >
+                  Instagram
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://facebook.com/TuriantheDurian"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-neutral-900 transition-colors"
+                >
+                  Facebook
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://www.tiktok.com/@turianthedurian"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-neutral-900 transition-colors"
+                >
+                  TikTok
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://www.youtube.com/@TuriantheDurian"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-neutral-900 transition-colors"
+                >
+                  YouTube
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <p className="mt-10 text-center text-sm text-neutral-500">
+          © 2025 Turian Media Company
+        </p>
       </div>
     </footer>
   );

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+import CartButton from './CartButton';
+import UserAvatar from './UserAvatar';
+import { useAuth } from '@/lib/auth-context';
+import { useLocation } from 'react-router-dom';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCartOpen: () => void;
+}
+
+export default function MobileNav({ open, onClose, onCartOpen }: Props) {
+  const { user } = useAuth();
+  const location = useLocation();
+
+  useEffect(() => {
+    onClose();
+  }, [location.pathname, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      id="nv-mobile-menu"
+      className={`nv-mobile-menu ${open ? 'open' : ''}`}
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="sheet flex flex-col gap-3 px-4 py-4 pb-[env(safe-area-inset-bottom)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          className="nv-icon-btn close"
+          aria-label="Close menu"
+          onClick={onClose}
+        >
+          ×
+        </button>
+
+        {user && (
+          <div className="flex gap-3">
+            <UserAvatar className="nv-icon-btn" />
+            <CartButton
+              className="nv-icon-btn"
+              onClick={() => {
+                onCartOpen();
+                onClose();
+              }}
+            />
+          </div>
+        )}
+
+        <nav aria-label="Mobile">
+          <a href="/worlds">Worlds</a>
+          <a href="/zones">Zones</a>
+          <a href="/marketplace">Marketplace</a>
+          <a href="/wishlist">Wishlist</a>
+          <a href="/naturversity">Naturversity</a>
+          <a href="/naturbank">NaturBank</a>
+          <a href="/navatar">Navatar</a>
+          <a href="/passport">Passport</a>
+          <a href="/turian">Turian</a>
+        </nav>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/SiteHeader.css
+++ b/src/components/SiteHeader.css
@@ -4,11 +4,17 @@
 
 .nv-site-header { position: sticky; top: 0; z-index: 50; background: #fff; }
 .nv-header-inner { display:flex; align-items:center; gap:12px; padding:12px 16px; }
-.nv-brand { display:flex; align-items:center; gap:10px; text-decoration:none; }
+.nv-brand { display:flex; align-items:center; gap:10px; text-decoration:none; flex-shrink:0; transition:opacity .2s; }
+.nv-brand:hover { opacity:.8; }
 .nv-brand-icon { width:40px; height:40px; }
-.nv-brand-name { font-weight:800; color:#2563eb; }
+.nv-brand-name { font-weight:800; color:var(--nv-blue-500); transition:color .2s; }
+.nv-brand:hover .nv-brand-name { color:var(--nv-blue-600); }
 
-.nv-actions { display:flex; gap:.5rem; margin-left:auto; }
+.nv-actions { display:flex; gap:.75rem; margin-left:auto; }
+@media (min-width:768px) { .nv-actions { gap:1rem; } }
+
+.mobile-hidden { display:none; }
+@media (min-width:1024px) { .mobile-hidden { display:inline-flex; } }
 
 /* Desktop nav hidden on mobile */
 .nv-desktop-nav { display:none; gap:16px; margin-left:24px; }
@@ -32,7 +38,8 @@
 .nv-icon-btn:focus-visible { outline:2px solid var(--nv-blue-500); outline-offset:2px; }
 
 /* Hamburger bars */
-.nv-hamburger .bar { display:block; width:18px; height:2px; border-radius:2px; background:var(--nv-blue-600); }
+.nv-hamburger .bar { display:block; width:18px; height:2px; border-radius:2px; background:var(--nv-blue-500); transition:background .2s; }
+.nv-hamburger:hover .bar { background:var(--nv-blue-600); }
 .nv-hamburger .bar + .bar { margin-top:4px; }
 
 /* Cart */
@@ -60,7 +67,8 @@
   border-top-left-radius:12px;
   border-bottom-left-radius:12px;
 }
-.nv-mobile-menu nav a { display:block; padding:12px 4px; font-weight:600; color:#2563eb; text-decoration:none; }
+.nv-mobile-menu nav a { display:block; padding:12px 4px; font-weight:600; color:var(--nv-blue-500); text-decoration:none; transition:color .2s; }
+.nv-mobile-menu nav a:hover { color:var(--nv-blue-600); }
 
 /* hide pills that previously rendered empty */
 .nv-avatar { display:block; width:28px; height:28px; border-radius:999px; background: var(--nv-blue-100); overflow:hidden; }

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -6,20 +6,25 @@ import { useAuth } from '@/lib/auth-context';
 import CartButton from './CartButton';
 import UserAvatar from './UserAvatar';
 import CartDrawer from './CartDrawer';
+import MobileNav from './MobileNav';
 
 export default function SiteHeader() {
   const { user, ready } = useAuth();
-  if (!ready || !user) return null;
-
   const [menuOpen, setMenuOpen] = useState(false);
   const [cartOpen, setCartOpen] = useState(false);
 
-  return (
+  if (!ready) return null;
+
+  const HeaderContent = () => (
     <>
       <header className="nv-site-header" role="banner">
         <div className="nv-header-inner">
           {/* Brand */}
-          <a className="nv-brand" href="/" aria-label="The Naturverse">
+          <a
+            className="nv-brand hover:opacity-80 transition-opacity"
+            href="/"
+            aria-label="The Naturverse"
+          >
             <img className="nv-brand-icon" src="/favicon-64x64.png" alt="" />
             <span className="nv-brand-name">The Naturverse</span>
           </a>
@@ -42,13 +47,13 @@ export default function SiteHeader() {
           {/* Right side actions */}
           <div className="nv-actions">
             <CartButton
-              className="nv-icon-btn"
+              className="nv-icon-btn mobile-hidden"
               onClick={() => {
                 setCartOpen(true);
                 setMenuOpen(false);
               }}
             />
-            <UserAvatar className="nv-icon-btn" />
+            <UserAvatar className="nv-icon-btn mobile-hidden" />
             <button
               type="button"
               className="nv-icon-btn nv-hamburger lg-hidden nav-toggle"
@@ -63,41 +68,17 @@ export default function SiteHeader() {
             </button>
           </div>
         </div>
-
-        {/* Mobile overlay menu */}
-        <div
-          id="nv-mobile-menu"
-          className={`nv-mobile-menu ${menuOpen ? 'open' : ''}`}
-          role="dialog"
-          aria-modal="true"
-          onClick={() => setMenuOpen(false)}
-        >
-          <div className="sheet" onClick={(e) => e.stopPropagation()}>
-            <button
-              className="nv-icon-btn close"
-              aria-label="Close menu"
-              onClick={() => setMenuOpen(false)}
-            >
-              ×
-            </button>
-
-            <nav aria-label="Mobile">
-              <a href="/worlds">Worlds</a>
-              <a href="/zones">Zones</a>
-              <a href="/marketplace">Marketplace</a>
-              <a href="/wishlist">Wishlist</a>
-              <a href="/naturversity">Naturversity</a>
-              <a href="/naturbank">NaturBank</a>
-              <a href="/navatar">Navatar</a>
-              <a href="/passport">Passport</a>
-              <a href="/turian">Turian</a>
-            </nav>
-          </div>
-        </div>
       </header>
 
+      <MobileNav
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        onCartOpen={() => setCartOpen(true)}
+      />
       <CartDrawer open={cartOpen} onClose={() => setCartOpen(false)} />
     </>
   );
+
+  return <>{user ? <HeaderContent /> : null}</>;
 }
 

--- a/src/styles/cart.css
+++ b/src/styles/cart.css
@@ -157,113 +157,6 @@
 }
 
 /* drawer */
-.cart-drawer {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-}
-.cart-drawer .scrim {
-  position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.35);
-  opacity: 0;
-  transition: 0.2s;
-}
-.cart-drawer .panel {
-  position: absolute;
-  right: -420px;
-  top: 0;
-  height: 100%;
-  width: 360px;
-  max-width: 90vw;
-  background: #fff;
-  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.15);
-  display: flex;
-  flex-direction: column;
-  transition: 0.25s;
-}
-.cart-drawer.open {
-  pointer-events: auto;
-}
-.cart-drawer.open .scrim {
-  opacity: 1;
-}
-.cart-drawer.open .panel {
-  right: 0;
-}
-.cart-drawer .hdr {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 16px 16px 8px;
-  border-bottom: 1px solid var(--nv-border);
-}
-.cart-drawer .lines {
-  list-style: none;
-  margin: 0;
-  padding: 12px 16px;
-  flex: 1;
-  overflow: auto;
-}
-.cart-drawer .line {
-  display: grid;
-  grid-template-columns: 1fr auto auto auto;
-  gap: 8px;
-  align-items: center;
-  padding: 8px 0;
-  border-bottom: 1px dashed var(--nv-border);
-}
-.cart-drawer .info {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-.cart-drawer .qty {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-.cart-drawer .qty input {
-  width: 40px;
-  text-align: center;
-}
-.cart-drawer .amt {
-  font-variant-numeric: tabular-nums;
-}
-.cart-drawer .rm {
-  background: none;
-  border: 0;
-  color: #ef4444;
-  cursor: pointer;
-}
-.cart-drawer .foot {
-  border-top: 1px solid var(--nv-border);
-  padding: 12px 16px;
-}
-.cart-drawer .total {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 10px;
-}
-.cart-drawer .actions {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.cart-drawer .btn {
-  display: inline-block;
-  padding: 10px 14px;
-  background: var(--nv-text);
-  color: #fff;
-  border-radius: 8px;
-  text-decoration: none;
-}
-.cart-drawer .link {
-  background: none;
-  border: 0;
-  color: var(--nv-blue-600);
-  cursor: pointer;
-}
 /* ==== Cart Page Fix ==== */
 .cart :is(h1, h2, h3, h4, h5, h6, p, span, label, small, a, strong) {
   color: var(--naturverse-blue) !important;
@@ -309,7 +202,7 @@
   text-align: center;
 }
 
-.cart-drawer { position: fixed; inset: 0; z-index: 60; display:flex; }
+.cart-drawer { position: fixed; inset: 0; z-index: 50; display:flex; pointer-events:auto; }
 .cart-drawer .backdrop { flex:1; background: rgba(0,0,0,.25); animation: fadeIn .25s ease; }
 .cart-panel {
   width: 380px; max-width: 100vw; height: 100%; background: #fff;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -910,3 +910,10 @@ main,
     margin-right: auto;
   }
 }
+
+:where(a,button,[role="button"],input,select,textarea):focus-visible{
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(16 185 129 / 40%);
+}
+
+.btn-tap{min-height:44px;min-width:44px;}


### PR DESCRIPTION
## Summary
- hide header/nav/cart while logged out, add mobile nav with profile/cart and hover/spacing polish
- restore multi-column footer with company/legal/follow links (X, Instagram, Facebook, TikTok, YouTube)
- add global focus ring utility and cart drawer auth gating with pointer events fixes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b62912c8c88329b471d08179b8a030