### PR TITLE
feat: add navatar picker and catalog

### DIFF
--- a/scripts/build-navatar-catalog.cjs
+++ b/scripts/build-navatar-catalog.cjs
@@ -1,42 +1,48 @@
-/* Scans /public/navatars for images and writes /public/navatar-catalog.json */
+// Scans /public/navatars and writes src/data/navatar-catalog.json
+// Netlify runs this before build via "prebuild" script.
 const fs = require('fs');
 const path = require('path');
 
-const NAVS_DIR = path.join(process.cwd(), 'public', 'navatars');
-const OUT = path.join(process.cwd(), 'public', 'navatar-catalog.json');
-const IMG_EXTS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif']);
+const PUB = path.resolve(process.cwd(), 'public', 'navatars');
+const OUT = path.resolve(process.cwd(), 'src', 'data');
+const OUT_FILE = path.join(OUT, 'navatar-catalog.json');
 
-function titleFromSlug(slug) {
-  return slug
-    .replace(/\.[^.]+$/, '')
-    .replace(/[-_]+/g, ' ')
-    .replace(/\b\w/g, (m) => m.toUpperCase());
+function walk(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(ent => {
+    const p = path.join(dir, ent.name);
+    if (ent.isDirectory()) return walk(p);
+    const lower = ent.name.toLowerCase();
+    if (!(/\.(png|jpg|jpeg|webp|svg)$/).test(lower)) return [];
+    return [p];
+  });
 }
 
-function walk(dir, base = '') {
-  const acc = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const p = path.join(dir, entry.name);
-    const rel = path.join(base, entry.name);
-    if (entry.isDirectory()) {
-      acc.push(...walk(p, rel));
-    } else if (IMG_EXTS.has(path.extname(entry.name).toLowerCase())) {
-      const slug = rel.replace(/\\/g, '/');
-      acc.push({
-        slug,
-        label: titleFromSlug(entry.name),
-        src: `/navatars/${slug}`
-      });
-    }
+function slugify(name) {
+  return name.toLowerCase()
+    .replace(/\.(png|jpg|jpeg|webp|svg)$/,'')
+    .replace(/[^a-z0-9]+/g,'-')
+    .replace(/^-+|-+$/g,'');
+}
+
+function run() {
+  if (!fs.existsSync(PUB)) {
+    console.warn(`[navatar] No /public/navatars directory found. Writing empty catalog.`);
   }
-  return acc;
+  const files = fs.existsSync(PUB) ? walk(PUB) : [];
+  const items = files.map(abs => {
+    const rel = abs.split(path.sep).join('/').split('/public/')[1]; // e.g. "navatars/turianscooter.png"
+    const label = path.basename(abs).replace(/\.(png|jpg|jpeg|webp|svg)$/i,'');
+    return {
+      slug: slugify(label),
+      label,
+      // public URL under /, safe to use in <img src>
+      src: `/${rel}`
+    };
+  });
+
+  if (!fs.existsSync(OUT)) fs.mkdirSync(OUT, { recursive: true });
+  fs.writeFileSync(OUT_FILE, JSON.stringify({ generatedAt: new Date().toISOString(), items }, null, 2));
+  console.log(`[navatar] Wrote ${items.length} items to ${OUT_FILE}`);
 }
 
-if (!fs.existsSync(NAVS_DIR)) {
-  fs.mkdirSync(NAVS_DIR, { recursive: true });
-}
-
-const items = walk(NAVS_DIR);
-fs.writeFileSync(OUT, JSON.stringify({ items }, null, 2));
-console.log(`[navatar] wrote catalog with ${items.length} items to ${OUT}`);
-
+run();

--- a/src/data/navatar-catalog.json
+++ b/src/data/navatar-catalog.json
@@ -1,0 +1,4 @@
+{
+  "generatedAt": "seed",
+  "items": []
+}

--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -1,5 +1,14 @@
-import { NAVATARS, Navatar } from '../data/navatars';
+import catalog from '../data/navatar-catalog.json';
+import { NAVATARS, Navatar as FullNavatar } from '../data/navatars';
 import { getSupabase } from './supabase-client';
+
+export type Navatar = { slug: string; label: string; src: string };
+export type NavatarCatalog = { generatedAt: string; items: Navatar[] };
+
+export function getCatalog(): NavatarCatalog {
+  // The build script keeps this fresh.
+  return catalog as NavatarCatalog;
+}
 
 const supabase = getSupabase();
 
@@ -26,7 +35,7 @@ export function setActiveLocal(id: string) {
   localStorage.setItem(LS_ACTIVE, id);
 }
 
-export async function listAll(): Promise<Navatar[]> {
+export async function listAll(): Promise<FullNavatar[]> {
   return NAVATARS;
 }
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,2 +1,32 @@
-export { supabase } from "./supabase-client";
+import { createClient } from '@supabase/supabase-js';
 
+const url = import.meta.env.VITE_SUPABASE_URL || import.meta.env.SUPABASE_URL;
+const anon = import.meta.env.VITE_SUPABASE_ANON_KEY || import.meta.env.SUPABASE_ANON_KEY;
+
+if (!url || !anon) {
+  // Fail loudly in preview so we see it
+  // eslint-disable-next-line no-console
+  console.warn('Supabase env vars missing: VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY');
+}
+
+export const supabase = createClient(url!, anon!);
+
+export async function getUserId() {
+  const { data } = await supabase.auth.getUser();
+  return data.user?.id ?? null;
+}
+
+// Upsert the selected navatar (no "kind" column assumed)
+export async function saveNavatarSelection(label: string, src: string) {
+  const user_id = await getUserId();
+  if (!user_id) throw new Error('Not logged in');
+
+  const { error } = await supabase
+    .from('avatars')
+    .upsert(
+      { user_id, label, src, updated_at: new Date().toISOString() },
+      { onConflict: 'user_id' } // assumes unique index/PK on user_id
+    );
+
+  if (error) throw error;
+}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,50 +1,35 @@
-import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { getMyNavatar } from '../../lib/supabase/navatars';
 import '../../styles/navatar.css';
 
 export default function NavatarHub() {
-  const [mine, setMine] = useState<any>(null);
-
-  useEffect(() => {
-    getMyNavatar().then(setMine).catch(() => setMine(null));
-  }, []);
-
   return (
-    <div className="navatar-wrap">
-      <div className="navatar-breadcrumbs">Home / Navatar</div>
-      <h1 className="navatar-title">Your Navatar</h1>
+    <main className="navatar-container">
+      <nav className="breadcrumbs">
+        <Link to="/">Home</Link> <span>/</span> <span>Navatar</span>
+      </nav>
 
-      {mine ? (
-        <div style={{display:'flex', gap:16, alignItems:'center', margin:'8px 0 24px'}}>
-          <img src={mine.src} alt={mine.label} style={{width:96, height:96, borderRadius:12, objectFit:'cover'}} />
-          <div>
-            <div style={{fontWeight:700}}>{mine.label}</div>
-            <div><Link to="/navatar/pick">Change</Link></div>
-          </div>
-        </div>
-      ) : (
-        <div style={{margin:'6px 0 24px'}}>No Navatar yet — pick one below.</div>
-      )}
+      <h1 className="page-title">Your Navatar</h1>
+      <p className="muted">No Navatar yet — pick one below.</p>
 
-      <div className="navatar-cards">
-        <div className="navatar-card">
-          <h3>Pick Navatar</h3>
+      <div className="hub-cards">
+        <section className="hub-card">
+          <h2>Pick Navatar</h2>
           <p>Choose from our characters.</p>
-          <Link to="/navatar/pick">Open</Link>
-        </div>
-        <div className="navatar-card">
-          <h3>Upload</h3>
+          <Link to="/navatar/pick" className="hub-link">Open</Link>
+        </section>
+
+        <section className="hub-card disabled">
+          <h2>Upload</h2>
           <p>Coming next.</p>
-          <Link to="/navatar/upload">View</Link>
-        </div>
-        <div className="navatar-card">
-          <h3>Describe &amp; Generate</h3>
+          <a className="hub-link" aria-disabled="true">View</a>
+        </section>
+
+        <section className="hub-card disabled">
+          <h2>Describe &amp; Generate</h2>
           <p>Coming next.</p>
-          <Link to="/navatar/generate">View</Link>
-        </div>
+          <a className="hub-link" aria-disabled="true">View</a>
+        </section>
       </div>
-    </div>
+    </main>
   );
 }
-

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,41 +1,106 @@
-/* Rarity frames */
-.navatar-frame { display:inline-grid; place-items:center; border-radius:50%; padding:2px; }
-.navatar-frame.starter { box-shadow: 0 0 0 2px #cfe0ff inset; }
-.navatar-frame.rare     { box-shadow: 0 0 0 2px #34d399 inset; }
-.navatar-frame.legendary{ box-shadow: 0 0 0 2px #f59e0b inset; }
-
-/* Compact inline pill */
-.navatar-inline {
-  display:inline-flex; gap:8px; align-items:center; padding:6px 10px;
-  border:1px solid #e5e7eb; border-radius:999px; background:#fff;
+.navatar-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 16px;
 }
 
-.navatar-inline .name { font-weight:600; font-size:.9rem; }
-.navatar-inline .action { font-size:.85rem; color:#2563eb; cursor:pointer; }
-.navatar-inline .action:hover { text-decoration:underline; }
+.page-title {
+  color: #1d4ff2;
+  font-size: 32px;
+  font-weight: 800;
+  margin: 8px 0 16px;
+}
 
-/* Hub */
-.navatar-wrap { max-width: 1100px; margin: 0 auto; padding: 24px; }
-.navatar-title { font-size: clamp(24px, 3.5vw, 40px); color: #2b58ff; font-weight: 800; margin: 12px 0 8px; }
-.navatar-breadcrumbs { color: #6b7280; margin-bottom: 16px; }
-.navatar-cards { display: grid; grid-template-columns: repeat(3, minmax(220px,1fr)); gap: 16px; }
-.navatar-card { background: #fff; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,.06); padding: 18px; transition: transform .12s ease; }
-.navatar-card:hover { transform: translateY(-2px); }
-.navatar-card h3 { margin: 6px 0 8px; color: #2b58ff; }
+.breadcrumbs {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 8px 0;
+}
+.breadcrumbs a {
+  color: #1d4ff2; /* blue per request */
+  text-decoration: none;
+  font-weight: 600;
+}
+.breadcrumbs span {
+  color: #6b7280;
+}
+.muted { color: #6b7280; }
 
-/* Pick page */
-.pick-wrap { max-width: 1100px; margin: 0 auto; padding: 24px; display: grid; grid-template-columns: 1fr 280px; gap: 24px; }
-.pick-title { font-size: clamp(22px, 3vw, 34px); color: #2b58ff; font-weight: 800; margin: 4px 0 12px; }
-.pick-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 14px; height: 70vh; overflow: auto; padding-right: 6px; }
-.pick-card { background: #fff; border-radius: 14px; padding: 10px; box-shadow: 0 8px 24px rgba(0,0,0,.07); border: 2px solid transparent; }
-.pick-card img { width: 100%; height: 180px; object-fit: cover; border-radius: 10px; display: block; }
-.pick-card.selected { border-color: #2b58ff; box-shadow: 0 0 0 4px rgba(43,88,255,.15); }
-.pick-side { position: sticky; top: 24px; align-self: start; }
-.pick-save { width: 100%; padding: 12px 16px; border: 0; border-radius: 10px; background: #2b58ff; color: #fff; font-weight: 700; }
-.pick-save[disabled] { opacity: .5; }
+.hub-cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+.hub-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 6px 22px rgba(0,0,0,.06);
+}
+.hub-card.disabled { opacity: .6; }
+.hub-card h2 {
+  margin: 0 0 6px;
+  color: #1d4ff2;
+}
+.hub-link {
+  display: inline-block;
+  margin-top: 8px;
+  color: #1d4ff2;
+  font-weight: 700;
+}
 
-@media (max-width: 860px) {
-  .pick-wrap { grid-template-columns: 1fr; }
-  .pick-side { position: static; }
-  .navatar-cards { grid-template-columns: 1fr; }
+.pick-layout {
+  display: grid;
+  grid-template-columns: 1fr 260px;
+  gap: 24px;
+  align-items: start;
+}
+
+/* Vertical, scrollable grid */
+.pick-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+  max-height: 70vh;        /* keeps page from getting too tall */
+  overflow-y: auto;        /* vertical scroll */
+  padding-right: 6px;
+}
+.pick-card {
+  border: 4px solid transparent;
+  border-radius: 16px;
+  padding: 6px;
+  background: #f7f8ff;
+  box-shadow: 0 6px 22px rgba(0,0,0,.06);
+}
+.pick-card img { width: 100%; height: auto; display:block; border-radius: 12px; }
+.pick-card.selected { border-color: #1d4ff2; }
+
+.pick-actions {
+  position: sticky;
+  top: 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.primary {
+  background: #1d4ff2;
+  color: #fff;
+  font-weight: 800;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 14px;
+  cursor: pointer;
+}
+.primary[disabled] { opacity: .6; cursor: default; }
+.err { color: #b91c1c; font-weight: 600; }
+.ok { color: #15803d; font-weight: 700; }
+
+/* Mobile */
+@media (max-width: 780px) {
+  .hub-cards { grid-template-columns: 1fr; }
+  .pick-layout { grid-template-columns: 1fr; }
+  .pick-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); max-height: none; }
+  .pick-actions { position: static; }
 }


### PR DESCRIPTION
## Summary
- build navatar catalog from /public/navatars during prebuild
- add Supabase helpers for saving chosen avatars
- add Navatar hub & picker pages with responsive styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6e3f043c48329a5d5d168527ee282