### PR TITLE
feat: enable avatar uploads

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,2 +1,1 @@
-export { supabase } from "./supabase-client";
-
+export { supabase, getSupabase } from "./supabase-client";

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useState, ChangeEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { getSupabase } from '../../lib/supabase-client';
+import { getSupabase } from '../../lib/supabase';
 import { useSession } from '../../lib/session';
 import '../../styles/navatar.css';
 
@@ -8,25 +8,40 @@ export default function NavatarUpload() {
   const navigate = useNavigate();
   const { user } = useSession();
   const supabase = getSupabase();
+
   const [file, setFile] = useState<File | null>(null);
   const [displayName, setDisplayName] = useState('');
   const [saving, setSaving] = useState(false);
+
+  function onFile(e: ChangeEvent<HTMLInputElement>) {
+    setFile(e.target.files?.[0] ?? null);
+  }
 
   async function handleUpload() {
     if (!user?.id) return alert('Please sign in');
     if (!file) return;
     setSaving(true);
     try {
-      const path = `${user.id}/${crypto.randomUUID()}-${file.name}`;
+      // ---- 1) upload to Storage at avatars/{userId}/{uuid}.{ext}
+      const ext = (file.name.split('.').pop() || 'png').toLowerCase();
+      const filename = `${crypto.randomUUID()}.${ext}`;
+      const path = `${user.id}/${filename}`;
+
       const { error: upErr } = await supabase.storage
         .from('avatars')
-        .upload(path, file, { cacheControl: '3600', upsert: false });
+        .upload(path, file, {
+          cacheControl: '3600',
+          contentType: file.type || undefined,
+          upsert: true,
+        });
       if (upErr) throw upErr;
 
+      // ---- 2) resolve a public URL for the uploaded file
       const { data: pub } = supabase.storage.from('avatars').getPublicUrl(path);
       const image_url = pub?.publicUrl;
-      if (!image_url) throw new Error('Public URL not available');
+      if (!image_url) throw new Error('Public URL not returned');
 
+      // ---- 3) upsert the DB row so this becomes the current avatar
       const { error: dbErr } = await supabase
         .from('avatars')
         .upsert(
@@ -40,9 +55,11 @@ export default function NavatarUpload() {
           { onConflict: 'user_id', ignoreDuplicates: false }
         );
       if (dbErr) throw dbErr;
+
+      // Go back to the profile and force refresh of current avatar
       navigate('/navatar?refresh=1');
     } catch (e: any) {
-      alert(e.message || String(e));
+      alert(e?.message || String(e));
     } finally {
       setSaving(false);
     }
@@ -58,10 +75,15 @@ export default function NavatarUpload() {
         <span>Upload</span>
       </nav>
       <h1>Upload Navatar</h1>
-      <div style={{display:'flex', flexDirection:'column', gap:12, maxWidth:400}}>
-        <input type="file" accept="image/*" onChange={e => setFile(e.target.files?.[0] ?? null)} />
-        <input type="text" placeholder="Name" value={displayName} onChange={e => setDisplayName(e.target.value)} />
-        <button className="primary" onClick={handleUpload} disabled={!file || saving}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <input type="file" accept="image/*" onChange={onFile} />
+        <input
+          type="text"
+          placeholder="Name (optional)"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+        />
+        <button className="primary" onClick={handleUpload} disabled={saving || !file}>
           {saving ? 'Saving…' : 'Upload'}
         </button>
       </div>


### PR DESCRIPTION
## Summary
- support retrieving Supabase client from central lib export
- enable uploading avatars to storage and saving public URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7ba4801948329b1de13de090f2f7b