### PR TITLE
Navatar UI polish with breadcrumbs and pages

### DIFF
--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import "@/styles/navatar.css";
+
+export default function GenerateNavatar() {
+  const [prompt, setPrompt] = useState("");
+  const [name, setName] = useState("");
+  const [sourceImageUrl, setSourceImageUrl] = useState("");
+  const [maskImageUrl, setMaskImageUrl] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+  const nav = useNavigate();
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(""); setBusy(true);
+    try {
+      const res = await fetch("/.netlify/functions/generate-navatar", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          prompt: prompt.trim(),
+          name: name.trim() || null,
+          userId: (window as any)?.__user?.id || null,
+          size: "1024x1024",
+          sourceImageUrl: sourceImageUrl.trim() || undefined,
+          maskImageUrl: maskImageUrl.trim() || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        setErr(text || `HTTP ${res.status}`);
+        return;
+      }
+      const { image_url } = await res.json();
+      nav("/navatar?refresh=1", { replace: true });
+    } catch (e: any) {
+      setErr(e?.message || "Network error");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="nv-wrap">
+      <nav className="nv-crumbs">
+        <Link to="/">Home</Link> / <Link to="/navatar">Navatar</Link> / <span>Describe &amp; Generate</span>
+      </nav>
+      <h1 className="nv-h1">Describe &amp; Generate</h1>
+
+      <form className="nv-card" onSubmit={onSubmit}>
+        <div className="nv-field">
+          <textarea className="nv-textarea"
+            placeholder={`Describe your Navatar (e.g., 'friendly water-buffalo spirit, gold robe, jungle temple, sunny morning, storybook style')`}
+            value={prompt} onChange={e=>setPrompt(e.target.value)} />
+        </div>
+
+        <div className="nv-field">
+          <input className="nv-input"
+            placeholder="(Optional) Source Image URL for edits/merge"
+            value={sourceImageUrl} onChange={e=>setSourceImageUrl(e.target.value)} />
+        </div>
+
+        <div className="nv-field">
+          <input className="nv-input"
+            placeholder="(Optional) Mask Image URL (transparent areas → replaced)"
+            value={maskImageUrl} onChange={e=>setMaskImageUrl(e.target.value)} />
+        </div>
+
+        <div className="nv-field">
+          <input className="nv-input" placeholder="Name (optional)"
+            value={name} onChange={e=>setName(e.target.value)} />
+        </div>
+
+        <button className="nv-btn nv-btn-primary" disabled={busy}>
+          {busy ? "Creating..." : "Save"}
+        </button>
+
+        {!!err && <div className="nv-error">{err}</div>}
+
+        <p style={{marginTop:14, color:"#7a8799"}}>
+          Tips: Keep faces centered, ask for full-body vs portrait, and mention “storybook / illustration / character sheet” for that Navatar vibe.
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,0 +1,32 @@
+import { Link } from "react-router-dom";
+import { getCurrent } from "@/lib/navatar/store";
+import "@/styles/navatar.css";
+
+export default function NavatarPage() {
+  const data = getCurrent();
+  const image_url = data?.photo;
+  const display = data?.name || "Me";
+
+  return (
+    <div className="nv-wrap">
+      <nav className="nv-crumbs">
+        <Link to="/">Home</Link> / <span>Navatar</span>
+      </nav>
+      <h1 className="nv-h1">Your Navatar</h1>
+
+      {image_url && (
+        <div className="nv-hero">
+          <img src={image_url} alt="Your Navatar" />
+        </div>
+      )}
+
+      <h2 style={{ textAlign: "center", margin: "4px 0 12px" }}>{display}</h2>
+
+      <div className="nv-actions">
+        <Link to="/navatar/pick" className="nv-btn nv-btn-primary">Pick Navatar</Link>
+        <Link to="/navatar/upload" className="nv-btn nv-btn-primary">Upload</Link>
+        <Link to="/navatar/generate" className="nv-btn nv-btn-primary">Describe &amp; Generate</Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -1,0 +1,39 @@
+import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import "@/styles/navatar.css";
+import { listMyNavatars } from "@/lib/api/navatar";
+import { setCurrent } from "@/lib/navatar/store";
+
+export default function PickNavatar() {
+  const [items, setItems] = useState<any[]>([]);
+
+  useEffect(() => {
+    listMyNavatars().then((res: any[]) => setItems(res)).catch(() => {});
+  }, []);
+
+  function pick(x: any) {
+    setCurrent({
+      name: x.name || "",
+      species: x.species || "",
+      base: x.base || "",
+      photo: x.image_url,
+    });
+  }
+
+  return (
+    <div className="nv-wrap">
+      <nav className="nv-crumbs">
+        <Link to="/">Home</Link> / <Link to="/navatar">Navatar</Link> / <span>Pick</span>
+      </nav>
+      <h1 className="nv-h1">Pick Navatar</h1>
+
+      <div className="nv-grid">
+        {items.map(x => (
+          <button key={x.id} className="nv-tile" onClick={() => pick(x)}>
+            <div className="img"><img src={x.image_url} alt="Navatar option" /></div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,0 +1,19 @@
+import { Link } from "react-router-dom";
+import "@/styles/navatar.css";
+
+export default function UploadNavatar() {
+  return (
+    <div className="nv-wrap">
+      <nav className="nv-crumbs">
+        <Link to="/">Home</Link> / <Link to="/navatar">Navatar</Link> / <span>Upload</span>
+      </nav>
+      <h1 className="nv-h1">Upload Navatar</h1>
+
+      <form className="nv-card" onSubmit={(e) => e.preventDefault()}>
+        <div className="nv-field"><input type="file" className="nv-input" /></div>
+        <div className="nv-field"><input className="nv-input" placeholder="Name (optional)" /></div>
+        <button className="nv-btn nv-btn-primary">Upload</button>
+      </form>
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -33,7 +33,10 @@ import BankWallet from './pages/naturbank/Wallet';
 import BankToken from './pages/naturbank/Token';
 import BankNFTs from './pages/naturbank/NFTs';
 import BankLearn from './pages/naturbank/Learn';
-import NavatarPage from './pages/Navatar';
+import NavatarPage from './pages/navatar';
+import GenerateNavatar from './pages/navatar/generate';
+import PickNavatar from './pages/navatar/pick';
+import UploadNavatar from './pages/navatar/upload';
 import PassportPage from './pages/passport';
 import LoginPage from './pages/Login';
 import Turian from './routes/turian';
@@ -105,8 +108,16 @@ export const router = createBrowserRouter([
       { path: 'privacy', element: <Privacy /> },
       { path: 'contact', element: <Contact /> },
       { path: 'accessibility', element: <Accessibility /> },
-      { path: 'about', element: <About /> },
-        { path: 'navatar', element: <NavatarPage /> },
+        { path: 'about', element: <About /> },
+        {
+          path: 'navatar',
+          children: [
+            { index: true, element: <NavatarPage /> },
+            { path: 'generate', element: <GenerateNavatar /> },
+            { path: 'pick', element: <PickNavatar /> },
+            { path: 'upload', element: <UploadNavatar /> },
+          ],
+        },
         { path: 'passport', element: <PassportPage /> },
         { path: 'auth/callback', element: <AuthCallback /> },
         { path: 'login', element: <LoginPage /> },

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,0 +1,40 @@
+/* layout */
+.nv-wrap { max-width: 1000px; margin: 0 auto; padding: 24px 16px; }
+.nv-card { max-width: 720px; margin: 0 auto; padding: 20px; border-radius: 16px;
+  background:#fff; box-shadow: 0 12px 30px rgba(0,0,0,.06); }
+
+/* breadcrumbs */
+.nv-crumbs { margin: 6px 0 14px; color: #8aa; font-weight: 600; }
+.nv-crumbs a { color: #1f50ff; text-decoration: none; }
+.nv-crumbs span { color: #99a; }
+
+/* headings + buttons */
+.nv-h1 { font-size: 34px; line-height: 1.2; margin: 2px 0 16px; color:#1f50ff; font-weight: 900; }
+.nv-btn { display:inline-block; border:0; border-radius:12px; padding:.9rem 1.3rem; font-weight:800; }
+.nv-btn-primary { background:#1f50ff; color:#fff; box-shadow:0 6px 0 rgba(31,80,255,.25); }
+.nv-btn-primary:disabled { opacity:.6; cursor:not-allowed; }
+
+/* form */
+.nv-field { width:100%; margin:10px 0; }
+.nv-input, .nv-textarea {
+  width:100%; border:1px solid #e3e7ee; border-radius:12px; padding:12px 14px; font-size:16px;
+  background:#f9fbff;
+}
+.nv-textarea { min-height: 120px; resize: vertical; }
+
+/* hero image (match Pick cards) */
+.nv-hero { width:100%; max-width:420px; aspect-ratio:3/4; border-radius:24px; margin:0 auto 14px; overflow:hidden; }
+.nv-hero img { width:100%; height:100%; object-fit:cover; display:block; background:#f5f7fb; }
+
+/* action row */
+.nv-actions { display:flex; gap:10px; flex-wrap:wrap; justify-content:center; margin: 8px 0 4px; }
+
+/* Pick grid fixes (keeps your look) */
+.nv-grid { display:grid; grid-template-columns: repeat(auto-fill,minmax(220px,1fr)); gap:16px; }
+.nv-tile { background:#fff; border-radius:20px; padding:10px; box-shadow:0 8px 24px rgba(0,0,0,.05); }
+.nv-tile .img { aspect-ratio:3/4; border-radius:16px; overflow:hidden; background:#f5f7fb; }
+.nv-tile img { width:100%; height:100%; object-fit:cover; display:block; }
+
+/* small */
+.nv-error { color:#d00; font-weight:700; margin-top:10px; }
+@media (max-width: 420px) { .nv-h1{font-size:28px} }


### PR DESCRIPTION
## Summary
- add shared `navatar.css` styles for layout, breadcrumbs, buttons and grids
- create Navatar pages for viewing, generating, picking and uploading navatars
- wire Navatar routes into router with nested navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TypeScript errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b81dc8fb20832982b85b84bcf43ff1