### PR TITLE
brand: The Naturverse + 2025 copyright + socials

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,19 @@
-import type { Metadata } from 'next';
-import { SITE_URL } from './lib/site';
+import { SITE } from '@/lib/site';
+import type { ReactNode } from 'react';
 import "../styles/globals.css";
 import "../styles/nav.css";
 
 // ensure absolute URLs in SEO metadata
-export const metadata: Metadata = {
-  metadataBase: new URL(SITE_URL),
+export const metadata = {
+  metadataBase: new URL(SITE.url),
+  title: {
+    default: SITE.name,
+    template: SITE.titleTemplate,
+  },
+  description: SITE.description,
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>{children}</body>

--- a/app/lib/site.ts
+++ b/app/lib/site.ts
@@ -1,1 +1,0 @@
-export const SITE_URL = 'https://thenaturverse.com'; // change if needed

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,9 +1,8 @@
-import type { MetadataRoute } from 'next';
-import { SITE_URL } from './lib/site';
+import { SITE } from '@/lib/site';
 
 export const dynamic = 'force-static';
 
-export default function robots(): MetadataRoute.Robots {
+export default function robots() {
   return {
     rules: [
       {
@@ -12,7 +11,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ['/api/*'],
       },
     ],
-    sitemap: `${SITE_URL}/sitemap.xml`,
-    host: SITE_URL,
+    sitemap: `${SITE.url}/sitemap.xml`,
+    host: SITE.url,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,4 @@
-import type { MetadataRoute } from 'next';
-import { SITE_URL } from './lib/site';
+import { SITE } from '@/lib/site';
 
 export const dynamic = 'force-static';
 
@@ -18,11 +17,11 @@ const PAGES = [
   '/turian',
 ];
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default function sitemap() {
   const now = new Date();
 
   return PAGES.map((path, i) => ({
-    url: `${SITE_URL}${path}`,
+    url: `${SITE.url}${path}`,
     lastModified: now,
     changeFrequency: path === '/' ? 'weekly' : 'monthly',
     priority: path === '/' ? 1 : 0.7 - i * 0.01,

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,17 +1,18 @@
-import React from "react";
-import { FOOTER_LINKS } from "../data/footer";
+import { SITE } from '@/lib/site';
 
 export default function Footer() {
+  const s = SITE.socials;
+
   return (
     <footer className="site-footer">
-      <div className="container" style={{display:"flex",justifyContent:"space-between",alignItems:"center",gap:12}}>
-        <small style={{ color: "var(--nv-blue-600)" }}>
-          © {new Date().getFullYear()} Naturverse™
-        </small>
-        <nav style={{display:"flex",gap:12,flexWrap:"wrap"}}>
-          {FOOTER_LINKS.map(l => (
-            <a key={l.href} href={l.href} className="muted">{l.label}</a>
-          ))}
+      <div className="container" style={{display:'flex',justifyContent:'space-between',alignItems:'center',gap:12}}>
+        <small style={{ color: 'var(--nv-blue-600)' }}>{SITE.copyright}</small>
+        <nav style={{display:'flex',gap:12,flexWrap:'wrap'}}>
+          <a style={{ color: 'var(--nv-blue-600)' }} href={s.youtube} target="_blank" rel="noreferrer">YouTube</a>
+          <a style={{ color: 'var(--nv-blue-600)' }} href={s.tiktok} target="_blank" rel="noreferrer">TikTok</a>
+          <a style={{ color: 'var(--nv-blue-600)' }} href={s.facebook} target="_blank" rel="noreferrer">Facebook</a>
+          <a style={{ color: 'var(--nv-blue-600)' }} href={s.x} target="_blank" rel="noreferrer">X</a>
+          <a style={{ color: 'var(--nv-blue-600)' }} href={s.instagram} target="_blank" rel="noreferrer">Instagram</a>
         </nav>
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import styles from './Header.module.css'
 import { useAuth } from '../hooks/useAuth'
+import { SITE } from '@/lib/site'
 
 export default function Header() {
   const { user, loading } = useAuth()
@@ -8,7 +9,7 @@ export default function Header() {
   return (
     <header className={styles.header}>
       <div className={styles.brand}>
-        <Link to="/">🌿 Naturverse</Link>
+        <Link to="/">🌿 {SITE.name}</Link>
       </div>
 
       {!loading && user && (

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -6,6 +6,7 @@ import Img from './Img';
 import AuthButton from './AuthButton';
 import CartBadge from './CartBadge';
 import { supabase } from '@/lib/supabase-client';
+import { SITE } from '@/lib/site';
 
 export default function SiteHeader() {
   const [open, setOpen] = useState(false);
@@ -31,8 +32,8 @@ export default function SiteHeader() {
       <div className="container">
         <div className="nav-left">
           <Link to="/" className="brand" onClick={() => setOpen(false)}>
-            <Img src="/favicon-32x32.png" width="28" height="28" alt="Naturverse" />
-            <span>Naturverse</span>
+            <Img src="/favicon-32x32.png" width="28" height="28" alt={SITE.shortName} />
+            <span>{SITE.name}</span>
           </Link>
           <nav className="nav nav-links">
             <NavLink

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -1,25 +1,22 @@
+import { SITE } from './site';
+
 export const siteUrl =
-  import.meta.env.NEXT_PUBLIC_SITE_URL || 'https://thenaturverse.com';
+  import.meta.env.NEXT_PUBLIC_SITE_URL || SITE.url;
 
 export const organizationLd = {
   '@context': 'https://schema.org',
   '@type': 'Organization',
-  name: 'Naturverse',
+  name: SITE.name,
   url: siteUrl,
   logo: `${siteUrl}/favicons/android-chrome-192x192.png`,
-  sameAs: [
-    'https://x.com/naturverse',
-    'https://instagram.com/naturverse',
-    'https://youtube.com/@naturverse',
-    'https://discord.gg',
-  ],
+  sameAs: Object.values(SITE.socials),
 };
 
 export const websiteLd = {
   '@context': 'https://schema.org',
   '@type': 'WebSite',
   url: siteUrl,
-  name: 'Naturverse',
+  name: SITE.name,
 };
 
 export const breadcrumbs = (

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,21 @@
+export const SITE = {
+  url: "https://thenaturverse.com",
+  name: "The Naturverse",
+  shortName: "The Naturverse",
+  description:
+    "Adventures across 14 kingdoms—stories, games, and learning for kids and families.",
+  // used by <head> or layout metadata where template is applied
+  titleTemplate: "%s • The Naturverse",
+
+  // footer / legal
+  copyright: "© 2025 Turian Media Company",
+
+  // social profiles (use brand blue via classes in components)
+  socials: {
+    youtube: "https://www.youtube.com/@TuriantheDurian",
+    tiktok: "https://www.tiktok.com/@turian.the.durian",
+    facebook: "https://www.facebook.com/TurianMediaCompany",
+    x: "https://x.com/TuriantheDurain",
+    instagram: "https://www.instagram.com/turianthedurian",
+  },
+} as const;


### PR DESCRIPTION
## Summary
- rename site to The Naturverse and centralize metadata/social config
- show The Naturverse in headers and footer, update copyright to © 2025 Turian Media Company
- add brand-blue links for YouTube, TikTok, Facebook, X, and Instagram
- drop Next.js type imports from layout, robots and sitemap modules to restore type checking

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: Argument of type 'Partial<Omit<...>>' is not assignable to parameter of type 'never')

------
https://chatgpt.com/codex/tasks/task_e_68b9971193d083298889d5b10550c213