### PR TITLE
feat: navatar picker from Supabase storage

### DIFF
--- a/src/lib/navatar-db.ts
+++ b/src/lib/navatar-db.ts
@@ -1,0 +1,23 @@
+import { supabase } from './supabase';
+
+export async function saveNavatarSelection(label: string, src: string) {
+  const { data: auth } = await supabase.auth.getUser();
+  const user = auth?.user;
+  if (!user) throw new Error('Please sign in');
+
+  const payload = {
+    user_id: user.id,     // trigger will set it too, but we provide it
+    label,
+    src,
+    method: 'pick',       // NOTE: relies on your existing "method" column
+    is_primary: true,
+    public: true
+  };
+
+  // User has exactly one primary avatar; upsert by user_id
+  const { error } = await supabase
+    .from('avatars')
+    .upsert(payload, { onConflict: 'user_id' });
+
+  if (error) throw error;
+}

--- a/src/lib/navatar-storage.ts
+++ b/src/lib/navatar-storage.ts
@@ -1,0 +1,38 @@
+import { supabase } from './supabase';
+
+const BUCKET = 'navatars';          // bucket name
+const FOLDER = 'navatars';          // folder inside bucket that holds images
+
+const IMAGE_RE = /\.(png|jpe?g|webp|gif)$/i;
+
+export type NavatarItem = {
+  slug: string;
+  label: string;
+  src: string;
+};
+
+function slugify(s: string) {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+export async function fetchNavatarCatalog(): Promise<NavatarItem[]> {
+  // list files in the folder (this is the key fix)
+  const { data, error } = await supabase
+    .storage
+    .from(BUCKET)
+    .list(FOLDER, { limit: 500, sortBy: { column: 'name', order: 'asc' } });
+
+  if (error) throw error;
+
+  const files = (data ?? []).filter(entry => IMAGE_RE.test(entry.name));
+
+  return files.map(f => {
+    const filepath = `${FOLDER}/${f.name}`;
+    const {
+      data: { publicUrl }
+    } = supabase.storage.from(BUCKET).getPublicUrl(filepath);
+
+    const label = f.name.replace(IMAGE_RE, '');
+    return { slug: slugify(label), label, src: publicUrl };
+  });
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL!;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchNavatarCatalog, type NavatarItem } from '../../lib/navatar-storage';
+import { saveNavatarSelection } from '../../lib/navatar-db';
+import '../../styles/navatar.css';
+
+export default function PickNavatarPage() {
+  const [items, setItems] = useState<NavatarItem[] | null>(null);
+  const [selected, setSelected] = useState<NavatarItem | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const list = await fetchNavatarCatalog();
+        if (alive) setItems(list);
+      } catch (e: any) {
+        console.error(e);
+        if (alive) setItems([]);
+      }
+    })();
+    return () => { alive = false; };
+  }, []);
+
+  async function onSave() {
+    if (!selected) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await saveNavatarSelection(selected.label, selected.src);
+      alert('Saved!');
+    } catch (e: any) {
+      console.error(e);
+      setError(e?.message || 'Error saving Navatar');
+      alert('Error saving Navatar');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const empty = items && items.length === 0;
+
+  return (
+    <div className="pick-wrap">
+      <nav className="breadcrumbs">
+        <Link to="/">Home</Link>
+        <span>/</span>
+        <Link to="/navatar">Navatar</Link>
+        <span>/</span>
+        <span>Pick</span>
+      </nav>
+
+      <h1 className="page-title">Pick Navatar</h1>
+
+      {items === null && <div className="pick-status">Loading…</div>}
+
+      {empty && (
+        <div className="pick-status">
+          No characters found in <code>/storage/navatars/navatars</code>.
+        </div>
+      )}
+
+      {items && items.length > 0 && (
+        <div className="pick-layout">
+          <div className="pick-grid" role="list" aria-label="Navatar catalog">
+            {items.map((it) => (
+              <button
+                key={it.slug}
+                type="button"
+                className={'pick-card' + (selected?.slug === it.slug ? ' selected' : '')}
+                onClick={() => setSelected(it)}
+                title={it.label}
+              >
+                <img loading="lazy" src={it.src} alt={it.label} />
+                <div className="pick-name">{it.label}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="pick-actions">
+        <button
+          className="primary"
+          disabled={!selected || saving}
+          onClick={onSave}
+          aria-disabled={!selected || saving}
+        >
+          {saving ? 'Saving…' : (selected ? `Save “${selected.label}”` : 'Pick one to save')}
+        </button>
+      </div>
+
+      {error && <div className="pick-error" role="alert">{error}</div>}
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -34,6 +34,7 @@ import BankToken from './pages/naturbank/Token';
 import BankNFTs from './pages/naturbank/NFTs';
 import BankLearn from './pages/naturbank/Learn';
 import NavatarPage from './pages/Navatar';
+import PickNavatarPage from './pages/navatar/pick';
 import PassportPage from './pages/passport';
 import LoginPage from './pages/Login';
 import Turian from './routes/turian';
@@ -106,7 +107,8 @@ export const router = createBrowserRouter([
       { path: 'contact', element: <Contact /> },
       { path: 'accessibility', element: <Accessibility /> },
       { path: 'about', element: <About /> },
-        { path: 'navatar', element: <NavatarPage /> },
+        { path: 'navatar/pick', element: <PickNavatarPage /> },
+      { path: 'navatar', element: <NavatarPage /> },
         { path: 'passport', element: <PassportPage /> },
         { path: 'auth/callback', element: <AuthCallback /> },
         { path: 'login', element: <LoginPage /> },

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,0 +1,49 @@
+.pick-wrap { padding: 1.25rem 1rem 3rem; }
+
+.breadcrumbs {
+  display: flex; gap: .5rem; align-items: center;
+  color: #2b6dff; margin: 0 auto 8px; max-width: 1100px;
+}
+.breadcrumbs a { color: #2b6dff; text-decoration: none; font-weight: 600; }
+.breadcrumbs span { opacity: .8; }
+
+.page-title {
+  max-width: 1100px; margin: 0 auto 16px;
+  color: #2b6dff; font-size: clamp(24px, 3.2vw, 40px);
+  line-height: 1.1; font-weight: 800;
+}
+
+.pick-status { max-width: 1100px; margin: 32px auto; opacity: .8; }
+
+.pick-layout { max-width: 1100px; margin: 0 auto; }
+.pick-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 16px;
+}
+.pick-card {
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
+  border: 2px solid #e6ecff; border-radius: 16px; padding: 12px;
+  background: #fff; cursor: pointer; transition: transform .06s ease, box-shadow .06s ease, border-color .06s ease;
+}
+.pick-card img { width: 100%; aspect-ratio: 1/1; object-fit: cover; border-radius: 12px; }
+.pick-card .pick-name { font-weight: 700; color: #2b6dff; font-size: 14px; text-align: center; }
+.pick-card:hover { transform: translateY(-1px); box-shadow: 0 2px 10px rgba(0,0,0,.08); border-color: #d7e2ff; }
+.pick-card.selected { border-color: #2b6dff; box-shadow: 0 0 0 4px rgba(43,109,255,.12); }
+
+.pick-actions {
+  max-width: 1100px; margin: 20px auto 0;
+  display: flex; justify-content: flex-end;
+}
+.primary {
+  min-width: 220px; height: 44px; border-radius: 22px;
+  border: none; font-weight: 800; font-size: 16px;
+  background: #2b6dff; color: #fff; opacity: 1;
+}
+.primary[disabled], .primary[aria-disabled="true"] {
+  opacity: .5; pointer-events: none;
+}
+
+@media (max-width: 720px) {
+  .pick-actions { justify-content: center; }
+}


### PR DESCRIPTION
## Summary
- create Supabase client wrapper
- load navatar images from storage and save selection
- add Pick Navatar page with responsive grid and blue breadcrumbs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find module 'next', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7061b7b508329a2a2258d3f194ac1