### PR TITLE
Hide header + navbar until signed in

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -27,6 +27,8 @@ export default function SiteHeader() {
     };
   }, []);
 
+  if (!user) return null;
+
   return (
     <header className={`site-header ${open ? 'open' : ''}`}>
       <div className="container">

--- a/src/layouts/Root.tsx
+++ b/src/layouts/Root.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 
@@ -7,17 +7,47 @@ import RouteProgress from '../components/RouteProgress';
 import SiteHeader from '../components/SiteHeader';
 import Footer from '../components/Footer';
 import { ErrorBoundary } from '../components/ErrorBoundary';
+import AuthButtons from '../components/AuthButtons';
+import { supabase } from '@/lib/supabase-client';
+import type { User } from '@supabase/supabase-js';
 
 export default function RootLayout() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    supabase.auth.getSession().then(({ data }) => {
+      if (!mounted) return;
+      setUser(data.session?.user ?? null);
+      setLoading(false);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
+      setUser(session?.user ?? null);
+    });
+    return () => {
+      mounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
   return (
     <ErrorBoundary>
       <HelmetProvider>
         <HeadPreloads />
         <RouteProgress />
         <div className="nv-root">
-          <SiteHeader />
+          {user && <SiteHeader />}
           <main className="pageRoot">
-            <Outlet />
+            {user ? (
+              <Outlet />
+            ) : !loading ? (
+              <div className="container" style={{ padding: '4rem 0', textAlign: 'center' }}>
+                <h1>Welcome to the Naturverse</h1>
+                <p>Please sign in to continue.</p>
+                <AuthButtons className="justify-center" />
+              </div>
+            ) : null}
           </main>
           <Footer />
         </div>


### PR DESCRIPTION
## Summary
- Hide SiteHeader until a user session is present
- Gate main content behind sign-in placeholder with CTA

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next/link' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b99c9c96dc8329afb997b242027e71