### PR TITLE
Centralize brand blue styling across app

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { SITE_URL } from './lib/site';
 import "../styles/globals.css";
 import "../styles/nav.css";
-import "../src/styles/brand.css";
+import '@/styles/brand.css';
 
 // ensure absolute URLs in SEO metadata
 export const metadata: Metadata = {

--- a/src/components/TurianWidget.tsx
+++ b/src/components/TurianWidget.tsx
@@ -40,7 +40,7 @@ export default function TurianWidget() {
       <button
         aria-label="Open Turian chat"
         onClick={() => setOpen(true)}
-        className="turian-fab nv-fab"
+        className="fab-btn turian-fab nv-fab"
       >
         💬
       </button>

--- a/src/pages/turian/index.tsx
+++ b/src/pages/turian/index.tsx
@@ -37,13 +37,18 @@ export default function TurianPage() {
   }
 
   return (
-    <div className="container" style={{ maxWidth: 820, margin: "0 auto" }}>
-      <nav className="crumbs">
+    <main className="turian container" style={{ maxWidth: 820, margin: "0 auto" }}>
+      <nav aria-label="breadcrumb" className="crumbs">
         <Link to="/">Home</Link> / <span>Turian</span>
       </nav>
       <h1 className="h1">Turian the Durian</h1>
 
-      <div className="chat-card">
+      <p className="tip">
+        Tip: In demo mode I use built-in answers. Switch to live later by setting
+        <code> VITE_AI_MODE=live</code> and deploying.
+      </p>
+
+      <div className="chat chat-card">
         <div className="status">
           {isDemo()
             ? "Offline demo — no external calls or costs."
@@ -103,11 +108,6 @@ export default function TurianPage() {
         </form>
         {err && <p style={{ color: "#d00", marginTop: 8 }}>{err}</p>}
       </div>
-
-      <p style={{ marginTop: 12, color: "#778" }}>
-        Tip: In demo mode I use built-in answers. Switch to live later by setting
-        <code> VITE_AI_MODE=live</code> and deploying.
-      </p>
-    </div>
+    </main>
   );
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,7 +5,7 @@ import { Img } from '../components';
 
 export default function Home() {
   return (
-    <main className="container">
+    <main className="home container">
       {/* Clean hero (no oversized emoji) */}
       <header className="home-hero">
         <h1>

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -1,79 +1,41 @@
-/* Brand tokens — edit here once to tweak your blue */
-:root {
-  --nv-primary-50:  #eff6ff;
-  --nv-primary-100: #dbeafe;
-  --nv-primary-200: #bfdbfe;
-  --nv-primary-300: #93c5fd;
-  --nv-primary-400: #60a5fa;
-  --nv-primary-500: #3b82f6; /* main */
-  --nv-primary-600: #2563eb; /* hover */
-  --nv-primary-700: #1d4ed8;
-  --nv-primary-800: #1e40af;
-  --nv-primary-900: #1e3a8a;
-
-  --nv-primary: var(--nv-primary-600);
-  --nv-primary-contrast: #ffffff;
-
-  /* Optional secondary/neutral hooks to expand later */
-  --nv-neutral: #1f2937;
+/* Brand tokens */
+:root{
+  --brand-50:#eef2ff;
+  --brand-100:#e0e7ff;
+  --brand-200:#c7d2fe;
+  --brand-300:#a5b4fc;
+  --brand-400:#818cf8;
+  --brand-500:#6366f1;
+  --brand-600:#2563eb; /* primary */
+  --brand-700:#1d4ed8; /* primary-hover */
 }
 
-/* Base layer: make common elements use the brand automatically */
-@layer base {
-  /* Links */
-  a {
-    color: var(--nv-primary);
-  }
-  a:hover { color: var(--nv-primary-700); }
-  a:focus-visible { outline: 2px solid var(--nv-primary-400); outline-offset: 2px; }
-
-  /* Breadcrumbs (handles simple markup and many libs) */
-  nav[aria-label="breadcrumb"] a,
-  .breadcrumb a {
-    color: var(--nv-primary);
-  }
-  nav[aria-label="breadcrumb"] a:hover,
-  .breadcrumb a:hover {
-    color: var(--nv-primary-700);
-  }
-
-  /* Tailwind/Daisy-style buttons (safe no-ops if class not present) */
-  .btn-primary,
-  .btn.brand,
-  .btn[data-variant="primary"] {
-    background-color: var(--nv-primary) !important;
-    border-color: var(--nv-primary) !important;
-    color: var(--nv-primary-contrast) !important;
-  }
-  .btn-primary:hover,
-  .btn.brand:hover,
-  .btn[data-variant="primary"]:hover {
-    background-color: var(--nv-primary-700) !important;
-    border-color: var(--nv-primary-700) !important;
-  }
-
-  /* Accent color for inputs/checkboxes (native) */
-  :root { accent-color: var(--nv-primary); }
+/* Breadcrumbs: any component with an aria-label of breadcrumb */
+[aria-label="breadcrumb"] a,
+.breadcrumb a{
+  color: var(--brand-600);
+  text-decoration: none;
+}
+[aria-label="breadcrumb"] a:hover,
+.breadcrumb a:hover{
+  color: var(--brand-700);
 }
 
-/* Utility layer: brand helpers even if not using Tailwind color names */
-@layer utilities {
-  .bg-brand      { background-color: var(--nv-primary); }
-  .bg-brand-600  { background-color: var(--nv-primary-600); }
-  .text-brand    { color: var(--nv-primary); }
-  .border-brand  { border-color: var(--nv-primary); }
-}
+/* Generic brand link helper (use where a link might miss Tailwind utilities) */
+a.brand-link{ color: var(--brand-600); }
+a.brand-link:hover{ color: var(--brand-700); }
 
-/* Turian FAB + chat bubble — class names are from the new widget PR */
-.nv-fab { 
-  background: var(--nv-primary); 
-  color: var(--nv-primary-contrast);
-}
-.nv-fab:hover { background: var(--nv-primary-700); }
+/* Turian page polish */
+.turian .tip,
+.turian .meta{ color: var(--brand-600); }
+.turian .chat input::placeholder{ color: var(--brand-600); opacity:.9; }
+.turian .chat button{ background: var(--brand-600); }
+.turian .chat button:hover{ background: var(--brand-700); }
 
-/* If your chat frame has a header bar, tint it */
-.nv-chat header,
-.turian-chat header {
-  background: var(--nv-primary);
-  color: var(--nv-primary-contrast);
-}
+/* Home cards & misc links that aren’t using Tailwind utilities */
+.home .card a{ color: var(--brand-600); }
+.home .card a:hover{ color: var(--brand-700); }
+
+/* Floating chat button */
+.fab-btn{ background: var(--brand-600); }
+.fab-btn:hover{ background: var(--brand-700); }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,30 +1,34 @@
 import type { Config } from 'tailwindcss';
 
-export default {
+const config: Config = {
   content: [
     './index.html',
     './app/**/*.{ts,tsx,js,jsx}',
     './components/**/*.{ts,tsx,js,jsx}',
-    './src/**/*.{ts,tsx,js,jsx}',
+    './src/**/*.{ts,tsx,js,jsx,vue}',
   ],
   theme: {
     extend: {
       colors: {
-        primary: {
-          50:  'var(--nv-primary-50)',
-          100: 'var(--nv-primary-100)',
-          200: 'var(--nv-primary-200)',
-          300: 'var(--nv-primary-300)',
-          400: 'var(--nv-primary-400)',
-          500: 'var(--nv-primary-500)',
-          600: 'var(--nv-primary-600)',
-          700: 'var(--nv-primary-700)',
-          800: 'var(--nv-primary-800)',
-          900: 'var(--nv-primary-900)',
-          DEFAULT: 'var(--nv-primary)',
+        brand: {
+          50:  '#eef2ff',
+          100: '#e0e7ff',
+          200: '#c7d2fe',
+          300: '#a5b4fc',
+          400: '#818cf8',
+          500: '#6366f1',
+          600: '#2563eb',
+          700: '#1d4ed8',
         },
       },
     },
   },
+  safelist: [
+    'text-brand-600','hover:text-brand-700',
+    'bg-brand-600','hover:bg-brand-700',
+    'border-brand-600'
+  ],
   plugins: [],
-} satisfies Config;
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- Add brand CSS tokens and helpers for consistent blue links and buttons
- Expose brand palette in Tailwind and safelist brand utilities
- Hook Turian page, home hub, and floating chat FAB to brand styles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b86e45fa6c83298adeba36f7a1f960