### PR TITLE
Nest wishlist under marketplace hub

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,7 +9,7 @@ const PAGES = [
   '/zones',
   '/marketplace',
   '/cart',
-  '/wishlist',
+  '/marketplace/wishlist',
   '/marketplace/checkout',
   '/naturversity',
   '/naturbank',

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -19,7 +19,6 @@ export default function NavBar() {
           <Link className="nv-link" href="/worlds">Worlds</Link>
           <Link className="nv-link" href="/zones">Zones</Link>
           <Link className="nv-link" href="/marketplace">Marketplace</Link>
-          <Link className="nv-link" href="/wishlist">Wishlist</Link>
           <Link className="nv-link" href="/naturversity">Naturversity</Link>
           <Link className="nv-link" href="/naturbank">NaturBank</Link>
           {/* Navatar is always enabled */}

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,6 +23,12 @@
   status = 200
   force  = true
 
+[[redirects]]
+  from = "/wishlist"
+  to = "/marketplace/wishlist"
+  status = 301
+  force = true
+
 # SPA fallback last
 [[redirects]]
   from = "/*"

--- a/netlify/functions/sitemap.ts
+++ b/netlify/functions/sitemap.ts
@@ -5,7 +5,7 @@ export default async () => {
   // TODO: expand this list or generate from content
   const urls = [
     '/', '/worlds', '/zones', '/marketplace',
-    '/wishlist', '/naturversity', '/naturbank', '/navatar', '/passport'
+    '/marketplace/wishlist', '/naturversity', '/naturbank', '/navatar', '/passport'
   ];
 
   const body =

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,7 +5,7 @@
   <url><loc>https://thenaturverse.com/worlds</loc><changefreq>weekly</changefreq><priority>0.9</priority><lastmod>2025-08-28</lastmod></url>
   <url><loc>https://thenaturverse.com/zones</loc><changefreq>weekly</changefreq><priority>0.9</priority><lastmod>2025-08-28</lastmod></url>
   <url><loc>https://thenaturverse.com/marketplace</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2025-08-28</lastmod></url>
-  <url><loc>https://thenaturverse.com/wishlist</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2025-08-28</lastmod></url>
+  <url><loc>https://thenaturverse.com/marketplace/wishlist</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2025-08-28</lastmod></url>
   <url><loc>https://thenaturverse.com/naturversity</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2025-08-28</lastmod></url>
   <url><loc>https://thenaturverse.com/naturbank</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2025-08-28</lastmod></url>
   <url><loc>https://thenaturverse.com/navatar</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2025-08-28</lastmod></url>

--- a/src/boot/warmup.ts
+++ b/src/boot/warmup.ts
@@ -10,8 +10,8 @@ const pages = import.meta.glob('../pages/**/*.tsx') as Record<string, Loader>;
 const CANDIDATES = [
   '../pages/Worlds.tsx',
   '../pages/Zones.tsx',
-  '../pages/Marketplace.tsx',
-  '../pages/Wishlist.tsx',
+  '../pages/marketplace.tsx',
+  '../pages/marketplace/Wishlist.tsx',
   '../pages/Naturversity.tsx',
   '../pages/NaturBank.tsx',
   '../pages/navatar.tsx',

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -7,7 +7,6 @@ export default function NavBar() {
       <a href="/worlds">Worlds</a>
       <a href="/zones">Zones</a>
       <a href="/marketplace">Marketplace</a>
-      <a href="/wishlist">Wishlist</a>
       <a href="/naturversity">Naturversity</a>
       <a href="/naturbank">NaturBank</a>
       <a href="/navatar">Navatar</a>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -30,7 +30,6 @@ export default function SiteHeader() {
               <a href="/worlds">Worlds</a>
               <a href="/zones">Zones</a>
               <a href="/marketplace">Marketplace</a>
-              <a href="/wishlist">Wishlist</a>
               <a href="/naturversity">Naturversity</a>
               <a href="/naturbank">NaturBank</a>
               <a href="/navatar">Navatar</a>
@@ -85,7 +84,6 @@ export default function SiteHeader() {
               <a href="/worlds">Worlds</a>
               <a href="/zones">Zones</a>
               <a href="/marketplace">Marketplace</a>
-              <a href="/wishlist">Wishlist</a>
               <a href="/naturversity">Naturversity</a>
               <a href="/naturbank">NaturBank</a>
               <a href="/navatar">Navatar</a>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -80,7 +80,7 @@ export default function UserMenu() {
           </div>
           <a href="/profile" className="item">Profile</a>
           <a href="/passport" className="item">Passport</a>
-          <a href="/wishlist" className="item">Wishlist</a>
+          <a href="/marketplace/wishlist" className="item">Wishlist</a>
           <button
             className="item danger"
             onClick={async () => {

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from "react";
+import { Link } from 'react-router-dom';
 import { PRODUCTS } from "../data/products";
 import { addToCart } from "../lib/cart";
 import RecentCarousel from "@/components/RecentCarousel";
@@ -15,8 +16,16 @@ export default function Marketplace() {
     : "Shop marketplace";
 
   return (
-    <main>
-      <h1>Marketplace</h1>
+    <main className="container py-8">
+      <h1 className="h1 mb-4">Marketplace</h1>
+
+      <div className="flex flex-wrap gap-3 mb-6">
+        <Link className="btn btn-outline" to="/marketplace/wishlist">Wishlist</Link>
+        <Link className="btn btn-outline" to="/marketplace/nft">NFT</Link>
+        <Link className="btn btn-outline" to="/marketplace/saved">Saved</Link>
+        <Link className="btn btn-outline" to="/marketplace/specials">Specials</Link>
+      </div>
+
       <a className="btn primary" href="#items" onClick={() => convert("market_cta", variant, { click: true })}>
         {ctaText}
       </a>

--- a/src/pages/marketplace/Nft.tsx
+++ b/src/pages/marketplace/Nft.tsx
@@ -1,0 +1,12 @@
+import Breadcrumbs from '../../components/Breadcrumbs';
+export default function MarketplaceNft() {
+  return (
+    <main className="container py-8">
+      <Breadcrumbs items={[{label:'Home',href:'/'},{label:'Marketplace',href:'/marketplace'},{label:'NFT'}]} />
+      <section className="card mt-4 p-6">
+        <h1 className="h1 mb-2">NFT</h1>
+        <p className="muted">Coming soon.</p>
+      </section>
+    </main>
+  );
+}

--- a/src/pages/marketplace/Saved.tsx
+++ b/src/pages/marketplace/Saved.tsx
@@ -1,0 +1,12 @@
+import Breadcrumbs from '../../components/Breadcrumbs';
+export default function MarketplaceSaved() {
+  return (
+    <main className="container py-8">
+      <Breadcrumbs items={[{label:'Home',href:'/'},{label:'Marketplace',href:'/marketplace'},{label:'Saved'}]} />
+      <section className="card mt-4 p-6">
+        <h1 className="h1 mb-2">Saved</h1>
+        <p className="muted">Coming soon.</p>
+      </section>
+    </main>
+  );
+}

--- a/src/pages/marketplace/Specials.tsx
+++ b/src/pages/marketplace/Specials.tsx
@@ -1,0 +1,12 @@
+import Breadcrumbs from '../../components/Breadcrumbs';
+export default function MarketplaceSpecials() {
+  return (
+    <main className="container py-8">
+      <Breadcrumbs items={[{label:'Home',href:'/'},{label:'Marketplace',href:'/marketplace'},{label:'Specials'}]} />
+      <section className="card mt-4 p-6">
+        <h1 className="h1 mb-2">Specials</h1>
+        <p className="muted">Coming soon.</p>
+      </section>
+    </main>
+  );
+}

--- a/src/pages/marketplace/Wishlist.tsx
+++ b/src/pages/marketplace/Wishlist.tsx
@@ -1,0 +1,25 @@
+import Breadcrumbs from '../../components/Breadcrumbs';
+
+export default function WishlistPage() {
+  return (
+    <main className="container py-8">
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Marketplace', href: '/marketplace' },
+          { label: 'Wishlist' },
+        ]}
+      />
+      <section className="card mt-4 p-6">
+        <h1 className="h1 mb-4">Wishlist</h1>
+        <p className="muted mb-6">Your wishlist is empty.</p>
+        {/* TODO: render list of wished items when data exists */}
+        <ol className="list-decimal pl-6 space-y-2">
+          <li className="text-muted-foreground">Slot 1</li>
+          <li className="text-muted-foreground">Slot 2</li>
+          <li className="text-muted-foreground">Slot 3</li>
+        </ol>
+      </section>
+    </main>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -10,6 +10,10 @@ import ZonesExplorer from './pages/ZonesExplorer';
 import ZoneDetail from './pages/zones/[slug]';
 import MarketplacePage from './pages/marketplace';
 import ProductPage from './pages/marketplace/[sku]';
+import WishlistPage from './pages/marketplace/Wishlist';
+import MarketplaceNft from './pages/marketplace/Nft';
+import MarketplaceSaved from './pages/marketplace/Saved';
+import MarketplaceSpecials from './pages/marketplace/Specials';
 import CartLoad from './pages/cart-load';
 import QuestsList from './pages/quests';
 import NewQuest from './pages/quests/new';
@@ -71,6 +75,10 @@ export const router = createBrowserRouter([
       { path: 'play/:quest', element: <PlayQuest /> },
 
       { path: 'marketplace', element: <MarketplacePage /> },
+      { path: 'marketplace/wishlist', element: <WishlistPage /> },
+      { path: 'marketplace/nft', element: <MarketplaceNft /> },
+      { path: 'marketplace/saved', element: <MarketplaceSaved /> },
+      { path: 'marketplace/specials', element: <MarketplaceSpecials /> },
       { path: 'marketplace/:sku', element: <ProductPage /> },
       { path: 'checkout', element: <CheckoutPage /> },
       { path: 'success', element: <SuccessPage /> },


### PR DESCRIPTION
## Summary
- Remove Wishlist from global nav components
- Add /marketplace/wishlist plus NFT, Saved and Specials stub pages with breadcrumbs
- Link subpages from Marketplace hub, update router, redirect and sitemaps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8764015948329a64a81544b016c1a