### PR TITLE
feat: add navatar hub

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "vite build"
   publish = "dist"
 
+[functions]
+  directory = "netlify/functions"
+
 # --- Static utility pages BEFORE SPA catch-all ---
 [[redirects]]
   from = "/kill-sw"

--- a/netlify/functions/navatar-generate.ts
+++ b/netlify/functions/navatar-generate.ts
@@ -4,41 +4,48 @@ const OPENAI_API_KEY = process.env.OPENAI_API_KEY!;
 
 export const handler: Handler = async (event) => {
   try {
-    const { prompt, n = 4, size = '512x512' } = JSON.parse(event.body || '{}');
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method Not Allowed' };
+    }
+    if (!OPENAI_API_KEY) {
+      return { statusCode: 500, body: 'Missing OPENAI_API_KEY' };
+    }
+    const { prompt } = JSON.parse(event.body || '{}');
     if (!prompt || typeof prompt !== 'string') {
       return { statusCode: 400, body: 'Missing prompt' };
     }
 
-    if (prompt.length > 400) {
-      return { statusCode: 400, body: 'Prompt too long (max 400 chars)' };
-    }
-
-    const composed = `Thailandia Flat style, cute mascot avatar, clean shapes, no text, white/soft background, 1:1. ${prompt}`;
-
-    const r = await fetch('https://api.openai.com/v1/images/generations', {
+    const resp = await fetch('https://api.openai.com/v1/images', {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${OPENAI_API_KEY}`,
+        'Authorization': `Bearer ${OPENAI_API_KEY}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
         model: 'gpt-image-1',
-        prompt: composed,
-        size,
-        n,
+        prompt,
+        size: '1024x1024',
         response_format: 'b64_json',
       }),
     });
 
-    if (!r.ok) {
-      const t = await r.text();
-      return { statusCode: 500, body: t };
+    if (!resp.ok) {
+      const txt = await resp.text();
+      return { statusCode: resp.status, body: txt };
     }
 
-    const json = await r.json();
-    const images = (json?.data || []).map((d: any) => d.b64_json);
-    return { statusCode: 200, body: JSON.stringify({ images }) };
-  } catch (e: any) {
-    return { statusCode: 500, body: JSON.stringify({ error: e?.message || 'Server error' }) };
+    const data = await resp.json();
+    const b64 = data?.data?.[0]?.b64_json;
+    if (!b64) return { statusCode: 502, body: 'No image returned' };
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ base64: b64, mime: 'image/png' }),
+    };
+  } catch (e:any) {
+    return { statusCode: 500, body: e.message || 'Server error' };
   }
 };
+
+export default handler;
+

--- a/src/components/CanonPicker.tsx
+++ b/src/components/CanonPicker.tsx
@@ -1,0 +1,43 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import { CANON_NAVATARS } from '@/lib/canon';
+
+export default function CanonPicker({ onPick }: { onPick: (url: string) => void }) {
+  const [q, setQ] = useState('');
+  const items = useMemo(() => {
+    const s = q.trim().toLowerCase();
+    if (!s) return CANON_NAVATARS;
+    return CANON_NAVATARS.filter(i =>
+      i.label.toLowerCase().includes(s) || (i.tags || []).some(t => t.toLowerCase().includes(s))
+    );
+  }, [q]);
+
+  return (
+    <div className="space-y-3">
+      <input
+        className="w-full rounded-lg border px-3 py-2"
+        placeholder="Search canon (e.g., panda, plant, ocean)"
+        value={q}
+        onChange={(e)=>setQ(e.target.value)}
+      />
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        {items.map((c) => (
+          <button
+            key={c.key}
+            onClick={() => onPick(c.url)}
+            className="group flex items-center gap-3 rounded-2xl border p-3 text-left hover:shadow-sm"
+          >
+            <img src={c.url} className="h-12 w-12 rounded-xl" alt={c.label} />
+            <div className="min-w-0">
+              <div className="truncate font-medium">{c.label}</div>
+              {c.tags?.length ? (
+                <div className="truncate text-xs text-gray-500">{c.tags.join(' · ')}</div>
+              ) : null}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -1,91 +1,33 @@
+'use client';
 import React from 'react';
-import { Navatar } from '../data/navatars';
-import { buyNavatarWithNatur } from '../lib/natur';
 
-type Props = {
-  nav: Navatar;
-  owned: boolean;
-  activeId?: string | null;
-  onGet?: (id: string) => void;
-  onUse: (id: string) => void;
-};
-
-export default function NavatarCard({ nav, owned, activeId, onGet, onUse }: Props) {
-  const isActive = activeId === nav.id;
-
-  async function startCheckout() {
-    const res = await fetch('/.netlify/functions/navatar-checkout', {
-      method: 'POST',
-      body: JSON.stringify({ user_id: (window as any).user?.id, navatar_id: nav.id, method: 'stripe' }),
-    });
-    const data = await res.json();
-    if (data.url) (window.location.href = data.url);
-    else alert(data.message || 'Checkout started');
-  }
-
-  async function payNatur() {
-    try {
-      const amt = nav.priceNatur ?? 100;
-      await buyNavatarWithNatur(nav.id, amt);
-      alert('Purchased with $NATUR \u2713');
-      onGet && onGet(nav.id);
-    } catch (e: any) {
-      alert(e?.message || 'Payment failed');
-    }
-  }
-
+export default function NavatarCard({
+  navatar,
+  onDelete,
+}: {
+  navatar: any;
+  onDelete: (id: string) => void;
+}) {
   return (
-    <div
-      style={{
-        border: '1px solid #e5e7eb',
-        borderRadius: 12,
-        padding: 16,
-        width: 240,
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 8,
-      }}
-    >
-      <img src={nav.img} alt={nav.name} width={200} height={200} style={{ alignSelf: 'center' }} />
-      <div style={{ fontWeight: 700 }}>{nav.name}</div>
-      <div style={{ display: 'flex', gap: 8, fontSize: 12, opacity: 0.8 }}>
-        <span>{nav.rarity}</span>
-        {nav.priceCents > 0 ? <span>${(nav.priceCents / 100).toFixed(2)}</span> : <span>Free</span>}
+    <div className="flex items-center gap-4 rounded-2xl border p-3 sm:p-4">
+      <img
+        src={navatar.image_url}
+        alt={navatar.name}
+        className="h-16 w-16 flex-none rounded-xl object-cover"
+      />
+      <div className="min-w-0">
+        <div className="truncate font-semibold">{navatar.name || 'Untitled'}</div>
+        <div className="text-sm text-gray-500">{navatar.method?.toUpperCase?.() || 'NAVATAR'}</div>
       </div>
+      <div className="ml-auto">
+        <button
+          onClick={() => onDelete(navatar.id)}
+          className="rounded-lg border px-3 py-1 text-sm hover:bg-gray-50"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}
 
-        {owned ? (
-          isActive ? (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#16a34a' }}>
-              <span className={`navatar-frame ${nav.rarity}`}>
-                <img src={nav.img} width={18} height={18} style={{ borderRadius: '50%' }} alt="" />
-              </span>
-              Active
-            </div>
-          ) : (
-            <button onClick={() => onUse(nav.id)} style={{ padding: '8px 12px', borderRadius: 8 }}>
-              Use
-            </button>
-          )
-        ) : nav.priceCents > 0 ? (
-          <div style={{ display: 'flex', gap: 8 }}>
-            <button
-              onClick={startCheckout}
-              style={{ padding: '8px 12px', borderRadius: 8 }}
-            >
-              Buy ${(nav.priceCents / 100).toFixed(2)}
-            </button>
-            <button
-              onClick={payNatur}
-              style={{ padding: '8px 12px', borderRadius: 8 }}
-            >
-              Pay {nav.priceNatur ?? 100} $NATUR
-            </button>
-          </div>
-        ) : (
-          <button onClick={() => onGet && onGet(nav.id)} style={{ padding: '8px 12px', borderRadius: 8 }}>
-            Get
-          </button>
-        )}
-      </div>
-    );
-  }

--- a/src/components/NavatarCreateModal.tsx
+++ b/src/components/NavatarCreateModal.tsx
@@ -1,0 +1,107 @@
+'use client';
+import React, { useState } from 'react';
+import { supabase } from '@/lib/supabase-browser';
+import { createAvatarRow, uploadToStorage, getUserId } from '@/lib/navatar-client';
+import CanonPicker from '@/components/CanonPicker';
+
+type Props = { open: boolean; onClose: () => void; onCreated: () => void; };
+type Tab = 'upload' | 'ai' | 'canon';
+
+export default function NavatarCreateModal({ open, onClose, onCreated }: Props) {
+  const [tab, setTab] = useState<Tab>('upload');
+  const [file, setFile] = useState<File | null>(null);
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState('avatar');
+  const [prompt, setPrompt] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  async function ensureUser() {
+    const uid = await getUserId();
+    if (!uid) throw new Error('Please sign in to create a Navatar.');
+    return uid;
+  }
+
+  async function onUpload(e: React.FormEvent) {
+    e.preventDefault(); setErr(null); setLoading(true);
+    try {
+      const uid = await ensureUser();
+      if (!file) throw new Error('Choose an image to upload.');
+      const { publicUrl } = await uploadToStorage(file, uid);
+      await createAvatarRow({ name: name || file.name.replace(/\.[^.]+$/, ''), category, image_url: publicUrl, method: 'upload' });
+      onCreated(); onClose();
+    } catch (e:any) { setErr(e.message || 'Upload failed'); } finally { setLoading(false); }
+  }
+
+  async function onAI(e: React.FormEvent) {
+    e.preventDefault(); setErr(null); setLoading(true);
+    try {
+      await ensureUser();
+      if (!prompt.trim()) throw new Error('Describe your Navatar.');
+      const res = await fetch('/.netlify/functions/navatar-generate', {
+        method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ prompt })
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const { base64, mime } = await res.json();
+      const bin = atob(base64); const bytes = new Uint8Array(bin.length);
+      for (let i=0;i<bin.length;i++) bytes[i] = bin.charCodeAt(i);
+      const imageFile = new File([bytes], 'navatar.png', { type: mime || 'image/png' });
+      const uid = await ensureUser();
+      const { publicUrl } = await uploadToStorage(imageFile, uid);
+      await createAvatarRow({ name: name || 'My Navatar', category, image_url: publicUrl, method: 'ai' });
+      onCreated(); onClose();
+    } catch (e:any) { setErr(e.message || 'Generation failed'); } finally { setLoading(false); }
+  }
+
+  async function onCanonPick(url: string) {
+    setErr(null); setLoading(true);
+    try {
+      await ensureUser();
+      await createAvatarRow({ name: name || 'Canon Navatar', category, image_url: url, method: 'canon' });
+      onCreated(); onClose();
+    } catch (e:any) { setErr(e.message || 'Could not save'); } finally { setLoading(false); }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-3">
+      <div className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-xl font-semibold">Create Navatar</h3>
+          <button onClick={onClose} className="rounded-lg px-3 py-1 hover:bg-gray-100">✕</button>
+        </div>
+
+        <div className="mb-4 grid grid-cols-3 gap-2">
+          <button onClick={()=>setTab('upload')} className={`rounded-full px-3 py-2 text-sm ${tab==='upload'?'bg-blue-600 text-white':'bg-gray-100'}`}>Upload</button>
+          <button onClick={()=>setTab('ai')}     className={`rounded-full px-3 py-2 text-sm ${tab==='ai'    ?'bg-blue-600 text-white':'bg-gray-100'}`}>Describe & Generate</button>
+          <button onClick={()=>setTab('canon')}  className={`rounded-full px-3 py-2 text-sm ${tab==='canon' ?'bg-blue-600 text-white':'bg-gray-100'}`}>Pick Canon</button>
+        </div>
+
+        <div className="space-y-3">
+          <input className="w-full rounded-lg border px-3 py-2" placeholder="Name (optional)" value={name} onChange={(e)=>setName(e.target.value)} />
+          <input className="w-full rounded-lg border px-3 py-2" placeholder="Category (optional)" value={category} onChange={(e)=>setCategory(e.target.value)} />
+        </div>
+
+        <div className="mt-4">
+          {tab==='upload' && (
+            <form onSubmit={onUpload} className="space-y-3">
+              <input type="file" accept="image/*" onChange={(e)=>setFile(e.target.files?.[0]||null)} />
+              <button disabled={loading} className="rounded-lg bg-blue-600 px-4 py-2 text-white">{loading?'Saving…':'Save'}</button>
+            </form>
+          )}
+          {tab==='ai' && (
+            <form onSubmit={onAI} className="space-y-3">
+              <textarea className="h-28 w-full rounded-lg border px-3 py-2" placeholder="Describe your Navatar (e.g., half turtle, half durian…)" value={prompt} onChange={(e)=>setPrompt(e.target.value)} />
+              <button disabled={loading} className="rounded-lg bg-blue-600 px-4 py-2 text-white">{loading?'Generating…':'Generate'}</button>
+            </form>
+          )}
+          {tab==='canon' && <CanonPicker onPick={onCanonPick} />}
+        </div>
+
+        {err && <p className="mt-4 text-sm text-red-600">{err}</p>}
+      </div>
+    </div>
+  );
+}
+

--- a/src/lib/canon.ts
+++ b/src/lib/canon.ts
@@ -1,0 +1,11 @@
+export type CanonItem = { key: string; label: string; url: string; tags?: string[] };
+
+export const CANON_NAVATARS: CanonItem[] = [
+  { key: 'bamboo',    label: 'Bamboo',    url: '/navatars/bamboo.svg',    tags: ['plant','calm'] },
+  { key: 'firefox',   label: 'Firefox',   url: '/navatars/firefox.svg',   tags: ['fox','red'] },
+  { key: 'oceanorb',  label: 'Ocean Orb', url: '/navatars/oceanorb.svg',  tags: ['ocean','blue'] },
+  { key: 'seedling',  label: 'Seedling',  url: '/navatars/seedling.svg',  tags: ['growth','green'] },
+  { key: 'splash',    label: 'Splash',    url: '/navatars/splash.svg',    tags: ['water','fun'] },
+  { key: 'zenpanda',  label: 'Zen Panda', url: '/navatars/zenpanda.svg',  tags: ['panda','calm'] },
+];
+

--- a/src/lib/navatar-client.ts
+++ b/src/lib/navatar-client.ts
@@ -1,0 +1,56 @@
+import { supabase } from './supabase-browser';
+
+export type NewAvatar = {
+  name: string;
+  category?: string | null;
+  image_url: string;
+  method: 'upload' | 'ai' | 'canon';
+  appearance_data?: any;
+};
+
+export async function getUserId() {
+  const { data: { user }, error } = await supabase.auth.getUser();
+  if (error) throw error;
+  return user?.id ?? null;
+}
+
+export async function listNavatars() {
+  const { data, error } = await supabase
+    .from('avatars')
+    .select('*')
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function createAvatarRow(a: NewAvatar) {
+  const userId = await getUserId();
+  if (!userId) throw new Error('Please sign in to create a Navatar.');
+  const { error } = await supabase.from('avatars').insert({
+    user_id: userId,
+    name: a.name,
+    category: a.category ?? 'avatar',
+    image_url: a.image_url,
+    method: a.method,
+    appearance_data: a.appearance_data ?? null,
+  });
+  if (error) throw error;
+}
+
+export async function deleteAvatar(id: string) {
+  const { error } = await supabase.from('avatars').delete().eq('id', id);
+  if (error) throw error;
+}
+
+export async function uploadToStorage(file: File, userId: string) {
+  const ext = file.name.split('.').pop() || 'png';
+  const path = `${userId}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+  const { error } = await supabase.storage.from('avatars').upload(path, file, {
+    contentType: file.type || 'image/png',
+    upsert: true,
+  });
+  if (error) throw error;
+  const { data } = supabase.storage.from('avatars').getPublicUrl(path);
+  return { path, publicUrl: data.publicUrl };
+}
+

--- a/src/lib/supabase-browser.ts
+++ b/src/lib/supabase-browser.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = import.meta.env.VITE_SUPABASE_URL!;
+const anon = import.meta.env.VITE_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(url, anon, {
+  auth: { persistSession: true, autoRefreshToken: true },
+});
+


### PR DESCRIPTION
## Summary
- replace /navatar with a full-featured hub for managing user Navatars
- add Supabase client helpers, creation modal, and canon picker
- wire Netlify function to OpenAI for image generation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b661a288508329bfcdf8231ad20d27