### PR TITLE
Add Navatar generation function and UI enhancements

### DIFF
--- a/netlify/functions/generateNavatar.ts
+++ b/netlify/functions/generateNavatar.ts
@@ -1,0 +1,116 @@
+import type { Handler } from '@netlify/functions';
+import OpenAI from 'openai';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const OPENAI_KEY = process.env.OPENAI_API_KEY!;
+const BUCKET = process.env.IMAGES_BUCKET || 'avatars';
+
+const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
+const openai = new OpenAI({ apiKey: OPENAI_KEY });
+
+// Tiny helper to fetch a remote image as a Buffer (for edits/var.)
+async function fetchAsBuffer(url: string) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`Fetch failed ${r.status}`);
+  const arrayBuf = await r.arrayBuffer();
+  return Buffer.from(arrayBuf);
+}
+
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method Not Allowed' };
+    }
+
+    const { prompt, userId, name, sourceImageUrl, maskImageUrl } = JSON.parse(event.body || '{}') as {
+      prompt: string;
+      userId: string;
+      name?: string;
+      sourceImageUrl?: string;
+      maskImageUrl?: string;
+    };
+
+    if (!userId) throw new Error('Missing userId');
+    if (!prompt && !sourceImageUrl) throw new Error('Provide a prompt or a source image');
+
+    // --- 1) Generate / Edit image via OpenAI ---
+    // We default to 1024 image for quality, can change to 512 to save cost.
+    // When sourceImageUrl is provided we do an "edit"; else we do "generation".
+    let imageB64: string;
+
+    if (sourceImageUrl) {
+      // EDIT (optionally with mask)
+      const image = await fetchAsBuffer(sourceImageUrl);
+      const mask = maskImageUrl ? await fetchAsBuffer(maskImageUrl) : undefined;
+
+      const edit = await openai.images.edits({
+        model: 'gpt-image-1',
+        prompt,
+        image,
+        ...(mask ? { mask } : {}),
+        size: '1024x1024',
+        response_format: 'b64_json',
+      });
+      imageB64 = edit.data[0].b64_json!;
+    } else {
+      // PURE GENERATION
+      const gen = await openai.images.generate({
+        model: 'gpt-image-1',
+        prompt,
+        size: '1024x1024',
+        response_format: 'b64_json',
+      });
+      imageB64 = gen.data[0].b64_json!;
+    }
+
+    const imageBuffer = Buffer.from(imageB64, 'base64');
+
+    // --- 2) Upload to Supabase Storage ---
+    // path: userId/<timestamp>.png
+    const filename = `${Date.now()}.png`;
+    const path = `${userId}/${filename}`;
+
+    const { error: upErr } = await supabase.storage
+      .from(BUCKET)
+      .upload(path, imageBuffer, {
+        contentType: 'image/png',
+        cacheControl: 'public, max-age=31536000, immutable',
+        upsert: true,
+      });
+    if (upErr) throw upErr;
+
+    const { data: pub } = supabase.storage.from(BUCKET).getPublicUrl(path);
+    const image_url = pub.publicUrl;
+    if (!image_url) throw new Error('Could not get public URL');
+
+    // --- 3) Upsert DB row ---
+    const { error: dbErr } = await supabase
+      .from('avatars')
+      .upsert(
+        {
+          user_id: userId,
+          name: name || 'Navatar',
+          category: 'generate',
+          method: 'generate',
+          image_url,
+        },
+        { onConflict: 'user_id', ignoreDuplicates: false }
+      );
+    if (dbErr) throw dbErr;
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ image_url }),
+      headers: { 'content-type': 'application/json' },
+    };
+  } catch (e: any) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: e?.message || String(e) }),
+      headers: { 'content-type': 'application/json' },
+    };
+  }
+};
+

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -60,7 +60,7 @@ export default function NavatarUpload() {
   }
 
   return (
-    <div className="container">
+    <div className="container wide">
       <nav className="nv-breadcrumbs brand-blue">
         <Link to="/">Home</Link><span className="sep">/</span>
         <Link to="/navatar">Navatar</Link><span className="sep">/</span>
@@ -69,10 +69,10 @@ export default function NavatarUpload() {
 
       <h1>Upload Navatar</h1>
 
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 640 }}>
-        <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
-        <input type="text" placeholder="Name (optional)" value={displayName} onChange={(e) => setDisplayName(e.target.value)} />
-        <button className="primary" onClick={handleUpload} disabled={saving || !file}>
+      <div className="formStack">
+        <input className="input fill" type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        <input className="input fill" type="text" placeholder="Name (optional)" value={displayName} onChange={(e) => setDisplayName(e.target.value)} />
+        <button className="primary block" onClick={handleUpload} disabled={saving || !file}>
           {saving ? 'Saving…' : 'Upload'}
         </button>
       </div>

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -4,3 +4,20 @@
 .navatar-card img { width:100%; height:100%; object-fit:contain; display:block; }
 .title { font-weight:700; margin-top:8px; }
 .primary { padding:10px 16px; border-radius:12px; }
+
+/* wider container for creation flows */
+.container.wide {
+  max-width: 980px;
+}
+
+/* simple vertical form layout */
+.formStack { display: flex; flex-direction: column; gap: 12px; }
+
+/* inputs full width within container */
+.input.fill { width: 100%; }
+
+/* big call-to-action spans container width */
+button.block { width: 100%; }
+
+/* tiny helper */
+.hint { margin-top: 10px; opacity: 0.8; font-size: 14px; }


### PR DESCRIPTION
## Summary
- add Netlify `generateNavatar` function to create and store AI navatars
- wire up Describe & Generate page to call function with full-width form layout
- polish Upload page and navatar styles for consistent full-width inputs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b7cc4adf1883299c23a1fecbfb3fb1