### PR TITLE
Nest wishlist under marketplace hub

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,7 +9,7 @@ const PAGES = [
   '/zones',
   '/marketplace',
   '/cart',
-  '/wishlist',
+  '/marketplace/wishlist',
   '/marketplace/checkout',
   '/naturversity',
   '/naturbank',

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -19,7 +19,7 @@ export default function NavBar() {
           <Link className="nv-link" href="/worlds">Worlds</Link>
           <Link className="nv-link" href="/zones">Zones</Link>
           <Link className="nv-link" href="/marketplace">Marketplace</Link>
-          <Link className="nv-link" href="/wishlist">Wishlist</Link>
+          <Link className="nv-link" href="/marketplace/wishlist">Wishlist</Link>
           <Link className="nv-link" href="/naturversity">Naturversity</Link>
           <Link className="nv-link" href="/naturbank">NaturBank</Link>
           {/* Navatar is always enabled */}

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,6 +23,12 @@
   status = 200
   force  = true
 
+[[redirects]]
+  from = "/wishlist"
+  to   = "/marketplace/wishlist"
+  status = 301
+  force  = true
+
 # SPA fallback last
 [[redirects]]
   from = "/*"

--- a/netlify/functions/sitemap.ts
+++ b/netlify/functions/sitemap.ts
@@ -5,7 +5,7 @@ export default async () => {
   // TODO: expand this list or generate from content
   const urls = [
     '/', '/worlds', '/zones', '/marketplace',
-    '/wishlist', '/naturversity', '/naturbank', '/navatar', '/passport'
+    '/marketplace/wishlist', '/naturversity', '/naturbank', '/navatar', '/passport'
   ];
 
   const body =

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,7 +5,7 @@
   <url><loc>https://thenaturverse.com/worlds</loc><changefreq>weekly</changefreq><priority>0.9</priority><lastmod>2025-08-28</lastmod></url>
   <url><loc>https://thenaturverse.com/zones</loc><changefreq>weekly</changefreq><priority>0.9</priority><lastmod>2025-08-28</lastmod></url>
   <url><loc>https://thenaturverse.com/marketplace</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2025-08-28</lastmod></url>
-  <url><loc>https://thenaturverse.com/wishlist</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2025-08-28</lastmod></url>
+  <url><loc>https://thenaturverse.com/marketplace/wishlist</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2025-08-28</lastmod></url>
   <url><loc>https://thenaturverse.com/naturversity</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2025-08-28</lastmod></url>
   <url><loc>https://thenaturverse.com/naturbank</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2025-08-28</lastmod></url>
   <url><loc>https://thenaturverse.com/navatar</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2025-08-28</lastmod></url>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -7,7 +7,7 @@ export default function NavBar() {
       <a href="/worlds">Worlds</a>
       <a href="/zones">Zones</a>
       <a href="/marketplace">Marketplace</a>
-      <a href="/wishlist">Wishlist</a>
+      <a href="/marketplace/wishlist">Wishlist</a>
       <a href="/naturversity">Naturversity</a>
       <a href="/naturbank">NaturBank</a>
       <a href="/navatar">Navatar</a>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -30,7 +30,7 @@ export default function SiteHeader() {
               <a href="/worlds">Worlds</a>
               <a href="/zones">Zones</a>
               <a href="/marketplace">Marketplace</a>
-              <a href="/wishlist">Wishlist</a>
+              <a href="/marketplace/wishlist">Wishlist</a>
               <a href="/naturversity">Naturversity</a>
               <a href="/naturbank">NaturBank</a>
               <a href="/navatar">Navatar</a>
@@ -85,7 +85,7 @@ export default function SiteHeader() {
               <a href="/worlds">Worlds</a>
               <a href="/zones">Zones</a>
               <a href="/marketplace">Marketplace</a>
-              <a href="/wishlist">Wishlist</a>
+              <a href="/marketplace/wishlist">Wishlist</a>
               <a href="/naturversity">Naturversity</a>
               <a href="/naturbank">NaturBank</a>
               <a href="/navatar">Navatar</a>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -80,7 +80,7 @@ export default function UserMenu() {
           </div>
           <a href="/profile" className="item">Profile</a>
           <a href="/passport" className="item">Passport</a>
-          <a href="/wishlist" className="item">Wishlist</a>
+          <a href="/marketplace/wishlist" className="item">Wishlist</a>
           <button
             className="item danger"
             onClick={async () => {

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from "react";
+import { Link } from "react-router-dom";
 import { PRODUCTS } from "../data/products";
 import { addToCart } from "../lib/cart";
 import RecentCarousel from "@/components/RecentCarousel";
@@ -20,6 +21,9 @@ export default function Marketplace() {
       <a className="btn primary" href="#items" onClick={() => convert("market_cta", variant, { click: true })}>
         {ctaText}
       </a>
+      <Link className="btn" to="/marketplace/wishlist">
+        Wishlist
+      </Link>
       <section className="grid" id="items">
         {PRODUCTS.map((p) => {
           const s = getStock(p.id);

--- a/src/pages/marketplace/Wishlist.tsx
+++ b/src/pages/marketplace/Wishlist.tsx
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { PRODUCTS } from '@/data/products';
+import { getWishlist } from '@/utils/wishlist';
+
+export default function WishlistPage() {
+  const [ids, setIds] = useState<string[]>(() => getWishlist());
+
+  useEffect(() => {
+    const onStorage = () => setIds(getWishlist());
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const items = PRODUCTS.filter(p => ids.includes(p.id));
+
+  return (
+    <main className="marketplace container" style={{ padding: 24 }}>
+      <nav aria-label="breadcrumb" className="mb-4">
+        <ol className="breadcrumb">
+          <li><Link to="/">Home</Link></li>
+          <li><Link to="/marketplace">Marketplace</Link></li>
+          <li aria-current="page">Wishlist</li>
+        </ol>
+      </nav>
+      {items.length > 0 ? (
+        <ul>
+          {items.map(p => (
+            <li key={p.id}>
+              <Link to={`/marketplace/${p.id}`}>{p.name}</Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>Your wishlist is empty.</p>
+      )}
+    </main>
+  );
+}
+

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -10,6 +10,7 @@ import ZonesExplorer from './pages/ZonesExplorer';
 import ZoneDetail from './pages/zones/[slug]';
 import MarketplacePage from './pages/marketplace';
 import ProductPage from './pages/marketplace/[sku]';
+import WishlistPage from './pages/marketplace/Wishlist';
 import CartLoad from './pages/cart-load';
 import QuestsList from './pages/quests';
 import NewQuest from './pages/quests/new';
@@ -71,6 +72,7 @@ export const router = createBrowserRouter([
       { path: 'play/:quest', element: <PlayQuest /> },
 
       { path: 'marketplace', element: <MarketplacePage /> },
+      { path: 'marketplace/wishlist', element: <WishlistPage /> },
       { path: 'marketplace/:sku', element: <ProductPage /> },
       { path: 'checkout', element: <CheckoutPage /> },
       { path: 'success', element: <SuccessPage /> },


### PR DESCRIPTION
## Summary
- add dedicated marketplace wishlist page with breadcrumbs
- wire up `/marketplace/wishlist` route and link from marketplace hub
- update navigation, sitemaps, and Netlify redirect to new nested wishlist path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b872afe5588329bc6e886ddf28f80e