### PR TITLE
Restrict Navatar upload formats and default name

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,2 +1,2 @@
-export { supabase } from "./supabase-client";
+export { supabase, getSupabase } from "./supabase-client";
 

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -45,7 +45,7 @@ export default function NavatarHub() {
                 borderRadius: 24,
               }}
             />
-            <div style={{fontWeight:700, fontSize:24}}>{mine.name}</div>
+            <div style={{ fontWeight: 700, fontSize: 24 }}>{mine.name || 'Navatar'}</div>
             <div style={{display:'flex', gap:12, marginTop:6, flexWrap:'wrap', justifyContent:'center'}}>
               <Link className="btn" to="/navatar/pick">Pick Navatar</Link>
               <Link className="btn" to="/navatar/upload">Upload</Link>

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,38 +1,72 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { getSupabase } from '../../lib/supabase-client';
+import { getSupabase } from '../../lib/supabase';
 import { useSession } from '../../lib/session';
 import '../../styles/navatar.css';
+
+const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
 
 export default function NavatarUpload() {
   const navigate = useNavigate();
   const { user } = useSession();
   const supabase = getSupabase();
+
   const [file, setFile] = useState<File | null>(null);
-  const [displayName, setDisplayName] = useState('');
+  const [displayName, setDisplayName] = useState<string>('');
   const [saving, setSaving] = useState(false);
+
+  function chooseFile(f: File | null) {
+    if (!f) {
+      setFile(null);
+      return;
+    }
+    if (!ALLOWED_TYPES.includes(f.type)) {
+      alert('Please choose a PNG, JPG/JPEG, or WEBP image.');
+      setFile(null);
+      return;
+    }
+    setFile(f);
+  }
 
   async function handleUpload() {
     if (!user?.id) return alert('Please sign in');
     if (!file) return;
+
     setSaving(true);
     try {
-      const path = `${user.id}/${crypto.randomUUID()}-${file.name}`;
+      const extRaw = (file.name.split('.').pop() || '').toLowerCase();
+      const ext =
+        extRaw === 'jpg'
+          ? 'jpg'
+          : extRaw === 'jpeg'
+          ? 'jpeg'
+          : extRaw === 'png'
+          ? 'png'
+          : extRaw === 'webp'
+          ? 'webp'
+          : 'jpg';
+      const key = crypto.randomUUID();
+      const path = `${user.id}/${key}.${ext}`;
+
       const { error: upErr } = await supabase.storage
         .from('avatars')
-        .upload(path, file, { cacheControl: '3600', upsert: false });
+        .upload(path, file, {
+          cacheControl: '3600',
+          upsert: false,
+          contentType: file.type || `image/${ext}`,
+        });
       if (upErr) throw upErr;
 
-      const { data: pub } = supabase.storage.from('avatars').getPublicUrl(path);
-      const image_url = pub?.publicUrl;
-      if (!image_url) throw new Error('Public URL not available');
+      const { data } = supabase.storage.from('avatars').getPublicUrl(path);
+      const image_url = data?.publicUrl;
+      if (!image_url) throw new Error('Public URL not returned');
 
       const { error: dbErr } = await supabase
         .from('avatars')
         .upsert(
           {
             user_id: user.id,
-            name: displayName || 'avatar',
+            name: (displayName || 'Navatar').trim(),
             category: 'upload',
             method: 'upload',
             image_url,
@@ -40,6 +74,7 @@ export default function NavatarUpload() {
           { onConflict: 'user_id', ignoreDuplicates: false }
         );
       if (dbErr) throw dbErr;
+
       navigate('/navatar?refresh=1');
     } catch (e: any) {
       alert(e.message || String(e));
@@ -58,10 +93,19 @@ export default function NavatarUpload() {
         <span>Upload</span>
       </nav>
       <h1>Upload Navatar</h1>
-      <div style={{display:'flex', flexDirection:'column', gap:12, maxWidth:400}}>
-        <input type="file" accept="image/*" onChange={e => setFile(e.target.files?.[0] ?? null)} />
-        <input type="text" placeholder="Name" value={displayName} onChange={e => setDisplayName(e.target.value)} />
-        <button className="primary" onClick={handleUpload} disabled={!file || saving}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 560 }}>
+        <input
+          type="file"
+          accept="image/png,image/jpeg,image/webp"
+          onChange={(e) => chooseFile(e.target.files?.[0] ?? null)}
+        />
+        <input
+          type="text"
+          placeholder="Name (optional)"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+        />
+        <button className="primary" onClick={handleUpload} disabled={saving || !file}>
           {saving ? 'Saving…' : 'Upload'}
         </button>
       </div>


### PR DESCRIPTION
## Summary
- validate uploaded Navatar files to allow only PNG, JPEG, or WEBP
- default uploaded Navatars to the name "Navatar" when no name provided
- show fallback "Navatar" title when viewing an unnamed Navatar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b7c06048ac83298685d5870d8b813a