### PR TITLE
Fix navatar upload URL and viewer sizing

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,2 +1,2 @@
-export { supabase } from "./supabase-client";
+export { supabase, getSupabase } from "./supabase-client";
 

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -38,10 +38,10 @@ export default function NavatarHub() {
               src={mine.image_url}
               alt={mine.name}
               style={{
-                maxWidth: '100%',
+                width: 'min(420px, 90vw)',
                 height: 'auto',
-                maxHeight: '70vh',
-                objectFit: 'contain',
+                aspectRatio: '3 / 4',
+                objectFit: 'cover',
                 borderRadius: 24,
               }}
             />

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,32 +1,45 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { getSupabase } from '../../lib/supabase-client';
+import { getSupabase } from '../../lib/supabase';
 import { useSession } from '../../lib/session';
 import '../../styles/navatar.css';
 
 export default function NavatarUpload() {
   const navigate = useNavigate();
-  const { user } = useSession();
+  const user = useSession().user;
   const supabase = getSupabase();
+
   const [file, setFile] = useState<File | null>(null);
-  const [displayName, setDisplayName] = useState('');
+  const [displayName, setDisplayName] = useState<string>('');
   const [saving, setSaving] = useState(false);
 
   async function handleUpload() {
     if (!user?.id) return alert('Please sign in');
     if (!file) return;
+
     setSaving(true);
     try {
-      const path = `${user.id}/${crypto.randomUUID()}-${file.name}`;
+      // ensure path starts with user id and includes an extension
+      const ext = (file.name.split('.').pop() || 'png').toLowerCase();
+      const key = crypto.randomUUID();
+      const path = `${user.id}/${key}.${ext}`;
+
+      // upload
       const { error: upErr } = await supabase.storage
         .from('avatars')
-        .upload(path, file, { cacheControl: '3600', upsert: false });
+        .upload(path, file, {
+          cacheControl: '3600',
+          upsert: false,
+          contentType: file.type || `image/${ext}`,
+        });
       if (upErr) throw upErr;
 
-      const { data: pub } = supabase.storage.from('avatars').getPublicUrl(path);
-      const image_url = pub?.publicUrl;
-      if (!image_url) throw new Error('Public URL not available');
+      // public URL (works with our public read policy)
+      const { data } = supabase.storage.from('avatars').getPublicUrl(path);
+      const image_url = data?.publicUrl;
+      if (!image_url) throw new Error('Public URL not returned');
 
+      // save to DB
       const { error: dbErr } = await supabase
         .from('avatars')
         .upsert(
@@ -37,9 +50,10 @@ export default function NavatarUpload() {
             method: 'upload',
             image_url,
           },
-          { onConflict: 'user_id', ignoreDuplicates: false }
+          { onConflict: 'user_id', ignoreDuplicates: false },
         );
       if (dbErr) throw dbErr;
+
       navigate('/navatar?refresh=1');
     } catch (e: any) {
       alert(e.message || String(e));
@@ -57,14 +71,26 @@ export default function NavatarUpload() {
         <span className="sep">/</span>
         <span>Upload</span>
       </nav>
+
       <h1>Upload Navatar</h1>
-      <div style={{display:'flex', flexDirection:'column', gap:12, maxWidth:400}}>
-        <input type="file" accept="image/*" onChange={e => setFile(e.target.files?.[0] ?? null)} />
-        <input type="text" placeholder="Name" value={displayName} onChange={e => setDisplayName(e.target.value)} />
-        <button className="primary" onClick={handleUpload} disabled={!file || saving}>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 560 }}>
+        <input
+          type="file"
+          accept="image/png,image/jpeg,image/webp"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        />
+        <input
+          type="text"
+          placeholder="Name (optional)"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+        />
+        <button className="primary" onClick={handleUpload} disabled={saving || !file}>
           {saving ? 'Saving…' : 'Upload'}
         </button>
       </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- ensure uploaded navatar paths include file extension and save public URL
- cap displayed navatar size to prevent oversized images
- re-export `getSupabase` from lib/supabase for consistent imports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7bdb3c8bc8329ae18c64894aa04df