### PR TITLE
Navatar MVP page with basic flows and web3 stubs

### DIFF
--- a/src/components/navatar/CanonPicker.tsx
+++ b/src/components/navatar/CanonPicker.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { CANON_NAVATARS, CanonNavatar } from '@/data/canonNavatars';
+
+type Props = { onPick: (nav: CanonNavatar) => void };
+
+export default function CanonPicker({ onPick }: Props) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+      {CANON_NAVATARS.map((c) => (
+        <button
+          key={c.key}
+          type="button"
+          onClick={() => onPick(c)}
+          className="rounded-xl border bg-white p-2 hover:shadow transition text-center"
+        >
+          <img src={c.image} alt={c.name} className="w-full h-32 object-cover rounded" />
+          <p className="mt-2 text-sm font-bold">{c.name}</p>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/navatar/NavatarCard.tsx
+++ b/src/components/navatar/NavatarCard.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Navatar, setPrimaryAvatar, deleteNavatar } from '@/lib/navatar';
+import { useAuth } from '@/lib/auth-context';
+
+interface Props {
+  avatar: Navatar;
+  onEdit: (av: Navatar) => void;
+  refresh: () => void;
+}
+
+export default function NavatarCard({ avatar, onEdit, refresh }: Props) {
+  const { user } = useAuth();
+  const { id, name, category, image_url, is_primary } = avatar;
+
+  const handlePrimary = async () => {
+    if (!user) return;
+    await setPrimaryAvatar(user.id, id, image_url);
+    refresh();
+  };
+
+  const handleDelete = async () => {
+    await deleteNavatar(id);
+    refresh();
+  };
+
+  return (
+    <div className="rounded-xl border bg-white p-4 shadow-sm hover:shadow transition">
+      <img src={image_url} alt={name} className="w-full h-48 object-cover rounded-md" />
+      <h3 className="mt-2 font-bold">{name}</h3>
+      <p className="text-sm text-gray-500">{category}</p>
+      <div className="mt-2 flex flex-wrap gap-2">
+        <button
+          onClick={handlePrimary}
+          className="px-2 py-1 rounded bg-blue-600 text-white text-sm"
+        >
+          {is_primary ? 'Primary' : 'Set Primary'}
+        </button>
+        <button
+          onClick={() => onEdit(avatar)}
+          className="px-2 py-1 rounded bg-gray-200 text-sm"
+        >
+          Edit
+        </button>
+        <button
+          onClick={handleDelete}
+          className="px-2 py-1 rounded bg-red-500 text-white text-sm"
+        >
+          Delete
+        </button>
+        <button
+          disabled
+          title="Coming soon"
+          className="px-2 py-1 rounded bg-gray-200 text-sm opacity-50 cursor-not-allowed"
+        >
+          Mint as NFT
+        </button>
+        <button
+          disabled
+          title="Coming soon"
+          className="px-2 py-1 rounded bg-gray-200 text-sm opacity-50 cursor-not-allowed"
+        >
+          Tip/Boost with NATUR
+        </button>
+        <button
+          disabled
+          title="Coming soon"
+          className="px-2 py-1 rounded bg-gray-200 text-sm opacity-50 cursor-not-allowed"
+        >
+          Order Plushie/T-Shirt
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/navatar/NavatarForm.tsx
+++ b/src/components/navatar/NavatarForm.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import CanonPicker from './CanonPicker';
+import { createNavatar, generateImageFromPrompt, Navatar } from '@/lib/navatar';
+
+interface Props {
+  onClose: () => void;
+  onSaved: () => void;
+  initial?: Navatar | null;
+}
+
+export default function NavatarForm({ onClose, onSaved, initial }: Props) {
+  const [tab, setTab] = useState<'upload' | 'ai' | 'canon'>('upload');
+  const [file, setFile] = useState<File | null>(null);
+  const [name, setName] = useState(initial?.name || '');
+  const [category, setCategory] = useState(initial?.category || '');
+  const [description, setDescription] = useState('');
+  const [generated, setGenerated] = useState<string>('');
+
+  async function saveUpload() {
+    if (!file) return;
+    await createNavatar({ method: 'upload', imageFileOrUrl: file, name, category, traits: {} });
+    onSaved();
+  }
+
+  async function generate() {
+    const b64 = await generateImageFromPrompt({ name, category }, description);
+    if (b64) setGenerated(`data:image/png;base64,${b64}`);
+  }
+
+  async function saveAi() {
+    if (!generated) return;
+    await createNavatar({ method: 'ai', imageFileOrUrl: generated, name, category, traits: { description } });
+    onSaved();
+  }
+
+  function pickCanon(nav: { key: string; name: string; category: string; image: string }) {
+    createNavatar({
+      method: 'canon',
+      imageFileOrUrl: nav.image,
+      name: nav.name,
+      category: nav.category,
+      traits: { canon_key: nav.key },
+    }).then(onSaved);
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/40 grid place-items-center z-50">
+      <div className="bg-white rounded-xl p-4 w-full max-w-2xl">
+        <div className="flex justify-between mb-4">
+          <div className="flex gap-2">
+            <button className={tab === 'upload' ? 'font-bold' : ''} onClick={() => setTab('upload')}>
+              Upload
+            </button>
+            <button className={tab === 'ai' ? 'font-bold' : ''} onClick={() => setTab('ai')}>
+              Describe & Generate
+            </button>
+            <button className={tab === 'canon' ? 'font-bold' : ''} onClick={() => setTab('canon')}>
+              Pick Canon
+            </button>
+          </div>
+          <button onClick={onClose}>✕</button>
+        </div>
+        {tab === 'upload' && (
+          <div className="space-y-2">
+            <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+            <input
+              className="border p-2 w-full"
+              placeholder="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <input
+              className="border p-2 w-full"
+              placeholder="Category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+            />
+            <button onClick={saveUpload} className="px-4 py-2 bg-blue-600 text-white rounded">
+              Save
+            </button>
+          </div>
+        )}
+        {tab === 'ai' && (
+          <div className="space-y-2">
+            <input
+              className="border p-2 w-full"
+              placeholder="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <input
+              className="border p-2 w-full"
+              placeholder="Category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+            />
+            <textarea
+              className="border p-2 w-full"
+              placeholder="Description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+            {generated && <img src={generated} alt="preview" className="w-48 h-48 object-cover" />}
+            <div className="flex gap-2">
+              <button onClick={generate} className="px-4 py-2 bg-gray-200 rounded">
+                Generate
+              </button>
+              {generated && (
+                <button onClick={saveAi} className="px-4 py-2 bg-blue-600 text-white rounded">
+                  Save
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+        {tab === 'canon' && <CanonPicker onPick={pickCanon} />}
+      </div>
+    </div>
+  );
+}

--- a/src/data/canonNavatars.ts
+++ b/src/data/canonNavatars.ts
@@ -1,0 +1,13 @@
+export type CanonNavatar = {
+  key: string;
+  name: string;
+  category: string;
+  image: string;
+};
+
+export const CANON_NAVATARS: CanonNavatar[] = [
+  { key: 'turian', name: 'Turian', category: 'spirit', image: '/navatars/turian.png' },
+  { key: 'mangsi', name: 'Mangsi', category: 'spirit', image: '/navatars/mangsi.png' },
+  { key: 'coconut-cruze', name: 'Coconut Cruze', category: 'fruit', image: '/navatars/coconut-cruze.png' },
+  { key: 'jay-sing', name: 'Jay-Sing', category: 'animal', image: '/navatars/jay-sing.png' },
+];

--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -1,22 +1,115 @@
-import { NAVATARS, Navatar } from '../data/navatars';
 import { getSupabase } from './supabase-client';
+import { uploadAvatar, getPublicUrl } from './storage';
 
-const supabase = getSupabase();
+export type Navatar = {
+  id: string;
+  user_id: string;
+  name: string;
+  category: string;
+  image_url: string;
+  traits: any;
+  method: 'upload' | 'ai' | 'canon';
+  is_primary: boolean;
+};
 
-const LS_OWNED = 'nv_owned_navatars';
-const LS_ACTIVE = 'nv_active_navatar';
+export async function getNavatars(userId: string): Promise<Navatar[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('avatars')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at');
+  if (error) throw error;
+  return (data as Navatar[]) || [];
+}
 
-function readOwnedLocal(): string[] {
-  try {
-    return JSON.parse(localStorage.getItem(LS_OWNED) || '[]');
-  } catch {
-    return [];
+export async function createNavatar({
+  method,
+  imageFileOrUrl,
+  name,
+  category,
+  traits,
+}: {
+  method: 'upload' | 'ai' | 'canon';
+  imageFileOrUrl: File | string;
+  name: string;
+  category: string;
+  traits: any;
+}): Promise<Navatar> {
+  const supabase = getSupabase();
+  const { data: u } = await supabase.auth.getUser();
+  const user = u?.user;
+  if (!user) throw new Error('Not authenticated');
+  let imageUrl = '';
+  if (typeof imageFileOrUrl === 'string') {
+    if (imageFileOrUrl.startsWith('data:')) {
+      const res = await fetch(imageFileOrUrl);
+      const blob = await res.blob();
+      const path = await uploadAvatar(user.id, new File([blob], 'navatar.png', { type: blob.type }));
+      imageUrl = await getPublicUrl(path!);
+    } else {
+      imageUrl = imageFileOrUrl;
+    }
+  } else {
+    const path = await uploadAvatar(user.id, imageFileOrUrl);
+    imageUrl = await getPublicUrl(path!);
   }
+  const { data, error } = await supabase
+    .from('avatars')
+    .insert({
+      user_id: user.id,
+      image_url: imageUrl,
+      name,
+      category,
+      traits,
+      method,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return data as Navatar;
 }
 
-function writeOwnedLocal(ids: string[]) {
-  localStorage.setItem(LS_OWNED, JSON.stringify([...new Set(ids)]));
+export async function updateNavatar(id: string, patch: Partial<Navatar>): Promise<Navatar> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase.from('avatars').update(patch).eq('id', id).select().single();
+  if (error) throw error;
+  return data as Navatar;
 }
+
+export async function deleteNavatar(id: string): Promise<void> {
+  const supabase = getSupabase();
+  await supabase.from('avatars').delete().eq('id', id);
+}
+
+export async function setPrimaryAvatar(userId: string, avatarId: string, imageUrl: string): Promise<void> {
+  const supabase = getSupabase();
+  await supabase.from('avatars').update({ is_primary: false }).eq('user_id', userId);
+  await supabase.from('avatars').update({ is_primary: true }).eq('id', avatarId);
+  await supabase.from('users').update({ avatar_url: imageUrl, primary_avatar_id: avatarId }).eq('id', userId);
+}
+
+export async function generateImageFromPrompt(traits: any, description: string): Promise<string> {
+  const promptParts = [
+    traits?.name,
+    traits?.category,
+    description,
+    'storybook, friendly, 2D, Naturverse style, clean white bg, centered',
+  ];
+  const prompt = promptParts.filter(Boolean).join(' ');
+  const res = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({ prompt, n: 1, size: '512x512', response_format: 'b64_json' }),
+  });
+  const json = await res.json();
+  return json.data?.[0]?.b64_json || '';
+}
+
+const LS_ACTIVE = 'nv_active_navatar';
 
 export function getActiveLocal(): string | null {
   return localStorage.getItem(LS_ACTIVE);
@@ -26,63 +119,24 @@ export function setActiveLocal(id: string) {
   localStorage.setItem(LS_ACTIVE, id);
 }
 
-export async function listAll(): Promise<Navatar[]> {
-  return NAVATARS;
-}
-
-export async function getOwned(): Promise<string[]> {
-  if (supabase) {
-    const { data: user } = await supabase.auth.getUser();
-    if (user?.user) {
-      const { data, error } = await supabase
-        .from('owned_navatars')
-        .select('navatar_id')
-        .eq('user_id', user.user.id);
-      if (!error && data) return data.map((r) => r.navatar_id as string);
-    }
-  }
-  return readOwnedLocal();
-}
-
-export async function own(id: string): Promise<void> {
-  if (supabase) {
-    const { data: user } = await supabase.auth.getUser();
-    if (user?.user) {
-      await supabase
-        .from('owned_navatars')
-        .insert({ user_id: user.user.id, navatar_id: id, source: 'claim' })
-        .select()
-        .single();
-      return;
-    }
-  }
-  const current = readOwnedLocal();
-  current.push(id);
-  writeOwnedLocal(current);
-}
-
 export async function getActive(): Promise<string | null> {
-  if (supabase) {
-    const { data: user } = await supabase.auth.getUser();
-    if (user?.user) {
-      const { data } = await supabase
-        .from('profiles')
-        .select('navatar_id')
-        .eq('id', user.user.id)
-        .single();
-      return (data?.navatar_id as string) || null;
-    }
-  }
-  return getActiveLocal();
+  const supabase = getSupabase();
+  const { data: u } = await supabase.auth.getUser();
+  const user = u?.user;
+  if (!user) return getActiveLocal();
+  const { data } = await supabase
+    .from('users')
+    .select('primary_avatar_id')
+    .eq('id', user.id)
+    .single();
+  return (data?.primary_avatar_id as string) || getActiveLocal();
 }
 
-export async function setActive(id: string) {
-  if (supabase) {
-    const { data: user } = await supabase.auth.getUser();
-    if (user?.user) {
-      await supabase.from('profiles').update({ navatar_id: id }).eq('id', user.user.id);
-      return;
-    }
-  }
+export async function setActive(id: string): Promise<void> {
+  const supabase = getSupabase();
+  const { data: u } = await supabase.auth.getUser();
+  const user = u?.user;
+  if (!user) return setActiveLocal(id);
+  await supabase.from('users').update({ primary_avatar_id: id }).eq('id', user.id);
   setActiveLocal(id);
 }

--- a/src/lib/web3/naturbank.ts
+++ b/src/lib/web3/naturbank.ts
@@ -1,0 +1,7 @@
+export async function mintNFT(avatarId: string) {
+  return { ok: false, reason: 'coming_soon' } as const;
+}
+
+export async function tipNatur(avatarId: string, amount: number) {
+  return { ok: false, reason: 'coming_soon' } as const;
+}

--- a/supabase/migrations/2026-03-01_navatar_mvp.sql
+++ b/supabase/migrations/2026-03-01_navatar_mvp.sql
@@ -1,0 +1,13 @@
+-- Navatar MVP enhancements
+-- Avatars enhancements
+alter table if exists avatars
+add column if not exists traits jsonb,
+add column if not exists method text check (method in ('upload','ai','canon')) default 'upload',
+add column if not exists is_primary boolean default false,
+add column if not exists chain_status text check (chain_status in ('none','queued','minted','failed')) default 'none';
+
+-- Optional: remember user’s primary avatar id
+alter table if exists users
+add column if not exists primary_avatar_id uuid references avatars(id);
+
+-- RLS note: ensure policies restrict rows to auth.uid().


### PR DESCRIPTION
## Summary
- add migration for avatar traits and primary avatar support
- scaffold navatar page with upload/AI/canon creation, listing, and primary selection
- stub naturbank web3 hooks

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b637e5e1ec832990a5fae2f3d29413