### PR TITLE
Constrain Navatar hero image width

### DIFF
--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -34,7 +34,14 @@ export default function NavatarHub() {
       {mine ? (
         <>
           <div style={{display:'flex', flexDirection:'column', alignItems:'center', gap:12}}>
-            <img src={mine.image_url} alt={mine.name} style={{width:320, height:320, objectFit:'cover', borderRadius:24}}/>
+            <div className="navatar-hero mx-auto w-full max-w-[560px] px-4">
+              <img
+                src={mine.image_url}
+                alt={mine.name}
+                className="block w-full aspect-square rounded-2xl object-cover"
+                loading="eager"
+              />
+            </div>
             <div style={{fontWeight:700, fontSize:24}}>{mine.name}</div>
             <div style={{display:'flex', gap:12, marginTop:6, flexWrap:'wrap', justifyContent:'center'}}>
               <Link className="btn" to="/navatar/pick">Pick Navatar</Link>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -676,3 +676,33 @@ footer a:hover {
 .card h3, .card h4, .card .label, .card .section-title {
   color: var(--naturverse-blue);
 }
+
+/* Navatar hero (desktop) — keep same look as gallery */
+.navatar-hero {
+  max-width: 560px;     /* desktop cap */
+  margin-inline: auto;
+  padding-inline: 16px; /* same breathing room as gallery */
+}
+
+/* Make the media square + cover like the gallery cards */
+.navatar-hero img,
+.navatar-hero picture,
+.navatar-hero canvas {
+  display: block;
+  width: 100%;
+  height: auto;               /* fallback */
+  aspect-ratio: 1 / 1;        /* square frame */
+  object-fit: cover;          /* fill square without distortion */
+  border-radius: 1rem;        /* rounded-2xl (~16px) */
+}
+
+/* Optional: older browser fallback for aspect-ratio */
+@supports not (aspect-ratio: 1 / 1) {
+  .navatar-hero { position: relative; }
+  .navatar-hero::before { content: ""; display: block; padding-top: 100%; }
+  .navatar-hero > img,
+  .navatar-hero > picture,
+  .navatar-hero > canvas {
+    position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;
+  }
+}


### PR DESCRIPTION
## Summary
- Wrap navatar hero in a dedicated container with square-cropped image
- Add global CSS to cap width and enforce square crop similar to gallery

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b7a63f01908329848cde43b44455cc