### PR TITLE
Navatar – AI Generate end-to-end fixes

### DIFF
--- a/netlify/functions/generate-navatar.ts
+++ b/netlify/functions/generate-navatar.ts
@@ -1,77 +1,138 @@
-import type { Handler } from "@netlify/functions";
-import OpenAI from "openai";
-import { createClient } from "@supabase/supabase-js";
+import type { Handler } from '@netlify/functions';
+import OpenAI from 'openai';
+import { createClient } from '@supabase/supabase-js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL!;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY!;
+const IMAGES_BUCKET = process.env.IMAGES_BUCKET || 'avatars';
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 
+// small helper
+const asBuf = async (url: string) => {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`Fetch failed ${r.status}`);
+  const ab = await r.arrayBuffer();
+  return Buffer.from(ab);
+};
+
+const json = (code: number, body: unknown) => ({
+  statusCode: code,
+  headers: {
+    'content-type': 'application/json',
+    'access-control-allow-origin': '*',
+  },
+  body: JSON.stringify(body),
+});
+
+type Payload = {
+  prompt?: string;
+  userId?: string;
+  name?: string;
+  sourceImageUrl?: string;
+  maskImageUrl?: string;
+};
+
 export const handler: Handler = async (event) => {
   try {
-    if (event.httpMethod !== "POST") {
-      return { statusCode: 405, body: "Method Not Allowed" };
+    if (event.httpMethod !== 'POST') {
+      return json(405, { error: 'Method not allowed' });
     }
 
-    const { user_id, name, prompt } = JSON.parse(event.body || "{}") as {
-      user_id?: string;
-      name?: string;
-      prompt: string;
-    };
+    const body = (event.body ?? '').trim();
+    if (!body) return json(400, { error: 'Missing JSON body' });
 
-    if (!prompt) {
-      return { statusCode: 400, body: JSON.stringify({ error: "Missing prompt" }) };
+    const { prompt, userId, name, sourceImageUrl, maskImageUrl } =
+      JSON.parse(body) as Payload;
+
+    if (!prompt && !sourceImageUrl) {
+      return json(400, { error: 'Provide prompt or sourceImageUrl' });
     }
 
-    // Generate image (no response_format param – it 400s on the latest SDK)
-    const img = await openai.images.generate({
-      model: "gpt-image-1",
-      prompt,
-      size: "1024x1024"
-    });
+    // ---- 1) Generate/Edit via OpenAI (no deprecated response_format) ----
+    let b64: string | undefined;
 
-    const b64 = img.data?.[0]?.b64_json;
-    if (!b64) {
-      return { statusCode: 502, body: JSON.stringify({ error: "No image returned" }) };
+    if (sourceImageUrl) {
+      const image = await asBuf(sourceImageUrl);
+      const mask = maskImageUrl ? await asBuf(maskImageUrl) : undefined;
+
+      const edit = await openai.images.edits({
+        model: 'gpt-image-1',
+        prompt: prompt ?? '',
+        image,
+        ...(mask ? { mask } : {}),
+        size: '1024x1024',
+      });
+
+      b64 = edit.data?.[0]?.b64_json;
+    } else {
+      const gen = await openai.images.generate({
+        model: 'gpt-image-1',
+        prompt: prompt ?? '',
+        size: '1024x1024',
+      });
+      b64 = gen.data?.[0]?.b64_json;
     }
 
-    const buffer = Buffer.from(b64, "base64");
-    const fileName = `ai/${user_id ?? "anon"}/${crypto.randomUUID()}.png`;
+    if (!b64) return json(502, { error: 'No image returned from OpenAI' });
+
+    // ---- 2) Upload to Supabase Storage ----
+    const buffer = Buffer.from(b64, 'base64');
+    const folder = `ai/${userId || 'anon'}`; // no leading slash
+    const filename = `${Date.now()}.png`;
+    const path = `${folder}/${filename}`;
 
     const { error: upErr } = await supabase
       .storage
-      .from("avatars")
-      .upload(fileName, buffer, { contentType: "image/png", upsert: false });
+      .from(IMAGES_BUCKET)
+      .upload(path, buffer, {
+        contentType: 'image/png',
+        cacheControl: 'public, max-age=31536000',
+        upsert: true,
+      });
+    if (upErr) return json(500, { error: `Upload failed: ${upErr.message}` });
 
-    if (upErr) {
-      return { statusCode: 500, body: JSON.stringify({ error: `Upload failed: ${upErr.message}` }) };
-    }
+    // public URL (v2 SDK)
+    const { data: pub } = supabase
+      .storage
+      .from(IMAGES_BUCKET)
+      .getPublicUrl(path);
 
-    const { data: pub } = supabase.storage.from("avatars").getPublicUrl(fileName);
-    const image_url = pub.publicUrl;
+    const image_url = pub?.publicUrl;
+    if (!image_url) return json(500, { error: 'Could not resolve public URL' });
 
-    const { error: insErr, data: row } = await supabase
-      .from("avatars")
-      .insert({
-        user_id: user_id ?? null,
-        name: name || "AI avatar",
-        method: "ai",
-        image_url
-      })
-      .select("*")
-      .single();
+    // ---- 3) Upsert DB row ----
+    const display = name?.trim() || 'Navatar';
+    const { error: dbErr } = await supabase
+      .from('avatars')
+      .upsert(
+        {
+          user_id: userId ?? null,
+          name: display,
+          category: 'generate',
+          method: 'generate',
+          image_url,
+        },
+        { onConflict: 'user_id' }
+      );
+    if (dbErr) return json(500, { error: `DB error: ${dbErr.message}` });
 
-    if (insErr) {
-      return { statusCode: 500, body: JSON.stringify({ error: `DB insert failed: ${insErr.message}` }) };
-    }
-
-    return { statusCode: 200, body: JSON.stringify({ avatar: row }) };
+    return json(200, { image_url });
   } catch (e: any) {
-    // Pass through OpenAI 403/permissions clearly
-    const msg = e?.response?.data?.error?.message || e?.message || "Unknown error";
-    const code = e?.status || e?.response?.status || 500;
-    return { statusCode: code, body: JSON.stringify({ error: msg }) };
+    // pass through useful details when possible
+    const status =
+      e?.status ||
+      e?.response?.status ||
+      500;
+
+    const message =
+      e?.message ||
+      e?.response?.data?.error?.message ||
+      'Server error';
+
+    return json(status, { error: message });
   }
 };
+

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -19,5 +19,31 @@
 /* big call-to-action spans container width */
 button.block { width: 100%; }
 
-/* tiny helper */
-.hint { margin-top: 10px; opacity: 0.8; font-size: 14px; }
+/* modern input styles */
+.container textarea,
+.container input[type="text"],
+.container input[type="url"] {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #d8e0f0;
+  border-radius: 10px;
+  font-size: 16px;
+}
+
+/* disabled button state */
+.container .primary[disabled] {
+  opacity: .6;
+  cursor: default;
+}
+
+/* hint box */
+.hint {
+  margin-top: 10px;
+  font-size: 14px;
+  border: 1px dashed #c7d3ee;
+  border-radius: 10px;
+  padding: 12px;
+  color: #3b4d7a;
+  background: #f7faff;
+}
+


### PR DESCRIPTION
## Summary
- Add robust `generate-navatar` Netlify function supporting image edits, Supabase upload, and DB upsert
- Improve Navatar generation page with safer fetch handling and optional source/mask inputs
- Polish Navatar CSS for full-width inputs, disabled buttons, and hint styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b7da4476948329a398a861a4b17ead