### PR TITLE
Style Navatar profile image like gallery

### DIFF
--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -34,7 +34,11 @@ export default function NavatarHub() {
       {mine ? (
         <>
           <div style={{display:'flex', flexDirection:'column', alignItems:'center', gap:12}}>
-            <img src={mine.image_url} alt={mine.name} style={{width:320, height:320, objectFit:'cover', borderRadius:24}}/>
+            <img
+              src={mine.image_url}
+              alt={mine.name}
+              className="w-full max-w-xs rounded-lg border bg-white p-2 object-contain"
+            />
             <div style={{fontWeight:700, fontSize:24}}>{mine.name}</div>
             <div style={{display:'flex', gap:12, marginTop:6, flexWrap:'wrap', justifyContent:'center'}}>
               <Link className="btn" to="/navatar/pick">Pick Navatar</Link>


### PR DESCRIPTION
## Summary
- style the Navatar profile picture like gallery images using object-contain and border

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7a25d6e4c8329bf4c633ed6ea6a25