### PR TITLE
refactor: unify brand and nav

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { useUser } from '@supabase/auth-helpers-react';
 import styles from '@/styles/Home.module.css';
 import { signInWithGoogle, sendMagicLink } from '@/lib/auth';
+import { BRAND_NAME } from '@/lib/brand';
 
 export default function Home() {
   const user = useUser();
@@ -32,7 +33,7 @@ export default function Home() {
   return (
     <main className={styles.home}>
       <section className={styles.hero}>
-        <h1>Welcome to the Naturverse™</h1>
+        <h1>Welcome to {BRAND_NAME}</h1>
         <p className="welcome-subtitle">A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.</p>
         {!user && <SignedOutCTA />}
       </section>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import ProfileHead from '@/components/ProfileHead';
 import { useAuth } from '@/lib/auth-context';
+import { BRAND_NAME } from '@/lib/brand';
 
 export default function NavBar() {
   const { ready, user } = useAuth();
@@ -13,13 +14,12 @@ export default function NavBar() {
   return (
     <header className="nv-nav">
       <div className="nv-nav-inner">
-        <Link className="nv-brand" href="/">Naturverse</Link>
+        <Link className="nv-brand" href="/">{BRAND_NAME}</Link>
 
         <nav className="nv-links">
           <Link className="nv-link" href="/worlds">Worlds</Link>
           <Link className="nv-link" href="/zones">Zones</Link>
           <Link className="nv-link" href="/marketplace">Marketplace</Link>
-          <Link className="nv-link" href="/wishlist">Wishlist</Link>
           <Link className="nv-link" href="/naturversity">Naturversity</Link>
           <Link className="nv-link" href="/naturbank">NaturBank</Link>
           {/* Navatar is always enabled */}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Naturverse</title>
+    <title>The Naturverse</title>
     <meta name="theme-color" content="#0ea5e9" />
 
     <!-- Replace deprecated Apple-only meta with cross-platform one -->
@@ -13,9 +13,9 @@
     <!-- SEO base -->
     <meta
       name="description"
-      content="Naturverse™ — playful worlds, learning quests, and kid-friendly creation."
+      content="The Naturverse — playful worlds, learning quests, and kid-friendly creation."
     />
-    <meta property="og:title" content="Naturverse" />
+    <meta property="og:title" content="The Naturverse" />
     <meta
       property="og:description"
       content="Play, learn, and explore kingdoms with your Navatar."
@@ -24,7 +24,7 @@
     <meta property="og:url" content="https://naturverse.netlify.app/" />
     <meta property="og:image" content="/favicon-512.png" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Naturverse" />
+    <meta name="twitter:title" content="The Naturverse" />
     <meta
       name="twitter:description"
       content="Play, learn, and explore kingdoms with your Navatar."

--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Img from './Img';
+import { BRAND_NAME } from '@/lib/brand';
 
 export type CardData = {
   id: string;
@@ -56,7 +57,7 @@ export const CharacterCard: React.FC<{ data: CardData }> = ({ data }) => {
         </dl>
       </div>
 
-      <div className="nv-card__footer">Naturverse • Character Card</div>
+      <div className="nv-card__footer">{BRAND_NAME} • Character Card</div>
     </div>
   );
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,18 +1,22 @@
-import { SITE } from '@/lib/site';
+import { COPYRIGHT, SOCIALS } from '@/lib/brand';
 
 export default function Footer() {
-  const s = SITE.socials;
-
   return (
     <footer className="site-footer">
-      <div className="container" style={{display:'flex',justifyContent:'space-between',alignItems:'center',gap:12}}>
-        <small style={{ color: 'var(--nv-blue-600)' }}>{SITE.copyright}</small>
-        <nav style={{display:'flex',gap:12,flexWrap:'wrap'}}>
-          <a style={{ color: 'var(--nv-blue-600)' }} href={s.youtube} target="_blank" rel="noreferrer">YouTube</a>
-          <a style={{ color: 'var(--nv-blue-600)' }} href={s.tiktok} target="_blank" rel="noreferrer">TikTok</a>
-          <a style={{ color: 'var(--nv-blue-600)' }} href={s.facebook} target="_blank" rel="noreferrer">Facebook</a>
-          <a style={{ color: 'var(--nv-blue-600)' }} href={s.x} target="_blank" rel="noreferrer">X</a>
-          <a style={{ color: 'var(--nv-blue-600)' }} href={s.instagram} target="_blank" rel="noreferrer">Instagram</a>
+      <div className="container flex justify-between items-center gap-3">
+        <p className="text-sm">{COPYRIGHT}</p>
+        <nav className="flex flex-wrap gap-4">
+          {SOCIALS.map((s) => (
+            <a
+              key={s.label}
+              href={s.href}
+              target="_blank"
+              rel="noreferrer"
+              className="link-blue"
+            >
+              {s.label}
+            </a>
+          ))}
         </nav>
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom'
 import styles from './Header.module.css'
 import { useAuth } from '../hooks/useAuth'
-import { SITE } from '@/lib/site'
+import { BRAND_NAME } from '@/lib/brand'
 
 export default function Header() {
   const { user, loading } = useAuth()
@@ -9,7 +9,7 @@ export default function Header() {
   return (
     <header className={styles.header}>
       <div className={styles.brand}>
-        <Link to="/">🌿 {SITE.name}</Link>
+        <Link to="/">🌿 {BRAND_NAME}</Link>
       </div>
 
       {!loading && user && (
@@ -17,7 +17,6 @@ export default function Header() {
           <Link to="/worlds">Worlds</Link>
           <Link to="/zones">Zones</Link>
           <Link to="/marketplace">Marketplace</Link>
-          <Link to="/wishlist">Wishlist</Link>
           <Link to="/naturversity">Naturversity</Link>
           <Link to="/naturbank">NaturBank</Link>
           <Link to="/navatar">Navatar</Link>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import SafeImg from "./SafeImg";
+import { BRAND_NAME } from "@/lib/brand";
 
 const isActive = (href: string) => typeof window !== "undefined" && window.location.pathname === href;
 
@@ -8,8 +9,8 @@ export default function Nav() {
     <>
       <a href="#main-content" className="visually-hidden-focusable">Skip to content</a>
         <nav className="topnav container">
-          <a href="/" aria-label="Naturverse Home" className={`toplink brand ${isActive("/") ? "active" : ""}`}>
-            <SafeImg src="/favicon-32x32.png" alt="Naturverse" width={24} height={24} />
+          <a href="/" aria-label={`${BRAND_NAME} Home`} className={`toplink brand ${isActive("/") ? "active" : ""}`}>
+            <SafeImg src="/favicon-32x32.png" alt={BRAND_NAME} width={24} height={24} />
           </a>
           <div className="links">
             <a href="/worlds" className={`toplink ${isActive("/worlds") ? "active" : ""}`}>Worlds</a>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { useState } from 'react';
 import styles from './NavBar.module.css';
 import { useAuth } from '@/lib/auth-context';
+import { BRAND_NAME } from '@/lib/brand';
 
 export default function NavBar() {
   const { ready, user } = useAuth();
@@ -17,13 +18,13 @@ export default function NavBar() {
         <a
           href="/"
           className="flex items-center gap-2"
-          aria-label="Naturverse home"
+          aria-label={`${BRAND_NAME} home`}
         >
           <picture>
             <source srcSet="/favicon.svg" type="image/svg+xml" />
             <img
               src="/favicon-64x64.png"
-              alt="Naturverse"
+              alt={BRAND_NAME}
               className="nv-logo"
               width={40}
               height={40}
@@ -32,14 +33,13 @@ export default function NavBar() {
             />
           </picture>
 
-          <span className="nv-brand text-nv-blue">Naturverse</span>
+          <span className="nv-brand text-nv-blue">{BRAND_NAME}</span>
         </a>
 
         <nav className={styles.links} aria-label="Primary">
           <Link to="/worlds">Worlds</Link>
           <Link to="/zones">Zones</Link>
           <Link to="/marketplace">Marketplace</Link>
-          <Link to="/wishlist">Wishlist</Link>
           <Link to="/naturversity">Naturversity</Link>
           <Link to="/naturbank">NaturBank</Link>
           <Link to="/navatar">Navatar</Link>
@@ -83,7 +83,6 @@ export default function NavBar() {
           <Link to="/worlds">Worlds</Link>
           <Link to="/zones">Zones</Link>
           <Link to="/marketplace">Marketplace</Link>
-          <Link to="/wishlist">Wishlist</Link>
           <Link to="/naturversity">Naturversity</Link>
           <Link to="/naturbank">NaturBank</Link>
           <Link to="/navatar">Navatar</Link>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -4,8 +4,8 @@ import './site-header.css';
 import Img from './Img';
 import AuthButton from './AuthButton';
 import CartBadge from './CartBadge';
-import { SITE } from '@/lib/site';
 import { useAuth } from '@/lib/auth-context';
+import { BRAND_NAME } from '@/lib/brand';
 
 export default function SiteHeader() {
   const [open, setOpen] = useState(false);
@@ -18,8 +18,8 @@ export default function SiteHeader() {
       <div className="container">
         <div className="nav-left">
           <Link to="/" className="brand" onClick={() => setOpen(false)}>
-            <Img src="/favicon-32x32.png" width="28" height="28" alt={SITE.shortName} />
-            <span>{SITE.name}</span>
+            <Img src="/favicon-32x32.png" width="28" height="28" alt={BRAND_NAME} />
+            <span>{BRAND_NAME}</span>
           </Link>
           <nav className="nav nav-links">
             <NavLink
@@ -42,13 +42,6 @@ export default function SiteHeader() {
               onClick={() => setOpen(false)}
             >
               Marketplace
-            </NavLink>
-            <NavLink
-              to="/wishlist"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              Wishlist
             </NavLink>
             <NavLink
               to="/naturversity"

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -77,7 +77,6 @@ export default function UserMenu() {
           </div>
           <a href="/profile" className="item">Profile</a>
           <a href="/passport" className="item">Passport</a>
-          <a href="/wishlist" className="item">Wishlist</a>
           <button
             className="item danger"
             onClick={async () => {

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Naturverse</title>
+    <title>The Naturverse</title>
     <!-- Naturverse: UI polish -->
     <meta name="theme-color" content="#2F7AE5" />
     <meta name="color-scheme" content="light" />

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -1,0 +1,9 @@
+export const BRAND_NAME = 'The Naturverse';
+export const COPYRIGHT = '© 2025 Turian Media Company';
+export const SOCIALS = [
+  { label: 'YouTube',   href: 'https://www.youtube.com/@TuriantheDurian' },
+  { label: 'TikTok',    href: 'https://www.tiktok.com/@turian.the.durian' },
+  { label: 'Facebook',  href: 'https://www.facebook.com/TurianMediaCompany' },
+  { label: 'X',         href: 'https://x.com/TuriantheDurain' },
+  { label: 'Instagram', href: 'https://www.instagram.com/turianthedurian' },
+];

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,8 +1,10 @@
+import { BRAND_NAME } from '@/lib/brand';
+
 export default function About() {
   return (
     <main id="main">
-      <h1>About Naturverse</h1>
-      <p>Naturverse is a playful, educational world built by Turian Media. More info coming soon.</p>
+      <h1>About {BRAND_NAME}</h1>
+      <p>{BRAND_NAME} is a playful, educational world built by Turian Media. More info coming soon.</p>
     </main>
   );
 }

--- a/src/pages/Accessibility.tsx
+++ b/src/pages/Accessibility.tsx
@@ -1,8 +1,13 @@
+import { BRAND_NAME } from '@/lib/brand';
+
 export default function Accessibility() {
   return (
     <main id="main">
       <h1>Accessibility</h1>
-      <p>We’re working to make Naturverse usable for everyone. If you encounter issues, contact us at <a href="mailto:accessibility@naturverse.com">accessibility@naturverse.com</a>.</p>
+      <p>
+        We’re working to make {BRAND_NAME} usable for everyone. If you encounter issues, contact us at
+        <a href="mailto:accessibility@naturverse.com">accessibility@naturverse.com</a>.
+      </p>
     </main>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { signInWithGoogle, sendMagicLink } from '@/lib/auth';
 import { useAuth } from '@/lib/auth-context';
 import ClickableCard from '@/components/ClickableCard';
+import { BRAND_NAME } from '@/lib/brand';
 
 export default function Home() {
   const { user } = useAuth();
@@ -11,7 +12,7 @@ export default function Home() {
   return (
     <main className={`${styles.page} ${!user ? 'guest-locked' : ''}`}>
       <section className={styles.hero}>
-        <h1 className={styles.title}>Welcome to the Naturverse™</h1>
+        <h1 className={styles.title}>Welcome to {BRAND_NAME}</h1>
         <p className={styles.subtitle}>
           A playful world of kingdoms, characters, and quests that teach wellness, creativity, and
           kindness.

--- a/src/pages/Navatar.tsx
+++ b/src/pages/Navatar.tsx
@@ -8,6 +8,7 @@ import Meta from "../components/Meta";
 import Breadcrumbs from "../components/Breadcrumbs";
 import PageHead from "../components/PageHead";
 import ShareNavatar from "../components/ShareNavatar";
+import { BRAND_NAME } from "../lib/brand";
 
 const BASES: NavatarBase[] = ["Animal", "Fruit", "Insect", "Spirit"];
 
@@ -69,8 +70,14 @@ export default function NavatarPage() {
 
   return (
     <div className="nvrs-section navatar page-wrap nv-secondary-scope nav-page">
-      <PageHead title="Naturverse — Navatar Creator" description="Design your character and save cards." />
-      <Meta title="Navatar Creator — Naturverse" description="Design your character and save cards." />
+      <PageHead
+        title={`${BRAND_NAME} — Navatar Creator`}
+        description="Design your character and save cards."
+      />
+      <Meta
+        title={`Navatar Creator — ${BRAND_NAME}`}
+        description="Design your character and save cards."
+      />
       <Breadcrumbs items={[{ href:"/", label:"Home" }, { label:"Navatar" }]} />
       <main id="main" data-page="navatar" className="page container navatar-page">
         <h1>Navatar Creator</h1>

--- a/src/pages/_meta.ts
+++ b/src/pages/_meta.ts
@@ -1,3 +1,5 @@
+import { BRAND_NAME } from "@/lib/brand";
+
 export const setTitle = (t: string) => {
-  if (typeof document !== "undefined") document.title = t ? `${t} · Naturverse` : "Naturverse";
+  if (typeof document !== "undefined") document.title = t ? `${t} · ${BRAND_NAME}` : BRAND_NAME;
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import { useAuth } from '@/lib/auth-context';
 import { Link, useNavigate } from 'react-router-dom';
 import { signInWithGoogle } from '@/lib/auth';
 import styles from '@/styles/home.module.css';
+import { BRAND_NAME } from '@/lib/brand';
 
 export default function Home() {
   const { user } = useAuth();
@@ -19,7 +20,7 @@ export default function Home() {
   return (
     <main className={styles.page}>
       <section className={styles.hero}>
-        <h1 className={styles.title}>Welcome to the Naturverse™</h1>
+        <h1 className={styles.title}>Welcome to {BRAND_NAME}</h1>
         <p className={styles.tagline}>
           A playful world of kingdoms, characters, and quests that teach wellness, creativity, and kindness.
         </p>

--- a/src/pages/zones/Future.tsx
+++ b/src/pages/zones/Future.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
+import { BRAND_NAME } from "@/lib/brand";
 
 export default function FutureZone() {
   return (
@@ -9,14 +10,14 @@ export default function FutureZone() {
 
         <h1>🔮 Future Zone</h1>
       <p className="muted">
-        A sneak peek at what's coming to the Naturverse. These features are in active design.
+        A sneak peek at what's coming to {BRAND_NAME}. These features are in active design.
       </p>
 
       <div className="cards">
         <a className="card" href="#" aria-disabled="true">
           <div className="tag soon">Coming Soon</div>
           <h2>AR / VR</h2>
-          <p>Immersive augmented & virtual reality adventures inside the Naturverse.</p>
+          <p>Immersive augmented & virtual reality adventures inside {BRAND_NAME}.</p>
         </a>
 
         <a className="card" href="#" aria-disabled="true">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import HubCard from '../components/HubCard';
 import HubGrid from '../components/HubGrid';
 import "./Home.css";
 import { Img } from '../components';
+import { BRAND_NAME } from '@/lib/brand';
 
 export default function Home() {
   return (
@@ -18,7 +19,7 @@ export default function Home() {
             alt=""
             aria-hidden="true"
           />
-          Welcome to the Naturverse™
+          Welcome to {BRAND_NAME}
         </h1>
         <p>Pick a hub to begin your adventure.</p>
       </header>

--- a/src/routes/zones/music/index.tsx
+++ b/src/routes/zones/music/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import Breadcrumbs from "../../../components/Breadcrumbs";
 import { autoGrantOncePerDay } from "@/lib/rewards";
 import { useToast } from "@/components/Toast";
+import { BRAND_NAME } from "@/lib/brand";
 import "../../../styles/zone-widgets.css";
 
   export default function Music() {
@@ -241,7 +242,7 @@ function StepSequencer() {
 /* ---------- Karaoke ---------- */
 type KLine = { t: number; text: string };
 const LYRICS: KLine[] = [
-  { t: 0, text: "Welcome to the Naturverse," },
+  { t: 0, text: `Welcome to the ${BRAND_NAME},` },
   { t: 2, text: "where winds and rivers rhyme." },
   { t: 4, text: "Pick a world and start your quest," },
   { t: 6, text: "one beat at a time." },


### PR DESCRIPTION
## Summary
- centralize brand info in `brand.ts`
- update header/footer to use brand constants and drop wishlist
- hide wishlist from user menu and top navs
- replace hardcoded Naturverse text with brand constant across pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b9f9dfb48329bea68ea91d0bb053