### PR TITLE
Navatar Hub v0.1.2 — show selected avatar and redirect after save

### DIFF
--- a/src/data/navatarCanons.ts
+++ b/src/data/navatarCanons.ts
@@ -1,0 +1,15 @@
+import catalog from './navatar-catalog.json';
+
+export type CanonNavatar = {
+  id: string;
+  title: string;
+  url: string;
+};
+
+const CANONS: CanonNavatar[] = (catalog as any[]).map(({ id, title, src }) => ({
+  id,
+  title,
+  url: src,
+}));
+
+export default CANONS;

--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -86,3 +86,36 @@ export async function setActive(id: string) {
   }
   setActiveLocal(id);
 }
+
+export type NavatarRow = {
+  id: string;
+  user_id: string;
+  name: string | null;
+  image_url: string | null;
+  method: string | null;
+  created_at: string;
+};
+
+export async function getMyLatestNavatar(userId: string) {
+  if (!supabase) throw new Error('Supabase not initialized');
+  const { data, error } = await supabase
+    .from('avatars')
+    .select('id,user_id,name,image_url,method,created_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle<NavatarRow>();
+  if (error) throw error;
+  return data;
+}
+
+export async function upsertNavatarSelection(userId: string, name: string, imageUrl: string) {
+  if (!supabase) throw new Error('Supabase not initialized');
+  const { error } = await supabase.from('avatars').insert({
+    user_id: userId,
+    name,
+    method: 'canon',
+    image_url: imageUrl,
+  });
+  if (error) throw error;
+}


### PR DESCRIPTION
## Summary
- show current user's saved Navatar on hub
- redirect back to hub after saving selection
- add minimal helpers for avatar queries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b7801e7234832982b52552753deee0