### PR TITLE
Fix Navatar upload and display

### DIFF
--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -3,7 +3,7 @@ import { useAuth } from "@/auth/AuthContext";
 
 export function useSession() {
   const { user } = useAuth();
-  return { user };
+  return user;
 }
 
 export async function getUserId(): Promise<string | null> {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,2 +1,2 @@
-export { supabase } from "./supabase-client";
+export { supabase, getSupabase } from "./supabase-client";
 

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { getSupabase } from '../../lib/supabase-client';
+import { getSupabase } from '../../lib/supabase';
 import { useSession } from '../../lib/session';
 import '../../styles/navatar.css';
 
 export default function NavatarGenerate() {
   const navigate = useNavigate();
-  const { user } = useSession();
+  const user = useSession();
   const supabase = getSupabase();
   const [imageUrl, setImageUrl] = useState('');
   const [title, setTitle] = useState('');
@@ -22,7 +22,7 @@ export default function NavatarGenerate() {
         .upsert(
           {
             user_id: user.id,
-            name: title || 'avatar',
+            name: title || 'Navatar',
             category: 'ai',
             method: 'generate',
             image_url: imageUrl,
@@ -49,9 +49,9 @@ export default function NavatarGenerate() {
       </nav>
       <h1>Describe &amp; Generate</h1>
       <p>Enter an image URL and name to save your generated Navatar.</p>
-      <div style={{display:'flex', flexDirection:'column', gap:12, maxWidth:400}}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 400 }}>
         <input type="text" placeholder="Image URL" value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
-        <input type="text" placeholder="Name" value={title} onChange={e => setTitle(e.target.value)} />
+        <input type="text" placeholder="Name (optional)" value={title} onChange={e => setTitle(e.target.value)} />
         <button className="primary" onClick={handleGenerateDone} disabled={!imageUrl || saving}>
           {saving ? 'Saving…' : 'Save'}
         </button>

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -33,20 +33,14 @@ export default function NavatarHub() {
 
       {mine ? (
         <>
-          <div style={{display:'flex', flexDirection:'column', alignItems:'center', gap:12}}>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
             <img
               src={mine.image_url}
-              alt={mine.name}
-              style={{
-                maxWidth: '100%',
-                height: 'auto',
-                maxHeight: '70vh',
-                objectFit: 'contain',
-                borderRadius: 24,
-              }}
+              alt={mine.name || 'Navatar'}
+              style={{ width: 320, height: 480, objectFit: 'cover', borderRadius: 24 }}
             />
-            <div style={{fontWeight:700, fontSize:24}}>{mine.name}</div>
-            <div style={{display:'flex', gap:12, marginTop:6, flexWrap:'wrap', justifyContent:'center'}}>
+            <div style={{ fontWeight: 700, fontSize: 24 }}>{mine.name || 'Navatar'}</div>
+            <div style={{ display: 'flex', gap: 12, marginTop: 6, flexWrap: 'wrap', justifyContent: 'center' }}>
               <Link className="btn" to="/navatar/pick">Pick Navatar</Link>
               <Link className="btn" to="/navatar/upload">Upload</Link>
               <Link className="btn" to="/navatar/generate">Describe &amp; Generate</Link>
@@ -56,7 +50,7 @@ export default function NavatarHub() {
       ) : (
         <>
           <p>No Navatar yet — pick one below.</p>
-          <div style={{display:'flex', justifyContent:'center', gap:16, flexWrap:'wrap'}}>
+          <div style={{ display: 'flex', justifyContent: 'center', gap: 16, flexWrap: 'wrap' }}>
             <Link className="btn" to="/navatar/pick">Pick Navatar</Link>
             <Link className="btn" to="/navatar/upload">Upload</Link>
             <Link className="btn" to="/navatar/generate">Describe &amp; Generate</Link>

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import CANONS from '../../data/navatarCanons';
-import { getSupabase } from '../../lib/supabase-client';
+import { getSupabase } from '../../lib/supabase';
 import { useSession } from '../../lib/session';
 import '../../styles/navatar.css';
 
@@ -10,7 +10,7 @@ export default function PickNavatarPage() {
   const [saving, setSaving] = useState(false);
   const canon = CANONS;
   const navigate = useNavigate();
-  const { user } = useSession();
+  const user = useSession();
   const supabase = getSupabase();
 
   async function savePickedCanon(pickedCanon: { title: string; url: string }) {

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,45 +1,56 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { getSupabase } from '../../lib/supabase-client';
+import { getSupabase } from '../../lib/supabase';
 import { useSession } from '../../lib/session';
 import '../../styles/navatar.css';
 
 export default function NavatarUpload() {
   const navigate = useNavigate();
-  const { user } = useSession();
+  const user = useSession();
   const supabase = getSupabase();
+
   const [file, setFile] = useState<File | null>(null);
   const [displayName, setDisplayName] = useState('');
   const [saving, setSaving] = useState(false);
 
   async function handleUpload() {
-    if (!user?.id) return alert('Please sign in');
+    if (!user?.id) return alert('Please sign in first');
     if (!file) return;
+
     setSaving(true);
     try {
       const path = `${user.id}/${crypto.randomUUID()}-${file.name}`;
-      const { error: upErr } = await supabase.storage
+
+      const { error: upErr } = await supabase
+        .storage
         .from('avatars')
-        .upload(path, file, { cacheControl: '3600', upsert: false });
+        .upload(path, file, {
+          cacheControl: '3600',
+          upsert: false,
+          contentType: file.type || 'image/png',
+        });
       if (upErr) throw upErr;
 
+      // always read the public URL like this
       const { data: pub } = supabase.storage.from('avatars').getPublicUrl(path);
-      const image_url = pub?.publicUrl;
-      if (!image_url) throw new Error('Public URL not available');
+      const image_url = pub.publicUrl;
+      if (!image_url) throw new Error('Public URL missing');
 
       const { error: dbErr } = await supabase
         .from('avatars')
         .upsert(
           {
             user_id: user.id,
-            name: displayName || 'avatar',
+            name: displayName || 'Navatar',
             category: 'upload',
             method: 'upload',
             image_url,
           },
           { onConflict: 'user_id', ignoreDuplicates: false }
         );
+
       if (dbErr) throw dbErr;
+
       navigate('/navatar?refresh=1');
     } catch (e: any) {
       alert(e.message || String(e));
@@ -51,17 +62,17 @@ export default function NavatarUpload() {
   return (
     <div className="container">
       <nav className="nv-breadcrumbs brand-blue">
-        <Link to="/">Home</Link>
-        <span className="sep">/</span>
-        <Link to="/navatar">Navatar</Link>
-        <span className="sep">/</span>
+        <Link to="/">Home</Link><span className="sep">/</span>
+        <Link to="/navatar">Navatar</Link><span className="sep">/</span>
         <span>Upload</span>
       </nav>
+
       <h1>Upload Navatar</h1>
-      <div style={{display:'flex', flexDirection:'column', gap:12, maxWidth:400}}>
-        <input type="file" accept="image/*" onChange={e => setFile(e.target.files?.[0] ?? null)} />
-        <input type="text" placeholder="Name" value={displayName} onChange={e => setDisplayName(e.target.value)} />
-        <button className="primary" onClick={handleUpload} disabled={!file || saving}>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 640 }}>
+        <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        <input type="text" placeholder="Name (optional)" value={displayName} onChange={(e) => setDisplayName(e.target.value)} />
+        <button className="primary" onClick={handleUpload} disabled={saving || !file}>
           {saving ? 'Saving…' : 'Upload'}
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Use shared Supabase helper and return session user directly
- Upload Navatar with explicit content type, public URL readback, and Navatar default name
- Show Navatar name fallback and consistent image sizing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7c34c470483299f8086c4d16b1d50