### PR TITLE
auth/guest-lock: hide top nav when signed-out, only auth buttons clickable on home

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,31 +1,17 @@
 import { Link, NavLink } from 'react-router-dom';
-import { useEffect, useState } from 'react';
-import type { User } from '@supabase/supabase-js';
+import { useState } from 'react';
 import './site-header.css';
 import Img from './Img';
 import AuthButton from './AuthButton';
 import CartBadge from './CartBadge';
-import { supabase } from '@/lib/supabase-client';
 import { SITE } from '@/lib/site';
+import { useAuth } from '@/lib/auth-context';
 
 export default function SiteHeader() {
   const [open, setOpen] = useState(false);
-  const [user, setUser] = useState<User | null>(null);
+  const { user } = useAuth();
 
-  useEffect(() => {
-    let mounted = true;
-    supabase.auth.getSession().then(({ data }) => {
-      if (!mounted) return;
-      setUser(data.session?.user ?? null);
-    });
-    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
-      setUser(session?.user ?? null);
-    });
-    return () => {
-      mounted = false;
-      sub.subscription.unsubscribe();
-    };
-  }, []);
+  if (!user) return null;
 
   return (
     <header className={`site-header ${open ? 'open' : ''}`}>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,7 +9,7 @@ export default function Home() {
   const isAuthed = !!user;
 
   return (
-    <main className={styles.page}>
+    <main className={`${styles.page} ${!user ? 'guest-locked' : ''}`}>
       <section className={styles.hero}>
         <h1 className={styles.title}>Welcome to the Naturverse™</h1>
         <p className={styles.subtitle}>
@@ -17,7 +17,7 @@ export default function Home() {
           kindness.
         </p>
         {!user && (
-          <div className={styles.ctaRow}>
+          <div className={`${styles.ctaRow} auth-buttons`}>
             <button
               type="button"
               className={styles.cta}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -198,6 +198,15 @@ textarea {
   background: var(--nv-surface);
 }
 
+/* Prevent any interaction while signed-out, but keep auth buttons active */
+.guest-locked { position: relative; }
+.guest-locked * { pointer-events: none !important; }
+.guest-locked .auth-buttons,
+.guest-locked .auth-buttons * { pointer-events: auto !important; }
+
+/* Optional: subtle visual cue (remove if you don’t want it) */
+/* .guest-locked { filter: grayscale(0); } */
+
 /* Language grid */
 .lang-grid {
   display: grid;


### PR DESCRIPTION
## Summary
- hide `SiteHeader` when no user is authenticated
- disable all home page interactions for guests except auth buttons
- add CSS to allow only auth buttons to receive pointer events on home

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations, and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a313453083299b55a17354c7305d