### PR TITLE
feat: add navatar hub and supabase pick flow

### DIFF
--- a/src/boot/warmup.ts
+++ b/src/boot/warmup.ts
@@ -2,6 +2,10 @@
 // - Uses import.meta.glob to discover *existing* pages
 // - Only preloads when idle & on decent connections
 
+import { listNavatars } from '../lib/navatar';
+
+listNavatars().catch(() => {});
+
 type Loader = () => Promise<unknown>;
 
 const pages = import.meta.glob('../pages/**/*.tsx') as Record<string, Loader>;

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,47 +1,33 @@
-import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { getMyNavatar } from '../../lib/supabase/navatars';
-import '../../styles/navatar.css';
+import { Link } from "react-router-dom";
+import "../../styles/navatar.css";
 
 export default function NavatarHub() {
-  const [mine, setMine] = useState<any>(null);
-
-  useEffect(() => {
-    getMyNavatar().then(setMine).catch(() => setMine(null));
-  }, []);
-
   return (
-    <div className="navatar-wrap">
-      <div className="navatar-breadcrumbs">Home / Navatar</div>
-      <h1 className="navatar-title">Your Navatar</h1>
+    <div className="nv-container">
+      <nav className="nv-crumbs">
+        <Link to="/">Home</Link> <span>/</span> <span>Navatar</span>
+      </nav>
 
-      {mine ? (
-        <div style={{display:'flex', gap:16, alignItems:'center', margin:'8px 0 24px'}}>
-          <img src={mine.src} alt={mine.label} style={{width:96, height:96, borderRadius:12, objectFit:'cover'}} />
-          <div>
-            <div style={{fontWeight:700}}>{mine.label}</div>
-            <div><Link to="/navatar/pick">Change</Link></div>
-          </div>
-        </div>
-      ) : (
-        <div style={{margin:'6px 0 24px'}}>No Navatar yet — pick one below.</div>
-      )}
+      <h1 className="nv-title">Your Navatar</h1>
+      <p className="nv-sub">No Navatar yet — pick one below.</p>
 
-      <div className="navatar-cards">
-        <div className="navatar-card">
+      <div className="nv-cards">
+        <div className="nv-card">
           <h3>Pick Navatar</h3>
           <p>Choose from our characters.</p>
-          <Link to="/navatar/pick">Open</Link>
+          <Link to="/navatar/pick" className="nv-link">Open</Link>
         </div>
-        <div className="navatar-card">
+
+        <div className="nv-card disabled">
           <h3>Upload</h3>
           <p>Coming next.</p>
-          <Link to="/navatar/upload">View</Link>
+          <span className="nv-link" aria-disabled>View</span>
         </div>
-        <div className="navatar-card">
+
+        <div className="nv-card disabled">
           <h3>Describe &amp; Generate</h3>
           <p>Coming next.</p>
-          <Link to="/navatar/generate">View</Link>
+          <span className="nv-link" aria-disabled>View</span>
         </div>
       </div>
     </div>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -29,8 +29,6 @@ import BankNFTs from './pages/naturbank/NFTs';
 import BankLearn from './pages/naturbank/Learn';
 import NavatarHub from './pages/navatar';
 import NavatarPick from './pages/navatar/pick';
-import NavatarUpload from './pages/navatar/upload';
-import NavatarGenerate from './pages/navatar/generate';
 import PassportPage from './pages/passport';
 import ProgressPage from './pages/progress';
 import LoginPage from './pages/Login';
@@ -104,8 +102,6 @@ export const router = createBrowserRouter([
       { path: 'about', element: <About /> },
       { path: 'navatar', element: <NavatarHub /> },
       { path: 'navatar/pick', element: <NavatarPick /> },
-      { path: 'navatar/upload', element: <NavatarUpload /> },
-      { path: 'navatar/generate', element: <NavatarGenerate /> },
       { path: 'progress', element: <ProgressPage /> },
       { path: 'passport', element: <PassportPage /> },
       { path: 'orders', element: <OrdersPage /> },

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,41 +1,132 @@
-/* Rarity frames */
-.navatar-frame { display:inline-grid; place-items:center; border-radius:50%; padding:2px; }
-.navatar-frame.starter { box-shadow: 0 0 0 2px #cfe0ff inset; }
-.navatar-frame.rare     { box-shadow: 0 0 0 2px #34d399 inset; }
-.navatar-frame.legendary{ box-shadow: 0 0 0 2px #f59e0b inset; }
 
-/* Compact inline pill */
-.navatar-inline {
-  display:inline-flex; gap:8px; align-items:center; padding:6px 10px;
-  border:1px solid #e5e7eb; border-radius:999px; background:#fff;
+.nv-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 16px;
 }
 
-.navatar-inline .name { font-weight:600; font-size:.9rem; }
-.navatar-inline .action { font-size:.85rem; color:#2563eb; cursor:pointer; }
-.navatar-inline .action:hover { text-decoration:underline; }
-
-/* Hub */
-.navatar-wrap { max-width: 1100px; margin: 0 auto; padding: 24px; }
-.navatar-title { font-size: clamp(24px, 3.5vw, 40px); color: #2b58ff; font-weight: 800; margin: 12px 0 8px; }
-.navatar-breadcrumbs { color: #6b7280; margin-bottom: 16px; }
-.navatar-cards { display: grid; grid-template-columns: repeat(3, minmax(220px,1fr)); gap: 16px; }
-.navatar-card { background: #fff; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,.06); padding: 18px; transition: transform .12s ease; }
-.navatar-card:hover { transform: translateY(-2px); }
-.navatar-card h3 { margin: 6px 0 8px; color: #2b58ff; }
-
-/* Pick page */
-.pick-wrap { max-width: 1100px; margin: 0 auto; padding: 24px; display: grid; grid-template-columns: 1fr 280px; gap: 24px; }
-.pick-title { font-size: clamp(22px, 3vw, 34px); color: #2b58ff; font-weight: 800; margin: 4px 0 12px; }
-.pick-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 14px; height: 70vh; overflow: auto; padding-right: 6px; }
-.pick-card { background: #fff; border-radius: 14px; padding: 10px; box-shadow: 0 8px 24px rgba(0,0,0,.07); border: 2px solid transparent; }
-.pick-card img { width: 100%; height: 180px; object-fit: cover; border-radius: 10px; display: block; }
-.pick-card.selected { border-color: #2b58ff; box-shadow: 0 0 0 4px rgba(43,88,255,.15); }
-.pick-side { position: sticky; top: 24px; align-self: start; }
-.pick-save { width: 100%; padding: 12px 16px; border: 0; border-radius: 10px; background: #2b58ff; color: #fff; font-weight: 700; }
-.pick-save[disabled] { opacity: .5; }
-
-@media (max-width: 860px) {
-  .pick-wrap { grid-template-columns: 1fr; }
-  .pick-side { position: static; }
-  .navatar-cards { grid-template-columns: 1fr; }
+.nv-crumbs {
+  margin: 8px 0 8px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
+.nv-crumbs a {
+  color: #2563eb; /* blue-600 */
+  text-decoration: none;
+}
+.nv-crumbs span {
+  color: #6b7280; /* gray-500 */
+}
+
+.nv-title {
+  color: #2563eb; /* blue-600 */
+  font-size: clamp(24px, 3.5vw, 36px);
+  font-weight: 800;
+  margin: 8px 0 16px;
+}
+
+.nv-sub {
+  margin-bottom: 16px;
+  color: #6b7280;
+}
+
+.nv-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.nv-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  padding: 16px;
+  background: white;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 3%);
+}
+.nv-card h3 {
+  margin: 0 0 6px;
+  font-size: 18px;
+}
+.nv-card p {
+  margin: 0 0 10px;
+  color: #6b7280;
+}
+.nv-card .nv-link {
+  color: #2563eb;
+  font-weight: 600;
+  text-decoration: underline;
+}
+.nv-card.disabled {
+  opacity: 0.6;
+}
+
+.nv-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 14px;
+  margin-top: 8px;
+}
+
+.nv-card.nv-pick {
+  padding: 10px;
+  text-align: center;
+  cursor: pointer;
+  border-radius: 16px;
+  transition: box-shadow .15s ease, transform .05s ease;
+}
+.nv-card.nv-pick img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 12px;
+  display: block;
+}
+.nv-card.nv-pick.selected {
+  box-shadow: 0 0 0 3px #2563eb inset;
+}
+.nv-pick-name {
+  margin-top: 8px;
+  font-size: 13px;
+  color: #374151;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nv-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.nv-primary {
+  background: #2563eb;
+  color: #fff;
+  font-weight: 700;
+  border: none;
+  border-radius: 12px;
+  padding: 10px 16px;
+}
+.nv-primary[disabled] {
+  opacity: 0.5;
+}
+
+.nv-err {
+  color: #b91c1c; /* red-700 */
+  font-size: 14px;
+}
+.nv-ok {
+  color: #065f46; /* emerald-800 */
+  font-size: 14px;
+}
+
+/* Improve mobile spacing */
+@media (max-width: 480px) {
+  .nv-container { padding: 12px; }
+  .nv-grid { gap: 10px; }
+  .nv-card.nv-pick { padding: 8px; }
+}
+


### PR DESCRIPTION
## Summary
- build navatar helper to list images from Supabase and upsert chosen avatar
- add hub and pick pages with responsive styles and router wiring
- warm up navatar list on boot

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6fd82b4c483299c446d622a92266f