### PR TITLE
feat: add Turian demo chat widget

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import SearchProvider from './search/SearchProvider';
 import CheckoutBanner from './components/CheckoutBanner';
 import ToastHost from '@/components/ToastHost';
 import CartShareLoader from '@/components/CartShareLoader';
+import TurianWidget from './components/TurianWidget';
 
 export default function App() {
   const [path, setPath] = useState(
@@ -72,6 +73,7 @@ export default function App() {
             </React.Suspense>
           </main>
         </div>
+        <TurianWidget />
       </SearchProvider>
   );
 }

--- a/src/components/TurianWidget.tsx
+++ b/src/components/TurianWidget.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import { isDemo } from "../lib/ai";
+
+type Msg = { who: "bot" | "you"; text: string };
+
+const demoReply = (q: string): string => {
+  const s = q.toLowerCase();
+  if (s.includes("world")) return "Worlds are big themed lands you can explore.";
+  if (s.includes("zone")) return "Zones are bite-sized adventures inside each World.";
+  if (s.includes("navatar") || s.includes("avatar"))
+    return "Navatar is your avatar. Generate one on the Navatar page—try storybook or character-sheet vibes!";
+  if (s.includes("bank")) return "NaturBank keeps your earned naturCoins safe.";
+  return "Got it! (Demo mode) — I’m not calling any AI right now.";
+};
+
+export default function TurianWidget() {
+  // Only mount in demo mode
+  if (!isDemo()) return null;
+
+  const [open, setOpen] = React.useState(false);
+  const [msgs, setMsgs] = React.useState<Msg[]>([
+    { who: "bot", text: "Hi! I’m Turian. Ask about Worlds, Zones, or Navatar." },
+  ]);
+  const [text, setText] = React.useState("");
+
+  const send = (e?: React.FormEvent) => {
+    e?.preventDefault();
+    const t = text.trim();
+    if (!t) return;
+    setMsgs((m) => [...m, { who: "you", text: t }]);
+    setText("");
+    // canned reply
+    setTimeout(() => {
+      setMsgs((m) => [...m, { who: "bot", text: demoReply(t) }]);
+    }, 250);
+  };
+
+  return (
+    <>
+      <button
+        aria-label="Open Turian chat"
+        onClick={() => setOpen(true)}
+        className="turian-fab"
+      >
+        💬
+      </button>
+
+      {open && (
+        <div className="turian-sheet" role="dialog" aria-modal="true">
+          <div className="turian-card">
+            <header className="turian-header">
+              <strong>Turian (demo)</strong>
+              <button className="turian-close" onClick={() => setOpen(false)}>×</button>
+            </header>
+
+            <div className="turian-log">
+              {msgs.map((m, i) => (
+                <div key={i} className={`turian-msg ${m.who}`}>
+                  <div className="bubble">{m.text}</div>
+                </div>
+              ))}
+            </div>
+
+            <form onSubmit={send} className="turian-entry">
+              <input
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                placeholder="Ask Turian about Worlds, Zones, or Navatar…"
+              />
+              <button className="btn-primary">Send</button>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,5 @@
+export type AIMode = "demo" | "live";
+export const AI_MODE: AIMode =
+  (import.meta.env.VITE_AI_MODE as AIMode) || "demo";
+
+export const isDemo = () => AI_MODE === "demo";

--- a/src/lib/turian.ts
+++ b/src/lib/turian.ts
@@ -1,4 +1,4 @@
-import { isDemo } from "@/config/ai";
+import { isDemo } from "@/lib/ai";
 
 // --- Demo script ----
 type Msg = { role: "user" | "assistant" | "system"; content: string };
@@ -28,7 +28,7 @@ function pickDemoReply(text: string): string {
 }
 
 export async function turianReply(messages: Msg[]): Promise<Msg> {
-  if (isDemo) {
+  if (isDemo()) {
     const lastUser = [...messages].reverse().find(m => m.role === "user");
     const answer = pickDemoReply(lastUser?.content || "");
     return { role: "assistant", content: answer };

--- a/src/pages/turian/index.tsx
+++ b/src/pages/turian/index.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { turianReply } from "@/lib/turian";
-import { isDemo, AI_MODE } from "@/config/ai";
+import { isDemo, AI_MODE } from "@/lib/ai";
 import { Link } from "react-router-dom";
+import "../../styles/turian.css";
 
 type Msg = { role: "user" | "assistant" | "system"; content: string };
 
@@ -37,46 +38,31 @@ export default function TurianPage() {
 
   return (
     <div className="container" style={{ maxWidth: 820, margin: "0 auto" }}>
-      <nav style={{ color: "#88a", margin: "8px 0 4px" }}>
+      <nav className="crumbs">
         <Link to="/">Home</Link> / <span>Turian</span>
       </nav>
-      <h1 style={{ color: "#1f50ff", fontSize: "2.25rem", margin: "8px 0 16px" }}>
-        Turian the Durian
-      </h1>
-      <p style={{ marginBottom: 12, color: "#667" }}>
-        {isDemo
-          ? "Offline demo — no external calls or costs."
-          : "Live AI mode — replies use your AI provider and may incur costs."}
-        {" "}
-        <span style={{ fontSize: 12, opacity: 0.7 }}>Mode: {AI_MODE}</span>
-      </p>
+      <h1 className="h1">Turian the Durian</h1>
 
-      <div
-        className="card"
-        style={{
-          background: "#fff",
-          borderRadius: 14,
-          boxShadow: "0 8px 30px rgba(0,0,0,.06)",
-          padding: 16,
-        }}
-      >
-        <div
-          style={{
-            height: 360,
-            overflow: "auto",
-            border: "1px solid #eef2f7",
-            borderRadius: 12,
-            padding: 12,
-            marginBottom: 12,
-            background: "#f9fbff",
-          }}
-        >
+      <div className="chat-card">
+        <div className="status">
+          {isDemo()
+            ? "Offline demo — no external calls or costs."
+            : "Live AI mode — replies use your AI provider and may incur costs."}{" "}
+          <em>Mode: {AI_MODE}</em>
+        </div>
+
+        <div className="chat-log">
           {msgs.map((m, i) => (
             <div
               key={i}
               style={{
                 margin: "6px 0",
-                textAlign: m.role === "assistant" ? "left" : m.role === "user" ? "right" : "center",
+                textAlign:
+                  m.role === "assistant"
+                    ? "left"
+                    : m.role === "user"
+                    ? "right"
+                    : "center",
                 opacity: m.role === "system" ? 0.7 : 1,
               }}
             >
@@ -102,30 +88,15 @@ export default function TurianPage() {
           ))}
         </div>
 
-        <form onSubmit={send} style={{ display: "flex", gap: 8 }}>
+        <form onSubmit={send} className="chat-entry">
           <input
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="Ask Turian about Worlds, Zones, or Navatar…"
-            style={{
-              flex: 1,
-              padding: "12px 14px",
-              borderRadius: 12,
-              border: "1px solid #dfe7f2",
-            }}
           />
           <button
-            className="btn"
+            className="btn-primary"
             disabled={busy || !input.trim()}
-            style={{
-              background: "#1f50ff",
-              color: "#fff",
-              border: 0,
-              borderRadius: 12,
-              padding: "12px 16px",
-              fontWeight: 700,
-              minWidth: 100,
-            }}
           >
             {busy ? "Thinking…" : "Send"}
           </button>

--- a/src/styles/turian.css
+++ b/src/styles/turian.css
@@ -388,3 +388,60 @@
 [data-page="turian"] .chatCard h3 {
   color: var(--naturverse-blue) !important;
 }
+
+/* Brand blues */
+:root{
+  --nv-blue:#1f50ff;
+  --nv-blue-2:#6a8aff;
+  --nv-bg:#f8faff;
+}
+
+.crumbs{color:var(--nv-blue-2); margin:.5rem 0 1rem}
+.crumbs a{color:var(--nv-blue)}
+
+.h1{font-size:2.25rem;color:var(--nv-blue);margin:.5rem 0 1rem}
+
+/* Page chat card */
+.chat-card{
+  background:#fff;border-radius:14px;box-shadow:0 8px 30px rgba(0,0,0,.06);
+  padding:1rem;max-width:800px;margin:0 auto;
+}
+.status{color:#5b6b88;margin:.25rem 0 1rem}
+.chat-log{background:var(--nv-bg);border:1px solid #e7ebff;border-radius:12px;
+  padding:10px;max-height:50vh;overflow:auto}
+.chat-entry{display:flex;gap:8px;margin-top:10px}
+.chat-entry input{flex:1;padding:.8rem;border:1px solid #d7ddff;border-radius:10px}
+.btn-primary{background:var(--nv-blue);color:#fff;border:0;padding:.8rem 1.1rem;border-radius:10px;font-weight:700}
+
+/* Floating widget */
+.turian-fab{
+  position:fixed;right:18px;bottom:18px;z-index:60;
+  width:56px;height:56px;border-radius:50%;border:0;
+  background:var(--nv-blue);color:#fff;font-size:22px;
+  box-shadow:0 10px 30px rgba(0,0,0,.18);cursor:pointer;
+}
+
+.turian-sheet{
+  position:fixed;inset:0;background:rgba(0,0,0,.25);
+  display:flex;align-items:flex-end;justify-content:flex-end;z-index:70;
+}
+.turian-card{
+  width:min(420px,100%);background:#fff;margin:12px;border-radius:14px;
+  box-shadow:0 20px 50px rgba(0,0,0,.25);display:flex;flex-direction:column;
+  max-height:85vh;
+}
+.turian-header{
+  display:flex;justify-content:space-between;align-items:center;
+  padding:.8rem 1rem;border-bottom:1px solid #eef1ff;color:#1b2a57
+}
+.turian-close{background:transparent;border:0;font-size:22px;cursor:pointer}
+.turian-log{padding:10px;overflow:auto;flex:1;background:var(--nv-bg)}
+.turian-msg{display:flex;margin:6px 0}
+.turian-msg.you{justify-content:flex-end}
+.turian-msg .bubble{
+  max-width:75%;padding:.6rem .8rem;border-radius:12px;border:1px solid #e7ebff;
+  background:#fff
+}
+.turian-msg.you .bubble{background:var(--nv-blue);color:#fff;border-color:var(--nv-blue)}
+.turian-entry{display:flex;gap:8px;padding:10px;border-top:1px solid #eef1ff}
+.turian-entry input{flex:1;padding:.8rem;border:1px solid #d7ddff;border-radius:10px}


### PR DESCRIPTION
## Summary
- add AI mode helper and demo-only Turian chat widget
- style Turian page with blue theme and floating chat
- mount widget globally across the app

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8566066d88329bc96bf43ec2b8eff