### PR TITLE
feat(navatar mvp): add navatar upload/AI/canon flow

### DIFF
--- a/src/components/navatar/CreateNavatarModal.tsx
+++ b/src/components/navatar/CreateNavatarModal.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import { uploadAvatarImage, createAvatar, generateImageFromPrompt } from '@/lib/navatar';
+
+export default function CreateNavatarModal({ user, onClose, onCreated }:{
+  user: any, onClose:()=>void, onCreated:()=>void
+}) {
+  const [tab, setTab] = useState<'upload'|'ai'|'canon'>('upload');
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState('animal');
+  const [file, setFile] = useState<File|null>(null);
+  const [desc, setDesc] = useState('');
+  const [aiPreview, setAiPreview] = useState<string>(''); // data URL
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string| null>(null);
+
+  const handleUploadSave = async () => {
+    if (!file || !name) return setError('Please choose an image and name');
+    setBusy(true); setError(null);
+    try {
+      const image_url = await uploadAvatarImage(user.id, file);
+      const { error } = await createAvatar({ user_id: user.id, name, category, method:'upload', image_url, traits:{ } });
+      if (error) throw error;
+      onCreated(); onClose();
+    } catch (e:any) { setError(e.message || 'Upload failed'); }
+    finally { setBusy(false); }
+  };
+
+  const handleAIGenerate = async () => {
+    setBusy(true); setError(null); setAiPreview('');
+    const prompt = `Naturverse style, friendly, clean white background, centered character portrait. Category: ${category}. Description: ${desc}`;
+    try {
+      const b64 = await generateImageFromPrompt(prompt);
+      if (!b64) throw new Error('No image returned');
+      setAiPreview(`data:image/png;base64,${b64}`);
+    } catch (e:any) {
+      setError(e.message === 'no_openai_key' ? 'AI generation disabled on this preview (no API key).' : e.message);
+    } finally { setBusy(false); }
+  };
+
+  const handleAISave = async () => {
+    if (!aiPreview || !name) return setError('Generate an image and add a name');
+    setBusy(true); setError(null);
+    try {
+      // convert dataURL -> blob -> File for upload
+      const res = await fetch(aiPreview); const blob = await res.blob();
+      const imageFile = new File([blob], `${crypto.randomUUID()}.png`, { type: 'image/png' });
+      const image_url = await uploadAvatarImage(user.id, imageFile);
+      const { error } = await createAvatar({ user_id: user.id, name, category, method:'ai', image_url, traits:{ desc } });
+      if (error) throw error;
+      onCreated(); onClose();
+    } catch (e:any) { setError(e.message || 'Save failed'); }
+    finally { setBusy(false); }
+  };
+
+  const handleCanonSave = async (canonKey:string, canonUrl:string) => {
+    setBusy(true); setError(null);
+    try {
+      const { error } = await createAvatar({
+        user_id: user.id, name: name || canonKey, category, method:'canon', image_url: canonUrl, traits:{ canonKey }
+      });
+      if (error) throw error;
+      onCreated(); onClose();
+    } catch (e:any) { setError(e.message); } finally { setBusy(false); }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-black/40 p-4">
+      <div className="w-full max-w-2xl rounded-2xl bg-white p-6 shadow-xl">
+        <div className="flex items-center gap-2 mb-4">
+          <button onClick={()=>setTab('upload')} className={`px-3 py-2 rounded ${tab==='upload'?'bg-blue-600 text-white':'bg-neutral-100'}`}>Upload</button>
+          <button onClick={()=>setTab('ai')} className={`px-3 py-2 rounded ${tab==='ai'?'bg-blue-600 text-white':'bg-neutral-100'}`}>Describe & Generate</button>
+          <button onClick={()=>setTab('canon')} className={`px-3 py-2 rounded ${tab==='canon'?'bg-blue-600 text-white':'bg-neutral-100'}`}>Pick Canon</button>
+          <div className="grow" />
+          <button onClick={onClose} className="px-3 py-2 rounded bg-neutral-100">✕</button>
+        </div>
+
+        {tab==='upload' && (
+          <div className="space-y-4">
+            <input type="file" accept="image/*" onChange={e=>setFile(e.target.files?.[0]||null)} />
+            <input placeholder="Name" className="w-full border rounded px-3 py-2" value={name} onChange={e=>setName(e.target.value)}/>
+            <input placeholder="Category (fruit/animal/spirit/insect)" className="w-full border rounded px-3 py-2" value={category} onChange={e=>setCategory(e.target.value)}/>
+            <button disabled={busy} onClick={handleUploadSave} className="px-4 py-2 rounded bg-blue-600 text-white">{busy?'Saving…':'Save'}</button>
+          </div>
+        )}
+
+        {tab==='ai' && (
+          <div className="space-y-4">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <input placeholder="Name" className="border rounded px-3 py-2" value={name} onChange={e=>setName(e.target.value)}/>
+              <input placeholder="Category (fruit/animal/spirit/insect)" className="border rounded px-3 py-2" value={category} onChange={e=>setCategory(e.target.value)}/>
+            </div>
+            <textarea placeholder="Describe your Navatar (e.g., half turtle half durian, friendly, explorer hat, blue leaf cape)" className="w-full border rounded px-3 py-2 min-h-[120px]" value={desc} onChange={e=>setDesc(e.target.value)}/>
+            <div className="flex items-center gap-3">
+              <button disabled={busy} onClick={handleAIGenerate} className="px-4 py-2 rounded bg-blue-600 text-white">{busy?'Generating…':'Generate'}</button>
+              {aiPreview && <button disabled={busy} onClick={handleAISave} className="px-4 py-2 rounded bg-emerald-600 text-white">{busy?'Saving…':'Save'}</button>}
+            </div>
+            {aiPreview && <img src={aiPreview} alt="preview" className="mt-4 w-48 h-48 object-cover rounded-xl border" />}
+            {error && <p className="text-sm text-red-600">{error}</p>}
+          </div>
+        )}
+
+        {tab==='canon' && (
+          <CanonGrid onPick={handleCanonSave} name={name} setName={setName} category={category} setCategory={setCategory}/>
+        )}
+
+        {error && tab!=='ai' && <p className="mt-4 text-sm text-red-600">{error}</p>}
+      </div>
+    </div>
+  );
+}
+
+function CanonGrid({ onPick, name, setName, category, setCategory }:{
+  onPick:(key:string,url:string)=>void; name:string; setName:(s:string)=>void; category:string; setCategory:(s:string)=>void;
+}) {
+  const canon = [
+    { key:'turian', label:'Turian the Durian', url:'/canon/turian.png', category:'fruit' },
+    { key:'mangsi', label:'Mangsi the Mangosteen', url:'/canon/mangsi.png', category:'fruit' },
+    // add as needed…
+  ];
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+        {canon.map(c=>(
+          <button key={c.key} onClick={()=>onPick(c.key, c.url)} className="border rounded-xl p-3 hover:shadow">
+            <img src={c.url} alt={c.label} className="w-full aspect-square object-cover rounded-md mb-2"/>
+            <div className="text-sm font-medium">{c.label}</div>
+          </button>
+        ))}
+      </div>
+      <input placeholder="Name (optional)" className="border rounded px-3 py-2" value={name} onChange={e=>setName(e.target.value)}/>
+      <input placeholder="Category" className="border rounded px-3 py-2" value={category} onChange={e=>setCategory(e.target.value)}/>
+    </div>
+  );
+}

--- a/src/pages/navatar.tsx
+++ b/src/pages/navatar.tsx
@@ -1,69 +1,62 @@
-import React, { useEffect, useState } from 'react';
-import { listAll, getOwned, getActive, setActive } from '../lib/navatar';
-import { Navatar } from '../data/navatars';
-import NavatarCard from '../components/NavatarCard';
-import ListNavatarModal from '../components/ListNavatarModal';
-import { useAuth } from '../lib/auth-context';
+import { useEffect, useState } from 'react';
+import { supabase, listAvatars, setPrimaryAvatar, deleteAvatar } from '@/lib/navatar';
+import CreateNavatarModal from '@/components/navatar/CreateNavatarModal';
 
-export default function YourNavatarPage() {
-  const [all, setAll] = useState<Navatar[]>([]);
-  const [owned, setOwned] = useState<string[]>([]);
-  const [active, setActiveId] = useState<string | null>(null);
-  const { user } = useAuth();
-  const [listingFor, setListingFor] = useState<string | undefined>();
+export default function NavatarPage() {
+  const [user, setUser] = useState<any>(null);
+  const [list, setList] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
 
-  useEffect(() => {
-    listAll().then(setAll);
-    getOwned().then(setOwned);
-    getActive().then(setActiveId);
-  }, []);
+  useEffect(()=>{ (async()=>{
+    const { data: { user } } = await supabase.auth.getUser();
+    setUser(user);
+    if (user) await refresh(user.id);
+    setLoading(false);
+  })(); }, []);
 
-  const mine = all.filter((n) => owned.includes(n.id));
+  async function refresh(uid:string){ const { data } = await listAvatars(uid); setList(data || []); }
 
-  async function onUse(id: string) {
-    await setActive(id);
-    setActiveId(await getActive());
+  if (!user) {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-12">
+        <h1 className="text-3xl font-semibold mb-3">My Navatars</h1>
+        <p className="mb-6 text-neutral-600">Sign in to create your Navatar.</p>
+        <a href="/signin" className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white">Log in</a>
+      </main>
+    );
   }
 
   return (
-    <div style={{ padding: '24px 16px', maxWidth: 1100, margin: '0 auto' }}>
-      <h1>Your Navatar</h1>
-      {mine.length === 0 ? (
-        <p>
-          You don’t own any Navatars yet. Visit the <a href="/marketplace/navatar">Marketplace</a> to
-          get one.
-        </p>
+    <main className="mx-auto max-w-5xl px-4 py-10">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-semibold">My Navatars</h1>
+        <button onClick={()=>setOpen(true)} className="rounded-lg bg-blue-600 px-4 py-2 text-white">Create Navatar</button>
+      </div>
+
+      {loading ? <p>Loading…</p> : list.length === 0 ? (
+        <div className="rounded-xl border p-10 text-center text-neutral-600">No navatars yet — create your first!</div>
       ) : (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, 240px)', gap: 16 }}>
-          {mine.map((n) => (
-            <div key={n.id} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              <NavatarCard
-                nav={n}
-                owned={true}
-                activeId={active}
-                onGet={() => {}}
-                onUse={onUse}
-              />
-              {user && (
-                <button
-                  onClick={() => setListingFor(n.id)}
-                  style={{ padding: '6px 10px', borderRadius: 8 }}
-                >
-                  List for sale
-                </button>
-              )}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {list.map(a=>(
+            <div key={a.id} className="rounded-xl border bg-white p-4 shadow-sm">
+              <img src={a.image_url} alt={a.name} className="w-full aspect-square object-cover rounded-lg mb-3"/>
+              <div className="font-medium">{a.name}</div>
+              <div className="text-sm text-neutral-500 mb-3">{a.category} {a.is_primary ? '· Primary' : ''}</div>
+              <div className="flex gap-2">
+                {!a.is_primary && (
+                  <button onClick={async()=>{ await setPrimaryAvatar(user.id, a.id, a.image_url); await refresh(user.id); }}
+                          className="rounded bg-emerald-600 px-3 py-1.5 text-white">Set Primary</button>
+                )}
+                <button onClick={async()=>{ await deleteAvatar(user.id, a.id); await refresh(user.id); }}
+                        className="rounded bg-neutral-100 px-3 py-1.5">Delete</button>
+              </div>
             </div>
           ))}
         </div>
       )}
-      {listingFor && user && (
-        <ListNavatarModal
-          navatarId={listingFor}
-          sellerUserId={user.id}
-          onClose={() => setListingFor(undefined)}
-          onListed={async () => {}}
-        />
-      )}
-    </div>
+
+      {open && <CreateNavatarModal user={user} onClose={()=>setOpen(false)} onCreated={()=>refresh(user.id)} />}
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- add Supabase navatar helpers for listing, upload, primary selection, deletion, and AI image generation
- implement Create Navatar modal with upload, OpenAI generation preview, and canon picker
- replace /navatar page with list/set-primary/delete flow using new helpers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b63bc399088329adacb0b0d363e7b8