### PR TITLE
Navatar Hub — fix upload image URL, clean UI modes, better AI errors

### DIFF
--- a/src/data/navatarCatalog.ts
+++ b/src/data/navatarCatalog.ts
@@ -1,0 +1,18 @@
+// src/data/navatarCatalog.ts
+// Auto-collect every image under /public/navatars on build
+// Add/remove files in that folder -> redeploy -> catalog updates
+const files = import.meta.glob("/public/navatars/*.{png,jpg,jpeg}", { eager: true, as: "url" });
+
+type Canon = { key: string; title: string; tags: string[]; image_url: string };
+
+const titleCase = (s: string) => s.replace(/[-_]/g, " ").replace(/\b\w/g, m => m.toUpperCase());
+
+export const NAVATAR_CATALOG: Canon[] = Object.entries(files).map(([path, url]) => {
+  const base = path.split("/").pop()!.replace(/\.(png|jpg|jpeg)$/i, "");
+  return {
+    key: base.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+    title: titleCase(base),
+    tags: base.split(/[-_ ]+/).map(t => t.toLowerCase()).filter(Boolean),
+    image_url: url as string
+  };
+});

--- a/src/lib/supa.ts
+++ b/src/lib/supa.ts
@@ -1,0 +1,12 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const supa = createClient(
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_ANON_KEY!,
+  {
+    auth: { persistSession: true, detectSessionInUrl: true }
+  }
+);
+
+export const publicUrl = (path: string) =>
+  supa.storage.from("avatars").getPublicUrl(path).data.publicUrl;

--- a/src/pages/navatar.tsx
+++ b/src/pages/navatar.tsx
@@ -1,299 +1,249 @@
-import { useEffect, useMemo, useState } from 'react'
-import { supabase } from '../lib/supabaseClient'
-import { publicUrlFromPath } from '../lib/storage'
+import { useEffect, useMemo, useState } from "react";
+import { supa, publicUrl } from "../lib/supa";
+import { NAVATAR_CATALOG } from "../data/navatarCatalog";
 
-type Avatar = {
-  id: string
-  name: string | null
-  method: 'upload' | 'canon' | 'ai'
-  image_url: string | null
-  appearance_data: any
-}
+type AvatarRow = {
+  id: string;
+  user_id: string|null;
+  name: string|null;
+  method: "upload"|"ai"|"canon";
+  image_url: string;
+};
 
-type Tab = 'upload' | 'generate' | 'canon' | null
+type Mode = "upload" | "generate" | "canon" | null;
 
 export default function NavatarPage() {
-  const [avatars, setAvatars] = useState<Avatar[]>([])
-  const [loading, setLoading] = useState(true)
-  const [openTab, setOpenTab] = useState<Tab>(null)
-  const [error, setError] = useState<string | null>(null)
+  const [session, setSession] = useState<any>(null);
+  const [avatars, setAvatars] = useState<AvatarRow[]>([]);
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<Mode>(null);
 
-  // Auto-catalog canon assets from /public/navatars
-  const canonItems = useMemo(() => {
-    // eager + as:url gives us the final asset URL at build
-    const glob = import.meta.glob('/public/navatars/*.png', { eager: true, as: 'url' }) as Record<
-      string,
-      string
-    >
-    return Object.entries(glob).map(([abs, url]) => {
-      const file = abs.split('/').pop()!.replace('.png', '')
-      return {
-        name: file,
-        url,
-        tags: file.toLowerCase().split(/[\s_-]+/),
-      }
-    })
-  }, [])
+  // upload state
+  const [file, setFile] = useState<File|null>(null);
+  // generate state
+  const [name, setName] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string|null>(null);
+  // canon state
+  const [canonKey, setCanonKey] = useState<string|null>(null);
 
   useEffect(() => {
-    ;(async () => {
-      const { data, error } = await supabase
-        .from('avatars')
-        .select('id,name,method,image_url,appearance_data')
-        .order('created_at', { ascending: false })
+    supa.auth.getSession().then(({ data }) => setSession(data.session));
+    load();
+  }, []);
 
-      if (!error && data) setAvatars(data as any)
-      setLoading(false)
-    })()
-  }, [])
+  async function load() {
+    const { data } = await supa.from("avatars").select("*").order("created_at", { ascending: false });
+    setAvatars(data || []);
+  }
 
   async function remove(id: string) {
-    setError(null)
-    const prev = avatars
-    setAvatars((as) => as.filter((a) => a.id !== id))
-    const { error } = await supabase.from('avatars').delete().eq('id', id)
-    if (error) {
-      setError(error.message)
-      setAvatars(prev)
-    }
+    await supa.from("avatars").delete().eq("id", id);
+    await load();
   }
 
-  // UPLOAD
-  const [uploadName, setUploadName] = useState('')
-  const [uploadPreview, setUploadPreview] = useState<string | null>(null)
-  const [uploadFile, setUploadFile] = useState<File | null>(null)
-
-  async function saveUpload() {
-    if (!uploadFile) return
-    setError(null)
-    // path: user uploads into avatars/uploads
-    const path = `uploads/${Date.now()}-${uploadFile.name.replace(/\s+/g, '-')}`
-    const { error: upErr } = await supabase.storage
-      .from('avatars')
-      .upload(path, uploadFile, { upsert: false })
-    if (upErr) return setError(upErr.message)
-
-    const url = publicUrlFromPath('avatars', path)
-
-    const { data, error: dbErr } = await supabase
-      .from('avatars')
-      .insert({
-        name: uploadName || uploadFile.name.replace(/\.[^.]+$/, ''),
-        method: 'upload',
-        image_url: url,
-        appearance_data: { path },
-      })
-      .select()
-      .single()
-
-    if (dbErr) return setError(dbErr.message)
-    setAvatars((a) => [data as any, ...a])
-    // reset form
-    setUploadFile(null)
-    setUploadPreview(null)
-    setUploadName('')
-    setOpenTab(null)
+  function resetModal() {
+    setMode(null);
+    setFile(null);
+    setName("");
+    setPrompt("");
+    setCanonKey(null);
+    setErr(null);
   }
 
-  // GENERATE
-  const [genName, setGenName] = useState('')
-  const [genPrompt, setGenPrompt] = useState('')
-
-  async function runGenerate() {
-    setError(null)
+  // --- Actions ---
+  async function onSaveUpload() {
+    if (!file) return;
+    setBusy(true); setErr(null);
     try {
-      const res = await fetch('/.netlify/functions/generate-navatar', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ name: genName || 'avatar', prompt: genPrompt }),
-      })
-      const body = await res.json().catch(() => ({}))
-      if (!res.ok) {
-        return setError(body?.error || `Error ${res.status}`)
-      }
-      if (body?.avatar) {
-        setAvatars((a) => [body.avatar, ...a])
-        setGenName('')
-        setGenPrompt('')
-        setOpenTab(null)
-      }
+      const path = `uploads/${session?.user?.id ?? "anon"}/${crypto.randomUUID()}-${file.name}`;
+      const { error } = await supa.storage.from("avatars").upload(path, file, { upsert: false });
+      if (error) throw error;
+
+      const url = publicUrl(path);
+      const { error: insErr } = await supa.from("avatars").insert({
+        user_id: session?.user?.id ?? null,
+        name: name || file.name.replace(/\.[^/.]+$/, ""),
+        method: "upload",
+        image_url: url
+      });
+      if (insErr) throw insErr;
+
+      await load();
+      setOpen(false); resetModal();
     } catch (e: any) {
-      setError(String(e?.message || e))
+      setErr(e?.message || "Upload failed");
+    } finally {
+      setBusy(false);
     }
   }
 
-  // CANON
-  async function chooseCanon(item: { name: string; url: string }) {
-    setError(null)
-    const { data, error } = await supabase
-      .from('avatars')
-      .insert({
-        name: item.name,
-        method: 'canon',
-        image_url: item.url,
-        appearance_data: { source: 'canon', file: item.name + '.png' },
-      })
-      .select()
-      .single()
-    if (error) return setError(error.message)
-    setAvatars((a) => [data as any, ...a])
-    setOpenTab(null)
+  async function onSaveCanon() {
+    if (!canonKey) return;
+    setBusy(true); setErr(null);
+    try {
+      const c = NAVATAR_CATALOG.find(c => c.key === canonKey)!;
+      const { error } = await supa.from("avatars").insert({
+        user_id: session?.user?.id ?? null,
+        name: name || c.title,
+        method: "canon",
+        image_url: c.image_url // direct URL in /public
+      });
+      if (error) throw error;
+      await load();
+      setOpen(false); resetModal();
+    } catch (e: any) {
+      setErr(e?.message || "Save failed");
+    } finally {
+      setBusy(false);
+    }
   }
+
+  async function onGenerate() {
+    if (!prompt.trim()) return;
+    setBusy(true); setErr(null);
+    try {
+      const res = await fetch("/.netlify/functions/generate-navatar", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          user_id: session?.user?.id ?? null,
+          name: name || "AI avatar",
+          prompt
+        })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Failed to generate");
+      await load();
+      setOpen(false); resetModal();
+    } catch (e: any) {
+      setErr(e?.message || "Failed to generate");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // --- UI helpers ---
+  const catalog = useMemo(() => NAVATAR_CATALOG, []);
+  const canGenerate = !err || !/403/.test(err); // button remains but message shows
 
   return (
-    <div className="container" style={{ maxWidth: 960, margin: '0 auto', padding: '16px' }}>
-      <h1 style={{ textAlign: 'center', marginBottom: 8 }}>Your Navatar</h1>
-      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 16 }}>
-        <button className="btn" onClick={() => setOpenTab('upload')}>Create Navatar</button>
+    <div className="container">
+      <h1 className="title">Your Navatar</h1>
+      <button className="btn" onClick={() => { setOpen(true); setMode(null); }}>Create Navatar</button>
+
+      {/* Current avatar list (simple: most recent at top) */}
+      <div className="current">
+        {avatars.map(a => (
+          <div key={a.id} className="card">
+            {/* If some rows still have a storage path, resolve to public url */}
+            <img src={/^https?:/.test(a.image_url) ? a.image_url : publicUrl(a.image_url)} alt={a.name ?? "avatar"} />
+            <div className="name">{a.name ?? a.method.toUpperCase()}</div>
+            <div className="method">{a.method.toUpperCase()}</div>
+            <button className="btn danger" onClick={() => remove(a.id)}>Delete</button>
+          </div>
+        ))}
       </div>
 
-      {error && (
-        <div style={{ color: '#b00020', textAlign: 'center', marginBottom: 12 }}>
-          {error}
-        </div>
-      )}
-
-      {/* List */}
-      {!loading && avatars.length > 0 && (
-        <div style={{ display: 'grid', gap: 24, gridTemplateColumns: '1fr' }}>
-          {avatars.map((a) => (
-            <div key={a.id} style={{ textAlign: 'center' }}>
-              {a.image_url && (
-                <img
-                  src={a.image_url}
-                  alt={a.name || 'navatar'}
-                  style={{ width: 340, maxWidth: '100%', borderRadius: 8 }}
-                />
-              )}
-              <div style={{ marginTop: 6, fontWeight: 600 }}>{a.name || '—'}</div>
-              <div style={{ fontSize: 12, opacity: 0.7 }}>{a.method.toUpperCase()}</div>
-              <button className="btn small" style={{ marginTop: 8 }} onClick={() => remove(a.id)}>
-                Delete
-              </button>
+      {/* Modal */}
+      {open && (
+        <>
+          <div className="backdrop" onClick={() => { setOpen(false); resetModal(); }} />
+          <div className="modal" role="dialog" aria-modal="true">
+            <div className="modal-head">
+              <h2>Create Navatar</h2>
+              <button className="icon" onClick={() => { setOpen(false); resetModal(); }}>✕</button>
             </div>
-          ))}
-        </div>
-      )}
 
-      {/* Modal-ish area */}
-      {openTab && (
-        <div style={{ marginTop: 28 }}>
-          <h2 style={{ textAlign: 'center', marginBottom: 12 }}>Create Navatar</h2>
-          <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 12 }}>
-            <button className="btn small" onClick={() => setOpenTab(null)}>✕</button>
-          </div>
+            {/* Mode tabs (exclusive) */}
+            <div className="modes">
+              <button className={`tab ${mode === "upload" ? "active" : ""}`} onClick={() => setMode("upload")}>Upload</button>
+              <button className={`tab ${mode === "generate" ? "active" : ""}`} onClick={() => setMode("generate")}>Describe & Generate</button>
+              <button className={`tab ${mode === "canon" ? "active" : ""}`} onClick={() => setMode("canon")}>Pick Canon</button>
+            </div>
 
-          {/* Tabs header */}
-          <div style={{ display: 'flex', gap: 12, justifyContent: 'center', marginBottom: 12 }}>
-            <button
-              className={`btn ${openTab === 'upload' ? 'primary' : 'ghost'}`}
-              onClick={() => setOpenTab('upload')}
-            >
-              Upload
-            </button>
-            <button
-              className={`btn ${openTab === 'generate' ? 'primary' : 'ghost'}`}
-              onClick={() => setOpenTab('generate')}
-            >
-              Describe &amp; Generate
-            </button>
-            <button
-              className={`btn ${openTab === 'canon' ? 'primary' : 'ghost'}`}
-              onClick={() => setOpenTab('canon')}
-            >
-              Pick Canon
-            </button>
-          </div>
+            <input
+              className="input"
+              placeholder="Name (optional)"
+              value={name}
+              onChange={e => setName(e.target.value)}
+            />
 
-          {/* Upload tab */}
-          {openTab === 'upload' && (
-            <div style={{ textAlign: 'center' }}>
-              <input
-                placeholder="Name (optional)"
-                value={uploadName}
-                onChange={(e) => setUploadName(e.target.value)}
-                style={{ padding: 8, width: 260, marginBottom: 8 }}
-              />
-              <input
-                type="file"
-                accept="image/*"
-                onChange={(e) => {
-                  const f = e.target.files?.[0] || null
-                  setUploadFile(f || null)
-                  setUploadPreview(f ? URL.createObjectURL(f) : null)
-                }}
-              />
-              {uploadPreview && (
-                <div style={{ marginTop: 10 }}>
-                  <img src={uploadPreview} style={{ maxWidth: 320, borderRadius: 8 }} />
+            {mode === "upload" && (
+              <div className="panel">
+                <input type="file" accept="image/*"
+                       onChange={e => setFile(e.target.files?.[0] ?? null)} />
+                {file && <img className="preview" src={URL.createObjectURL(file)} alt="preview" />}
+                <button className="btn primary" disabled={!file || busy} onClick={onSaveUpload}>
+                  {busy ? "Saving…" : "Save"}
+                </button>
+              </div>
+            )}
+
+            {mode === "generate" && (
+              <div className="panel">
+                <textarea className="textarea" placeholder="Describe your Navatar…" value={prompt}
+                          onChange={e => setPrompt(e.target.value)} />
+                <button className="btn primary" disabled={!prompt || busy || !canGenerate} onClick={onGenerate}>
+                  {busy ? "Generating…" : "Generate"}
+                </button>
+                {!!err && <p className="error">{err}</p>}
+              </div>
+            )}
+
+            {mode === "canon" && (
+              <div className="panel">
+                <div className="grid">
+                  {catalog.map(c => (
+                    <button key={c.key}
+                            className={`canon ${canonKey === c.key ? "selected" : ""}`}
+                            onClick={() => setCanonKey(c.key)}>
+                      <img src={c.image_url} alt={c.title} />
+                      <div className="label">{c.title}</div>
+                    </button>
+                  ))}
                 </div>
-              )}
-              <div style={{ marginTop: 10 }}>
-                <button className="btn" onClick={saveUpload} disabled={!uploadFile}>
-                  Save
+                <button className="btn primary" disabled={!canonKey || busy} onClick={onSaveCanon}>
+                  {busy ? "Saving…" : "Save"}
                 </button>
               </div>
-            </div>
-          )}
-
-          {/* Generate tab */}
-          {openTab === 'generate' && (
-            <div style={{ textAlign: 'center' }}>
-              <input
-                placeholder="Name (optional)"
-                value={genName}
-                onChange={(e) => setGenName(e.target.value)}
-                style={{ padding: 8, width: 260, marginBottom: 8 }}
-              />
-              <textarea
-                placeholder="Describe your navatar..."
-                value={genPrompt}
-                onChange={(e) => setGenPrompt(e.target.value)}
-                style={{ padding: 8, width: 320, height: 80 }}
-              />
-              <div style={{ marginTop: 10 }}>
-                <button className="btn" onClick={runGenerate}>Generate</button>
-              </div>
-              <div style={{ fontSize: 12, opacity: 0.7, marginTop: 8 }}>
-                If your OpenAI org isn’t verified for images, you’ll see a clear 403 message here.
-              </div>
-            </div>
-          )}
-
-          {/* Canon tab */}
-          {openTab === 'canon' && (
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: 'repeat(auto-fill, minmax(220px,1fr))',
-                gap: 12,
-              }}
-            >
-              {canonItems.map((c) => (
-                <button
-                  key={c.url}
-                  onClick={() => chooseCanon(c)}
-                  style={{
-                    border: 'none',
-                    background: '#1f5cff',
-                    color: 'white',
-                    padding: 8,
-                    borderRadius: 12,
-                    textAlign: 'center',
-                  }}
-                >
-                  <img
-                    src={c.url}
-                    alt={c.name}
-                    style={{ display: 'block', width: '100%', borderRadius: 10 }}
-                  />
-                  <div style={{ marginTop: 6, fontWeight: 600 }}>{c.name}</div>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        </>
       )}
+
+      {/* styles */}
+      <style jsx>{`
+        .container { max-width: 980px; margin: 0 auto; padding: 24px; }
+        .title { text-align: center; margin-bottom: 12px; }
+        .btn { padding: 10px 16px; border-radius: 10px; background:#2b6bff; color:#fff; border:0; }
+        .btn.danger { background:#e24; }
+        .current { display:grid; gap:24px; grid-template-columns: 1fr; margin-top: 24px; }
+        .card { display:flex; flex-direction:column; align-items:center; gap:8px; }
+        .card img { width: 360px; max-width: 100%; border-radius: 14px; display:block; }
+        .modal { position: fixed; top:50%; left:50%; transform: translate(-50%, -50%); width: min(980px, 95vw);
+                 background:#fff; border-radius: 16px; box-shadow: 0 20px 80px rgba(0,0,0,.25); padding: 16px; z-index: 60; }
+        .backdrop { position: fixed; inset:0; background: rgba(0,0,0,.45); z-index: 50; }
+        .modal-head { display:flex; justify-content:space-between; align-items:center; }
+        .icon { border:0; background:#eee; border-radius: 8px; padding: 6px 10px; }
+        .modes { display:flex; gap:12px; justify-content:center; margin: 12px 0; }
+        .tab { background:#79b; color:#fff; border:0; border-radius:10px; padding:10px 12px; opacity: .6; }
+        .tab.active { opacity: 1; box-shadow: 0 4px 0 #6aa; }
+        .input, .textarea { width:100%; padding:10px 12px; border-radius:10px; border:1px solid #d0d5e0; margin:8px 0; }
+        .textarea { min-height: 90px; resize: vertical; }
+        .panel { display:flex; flex-direction:column; gap:12px; align-items:center; }
+        .preview { width: 320px; max-width: 100%; border-radius: 12px; }
+        .grid { display:grid; gap:18px; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); width:100%; }
+        .canon { background:#eaf1ff; border:2px solid transparent; border-radius: 16px; padding:8px; }
+        .canon.selected { border-color:#2b6bff; }
+        .canon img { width:100%; border-radius: 12px; display:block; }
+        .label { text-align:center; padding:8px 0 2px; font-weight:600; }
+        .error { color:#b00; margin:0; }
+        @media (min-width: 860px) {
+          .current { grid-template-columns: repeat(2, 1fr); }
+        }
+      `}</style>
     </div>
-  )
+  );
 }

--- a/src/types/tables.ts
+++ b/src/types/tables.ts
@@ -1,0 +1,9 @@
+export type AvatarMethod = "upload" | "ai" | "canon";
+export interface AvatarRow {
+  id: string;
+  user_id: string|null;
+  name: string|null;
+  method: AvatarMethod;
+  image_url: string; // always a public URL now
+  created_at?: string;
+}


### PR DESCRIPTION
## Summary
- Save generated navatars via Netlify function that uploads to Supabase storage and handles OpenAI errors
- Autoload canon navatars from `/public/navatars` and expose helper for public storage URLs
- Rewrite navatar page with exclusive Upload/Generate/Canon modes, centered modal, and immediate image display

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6915271d08329875c11736dfdafea