### PR TITLE
feat: set brand blue globally

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { SITE_URL } from './lib/site';
 import "../styles/globals.css";
 import "../styles/nav.css";
+import "../src/styles/brand.css";
 
 // ensure absolute URLs in SEO metadata
 export const metadata: Metadata = {

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -55,7 +55,7 @@ export function Breadcrumbs(props: { items?: Crumb[] }) {
   if (items.length <= 1) return null;
 
   return (
-    <nav aria-label="Breadcrumb" className="nv-breadcrumbs brand-blue">
+    <nav aria-label="breadcrumb" className="nv-breadcrumbs brand-blue">
       <ol>
         {items.map((c, i) => {
           const isLast = i === items.length - 1;

--- a/src/components/TurianWidget.tsx
+++ b/src/components/TurianWidget.tsx
@@ -40,13 +40,13 @@ export default function TurianWidget() {
       <button
         aria-label="Open Turian chat"
         onClick={() => setOpen(true)}
-        className="turian-fab"
+        className="turian-fab nv-fab"
       >
         💬
       </button>
 
       {open && (
-        <div className="turian-sheet" role="dialog" aria-modal="true">
+        <div className="turian-sheet turian-chat" role="dialog" aria-modal="true">
           <div className="turian-card">
             <header className="turian-header">
               <strong>Turian (demo)</strong>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,7 @@ import './styles/mega-features.css';
 import './index.css';
 import './styles/theme.css';
 import './styles/cart.css';
+import './styles/brand.css';
 import { applyTheme, getTheme } from './lib/theme';
 import ToastProvider from './components/Toast';
 import { supabase } from '@/lib/supabase-client';

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -1,0 +1,79 @@
+/* Brand tokens — edit here once to tweak your blue */
+:root {
+  --nv-primary-50:  #eff6ff;
+  --nv-primary-100: #dbeafe;
+  --nv-primary-200: #bfdbfe;
+  --nv-primary-300: #93c5fd;
+  --nv-primary-400: #60a5fa;
+  --nv-primary-500: #3b82f6; /* main */
+  --nv-primary-600: #2563eb; /* hover */
+  --nv-primary-700: #1d4ed8;
+  --nv-primary-800: #1e40af;
+  --nv-primary-900: #1e3a8a;
+
+  --nv-primary: var(--nv-primary-600);
+  --nv-primary-contrast: #ffffff;
+
+  /* Optional secondary/neutral hooks to expand later */
+  --nv-neutral: #1f2937;
+}
+
+/* Base layer: make common elements use the brand automatically */
+@layer base {
+  /* Links */
+  a {
+    color: var(--nv-primary);
+  }
+  a:hover { color: var(--nv-primary-700); }
+  a:focus-visible { outline: 2px solid var(--nv-primary-400); outline-offset: 2px; }
+
+  /* Breadcrumbs (handles simple markup and many libs) */
+  nav[aria-label="breadcrumb"] a,
+  .breadcrumb a {
+    color: var(--nv-primary);
+  }
+  nav[aria-label="breadcrumb"] a:hover,
+  .breadcrumb a:hover {
+    color: var(--nv-primary-700);
+  }
+
+  /* Tailwind/Daisy-style buttons (safe no-ops if class not present) */
+  .btn-primary,
+  .btn.brand,
+  .btn[data-variant="primary"] {
+    background-color: var(--nv-primary) !important;
+    border-color: var(--nv-primary) !important;
+    color: var(--nv-primary-contrast) !important;
+  }
+  .btn-primary:hover,
+  .btn.brand:hover,
+  .btn[data-variant="primary"]:hover {
+    background-color: var(--nv-primary-700) !important;
+    border-color: var(--nv-primary-700) !important;
+  }
+
+  /* Accent color for inputs/checkboxes (native) */
+  :root { accent-color: var(--nv-primary); }
+}
+
+/* Utility layer: brand helpers even if not using Tailwind color names */
+@layer utilities {
+  .bg-brand      { background-color: var(--nv-primary); }
+  .bg-brand-600  { background-color: var(--nv-primary-600); }
+  .text-brand    { color: var(--nv-primary); }
+  .border-brand  { border-color: var(--nv-primary); }
+}
+
+/* Turian FAB + chat bubble — class names are from the new widget PR */
+.nv-fab { 
+  background: var(--nv-primary); 
+  color: var(--nv-primary-contrast);
+}
+.nv-fab:hover { background: var(--nv-primary-700); }
+
+/* If your chat frame has a header bar, tint it */
+.nv-chat header,
+.turian-chat header {
+  background: var(--nv-primary);
+  color: var(--nv-primary-contrast);
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,30 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: [
+    './index.html',
+    './app/**/*.{ts,tsx,js,jsx}',
+    './components/**/*.{ts,tsx,js,jsx}',
+    './src/**/*.{ts,tsx,js,jsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50:  'var(--nv-primary-50)',
+          100: 'var(--nv-primary-100)',
+          200: 'var(--nv-primary-200)',
+          300: 'var(--nv-primary-300)',
+          400: 'var(--nv-primary-400)',
+          500: 'var(--nv-primary-500)',
+          600: 'var(--nv-primary-600)',
+          700: 'var(--nv-primary-700)',
+          800: 'var(--nv-primary-800)',
+          900: 'var(--nv-primary-900)',
+          DEFAULT: 'var(--nv-primary)',
+        },
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
## Summary
- define brand color CSS tokens and base styles
- map Tailwind `primary` palette to brand tokens
- apply brand styling to breadcrumbs, buttons, and Turian chat

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b86a8c5e908329a705330d3d6314b8