### PR TITLE
Refactor Navatar generation and styling

### DIFF
--- a/netlify/functions/generate-navatar.ts
+++ b/netlify/functions/generate-navatar.ts
@@ -1,138 +1,138 @@
-import type { Handler } from '@netlify/functions';
-import OpenAI from 'openai';
-import { createClient } from '@supabase/supabase-js';
+import type { Handler } from "@netlify/functions";
+import OpenAI from "openai";
+import { createClient } from "@supabase/supabase-js";
 
 const SUPABASE_URL = process.env.SUPABASE_URL!;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY!;
-const IMAGES_BUCKET = process.env.IMAGES_BUCKET || 'avatars';
+const BUCKET = process.env.IMAGES_BUCKET || "avatars";
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
-// small helper
-const asBuf = async (url: string) => {
-  const r = await fetch(url);
-  if (!r.ok) throw new Error(`Fetch failed ${r.status}`);
-  const ab = await r.arrayBuffer();
-  return Buffer.from(ab);
-};
-
-const json = (code: number, body: unknown) => ({
-  statusCode: code,
-  headers: {
-    'content-type': 'application/json',
-    'access-control-allow-origin': '*',
-  },
-  body: JSON.stringify(body),
-});
-
-type Payload = {
-  prompt?: string;
-  userId?: string;
-  name?: string;
-  sourceImageUrl?: string;
-  maskImageUrl?: string;
-};
+function dataUrlToBuffer(dataUrl?: string | null) {
+  if (!dataUrl) return undefined;
+  // data:image/png;base64,AAAA...
+  const comma = dataUrl.indexOf(",");
+  const b64 = comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl;
+  return Buffer.from(b64, "base64");
+}
 
 export const handler: Handler = async (event) => {
   try {
-    if (event.httpMethod !== 'POST') {
-      return json(405, { error: 'Method not allowed' });
+    if (event.httpMethod !== "POST") {
+      return { statusCode: 405, body: "Method Not Allowed" };
     }
 
-    const body = (event.body ?? '').trim();
-    if (!body) return json(400, { error: 'Missing JSON body' });
+    const { prompt, name, userId, sourceDataUrl, maskDataUrl } = JSON.parse(
+      event.body || "{}"
+    ) as {
+      prompt?: string;
+      name?: string;
+      userId?: string;
+      sourceDataUrl?: string | null; // data URL (optional)
+      maskDataUrl?: string | null; // data URL (optional)
+    };
 
-    const { prompt, userId, name, sourceImageUrl, maskImageUrl } =
-      JSON.parse(body) as Payload;
-
-    if (!prompt && !sourceImageUrl) {
-      return json(400, { error: 'Provide prompt or sourceImageUrl' });
+    if (!prompt && !sourceDataUrl) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: "Provide prompt or a source image." }),
+        headers: { "content-type": "application/json" },
+      };
     }
 
-    // ---- 1) Generate/Edit via OpenAI (no deprecated response_format) ----
+    // ---- 1) Generate/Edit image via OpenAI (NO response_format param) ----
     let b64: string | undefined;
 
-    if (sourceImageUrl) {
-      const image = await asBuf(sourceImageUrl);
-      const mask = maskImageUrl ? await asBuf(maskImageUrl) : undefined;
+    if (sourceDataUrl) {
+      const imageBuf = dataUrlToBuffer(sourceDataUrl)!;
+      const maskBuf = dataUrlToBuffer(maskDataUrl || undefined);
 
-      const edit = await openai.images.edits({
-        model: 'gpt-image-1',
-        prompt: prompt ?? '',
-        image,
-        ...(mask ? { mask } : {}),
-        size: '1024x1024',
+      const resp = await openai.images.edits({
+        model: "gpt-image-1",
+        prompt: prompt || "",
+        image: imageBuf,
+        ...(maskBuf ? { mask: maskBuf } : {}),
+        size: "1024x1024",
       });
 
-      b64 = edit.data?.[0]?.b64_json;
+      b64 = resp.data?.[0]?.b64_json;
     } else {
-      const gen = await openai.images.generate({
-        model: 'gpt-image-1',
-        prompt: prompt ?? '',
-        size: '1024x1024',
+      const resp = await openai.images.generate({
+        model: "gpt-image-1",
+        prompt: prompt!,
+        size: "1024x1024",
       });
-      b64 = gen.data?.[0]?.b64_json;
+      b64 = resp.data?.[0]?.b64_json;
     }
 
-    if (!b64) return json(502, { error: 'No image returned from OpenAI' });
+    if (!b64) {
+      return {
+        statusCode: 502,
+        body: JSON.stringify({ error: "Image generation failed" }),
+        headers: { "content-type": "application/json" },
+      };
+    }
 
     // ---- 2) Upload to Supabase Storage ----
-    const buffer = Buffer.from(b64, 'base64');
-    const folder = `ai/${userId || 'anon'}`; // no leading slash
-    const filename = `${Date.now()}.png`;
-    const path = `${folder}/${filename}`;
+    const buffer = Buffer.from(b64, "base64");
+    const filename = `ai/${userId || "anon"}/${Date.now()}.png`;
 
-    const { error: upErr } = await supabase
-      .storage
-      .from(IMAGES_BUCKET)
-      .upload(path, buffer, {
-        contentType: 'image/png',
-        cacheControl: 'public, max-age=31536000',
-        upsert: true,
-      });
-    if (upErr) return json(500, { error: `Upload failed: ${upErr.message}` });
+    const { error: upErr } = await supabase.storage
+      .from(BUCKET)
+      .upload(filename, buffer, { contentType: "image/png", upsert: false });
 
-    // public URL (v2 SDK)
-    const { data: pub } = supabase
-      .storage
-      .from(IMAGES_BUCKET)
-      .getPublicUrl(path);
+    if (upErr) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: upErr.message }),
+        headers: { "content-type": "application/json" },
+      };
+    }
 
-    const image_url = pub?.publicUrl;
-    if (!image_url) return json(500, { error: 'Could not resolve public URL' });
+    const { data: pub } = supabase.storage.from(BUCKET).getPublicUrl(filename);
+    const image_url = pub.publicUrl;
 
-    // ---- 3) Upsert DB row ----
-    const display = name?.trim() || 'Navatar';
-    const { error: dbErr } = await supabase
-      .from('avatars')
-      .upsert(
-        {
-          user_id: userId ?? null,
-          name: display,
-          category: 'generate',
-          method: 'generate',
-          image_url,
-        },
-        { onConflict: 'user_id' }
-      );
-    if (dbErr) return json(500, { error: `DB error: ${dbErr.message}` });
+    // ---- 3) Insert DB row ----
+    const { error: insErr } = await supabase
+      .from("avatars")
+      .insert({
+        user_id: userId || null,
+        name: name || "AI avatar",
+        category: "generate",
+        method: "ai", // allowed by your updated CHECK constraint
+        image_url,
+        image_path: filename,
+        is_public: false,
+        is_primary: false,
+        status: "ready",
+      })
+      .select("*")
+      .single();
 
-    return json(200, { image_url });
+    if (insErr) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: insErr.message }),
+        headers: { "content-type": "application/json" },
+      };
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ image_url }),
+      headers: { "content-type": "application/json" },
+    };
   } catch (e: any) {
-    // pass through useful details when possible
-    const status =
-      e?.status ||
-      e?.response?.status ||
-      500;
-
-    const message =
-      e?.message ||
-      e?.response?.data?.error?.message ||
-      'Server error';
-
-    return json(status, { error: message });
+    const msg =
+      e?.response?.data?.error?.message || e?.message || "Unknown error";
+    const code = e?.status || 500;
+    return {
+      statusCode: code,
+      body: JSON.stringify({ error: msg }),
+      headers: { "content-type": "application/json" },
+    };
   }
 };
 

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,100 +1,120 @@
-import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { useSession } from '../../lib/session';
-import '../../styles/navatar.css';
+import { useState } from "react";
+import { useSession } from "@/lib/session"; // or however you read user id
+import "@/styles/navatar.css";
 
-export default function NavatarGenerate() {
-  const navigate = useNavigate();
-  const user = useSession();
-  const [prompt, setPrompt] = useState('');
-  const [srcUrl, setSrcUrl] = useState('');
-  const [maskUrl, setMaskUrl] = useState('');
-  const [name, setName] = useState('');
-  const [saving, setSaving] = useState(false);
+async function fileToDataUrl(file: File | null): Promise<string | null> {
+  if (!file) return null;
+  return new Promise((resolve) => {
+    const r = new FileReader();
+    r.onload = () => resolve(r.result as string);
+    r.readAsDataURL(file);
+  });
+}
 
-  async function handleSave() {
-    if (!prompt && !srcUrl) {
-      alert('Enter a prompt or a source image URL');
-      return;
-    }
-    setSaving(true);
+export default function NavatarGeneratePage() {
+  const { user } = useSession(); // assumes user?.id
+  const [prompt, setPrompt] = useState("");
+  const [name, setName] = useState("");
+  const [sourceFile, setSourceFile] = useState<File | null>(null);
+  const [maskFile, setMaskFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [ok, setOk] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setOk(null);
+    setLoading(true);
+
     try {
-      const r = await fetch('/.netlify/functions/generate-navatar', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          prompt,
-          userId: user?.id,
-          name,
-          sourceImageUrl: srcUrl || undefined,
-          maskImageUrl: maskUrl || undefined,
-        }),
+      const body = {
+        prompt: prompt.trim(),
+        name: name.trim() || undefined,
+        userId: user?.id || undefined,
+        sourceDataUrl: await fileToDataUrl(sourceFile),
+        maskDataUrl: await fileToDataUrl(maskFile),
+      };
+
+      const res = await fetch("/.netlify/functions/generate-navatar", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
       });
 
-      const text = await r.text(); // robust: read text first
-      let data: any = {};
-      try { data = text ? JSON.parse(text) : {}; } catch {
-        // backend guaranteed JSON; this guards against upstream HTML errors
-        throw new Error(text || 'Server returned non-JSON response');
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(json?.error || `HTTP ${res.status}`);
       }
-
-      if (!r.ok) {
-        throw new Error(data?.error || 'Create failed');
-      }
-
-      navigate('/navatar?refresh=1');
-    } catch (e: any) {
-      alert(e?.message || String(e));
+      setOk("Created! Opened/saved to your Navatars.");
+      // optionally navigate to /navatar or refresh
+      // location.href = "/navatar?refresh=1";
+    } catch (err: any) {
+      setError(err.message || "Create failed");
     } finally {
-      setSaving(false);
+      setLoading(false);
     }
   }
 
   return (
-    <div className="container">
-      <nav className="nv-breadcrumbs brand-blue">
-        <Link to="/">Home</Link><span className="sep">/</span>
-        <Link to="/navatar">Navatar</Link><span className="sep">/</span>
-        <span>Describe &amp; Generate</span>
+    <div className="nv-container">
+      <nav className="nv-breadcrumbs">
+        <a href="/">Home</a> <span>/</span>
+        <a href="/navatar">Navatar</a> <span>/</span>
+        <span className="current">Describe &amp; Generate</span>
       </nav>
 
-      <h1>Describe &amp; Generate</h1>
+      <h1 className="nv-title">Describe &amp; Generate</h1>
 
-      <div style={{display:'flex', flexDirection:'column', gap:12, maxWidth:720, margin:'0 auto'}}>
+      <form className="nv-card" onSubmit={onSubmit}>
+        <label className="nv-label">Describe your Navatar</label>
         <textarea
-          placeholder="Describe your Navatar (e.g., ‘friendly water-buffalo spirit, gold robe, jungle temple, sunny morning, storybook style’)
-"          value={prompt}
-          onChange={e => setPrompt(e.target.value)}
-          rows={4}
-          style={{width:'100%'}}
+          className="nv-input nv-textarea"
+          placeholder={`e.g., "friendly water-buffalo spirit, gold robe, jungle temple, sunny morning, storybook style"`}
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          required={!sourceFile}
         />
+
+        <div className="nv-file-block">
+          <label className="nv-label">Source Image (optional)</label>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => setSourceFile(e.target.files?.[0] || null)}
+          />
+        </div>
+
+        <div className="nv-file-block">
+          <label className="nv-label">
+            Mask Image (optional, transparent areas → replaced)
+          </label>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => setMaskFile(e.target.files?.[0] || null)}
+          />
+        </div>
+
         <input
-          type="url"
-          placeholder="(Optional) Source Image URL for edits/merge"
-          value={srcUrl}
-          onChange={e => setSrcUrl(e.target.value)}
-        />
-        <input
-          type="url"
-          placeholder="(Optional) Mask Image URL (transparent areas → replaced)"
-          value={maskUrl}
-          onChange={e => setMaskUrl(e.target.value)}
-        />
-        <input
-          type="text"
+          className="nv-input"
           placeholder="Name (optional)"
           value={name}
-          onChange={e => setName(e.target.value)}
+          onChange={(e) => setName(e.target.value)}
         />
 
-        <button className="primary" disabled={saving} onClick={handleSave}>
-          {saving ? 'Creating…' : 'Save'}
-        </button>
+        {error && <div className="nv-error">{error}</div>}
+        {ok && <div className="nv-success">{ok}</div>}
 
-        <p className="hint">
-          Tips: Keep faces centered, ask for full-body vs portrait, and mention “storybook / illustration / character sheet” for that Navatar vibe.
-        </p>
-      </div>
+        <button disabled={loading} className="nv-btn nv-btn-primary">
+          {loading ? "Creating..." : "Save"}
+        </button>
+      </form>
+
+      <p className="nv-tip">
+        Tips: Keep faces centered, ask for full-body vs portrait, and mention
+        “storybook / illustration / character sheet” for that Navatar vibe.
+      </p>
     </div>
   );
 }

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,49 +1,101 @@
-.card { background:#fff; border-radius:16px; padding:12px; box-shadow:0 1px 4px rgba(0,0,0,.08); border:2px solid transparent; }
-.card.isSelected { border-color:#3b82f6; box-shadow:0 0 0 3px rgba(59,130,246,.25); }
-.navatar-card { aspect-ratio:1/1; border-radius:16px; overflow:hidden; background:#fff; }
-.navatar-card img { width:100%; height:100%; object-fit:contain; display:block; }
-.title { font-weight:700; margin-top:8px; }
-.primary { padding:10px 16px; border-radius:12px; }
-
-/* wider container for creation flows */
-.container.wide {
-  max-width: 980px;
+/* src/styles/navatar.css */
+:root {
+  --nv-blue: #1e63ff;
+  --nv-blue-600: #1449c7;
+  --nv-bg: #ffffff;
+  --nv-border: #e7e7ee;
+  --nv-text: #1d1d28;
+  --nv-muted: #6a6a7a;
+  --nv-error: #d93025;
+  --nv-success: #1a7f37;
 }
 
-/* simple vertical form layout */
-.formStack { display: flex; flex-direction: column; gap: 12px; }
-
-/* inputs full width within container */
-.input.fill { width: 100%; }
-
-/* big call-to-action spans container width */
-button.block { width: 100%; }
-
-/* modern input styles */
-.container textarea,
-.container input[type="text"],
-.container input[type="url"] {
-  width: 100%;
-  padding: 12px;
-  border: 1px solid #d8e0f0;
-  border-radius: 10px;
-  font-size: 16px;
+.nv-container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 16px 48px;
 }
 
-/* disabled button state */
-.container .primary[disabled] {
-  opacity: .6;
-  cursor: default;
-}
-
-/* hint box */
-.hint {
-  margin-top: 10px;
+.nv-breadcrumbs {
+  margin: 16px 0 8px;
   font-size: 14px;
-  border: 1px dashed #c7d3ee;
+  color: var(--nv-muted);
+}
+.nv-breadcrumbs a { color: var(--nv-blue); text-decoration: none; }
+.nv-breadcrumbs span { margin: 0 6px; }
+.nv-breadcrumbs .current { color: var(--nv-muted); }
+
+.nv-title {
+  color: var(--nv-blue);
+  font-size: 32px;
+  margin: 8px 0 16px;
+  text-align: left;
+}
+
+.nv-card {
+  background: var(--nv-bg);
+  border: 1px solid var(--nv-border);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.nv-label {
+  display: block;
+  color: var(--nv-blue);
+  font-weight: 600;
+  margin: 12px 0 6px;
+}
+
+.nv-input, .nv-textarea, .nv-card input[type="file"] {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--nv-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 16px;
+  color: var(--nv-text);
+  background: #fff;
+}
+
+.nv-textarea { min-height: 120px; resize: vertical; }
+
+.nv-file-block { margin-top: 8px; }
+
+.nv-btn {
+  display: inline-block;
+  margin-top: 16px;
+  padding: 12px 18px;
+  font-size: 16px;
+  border: none;
   border-radius: 10px;
-  padding: 12px;
-  color: #3b4d7a;
-  background: #f7faff;
+  cursor: pointer;
+}
+
+.nv-btn-primary {
+  background: var(--nv-blue);
+  color: #fff;
+}
+.nv-btn-primary:disabled {
+  opacity: 0.7;
+  cursor: default;
+  background: var(--nv-blue-600);
+}
+
+.nv-error {
+  margin-top: 10px;
+  color: var(--nv-error);
+  font-weight: 600;
+}
+.nv-success {
+  margin-top: 10px;
+  color: var(--nv-success);
+  font-weight: 600;
+}
+
+.nv-tip {
+  margin-top: 12px;
+  color: var(--nv-muted);
+  font-size: 14px;
+  text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- Replace Navatar generation function to remove `response_format` and upload generated images through Supabase
- Rebuild client page to post JSON with optional data URLs and show inline status messages
- Revamp Navatar styles with centered layout, breadcrumbs, and brand blue button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b7f4a6aa1c8329b68bfa9d3b277c37