### PR TITLE
Brand color sweep + Turian/Home polish

### DIFF
--- a/client/src/pages/Codex.tsx
+++ b/client/src/pages/Codex.tsx
@@ -110,7 +110,7 @@ export default function Codex() {
       case 'quiz':
         return 'bg-turquoise text-white';
       case 'music':
-        return 'bg-sunny text-black';
+        return 'bg-sunny text-strong';
       case 'achievement':
         return 'bg-coral text-white';
       default:

--- a/client/src/pages/Market.tsx
+++ b/client/src/pages/Market.tsx
@@ -117,7 +117,7 @@ export default function Market() {
       case 'epic':
         return 'bg-magic text-white';
       case 'legendary':
-        return 'bg-sunny text-black';
+        return 'bg-sunny text-strong';
       default:
         return 'bg-gray-500 text-white';
     }

--- a/client/src/pages/Modules.tsx
+++ b/client/src/pages/Modules.tsx
@@ -107,7 +107,7 @@ export default function Modules() {
       case 'beginner':
         return 'bg-nature text-white';
       case 'intermediate':
-        return 'bg-sunny text-black';
+        return 'bg-sunny text-strong';
       case 'advanced':
         return 'bg-coral text-white';
       default:
@@ -226,7 +226,7 @@ export default function Modules() {
                       module.isCompleted
                         ? 'bg-nature text-white'
                         : module.progress > 0
-                          ? 'bg-sunny hover:bg-yellow-500 text-black'
+                          ? 'bg-sunny hover:bg-yellow-500 text-strong'
                           : 'bg-turquoise hover:bg-teal-600 text-white'
                     }`}
                     data-testid={`button-module-${module.id}`}

--- a/client/src/pages/Music.tsx
+++ b/client/src/pages/Music.tsx
@@ -68,7 +68,7 @@ export default function Music() {
       case 'play':
         return 'bg-turquoise text-white';
       case 'learn':
-        return 'bg-sunny text-black';
+        return 'bg-sunny text-strong';
       default:
         return 'bg-gray-500 text-white';
     }

--- a/client/src/pages/Zone.tsx
+++ b/client/src/pages/Zone.tsx
@@ -202,7 +202,7 @@ export default function Zone() {
       case 'easy':
         return 'bg-nature text-white';
       case 'medium':
-        return 'bg-sunny text-black';
+        return 'bg-sunny text-strong';
       case 'hard':
         return 'bg-coral text-white';
       default:

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "react-router-dom";
-import * as React from "react";
+import React, { useMemo } from "react";
 
 type Crumb = { label: string; href?: string };
 
@@ -27,19 +27,15 @@ const LABELS: Record<string, string> = {
   stories: "Stories",
 };
 
-export function Breadcrumbs(props: { items?: Crumb[] }) {
+export function Breadcrumbs({ items }: { items?: Crumb[] }) {
   const location = useLocation();
 
-  // Allow explicit items to override auto mode when needed
-  const items: Crumb[] = React.useMemo(() => {
-    if (props.items?.length) return props.items;
+  const computed: Crumb[] = useMemo(() => {
+    if (items?.length) return items;
 
     const parts = location.pathname.replace(/^\/+|\/+$/g, "").split("/");
-    const acc: Crumb[] = [];
+    const acc: Crumb[] = [{ label: "Home", href: "/" }];
     let path = "";
-
-    // Always include Home
-    acc.push({ label: "Home", href: "/" });
 
     parts.forEach((seg, i) => {
       if (!seg) return;
@@ -50,24 +46,28 @@ export function Breadcrumbs(props: { items?: Crumb[] }) {
     });
 
     return acc;
-  }, [location.pathname, props.items]);
+  }, [location.pathname, items]);
 
-  if (items.length <= 1) return null;
+  if (computed.length <= 1) return null;
 
   return (
-    <nav aria-label="breadcrumb" className="nv-breadcrumbs brand-blue">
-      <ol>
-        {items.map((c, i) => {
-          const isLast = i === items.length - 1;
-          return (
-            <li key={`${c.label}-${i}`} aria-current={isLast ? "page" : undefined}>
-              {c.href && !isLast ? <Link to={c.href}>{c.label}</Link> : <span>{c.label}</span>}
-              {!isLast && <span className="sep"> / </span>}
-            </li>
-          );
-        })}
+    <nav aria-label="breadcrumb" className="mb-4">
+      <ol className="flex flex-wrap gap-2 text-sm text-muted">
+        {computed.map((it, i) => (
+          <li key={i} className="flex items-center gap-2">
+            {it.href ? (
+              <Link to={it.href} className="hover:underline">
+                {it.label}
+              </Link>
+            ) : (
+              <span className="text-strong">{it.label}</span>
+            )}
+            {i < computed.length - 1 && <span className="text-muted">/</span>}
+          </li>
+        ))}
       </ol>
     </nav>
   );
 }
+
 export default Breadcrumbs;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: string;
+};
+
+export default function Button({ className = '', variant = 'brand', ...rest }: Props) {
+  const base =
+    variant === 'brand'
+      ? 'bg-primary-600 hover:bg-primary-700 text-white rounded-xl shadow-md'
+      : '';
+  return <button className={`${base} ${className}`} data-variant={variant} {...rest} />;
+}
+

--- a/src/components/ChatFab.tsx
+++ b/src/components/ChatFab.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export default function ChatFab({ className = '', children, ...props }: Props) {
+  return (
+    <button
+      type="button"
+      className={`brand-fab fixed bottom-6 right-6 h-14 w-14 rounded-full shadow-lg flex items-center justify-center ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+

--- a/src/components/TurianWidget.tsx
+++ b/src/components/TurianWidget.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import { isDemo } from "../lib/ai";
+import ChatFab from "./ChatFab";
+import Button from "./Button";
 
 type Msg = { who: "bot" | "you"; text: string };
 
@@ -37,13 +39,9 @@ export default function TurianWidget() {
 
   return (
     <>
-      <button
-        aria-label="Open Turian chat"
-        onClick={() => setOpen(true)}
-        className="fab-btn turian-fab nv-fab"
-      >
+      <ChatFab aria-label="Open Turian chat" onClick={() => setOpen(true)}>
         💬
-      </button>
+      </ChatFab>
 
       {open && (
         <div className="turian-sheet turian-chat" role="dialog" aria-modal="true">
@@ -67,7 +65,7 @@ export default function TurianWidget() {
                 onChange={(e) => setText(e.target.value)}
                 placeholder="Ask Turian about Worlds, Zones, or Navatar…"
               />
-              <button className="btn-primary">Send</button>
+              <Button type="submit" disabled={!text.trim()}>Send</Button>
             </form>
           </div>
         </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,8 +13,8 @@ export default function Home() {
   return (
     <main className={`${styles.page} nv-container`}>
       <section className={styles.hero}>
-        <h1 className={styles.title}>Welcome to the Naturverse™</h1>
-        <p className={styles.subtitle}>
+        <h1 className={`${styles.title} text-5xl font-extrabold text-strong`}>Welcome to the Naturverse™</h1>
+        <p className={`${styles.subtitle} mt-2 text-xl text-muted`}>
           A playful world of kingdoms, characters, and quests that teach wellness, creativity, and
           kindness.
         </p>

--- a/src/pages/turian/index.tsx
+++ b/src/pages/turian/index.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { turianReply } from "@/lib/turian";
 import { isDemo, AI_MODE } from "@/lib/ai";
-import { Link } from "react-router-dom";
+import Breadcrumbs from "../../components/Breadcrumbs";
+import Button from "../../components/Button";
 import "../../styles/turian.css";
 
 type Msg = { role: "user" | "assistant" | "system"; content: string };
@@ -37,18 +38,17 @@ export default function TurianPage() {
   }
 
   return (
-    <main className="turian container" style={{ maxWidth: 820, margin: "0 auto" }}>
-      <nav aria-label="breadcrumb" className="crumbs">
-        <Link to="/">Home</Link> / <span>Turian</span>
-      </nav>
-      <h1 className="h1">Turian the Durian</h1>
+    <main className="turian container max-w-[820px] mx-auto">
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "Turian" }]} />
+      <h1 className="text-4xl font-extrabold text-strong">Turian the Durian</h1>
 
-      <p className="tip">
+      <p className="mt-2 text-sm brand-muted">
         Tip: In demo mode I use built-in answers. Switch to live later by setting
-        <code> VITE_AI_MODE=live</code> and deploying.
+        <code className="mx-1 rounded bg-primary-50 px-2 py-0.5 text-primary-700">VITE_AI_MODE=live</code>
+        and deploying.
       </p>
 
-      <div className="chat chat-card">
+      <section className="brand-chat mt-6 rounded-2xl border border-primary-100 bg-white p-4 shadow-sm">
         <div className="status">
           {isDemo()
             ? "Offline demo — no external calls or costs."
@@ -80,10 +80,10 @@ export default function TurianPage() {
                     m.role === "assistant"
                       ? "#ffffff"
                       : m.role === "user"
-                      ? "#1f50ff"
+                      ? "var(--brand-primary-600)"
                       : "transparent",
-                  color: m.role === "user" ? "#fff" : "#222",
-                  border: m.role === "assistant" ? "1px solid #e8eef7" : "none",
+                  color: m.role === "user" ? "#fff" : "var(--text-base)",
+                  border: m.role === "assistant" ? "1px solid var(--brand-primary-100)" : "none",
                   maxWidth: 560,
                 }}
               >
@@ -99,15 +99,12 @@ export default function TurianPage() {
             onChange={(e) => setInput(e.target.value)}
             placeholder="Ask Turian about Worlds, Zones, or Navatar…"
           />
-          <button
-            className="btn-primary"
-            disabled={busy || !input.trim()}
-          >
+          <Button disabled={busy || !input.trim()}>
             {busy ? "Thinking…" : "Send"}
-          </button>
+          </Button>
         </form>
         {err && <p style={{ color: "#d00", marginTop: 8 }}>{err}</p>}
-      </div>
+      </section>
     </main>
   );
 }

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -1,41 +1,64 @@
-/* Brand tokens */
 :root{
-  --brand-50:#eef2ff;
-  --brand-100:#e0e7ff;
-  --brand-200:#c7d2fe;
-  --brand-300:#a5b4fc;
-  --brand-400:#818cf8;
-  --brand-500:#6366f1;
-  --brand-600:#2563eb; /* primary */
-  --brand-700:#1d4ed8; /* primary-hover */
+  --brand-primary-50:  #eef2ff;
+  --brand-primary-100: #e0e7ff;
+  --brand-primary-200: #c7d2fe;
+  --brand-primary-300: #a5b4fc;
+  --brand-primary-400: #818cf8;
+  --brand-primary-500: #6366f1; /* main */
+  --brand-primary-600: #4f46e5;
+  --brand-primary-700: #4338ca;
+  --brand-primary-800: #3730a3;
+  --brand-primary-900: #312e81;
+
+  --text-strong: #0b1635;      /* deep navy for headings */
+  --text-base:   #0f1e46;      /* default body */
+  --text-muted:  #51607d;      /* captions / hints */
+
+  --ring-brand:  var(--brand-primary-500);
 }
 
-/* Breadcrumbs: any component with an aria-label of breadcrumb */
-[aria-label="breadcrumb"] a,
-.breadcrumb a{
-  color: var(--brand-600);
-  text-decoration: none;
-}
-[aria-label="breadcrumb"] a:hover,
-.breadcrumb a:hover{
-  color: var(--brand-700);
+/* Global defaults */
+html, body{
+  color: var(--text-base);
 }
 
-/* Generic brand link helper (use where a link might miss Tailwind utilities) */
-a.brand-link{ color: var(--brand-600); }
-a.brand-link:hover{ color: var(--brand-700); }
+a{
+  color: var(--brand-primary-600);
+}
+a:hover{
+  color: var(--brand-primary-700);
+}
 
-/* Turian page polish */
-.turian .tip,
-.turian .meta{ color: var(--brand-600); }
-.turian .chat input::placeholder{ color: var(--brand-600); opacity:.9; }
-.turian .chat button{ background: var(--brand-600); }
-.turian .chat button:hover{ background: var(--brand-700); }
+/* Buttons that don't already use Tailwind bg utilities */
+.btn, button.brand, [data-variant="brand"]{
+  background: var(--brand-primary-600);
+  color: white;
+  border-radius: .6rem;
+  box-shadow: 0 6px 0 0 color-mix(in srgb, var(--brand-primary-900) 35%, transparent);
+}
+.btn:hover, button.brand:hover, [data-variant="brand"]:hover{
+  background: var(--brand-primary-700);
+}
 
-/* Home cards & misc links that aren’t using Tailwind utilities */
-.home .card a{ color: var(--brand-600); }
-.home .card a:hover{ color: var(--brand-700); }
+/* Breadcrumbs */
+nav[aria-label="breadcrumb"] a{
+  color: var(--brand-primary-600);
+}
+nav[aria-label="breadcrumb"] a:hover{
+  color: var(--brand-primary-700);
+}
 
-/* Floating chat button */
-.fab-btn{ background: var(--brand-600); }
-.fab-btn:hover{ background: var(--brand-700); }
+/* Chat FAB & chat shell */
+.brand-fab{
+  background: var(--brand-primary-600);
+  color:#fff;
+}
+.brand-fab:hover{ background: var(--brand-primary-700); }
+.brand-chat h1, .brand-chat h2{ color: var(--text-strong); }
+.brand-chat .hint, .brand-muted{ color: var(--text-muted); }
+
+/* Inputs ring */
+:focus-visible{
+  outline-color: var(--ring-brand);
+}
+

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -234,10 +234,3 @@
   border: none !important;
 }
 
-/* ---------- Don’t let imported “seeder” templates override us ---------- */
-.navatar-page [style*="color:#000"],
-.naturbank-page [style*="color:#000"],
-.zones-page2   [style*="color:#000"],
-.world-page    [style*="color:#000"] {
-  color: var(--naturverse-blue) !important;
-}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,28 +5,39 @@ const config: Config = {
     './index.html',
     './app/**/*.{ts,tsx,js,jsx}',
     './components/**/*.{ts,tsx,js,jsx}',
+    './client/**/*.{ts,tsx,js,jsx}',
     './src/**/*.{ts,tsx,js,jsx,vue}',
   ],
   theme: {
     extend: {
       colors: {
-        brand: {
-          50:  '#eef2ff',
-          100: '#e0e7ff',
-          200: '#c7d2fe',
-          300: '#a5b4fc',
-          400: '#818cf8',
-          500: '#6366f1',
-          600: '#2563eb',
-          700: '#1d4ed8',
+        primary: {
+          50:  'var(--brand-primary-50)',
+          100: 'var(--brand-primary-100)',
+          200: 'var(--brand-primary-200)',
+          300: 'var(--brand-primary-300)',
+          400: 'var(--brand-primary-400)',
+          500: 'var(--brand-primary-500)',
+          600: 'var(--brand-primary-600)',
+          700: 'var(--brand-primary-700)',
+          800: 'var(--brand-primary-800)',
+          900: 'var(--brand-primary-900)',
         },
+      },
+      textColor: {
+        DEFAULT: 'var(--text-base)',
+        strong:  'var(--text-strong)',
+        muted:   'var(--text-muted)',
+      },
+      ringColor: {
+        brand: 'var(--ring-brand)',
       },
     },
   },
   safelist: [
-    'text-brand-600','hover:text-brand-700',
-    'bg-brand-600','hover:bg-brand-700',
-    'border-brand-600'
+    'text-primary-600','hover:text-primary-700',
+    'bg-primary-600','hover:bg-primary-700',
+    'border-primary-600'
   ],
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- centralize brand tokens and default link/button colors
- map Tailwind primary palette and text tokens to CSS variables
- make breadcrumbs, chat FAB, and generic buttons brand-blue by default
- apply brand polish to Turian and Home pages and remove stray `text-black`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b87a4d776483299b134e72d79e8686