### PR TITLE
feat: add navatar generation

### DIFF
--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,101 +1,110 @@
-import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { useSession } from '../../lib/session';
-import '../../styles/navatar.css';
+import { useState } from "react";
+import { createClient } from "@supabase/supabase-js";
 
-export default function NavatarGenerate() {
-  const navigate = useNavigate();
-  const user = useSession();
-  const [prompt, setPrompt] = useState('');
-  const [srcUrl, setSrcUrl] = useState('');
-  const [maskUrl, setMaskUrl] = useState('');
-  const [name, setName] = useState('');
-  const [saving, setSaving] = useState(false);
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_ANON_KEY!
+);
 
-  async function handleSave() {
-    if (!prompt && !srcUrl) {
-      alert('Enter a prompt or a source image URL');
-      return;
-    }
-    setSaving(true);
+export default function GenerateNavatarPage() {
+  const [prompt, setPrompt] = useState("");
+  const [name, setName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [ok, setOk] = useState<string | null>(null);
+
+  // present but not used yet (we’ll wire edit/mask next)
+  const [sourceFile] = useState<File | null>(null);
+  const [maskFile] = useState<File | null>(null);
+
+  async function getUserId(): Promise<string | undefined> {
+    const { data } = await supabase.auth.getUser();
+    return data.user?.id;
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    setOk(null);
+    setLoading(true);
     try {
-      const r = await fetch('/.netlify/functions/generate-navatar', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          prompt,
-          userId: user?.id,
-          name,
-          sourceImageUrl: srcUrl || undefined,
-          maskImageUrl: maskUrl || undefined,
-        }),
+      const user_id = await getUserId();
+
+      const res = await fetch("/.netlify/functions/generate-navatar", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ user_id, name, prompt })
       });
 
-      const text = await r.text(); // robust: read text first
-      let data: any = {};
-      try { data = text ? JSON.parse(text) : {}; } catch {
-        // backend guaranteed JSON; this guards against upstream HTML errors
-        throw new Error(text || 'Server returned non-JSON response');
+      const text = await res.text();
+      let json: any = {};
+      try { json = JSON.parse(text || "{}"); } catch { /* non-JSON */ }
+
+      if (!res.ok) {
+        throw new Error(json?.error || `HTTP ${res.status}`);
       }
 
-      if (!r.ok) {
-        throw new Error(data?.error || 'Create failed');
-      }
-
-      navigate('/navatar?refresh=1');
+      setOk("Created!");
+      // Optionally navigate to /navatar?refresh=1
+      // window.location.href = "/navatar?refresh=1";
     } catch (e: any) {
-      alert(e?.message || String(e));
+      setErr(e?.message || "Create failed");
+      alert(e?.message || "Create failed");
     } finally {
-      setSaving(false);
+      setLoading(false);
     }
   }
 
   return (
     <div className="container">
-      <nav className="nv-breadcrumbs brand-blue">
-        <Link to="/">Home</Link><span className="sep">/</span>
-        <Link to="/navatar">Navatar</Link><span className="sep">/</span>
-        <span>Describe &amp; Generate</span>
+      {/* breadcrumbs */}
+      <nav style={{ margin: "8px 0", fontSize: 14 }}>
+        <a href="/">Home</a> &nbsp; / &nbsp;
+        <a href="/navatar">Navatar</a> &nbsp; / &nbsp;
+        <strong>Describe &amp; Generate</strong>
       </nav>
 
       <h1>Describe &amp; Generate</h1>
 
-      <div style={{display:'flex', flexDirection:'column', gap:12, maxWidth:720, margin:'0 auto'}}>
+      <form onSubmit={onSubmit} style={{ maxWidth: 720 }}>
         <textarea
-          placeholder="Describe your Navatar (e.g., ‘friendly water-buffalo spirit, gold robe, jungle temple, sunny morning, storybook style’)
-"          value={prompt}
-          onChange={e => setPrompt(e.target.value)}
-          rows={4}
-          style={{width:'100%'}}
+          placeholder="Describe your Navatar (e.g., 'friendly water-buffalo spirit, gold robe, jungle temple, storybook style')"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          required
+          style={{ width: "100%", minHeight: 120, marginBottom: 16 }}
         />
+
+        {/* visible now; editing/masking coming next release */}
+        <label style={{ display: "block", marginBottom: 8 }}>
+          Source Image (optional)
+          <input type="file" accept="image/*" disabled style={{ display: "block", marginTop: 4 }} />
+        </label>
+
+        <label style={{ display: "block", marginBottom: 16 }}>
+          Mask Image (optional, transparent areas → replaced)
+          <input type="file" accept="image/*" disabled style={{ display: "block", marginTop: 4 }} />
+        </label>
+
         <input
-          type="url"
-          placeholder="(Optional) Source Image URL for edits/merge"
-          value={srcUrl}
-          onChange={e => setSrcUrl(e.target.value)}
-        />
-        <input
-          type="url"
-          placeholder="(Optional) Mask Image URL (transparent areas → replaced)"
-          value={maskUrl}
-          onChange={e => setMaskUrl(e.target.value)}
-        />
-        <input
-          type="text"
           placeholder="Name (optional)"
           value={name}
-          onChange={e => setName(e.target.value)}
+          onChange={(e) => setName(e.target.value)}
+          style={{ width: "100%", marginBottom: 16, height: 40, padding: "0 10px" }}
         />
 
-        <button className="primary" disabled={saving} onClick={handleSave}>
-          {saving ? 'Creating…' : 'Save'}
+        <button type="submit" disabled={loading} style={{ height: 44, minWidth: 160 }}>
+          {loading ? "Creating..." : "Save"}
         </button>
 
-        <p className="hint">
-          Tips: Keep faces centered, ask for full-body vs portrait, and mention “storybook / illustration / character sheet” for that Navatar vibe.
+        {err && <p style={{ color: "crimson", marginTop: 12 }}>{err}</p>}
+        {ok && <p style={{ color: "seagreen", marginTop: 12 }}>{ok}</p>}
+
+        <p style={{ marginTop: 16, fontSize: 13, opacity: 0.75 }}>
+          Tips: Keep faces centered, ask for full-body vs portrait, and mention
+          “storybook / illustration / character sheet” for that Navatar vibe.
         </p>
-      </div>
+      </form>
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- add Netlify function to generate and store AI avatars
- add UI page to create Navatars with breadcrumbs and error handling

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7f1a3be6c83298c7aa8b6532e8cbf