### PR TITLE
feat(navatar): describe & generate (text/image → image) + save

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ NEXT_PUBLIC_ENABLE_AUTO_STAMPS=true
 
 # Serverless only (set in Netlify UI → Site settings → Environment):
 OPENAI_API_KEY=
+SUPABASE_URL=your-url
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE=
 VITE_ENABLE_GAMIFICATION=false
 VITE_ENABLE_LEADERBOARD=false
 VITE_ENABLE_STREAKS=false

--- a/netlify/functions/generateNavatar.ts
+++ b/netlify/functions/generateNavatar.ts
@@ -1,0 +1,106 @@
+import { Handler } from '@netlify/functions';
+import OpenAI from 'openai';
+import { createClient } from '@supabase/supabase-js';
+import crypto from 'crypto';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE!
+);
+
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method Not Allowed' };
+    }
+    const auth = event.headers['authorization'] || '';
+    const jwt = auth.replace('Bearer ', '');
+    const { data: { user }, error: authErr } =
+      await supabase.auth.getUser(jwt);
+    if (authErr || !user) return { statusCode: 401, body: 'Unauthorized' };
+
+    const form = JSON.parse(event.body || '{}') as {
+      prompt: string;
+      sourceImageUrl?: string;
+      maskImageUrl?: string;
+      name?: string;
+    };
+    const { prompt, sourceImageUrl, maskImageUrl, name } = form;
+    if (!prompt?.trim()) return { statusCode: 400, body: 'Missing prompt' };
+
+    const { count } = await supabase
+      .from('navatar_generations')
+      .select('*', { count: 'exact', head: true })
+      .gte('created_at', new Date(Date.now() - 24*60*60*1000).toISOString())
+      .eq('user_id', user.id);
+    if ((count ?? 0) >= 10) {
+      return { statusCode: 429, body: 'Daily limit reached' };
+    }
+
+    const { data: gen, error: insErr } = await supabase
+      .from('navatar_generations')
+      .insert({
+        user_id: user.id,
+        prompt,
+        source_image_url: sourceImageUrl || null,
+        mask_image_url: maskImageUrl || null,
+        status: 'queued'
+      })
+      .select()
+      .single();
+    if (insErr) throw insErr;
+
+    // 2) call OpenAI Images (text-to-image or image edit)
+    // gpt-image-1 supports prompt-only or image[]+prompt
+    const images: any[] = [];
+    if (sourceImageUrl) images.push({ image: sourceImageUrl });
+    if (maskImageUrl) images.push({ mask: maskImageUrl });
+    const result = await openai.images.generate({
+      model: 'gpt-image-1',
+      prompt,
+      size: '1024x1024',
+      ...(images.length ? { image: images } : {})
+    });
+
+    const b64 = result.data?.[0]?.b64_json;
+    if (!b64) throw new Error('No image returned');
+
+    const bytes = Buffer.from(b64, 'base64');
+    const fileName = crypto.randomUUID() + '.png';
+    const path = `generated/${user.id}/${fileName}`;
+
+    const { error: upErr } = await supabase.storage
+      .from('avatars')
+      .upload(path, bytes, { contentType: 'image/png', upsert: false });
+    if (upErr) throw upErr;
+
+    const { data: pub } = await supabase.storage
+      .from('avatars')
+      .getPublicUrl(path);
+    const publicUrl = pub?.publicUrl;
+
+    await supabase.from('navatar_generations').update({
+      status: 'succeeded',
+      result_image_url: publicUrl,
+      completed_at: new Date().toISOString()
+    }).eq('id', gen.id);
+
+    await supabase.from('avatars').upsert({
+      user_id: user.id,
+      name: name || 'Navatar',
+      category: 'avatar',
+      method: 'generate',
+      image_url: publicUrl
+    }, { onConflict: 'user_id', ignoreDuplicates: false });
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ image_url: publicUrl, id: gen.id })
+    };
+  } catch (e: any) {
+    return { statusCode: 500, body: String(e?.message || e) };
+  }
+};
+

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,0 +1,21 @@
+import { getSupabase } from './supabase';
+
+export async function generateNavatar(opts: {
+  prompt: string;
+  sourceImageUrl?: string;
+  maskImageUrl?: string;
+  name?: string;
+}) {
+  const supabase = getSupabase();
+  const { data: { session } } = await supabase.auth.getSession();
+  const res = await fetch('/.netlify/functions/generateNavatar', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: session?.access_token ? `Bearer ${session.access_token}` : ''
+    },
+    body: JSON.stringify(opts)
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json() as Promise<{ image_url: string; id: string }>;
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,38 +1,32 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { getSupabase } from '../../lib/supabase';
 import { useSession } from '../../lib/session';
+import { generateNavatar } from '../../lib/openai';
 import '../../styles/navatar.css';
 
 export default function NavatarGenerate() {
   const navigate = useNavigate();
   const user = useSession();
-  const supabase = getSupabase();
-  const [imageUrl, setImageUrl] = useState('');
-  const [title, setTitle] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [name, setName] = useState('');
+  const [srcUrl, setSrcUrl] = useState('');
+  const [maskUrl, setMaskUrl] = useState('');
   const [saving, setSaving] = useState(false);
+  const disabled = saving || !prompt.trim();
 
-  async function handleGenerateDone() {
+  async function onSave() {
     if (!user?.id) return alert('Please sign in');
-    if (!imageUrl) return;
     setSaving(true);
     try {
-      const { error } = await supabase
-        .from('avatars')
-        .upsert(
-          {
-            user_id: user.id,
-            name: title || 'Navatar',
-            category: 'ai',
-            method: 'generate',
-            image_url: imageUrl,
-          },
-          { onConflict: 'user_id', ignoreDuplicates: false }
-        );
-      if (error) throw error;
+      const { image_url } = await generateNavatar({
+        prompt,
+        sourceImageUrl: srcUrl || undefined,
+        maskImageUrl: maskUrl || undefined,
+        name: name || undefined
+      });
       navigate('/navatar?refresh=1');
     } catch (e: any) {
-      alert(e.message || String(e));
+      alert(e?.message || String(e));
     } finally {
       setSaving(false);
     }
@@ -41,21 +35,35 @@ export default function NavatarGenerate() {
   return (
     <div className="container">
       <nav className="nv-breadcrumbs brand-blue">
-        <Link to="/">Home</Link>
-        <span className="sep">/</span>
-        <Link to="/navatar">Navatar</Link>
-        <span className="sep">/</span>
+        <Link to="/">Home</Link><span className="sep">/</span>
+        <Link to="/navatar">Navatar</Link><span className="sep">/</span>
         <span>Describe &amp; Generate</span>
       </nav>
+
       <h1>Describe &amp; Generate</h1>
-      <p>Enter an image URL and name to save your generated Navatar.</p>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 400 }}>
-        <input type="text" placeholder="Image URL" value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
-        <input type="text" placeholder="Name (optional)" value={title} onChange={e => setTitle(e.target.value)} />
-        <button className="primary" onClick={handleGenerateDone} disabled={!imageUrl || saving}>
-          {saving ? 'Saving…' : 'Save'}
+
+      <div style={{display:'flex', flexDirection:'column', gap:12, maxWidth:640}}>
+        <textarea
+          value={prompt}
+          onChange={e=>setPrompt(e.target.value)}
+          placeholder="Describe your Navatar (e.g., 'friendly water-buffalo spirit, gold robe, jungle temple, sunny morning, storybook style')"
+          rows={4}
+        />
+        <input value={srcUrl} onChange={e=>setSrcUrl(e.target.value)}
+               placeholder="(Optional) Source Image URL for edits/merge" />
+        <input value={maskUrl} onChange={e=>setMaskUrl(e.target.value)}
+               placeholder="(Optional) Mask Image URL (transparent areas = replaced)" />
+        <input value={name} onChange={e=>setName(e.target.value)}
+               placeholder="Name (optional)" />
+        <button className="primary" disabled={disabled} onClick={onSave}>
+          {saving ? 'Creating…' : 'Save'}
         </button>
       </div>
+
+      <p style={{marginTop:16, opacity:.7}}>
+        Tips: Keep faces centered, ask for full-body vs portrait, and mention
+        “storybook / illustration / character sheet” for that Navatar vibe.
+      </p>
     </div>
   );
 }

--- a/supabase/migrations/2026-01-04_navatar_generations.sql
+++ b/supabase/migrations/2026-01-04_navatar_generations.sql
@@ -1,0 +1,58 @@
+-- A) log table
+create table if not exists public.navatar_generations (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  prompt text not null,
+  source_image_url text,
+  mask_image_url text,
+  result_image_url text,
+  model text not null default 'gpt-image-1',
+  status text not null default 'queued',
+  error text,
+  created_at timestamptz not null default now(),
+  completed_at timestamptz
+);
+
+-- B) row-level security
+alter table public.navatar_generations enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='navatar_generations'
+      and policyname='cg_select_own_generations'
+  ) then
+    create policy cg_select_own_generations
+      on public.navatar_generations for select
+      using (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='navatar_generations'
+      and policyname='cg_insert_own_generations'
+  ) then
+    create policy cg_insert_own_generations
+      on public.navatar_generations for insert
+      with check (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='navatar_generations'
+      and policyname='cg_update_own_generations'
+  ) then
+    create policy cg_update_own_generations
+      on public.navatar_generations for update
+      using (auth.uid() = user_id)
+      with check (auth.uid() = user_id);
+  end if;
+end $$;
+
+-- C) fast lookup by user
+create index if not exists navgen_user_created_idx
+  on public.navatar_generations (user_id, created_at desc);


### PR DESCRIPTION
## Summary
- add `generateNavatar` Netlify function to create or edit images with OpenAI and log results
- new `navatar_generations` table, policies, and index
- client helper and page for prompting, optional source/mask URLs, and saving as Navatar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b7c84feadc83299c7e10271a8169a0