### PR TITLE
Navatar generate: fix OpenAI params + endpoint, faster default, UI polish

### DIFF
--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -47,3 +47,29 @@ button.block { width: 100%; }
   background: #f7faff;
 }
 
+.nav-page {
+  max-width: 740px;
+  margin: 0 auto;
+  padding: 24px 16px 56px;
+}
+.nav-card {
+  background: #fff;
+  border: 1px solid #e7eaf3;
+  border-radius: 14px;
+  padding: 18px;
+  box-shadow: 0 1px 2px rgba(16,24,40,.04);
+}
+.nav-title { color: #2b59ff; }
+.nav-btn {
+  background: #2b59ff;
+  color: #fff;
+  border: 0;
+  border-radius: 12px;
+  padding: 12px 20px;
+  font-weight: 700;
+}
+.nav-btn[disabled] { opacity: .6 }
+.nav-error { color: #e11d48; font-weight: 600; text-align: center; margin-top: 12px;}
+.breadcrumbs { color:#6b7280; font-size:.95rem; margin-bottom: 8px; }
+.breadcrumbs a { color:#2b59ff; text-decoration:none; }
+


### PR DESCRIPTION
## Summary
- overhaul Navatar generation function to support multipart inputs, default to 512×512, and store images in Supabase
- update Navatar generation UI to post FormData to the new endpoint and surface errors
- add centered layout and brand styling for the Navatar page

## Testing
- ⚠️ `npm test` (no tests defined)


------
https://chatgpt.com/codex/tasks/task_e_68b7f9c19cec83298693f285849c4b25