### PR TITLE
feat: polish Navatar picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "prebuild": "node scripts/build-navatar-catalog.cjs",
     "build": "vite build",
     "preview": "vite preview",
     "clean": "rimraf dist || rm -rf dist"

--- a/public/navatars/catalog.json
+++ b/public/navatars/catalog.json
@@ -1,0 +1,12 @@
+[
+  {
+    "label": "Turian Scooter",
+    "slug": "turianscooter",
+    "src": "/navatars/turianscooter.png"
+  },
+  {
+    "label": "Turian Classic",
+    "slug": "turianclassic",
+    "src": "/navatars/turianclassic.png"
+  }
+]

--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -1,7 +1,9 @@
 import { NAVATARS, Navatar } from '../data/navatars';
-import { getSupabase } from './supabase-client';
+import { createClient } from '@supabase/supabase-js';
 
-const supabase = getSupabase();
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL!;
+const supabaseAnon = import.meta.env.VITE_SUPABASE_ANON_KEY!;
+export const supabase = createClient(supabaseUrl, supabaseAnon);
 
 const LS_OWNED = 'nv_owned_navatars';
 const LS_ACTIVE = 'nv_active_navatar';
@@ -85,4 +87,22 @@ export async function setActive(id: string) {
     }
   }
   setActiveLocal(id);
+}
+
+/** Upsert the user's chosen navatar into the avatars table. */
+export async function saveNavatarSelection(label: string, src: string) {
+  const { data: { user }, error: userErr } = await supabase.auth.getUser();
+  if (userErr) throw userErr;
+  if (!user) throw new Error('Not signed in');
+
+  // We assume table public.avatars has columns: user_id (uuid), label (text), src (text)
+  // and a unique index/PK on user_id so we can upsert.
+  const { error } = await supabase
+    .from('avatars')
+    .upsert(
+      { user_id: user.id, label, src },
+      { onConflict: 'user_id' }
+    );
+
+  if (error) throw error;
 }

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -24,18 +24,47 @@
 .navatar-card h3 { margin: 6px 0 8px; color: #2b58ff; }
 
 /* Pick page */
-.pick-wrap { max-width: 1100px; margin: 0 auto; padding: 24px; display: grid; grid-template-columns: 1fr 280px; gap: 24px; }
-.pick-title { font-size: clamp(22px, 3vw, 34px); color: #2b58ff; font-weight: 800; margin: 4px 0 12px; }
-.pick-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 14px; height: 70vh; overflow: auto; padding-right: 6px; }
-.pick-card { background: #fff; border-radius: 14px; padding: 10px; box-shadow: 0 8px 24px rgba(0,0,0,.07); border: 2px solid transparent; }
-.pick-card img { width: 100%; height: 180px; object-fit: cover; border-radius: 10px; display: block; }
-.pick-card.selected { border-color: #2b58ff; box-shadow: 0 0 0 4px rgba(43,88,255,.15); }
-.pick-side { position: sticky; top: 24px; align-self: start; }
-.pick-save { width: 100%; padding: 12px 16px; border: 0; border-radius: 10px; background: #2b58ff; color: #fff; font-weight: 700; }
-.pick-save[disabled] { opacity: .5; }
+.navatar-page { max-width: 1080px; margin: 0 auto; padding: 24px 16px; }
 
-@media (max-width: 860px) {
-  .pick-wrap { grid-template-columns: 1fr; }
-  .pick-side { position: static; }
-  .navatar-cards { grid-template-columns: 1fr; }
+.breadcrumbs { margin: 4px 0 8px; font-size: 14px; }
+.breadcrumbs a { color: #1a73e8; text-decoration: none; }
+.breadcrumbs span { color: #8aa3c4; margin: 0 6px; }
+
+.page-title { font-size: 36px; color: #2b57ff; margin: 8px 0 20px; line-height: 1.1; }
+
+.muted { color: #8aa3c4; }
+
+.error { color: #b00020; margin-bottom: 12px; }
+
+.pick-layout { display: grid; grid-template-columns: 1fr 220px; gap: 16px; }
+@media (max-width: 900px) {
+  .pick-layout { grid-template-columns: 1fr; }
 }
+
+.pick-grid {
+  list-style: none; padding: 0; margin: 0;
+  display: grid; gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  max-height: 70vh; overflow: auto; padding-right: 6px;
+}
+.pick-grid li { display: contents; }
+
+.pick-card {
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
+  border: 2px solid #e5e9f5; background: #fff; border-radius: 14px;
+  padding: 10px; cursor: pointer;
+  transition: box-shadow .15s, border-color .15s, transform .05s;
+  width: 100%;
+}
+.pick-card:hover { border-color: #cfd8ff; box-shadow: 0 2px 10px rgba(0,0,0,.05); }
+.pick-card.selected { border-color: #2b57ff; box-shadow: 0 0 0 3px rgba(43,87,255,.15); }
+
+.pick-card img { width: 100%; height: 220px; object-fit: cover; border-radius: 10px; background:#f7f9ff; }
+.pick-name { color: #2b57ff; font-weight: 600; line-height: 1.2; text-align: center; }
+
+.pick-actions { display:flex; align-items:flex-start; justify-content:center; padding-top: 6px; }
+.primary {
+  background: #2b57ff; color: white; border: 0; border-radius: 10px;
+  padding: 12px 18px; font-weight: 700; cursor: pointer; min-width: 200px;
+}
+.primary:disabled { background: #cbd5ff; cursor: not-allowed; }


### PR DESCRIPTION
## Summary
- load Navatar catalog from text-only JSON
- responsive picker layout with breadcrumbs and save upsert
- remove prebuild catalog script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `VITE_SUPABASE_URL=https://example.com VITE_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6e018b2a0832991654b122ea92e91