### PR TITLE
Navatar Pick — read from Supabase Storage (no binaries), fix mobile grid & save

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "prebuild": "node scripts/build-navatar-catalog.cjs",
     "build": "vite build",
     "preview": "vite preview",
     "clean": "rimraf dist || rm -rf dist"

--- a/src/lib/navatar-supabase.ts
+++ b/src/lib/navatar-supabase.ts
@@ -1,0 +1,46 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnon = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+export const supabase = createClient(supabaseUrl, supabaseAnon, {
+  auth: { persistSession: true }
+});
+
+export type NavatarItem = { slug: string; label: string; src: string };
+
+/** List public images in the `navatars` storage bucket. */
+export async function listPublicNavatars(): Promise<NavatarItem[]> {
+  const s = supabase.storage.from('navatars');
+
+  // Root listing; set limit high enough for your gallery size
+  const { data, error } = await s.list('', { limit: 1000, sortBy: { column: 'name', order: 'asc' } });
+  if (error || !data) return [];
+
+  return data
+    .filter(obj => obj.id && obj.name && !obj.metadata?.isDirectory)
+    .filter(obj => /(\.png|\.jpg|\.jpeg|\.webp)$/i.test(obj.name))
+    .map(obj => {
+      const label = obj.name.replace(/\.[^.]+$/, '');
+      const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+      const { data: urlData } = s.getPublicUrl(obj.name);
+      const src = urlData?.publicUrl ?? '';
+      return { slug, label, src };
+    })
+    .filter(it => !!it.src);
+}
+
+/** Upsert the selected navatar for the current user. */
+export async function saveNavatarSelection(label: string, src: string) {
+  const { data: { user }, error: userErr } = await supabase.auth.getUser();
+  if (userErr) throw userErr;
+  if (!user) throw new Error('Not signed in.');
+
+  const payload = { user_id: user.id, label, src };
+  const { error } = await supabase
+    .from('avatars')
+    .upsert(payload, { onConflict: 'user_id' })
+    .eq('user_id', user.id);
+
+  if (error) throw error;
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -28,7 +28,7 @@ import BankToken from './pages/naturbank/Token';
 import BankNFTs from './pages/naturbank/NFTs';
 import BankLearn from './pages/naturbank/Learn';
 import NavatarHub from './pages/navatar';
-import NavatarPick from './pages/navatar/pick';
+import PickNavatar from './pages/navatar/pick';
 import NavatarUpload from './pages/navatar/upload';
 import NavatarGenerate from './pages/navatar/generate';
 import PassportPage from './pages/passport';
@@ -103,7 +103,7 @@ export const router = createBrowserRouter([
       { path: 'accessibility', element: <Accessibility /> },
       { path: 'about', element: <About /> },
       { path: 'navatar', element: <NavatarHub /> },
-      { path: 'navatar/pick', element: <NavatarPick /> },
+      { path: 'navatar/pick', element: <PickNavatar /> },
       { path: 'navatar/upload', element: <NavatarUpload /> },
       { path: 'navatar/generate', element: <NavatarGenerate /> },
       { path: 'progress', element: <ProgressPage /> },

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -16,26 +16,31 @@
 
 /* Hub */
 .navatar-wrap { max-width: 1100px; margin: 0 auto; padding: 24px; }
-.navatar-title { font-size: clamp(24px, 3.5vw, 40px); color: #2b58ff; font-weight: 800; margin: 12px 0 8px; }
-.navatar-breadcrumbs { color: #6b7280; margin-bottom: 16px; }
+.page-title, .navatar-title { font-size: clamp(24px, 3.5vw, 40px); color: #2b58ff; font-weight: 800; margin: 12px 0 8px; }
+.breadcrumbs, .navatar-breadcrumbs { color: #2b58ff; margin-bottom: 16px; }
 .navatar-cards { display: grid; grid-template-columns: repeat(3, minmax(220px,1fr)); gap: 16px; }
 .navatar-card { background: #fff; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,.06); padding: 18px; transition: transform .12s ease; }
 .navatar-card:hover { transform: translateY(-2px); }
 .navatar-card h3 { margin: 6px 0 8px; color: #2b58ff; }
 
+
 /* Pick page */
-.pick-wrap { max-width: 1100px; margin: 0 auto; padding: 24px; display: grid; grid-template-columns: 1fr 280px; gap: 24px; }
-.pick-title { font-size: clamp(22px, 3vw, 34px); color: #2b58ff; font-weight: 800; margin: 4px 0 12px; }
+.pick-layout { display: grid; grid-template-columns: 1fr 280px; gap: 24px; }
 .pick-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 14px; height: 70vh; overflow: auto; padding-right: 6px; }
 .pick-card { background: #fff; border-radius: 14px; padding: 10px; box-shadow: 0 8px 24px rgba(0,0,0,.07); border: 2px solid transparent; }
 .pick-card img { width: 100%; height: 180px; object-fit: cover; border-radius: 10px; display: block; }
 .pick-card.selected { border-color: #2b58ff; box-shadow: 0 0 0 4px rgba(43,88,255,.15); }
-.pick-side { position: sticky; top: 24px; align-self: start; }
-.pick-save { width: 100%; padding: 12px 16px; border: 0; border-radius: 10px; background: #2b58ff; color: #fff; font-weight: 700; }
-.pick-save[disabled] { opacity: .5; }
+.pick-card .label { display: block; margin-top: 8px; font-weight: 700; }
+.actions { position: sticky; top: 24px; align-self: start; display:flex; flex-direction:column; gap:12px; }
+.notice { font-size: .9rem; }
+.notice.ok { color: #16a34a; }
+.notice.err { color: #dc2626; }
+.primary { width: 100%; padding: 12px 16px; border: 0; border-radius: 10px; background: #2b58ff; color: #fff; font-weight: 700; }
+.primary[disabled] { opacity: .5; }
 
 @media (max-width: 860px) {
-  .pick-wrap { grid-template-columns: 1fr; }
-  .pick-side { position: static; }
+  .pick-layout { grid-template-columns: 1fr; }
+  .actions { position: static; }
+  .pick-grid { height: auto; }
   .navatar-cards { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
## Summary
- Load navatar catalog directly from Supabase Storage and upsert selection
- Remove build-time navatar catalog generation
- Replace navatar pick page with responsive grid and mobile-friendly layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6f3955d28832991dbe42d4f683d0a