### PR TITLE
feat: add navatar hub with create modal and AI generation

### DIFF
--- a/components/NavatarCard.tsx
+++ b/components/NavatarCard.tsx
@@ -1,22 +1,61 @@
-import Image from "next/image";
+'use client';
+import React, { useState } from 'react';
+import type { Navatar } from '@/lib/navatar';
+import { deleteAvatar, setPrimaryAvatar } from '@/lib/navatar';
 
-export default function NavatarCard({ navatar }: { navatar: any }) {
+export default function NavatarCard({ navatar, onChanged }: { navatar: Navatar; onChanged: () => void }) {
+  const [busy, setBusy] = useState(false);
+
+  async function handleDelete() {
+    if (!confirm('Delete this Navatar?')) return;
+    setBusy(true);
+    await deleteAvatar(navatar.id);
+    setBusy(false);
+    onChanged();
+  }
+
+  async function handlePrimary() {
+    setBusy(true);
+    await setPrimaryAvatar(navatar.id);
+    setBusy(false);
+    onChanged();
+  }
+
   return (
-    <div className="character-card">
-      <h3 className="card-title">Your Navatar</h3>
-      <div className="card-image-container">
-        <Image
-          src={navatar.image_url}
-          alt={navatar.name || "Navatar"}
-          width={400}
-          height={240}
-          className="card-image"
-        />
-      </div>
-      <div className="card-body">
-        <p><strong>Name:</strong> {navatar.name}</p>
-        <p><strong>Category:</strong> {navatar.category}</p>
-        <p><strong>Created:</strong> {new Date(navatar.created_at).toLocaleDateString()}</p>
+    <div className="flex items-center gap-4 rounded-2xl border p-3">
+      <img
+        src={navatar.thumbnail_url || navatar.image_url || '/navatars/seedling.svg'}
+        className="h-16 w-16 rounded-xl object-cover"
+        alt={navatar.name || 'Navatar'}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <h4 className="truncate text-base font-semibold">{navatar.name || 'Untitled'}</h4>
+          {navatar.is_primary ? (
+            <span className="rounded-full bg-green-600 px-2 py-0.5 text-xs text-white">Primary</span>
+          ) : null}
+          <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs">{navatar.method}</span>
+          {navatar.status && (
+            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs">{navatar.status}</span>
+          )}
+        </div>
+        {navatar.status_message && (
+          <p className="truncate text-xs text-gray-500">{navatar.status_message}</p>
+        )}
+        <div className="mt-2 flex gap-2">
+          {!navatar.is_primary && (
+            <button
+              onClick={handlePrimary}
+              disabled={busy}
+              className="rounded-lg bg-blue-600 px-3 py-1 text-sm text-white"
+            >
+              Set as primary
+            </button>
+          )}
+          <button onClick={handleDelete} disabled={busy} className="rounded-lg bg-gray-100 px-3 py-1 text-sm">
+            Delete
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/components/NavatarCreateModal.tsx
+++ b/components/NavatarCreateModal.tsx
@@ -1,0 +1,242 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import { supabase, uploadToStorage, createAvatarRow, publicCanonOptions } from '@/lib/navatar';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void; // refresh list callback
+};
+
+type Tab = 'upload' | 'ai' | 'canon';
+
+export default function NavatarCreateModal({ open, onClose, onCreated }: Props) {
+  const [tab, setTab] = useState<Tab>('upload');
+
+  // upload
+  const [file, setFile] = useState<File | null>(null);
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState('avatar');
+
+  // ai
+  const [prompt, setPrompt] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setError] = useState<string | null>(null);
+
+  // canon
+  const canon = useMemo(() => publicCanonOptions(), []);
+
+  if (!open) return null;
+
+  async function ensureUser() {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new Error('Please sign in to create a Navatar.');
+    return user.id;
+  }
+
+  async function handleUploadSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const userId = await ensureUser();
+      if (!file) throw new Error('Choose an image to upload');
+
+      const { path, publicUrl } = await uploadToStorage(file, userId);
+      await createAvatarRow({
+        name: name || file.name.replace(/\.[^.]+$/, ''),
+        category,
+        method: 'upload',
+        image_url: publicUrl,
+        image_path: path,
+        status: 'ready',
+      });
+
+      onCreated();
+      onClose();
+    } catch (err: any) {
+      setError(err.message || 'Upload failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleAiSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const userId = await ensureUser();
+      if (!prompt.trim()) throw new Error('Describe your Navatar');
+
+      const res = await fetch('/.netlify/functions/navatar-generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt }),
+      });
+      if (!res.ok) {
+        const t = await res.text();
+        throw new Error(t || 'Generation failed');
+      }
+      const { base64, mime } = (await res.json()) as { base64: string; mime: string };
+
+      // turn base64 to File
+      const bin = atob(base64);
+      const arr = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+      const blob = new Blob([arr], { type: mime || 'image/png' });
+      const genFile = new File([blob], 'navatar.png', { type: mime || 'image/png' });
+
+      const { path, publicUrl } = await uploadToStorage(genFile, userId);
+      await createAvatarRow({
+        name: name || 'My Navatar',
+        category,
+        method: 'ai',
+        image_url: publicUrl,
+        image_path: path,
+        status: 'ready',
+      });
+
+      onCreated();
+      onClose();
+    } catch (err: any) {
+      setError(err.message || 'Generation failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleCanonPick(url: string) {
+    setLoading(true);
+    setError(null);
+    try {
+      await ensureUser();
+      await createAvatarRow({
+        name: name || 'Canon Navatar',
+        category,
+        method: 'canon',
+        image_url: url,
+        image_path: null,
+        status: 'ready',
+      });
+      onCreated();
+      onClose();
+    } catch (err: any) {
+      setError(err.message || 'Could not add canon Navatar');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
+      <div className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-xl font-semibold">Create Navatar</h3>
+          <button onClick={onClose} className="rounded-lg px-3 py-1 hover:bg-gray-100">
+            ✕
+          </button>
+        </div>
+
+        <div className="mb-4 flex gap-2">
+          {(['upload', 'ai', 'canon'] as Tab[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`rounded-full px-3 py-1 text-sm ${
+                tab === t ? 'bg-blue-600 text-white' : 'bg-gray-100'
+              }`}
+            >
+              {t === 'upload' ? 'Upload' : t === 'ai' ? 'Describe & Generate' : 'Pick Canon'}
+            </button>
+          ))}
+        </div>
+
+        {tab === 'upload' && (
+          <form onSubmit={handleUploadSubmit} className="space-y-3">
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => setFile(e.target.files?.[0] || null)}
+            />
+            <input
+              className="w-full rounded-lg border px-3 py-2"
+              placeholder="Name (optional)"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <input
+              className="w-full rounded-lg border px-3 py-2"
+              placeholder="Category (optional)"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+            />
+            <button disabled={loading} className="rounded-lg bg-blue-600 px-4 py-2 text-white">
+              {loading ? 'Saving…' : 'Save'}
+            </button>
+          </form>
+        )}
+
+        {tab === 'ai' && (
+          <form onSubmit={handleAiSubmit} className="space-y-3">
+            <input
+              className="w-full rounded-lg border px-3 py-2"
+              placeholder="Name (optional)"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <input
+              className="w-full rounded-lg border px-3 py-2"
+              placeholder="Category (optional)"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+            />
+            <textarea
+              className="h-28 w-full rounded-lg border px-3 py-2"
+              placeholder="Describe your Navatar (e.g., 'half turtle, half durian, friendly, vibrant shells…')"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+            />
+            <button disabled={loading} className="rounded-lg bg-blue-600 px-4 py-2 text-white">
+              {loading ? 'Generating…' : 'Generate'}
+            </button>
+          </form>
+        )}
+
+        {tab === 'canon' && (
+          <div className="space-y-3">
+            <input
+              className="w-full rounded-lg border px-3 py-2"
+              placeholder="Name (optional)"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <input
+              className="w-full rounded-lg border px-3 py-2"
+              placeholder="Category (optional)"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+            />
+            <div className="grid grid-cols-2 gap-3">
+              {canon.map((c) => (
+                <button
+                  key={c.key}
+                  onClick={() => handleCanonPick(c.url)}
+                  className="flex items-center gap-3 rounded-lg border p-3 hover:bg-gray-50"
+                >
+                  <img src={c.url} className="h-10 w-10" alt={c.label} />
+                  <span>{c.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {errorMsg && <p className="mt-4 text-sm text-red-600">{errorMsg}</p>}
+      </div>
+    </div>
+  );
+}
+

--- a/lib/navatar.ts
+++ b/lib/navatar.ts
@@ -1,0 +1,93 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL!;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY!;
+export const supabase = createClient(supabaseUrl, supabaseKey);
+
+export type Navatar = {
+  id: string;
+  user_id: string | null;
+  name: string | null;
+  category: string | null;
+  image_url: string | null;
+  image_path: string | null;
+  thumbnail_url: string | null;
+  method: 'upload' | 'ai' | 'canon';
+  is_primary: boolean | null;
+  is_public: boolean | null;
+  status: string | null;
+  status_message: string | null;
+  created_at: string | null;
+};
+
+const BUCKET = 'avatars';
+
+export async function listNavatars() {
+  const { data, error } = await supabase
+    .from('avatars')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+  return (data || []) as Navatar[];
+}
+
+export async function uploadToStorage(file: File, userId: string) {
+  const ext = file.name.split('.').pop() || 'png';
+  const path = `${userId}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+
+  const { error: upErr } = await supabase.storage.from(BUCKET).upload(path, file, {
+    contentType: file.type || 'image/png',
+    upsert: false,
+  });
+  if (upErr) throw upErr;
+
+  const { data: pub } = supabase.storage.from(BUCKET).getPublicUrl(path);
+  return { path, publicUrl: pub?.publicUrl || null };
+}
+
+export async function createAvatarRow(partial: Partial<Navatar>) {
+  const payload = {
+    method: 'upload',
+    status: 'ready',
+    is_primary: false,
+    is_public: false,
+    ...partial,
+  };
+  const { data, error } = await supabase.from('avatars').insert(payload).select('*').single();
+  if (error) throw error;
+  return data as Navatar;
+}
+
+export async function deleteAvatar(id: string) {
+  const { error } = await supabase.from('avatars').delete().eq('id', id);
+  if (error) throw error;
+}
+
+export async function setPrimaryAvatar(id: string) {
+  // Get current user
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not signed in');
+
+  // set all false, then one true (within RLS)
+  const { error: e1 } = await supabase.from('avatars').update({ is_primary: false }).eq('user_id', user.id);
+  if (e1) throw e1;
+
+  const { error: e2 } = await supabase.from('avatars').update({ is_primary: true }).eq('id', id);
+  if (e2) throw e2;
+}
+
+export function publicCanonOptions() {
+  // Keep in sync with /public/navatars
+  return [
+    { key: 'bamboo', label: 'Bamboo', url: '/navatars/bamboo.svg' },
+    { key: 'firefox', label: 'Firefox', url: '/navatars/firefox.svg' },
+    { key: 'oceanorb', label: 'Ocean Orb', url: '/navatars/oceanorb.svg' },
+    { key: 'seedling', label: 'Seedling', url: '/navatars/seedling.svg' },
+    { key: 'splash', label: 'Splash', url: '/navatars/splash.svg' },
+    { key: 'zenpanda', label: 'Zen Panda', url: '/navatars/zenpanda.svg' },
+  ];
+}
+

--- a/netlify/functions/navatar-generate.ts
+++ b/netlify/functions/navatar-generate.ts
@@ -1,44 +1,37 @@
 import type { Handler } from '@netlify/functions';
+import OpenAI from 'openai';
 
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY!;
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
 
 export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method not allowed' };
+  }
   try {
-    const { prompt, n = 4, size = '512x512' } = JSON.parse(event.body || '{}');
+    const { prompt } = JSON.parse(event.body || '{}');
     if (!prompt || typeof prompt !== 'string') {
       return { statusCode: 400, body: 'Missing prompt' };
     }
 
-    if (prompt.length > 400) {
-      return { statusCode: 400, body: 'Prompt too long (max 400 chars)' };
-    }
-
-    const composed = `Thailandia Flat style, cute mascot avatar, clean shapes, no text, white/soft background, 1:1. ${prompt}`;
-
-    const r = await fetch('https://api.openai.com/v1/images/generations', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${OPENAI_API_KEY}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'gpt-image-1',
-        prompt: composed,
-        size,
-        n,
-        response_format: 'b64_json',
-      }),
+    // Simple, single best image
+    const img = await client.images.generate({
+      model: 'gpt-image-1',
+      prompt,
+      size: '1024x1024',
+      n: 1,
     });
 
-    if (!r.ok) {
-      const t = await r.text();
-      return { statusCode: 500, body: t };
-    }
+    const b64 = img.data?.[0]?.b64_json;
+    if (!b64) return { statusCode: 500, body: 'No image returned' };
 
-    const json = await r.json();
-    const images = (json?.data || []).map((d: any) => d.b64_json);
-    return { statusCode: 200, body: JSON.stringify({ images }) };
-  } catch (e: any) {
-    return { statusCode: 500, body: JSON.stringify({ error: e?.message || 'Server error' }) };
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ base64: b64, mime: 'image/png' }),
+      headers: { 'Content-Type': 'application/json' },
+    };
+  } catch (err: any) {
+    return { statusCode: 500, body: err?.message || 'Generation error' };
   }
 };
+
+export default handler;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-helmet-async": "^2.0.4",
     "stripe": "^14.0.0",
     "ethers": "^6.13.2",
-    "luxon": "^3.4.4"
+    "luxon": "^3.4.4",
+    "openai": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",

--- a/pages/navatar.tsx
+++ b/pages/navatar.tsx
@@ -1,0 +1,55 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { listNavatars } from '@/lib/navatar';
+import type { Navatar } from '@/lib/navatar';
+import NavatarCard from '@/components/NavatarCard';
+import NavatarCreateModal from '@/components/NavatarCreateModal';
+import { supabase } from '@/lib/navatar';
+
+export default function NavatarPage() {
+  const [navatars, setNavatars] = useState<Navatar[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  async function refresh() {
+    setLoading(true);
+    const rows = await listNavatars();
+    setNavatars(rows);
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    refresh();
+    // when auth state changes, reload list
+    const { data: sub } = supabase.auth.onAuthStateChange(() => refresh());
+    return () => {
+      sub.subscription?.unsubscribe();
+    };
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-3xl font-extrabold">My Navatars</h1>
+        <button onClick={() => setCreating(true)} className="rounded-xl bg-blue-600 px-4 py-2 text-white">
+          Create Navatar
+        </button>
+      </div>
+
+      {loading ? (
+        <p>Loading…</p>
+      ) : navatars.length === 0 ? (
+        <p className="text-gray-600">You don’t own any Navatars yet — create your first!</p>
+      ) : (
+        <div className="grid gap-3">
+          {navatars.map((n) => (
+            <NavatarCard key={n.id} navatar={n} onChanged={refresh} />
+          ))}
+        </div>
+      )}
+
+      <NavatarCreateModal open={creating} onClose={() => setCreating(false)} onCreated={refresh} />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Supabase navatar helper with CRUD and storage
- implement Navatar creation modal with upload, AI generation, and canon options
- add Navatar hub page and card actions to manage avatars
- add Netlify function using OpenAI to generate navatar images
- include OpenAI dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b65d2883dc8329bbd9a7a0ba64aaef