### PR TITLE
Remove timeout setting for generate-navatar function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -39,6 +39,4 @@
     Cache-Control = "no-store"
     Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
 
-# (Optional) per-function override — use a child table, not [[functions]]
-[functions."generate-navatar"]
-  timeout = 26
+


### PR DESCRIPTION
## PR Checklist

- [ ] `npm test`
- [ ] `node -e "process.exit(!(process.env.VITE_SUPABASE_URL && process.env.VITE_SUPABASE_ANON_KEY) ? 1 : 0)"`
