### PR TITLE
Navatar — reliable save + blue breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -55,7 +55,7 @@ export function Breadcrumbs(props: { items?: Crumb[] }) {
   if (items.length <= 1) return null;
 
   return (
-    <nav aria-label="Breadcrumb" className="nv-breadcrumbs">
+    <nav aria-label="Breadcrumb" className="nv-breadcrumbs brand-blue">
       <ol>
         {items.map((c, i) => {
           const isLast = i === items.length - 1;

--- a/src/lib/avatars.ts
+++ b/src/lib/avatars.ts
@@ -4,8 +4,8 @@ export type AvatarRow = {
   id?: string;
   user_id: string;
   name: string;
-  category: 'canon' | 'upload' | 'generate';
-  method: 'pick' | 'upload' | 'ai';
+  category: 'canon' | 'upload' | 'ai';
+  method: 'pick' | 'upload' | 'generate';
   image_url: string;
   updated_at?: string;
 };
@@ -32,9 +32,8 @@ export async function upsertMyAvatar(payload: Omit<AvatarRow, 'id'|'updated_at'|
     .from('avatars')
     .upsert({
       user_id: user.id,
-      ...payload,
-      updated_at: new Date().toISOString()
-    }, { onConflict: 'user_id' });
+      ...payload
+    }, { onConflict: 'user_id', ignoreDuplicates: false });
 
   if (error) throw error;
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,12 +1,61 @@
-import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { getSupabase } from '../../lib/supabase-client';
+import { useSession } from '../../lib/session';
 import '../../styles/navatar.css';
+
 export default function NavatarGenerate() {
+  const navigate = useNavigate();
+  const { user } = useSession();
+  const supabase = getSupabase();
+  const [imageUrl, setImageUrl] = useState('');
+  const [title, setTitle] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  async function handleGenerateDone() {
+    if (!user?.id) return alert('Please sign in');
+    if (!imageUrl) return;
+    setSaving(true);
+    try {
+      const { error } = await supabase
+        .from('avatars')
+        .upsert(
+          {
+            user_id: user.id,
+            name: title || 'avatar',
+            category: 'ai',
+            method: 'generate',
+            image_url: imageUrl,
+          },
+          { onConflict: 'user_id', ignoreDuplicates: false }
+        );
+      if (error) throw error;
+      navigate('/navatar?refresh=1');
+    } catch (e: any) {
+      alert(e.message || String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
-    <div className="navatar-wrap">
-      <div className="navatar-breadcrumbs"><Link to="/">Home</Link> / <Link to="/navatar">Navatar</Link> / Describe &amp; Generate</div>
-      <h1 className="navatar-title">Describe &amp; Generate (Coming Soon)</h1>
-      <p>We’ll add the AI image flow after Upload.</p>
+    <div className="container">
+      <nav className="nv-breadcrumbs brand-blue">
+        <Link to="/">Home</Link>
+        <span className="sep">/</span>
+        <Link to="/navatar">Navatar</Link>
+        <span className="sep">/</span>
+        <span>Describe &amp; Generate</span>
+      </nav>
+      <h1>Describe &amp; Generate</h1>
+      <p>Enter an image URL and name to save your generated Navatar.</p>
+      <div style={{display:'flex', flexDirection:'column', gap:12, maxWidth:400}}>
+        <input type="text" placeholder="Image URL" value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
+        <input type="text" placeholder="Name" value={title} onChange={e => setTitle(e.target.value)} />
+        <button className="primary" onClick={handleGenerateDone} disabled={!imageUrl || saving}>
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
     </div>
   );
 }
-

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,23 +1,34 @@
 import { useEffect, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
 import { getMyAvatar } from '../../lib/avatars';
-import { Link } from 'react-router-dom';
 
 export default function NavatarHub() {
   const [loading, setLoading] = useState(true);
   const [mine, setMine] = useState<any>(null);
+  const [searchParams] = useSearchParams();
 
+  async function loadMyNavatar() {
+    setLoading(true);
+    try {
+      setMine(await getMyAvatar());
+    } finally {
+      setLoading(false);
+    }
+  }
+  useEffect(() => { loadMyNavatar(); }, []);
   useEffect(() => {
-    (async () => {
-      try { setMine(await getMyAvatar()); }
-      finally { setLoading(false); }
-    })();
-  }, []);
+    if (searchParams.get('refresh')) loadMyNavatar();
+  }, [searchParams]);
 
   if (loading) return <div className="container"><h1>Your Navatar</h1><p>Loading…</p></div>;
 
   return (
     <div className="container">
-      <nav className="crumbs">Home / Navatar</nav>
+      <nav className="nv-breadcrumbs brand-blue">
+        <Link to="/">Home</Link>
+        <span className="sep">/</span>
+        <span>Navatar</span>
+      </nav>
       <h1>Your Navatar</h1>
 
       {mine ? (

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,12 +1,70 @@
-import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { getSupabase } from '../../lib/supabase-client';
+import { useSession } from '../../lib/session';
 import '../../styles/navatar.css';
+
 export default function NavatarUpload() {
+  const navigate = useNavigate();
+  const { user } = useSession();
+  const supabase = getSupabase();
+  const [file, setFile] = useState<File | null>(null);
+  const [displayName, setDisplayName] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  async function handleUpload() {
+    if (!user?.id) return alert('Please sign in');
+    if (!file) return;
+    setSaving(true);
+    try {
+      const path = `${user.id}/${crypto.randomUUID()}-${file.name}`;
+      const { error: upErr } = await supabase.storage
+        .from('avatars')
+        .upload(path, file, { cacheControl: '3600', upsert: false });
+      if (upErr) throw upErr;
+
+      const { data: pub } = supabase.storage.from('avatars').getPublicUrl(path);
+      const image_url = pub?.publicUrl;
+      if (!image_url) throw new Error('Public URL not available');
+
+      const { error: dbErr } = await supabase
+        .from('avatars')
+        .upsert(
+          {
+            user_id: user.id,
+            name: displayName || 'avatar',
+            category: 'upload',
+            method: 'upload',
+            image_url,
+          },
+          { onConflict: 'user_id', ignoreDuplicates: false }
+        );
+      if (dbErr) throw dbErr;
+      navigate('/navatar?refresh=1');
+    } catch (e: any) {
+      alert(e.message || String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
-    <div className="navatar-wrap">
-      <div className="navatar-breadcrumbs"><Link to="/">Home</Link> / <Link to="/navatar">Navatar</Link> / Upload</div>
-      <h1 className="navatar-title">Upload (Coming Soon)</h1>
-      <p>We’ll wire this up next.</p>
+    <div className="container">
+      <nav className="nv-breadcrumbs brand-blue">
+        <Link to="/">Home</Link>
+        <span className="sep">/</span>
+        <Link to="/navatar">Navatar</Link>
+        <span className="sep">/</span>
+        <span>Upload</span>
+      </nav>
+      <h1>Upload Navatar</h1>
+      <div style={{display:'flex', flexDirection:'column', gap:12, maxWidth:400}}>
+        <input type="file" accept="image/*" onChange={e => setFile(e.target.files?.[0] ?? null)} />
+        <input type="text" placeholder="Name" value={displayName} onChange={e => setDisplayName(e.target.value)} />
+        <button className="primary" onClick={handleUpload} disabled={!file || saving}>
+          {saving ? 'Saving…' : 'Upload'}
+        </button>
+      </div>
     </div>
   );
 }
-

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,5 +1,6 @@
 .card { background:#fff; border-radius:16px; padding:12px; box-shadow:0 1px 4px rgba(0,0,0,.08); border:2px solid transparent; }
 .card.isSelected { border-color:#3b82f6; box-shadow:0 0 0 3px rgba(59,130,246,.25); }
-.thumb { width:100%; aspect-ratio:1/1; object-fit:cover; border-radius:12px; }
+.navatar-card { aspect-ratio:1/1; border-radius:16px; overflow:hidden; background:#fff; }
+.navatar-card img { width:100%; height:100%; object-fit:contain; display:block; }
 .title { font-weight:700; margin-top:8px; }
 .primary { padding:10px 16px; border-radius:12px; }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -255,6 +255,13 @@ footer,
   color: #1a4d9c !important;
 }
 
+/* Brand blue for breadcrumbs links and separators */
+.nv-breadcrumbs.brand-blue a,
+.nv-breadcrumbs.brand-blue span,
+.nv-breadcrumbs.brand-blue .sep {
+  color: #1e64ff !important;
+}
+
 /* Ensure links keep their current hover/active colors */
 a {
   color: #1a4d9c;


### PR DESCRIPTION
## Summary
- upsert a single avatar row per user and reload hub after saving
- add upload and generate flows with proper method tracking
- ensure breadcrumbs render in brand blue and navatar cards fit images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b79f1d14f48329857d0cec7c8820a5