### PR TITLE
Fix Navatar generate flow with updated OpenAI Images API

### DIFF
--- a/netlify/functions/generate-navatar.ts
+++ b/netlify/functions/generate-navatar.ts
@@ -1,77 +1,146 @@
-import type { Handler } from "@netlify/functions";
-import OpenAI from "openai";
-import { createClient } from "@supabase/supabase-js";
+// netlify/functions/generate-navatar.ts
+import type { Handler } from '@netlify/functions';
+import OpenAI from 'openai';
+import { createClient } from '@supabase/supabase-js';
+import { toFile } from 'openai/uploads';
 
+// ---- ENV ----
+// These must exist in Netlify site > Site configuration > Environment variables
 const SUPABASE_URL = process.env.SUPABASE_URL!;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY!;
 
+// Bucket name in Supabase Storage (public)
+const BUCKET = 'avatars';
+
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 
+// helper: fetch a remote image into a Buffer
+async function fetchAsBuffer(url: string): Promise<Buffer> {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`Fetch failed (${r.status}) for ${url}`);
+  const arrayBuf = await r.arrayBuffer();
+  return Buffer.from(arrayBuf);
+}
+
 export const handler: Handler = async (event) => {
   try {
-    if (event.httpMethod !== "POST") {
-      return { statusCode: 405, body: "Method Not Allowed" };
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method not allowed' };
     }
 
-    const { user_id, name, prompt } = JSON.parse(event.body || "{}") as {
+    type Payload = {
+      prompt?: string;
       user_id?: string;
       name?: string;
-      prompt: string;
+      sourceImageUrl?: string; // optional for EDIT / MERGE
+      maskImageUrl?: string; // optional transparent mask
     };
 
-    if (!prompt) {
-      return { statusCode: 400, body: JSON.stringify({ error: "Missing prompt" }) };
+    const { prompt, user_id, name, sourceImageUrl, maskImageUrl } = JSON.parse(
+      event.body || '{}',
+    ) as Payload;
+
+    if (!prompt && !sourceImageUrl) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Provide a prompt or a sourceImageUrl.' }),
+      };
     }
 
-    // Generate image (no response_format param – it 400s on the latest SDK)
-    const img = await openai.images.generate({
-      model: "gpt-image-1",
-      prompt,
-      size: "1024x1024"
+    // ---- 1) Generate or Edit via OpenAI ----
+    // Default 1024 for nice quality
+    let b64: string;
+
+    if (sourceImageUrl) {
+      // EDIT/MERGE path
+      const imageBuf = await fetchAsBuffer(sourceImageUrl);
+      const maskBuf = maskImageUrl ? await fetchAsBuffer(maskImageUrl) : undefined;
+
+      const imageFile = await toFile(imageBuf, 'image.png', { type: 'image/png' });
+      const maskFile = maskBuf
+        ? await toFile(maskBuf, 'mask.png', { type: 'image/png' })
+        : undefined;
+
+      const edited = await openai.images.edit({
+        model: 'gpt-image-1',
+        image: imageFile,
+        // include mask if provided (transparent regions are replaced)
+        ...(maskFile ? { mask: maskFile } : {}),
+        prompt: prompt || '',
+        size: '1024x1024',
+      });
+
+      b64 = edited.data[0].b64_json!;
+    } else {
+      // PURE GENERATION
+      const gen = await openai.images.generate({
+        model: 'gpt-image-1',
+        prompt: prompt!,
+        size: '1024x1024',
+      });
+      b64 = gen.data[0].b64_json!;
+    }
+
+    if (!b64) {
+      return { statusCode: 502, body: JSON.stringify({ error: 'No image returned.' }) };
+    }
+
+    // ---- 2) Upload the image to Supabase Storage ----
+    const buffer = Buffer.from(b64, 'base64');
+    const uid = user_id || 'anon';
+    const fileName = `ai/${uid}/${Date.now()}.png`;
+
+    const { error: upErr } = await supabase.storage.from(BUCKET).upload(fileName, buffer, {
+      contentType: 'image/png',
+      cacheControl: 'public, max-age=31536000, immutable',
+      upsert: true,
     });
 
-    const b64 = img.data?.[0]?.b64_json;
-    if (!b64) {
-      return { statusCode: 502, body: JSON.stringify({ error: "No image returned" }) };
-    }
-
-    const buffer = Buffer.from(b64, "base64");
-    const fileName = `ai/${user_id ?? "anon"}/${crypto.randomUUID()}.png`;
-
-    const { error: upErr } = await supabase
-      .storage
-      .from("avatars")
-      .upload(fileName, buffer, { contentType: "image/png", upsert: false });
-
     if (upErr) {
-      return { statusCode: 500, body: JSON.stringify({ error: `Upload failed: ${upErr.message}` }) };
+      return { statusCode: 500, body: JSON.stringify({ error: upErr.message }) };
     }
 
-    const { data: pub } = supabase.storage.from("avatars").getPublicUrl(fileName);
-    const image_url = pub.publicUrl;
+    const pub = supabase.storage.from(BUCKET).getPublicUrl(fileName);
+    const image_url = pub.data?.publicUrl;
+    if (!image_url) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: 'Could not resolve public URL', path: fileName }),
+      };
+    }
 
-    const { error: insErr, data: row } = await supabase
-      .from("avatars")
-      .insert({
+    // ---- 3) Upsert DB row ----
+    const { error: insErr } = await supabase.from('avatars').upsert(
+      {
         user_id: user_id ?? null,
-        name: name || "AI avatar",
-        method: "ai",
-        image_url
-      })
-      .select("*")
-      .single();
+        name: name || 'Navatar',
+        category: 'generate',
+        method: 'ai',
+        image_url,
+      },
+      { onConflict: 'user_id', ignoreDuplicates: false },
+    );
 
     if (insErr) {
-      return { statusCode: 500, body: JSON.stringify({ error: `DB insert failed: ${insErr.message}` }) };
+      return { statusCode: 500, body: JSON.stringify({ error: insErr.message }) };
     }
 
-    return { statusCode: 200, body: JSON.stringify({ avatar: row }) };
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ image_url }),
+      headers: { 'content-type': 'application/json' },
+    };
   } catch (e: any) {
-    // Pass through OpenAI 403/permissions clearly
-    const msg = e?.response?.data?.error?.message || e?.message || "Unknown error";
-    const code = e?.status || e?.response?.status || 500;
-    return { statusCode: code, body: JSON.stringify({ error: msg }) };
+    // Bubble up helpful OpenAI or Supabase messaging
+    const msg =
+      e?.response?.data?.error?.message || e?.message || 'Unexpected error in generate-navatar';
+    const code = e?.status || 500;
+    return {
+      statusCode: code,
+      body: JSON.stringify({ error: msg }),
+      headers: { 'content-type': 'application/json' },
+    };
   }
 };


### PR DESCRIPTION
## Summary
- Rewrite `generate-navatar` Netlify function to use current OpenAI Images API, support edits, and upload to Supabase with stable paths
- Refresh Navatar generation page with full-width form inputs and improved save flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7d6ae643083299a0759452f89f262