### PR TITLE
footer: lock 2025 copyright (brand-blue) + spaced socials

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,16 +5,31 @@ export default function Footer() {
 
   return (
     <footer className="site-footer">
-      <div className="container" style={{display:'flex',justifyContent:'space-between',alignItems:'center',gap:12}}>
-        <small style={{ color: 'var(--nv-blue-600)' }}>{SITE.copyright}</small>
-        <nav style={{display:'flex',gap:12,flexWrap:'wrap'}}>
-          <a style={{ color: 'var(--nv-blue-600)' }} href={s.youtube} target="_blank" rel="noreferrer">YouTube</a>
-          <a style={{ color: 'var(--nv-blue-600)' }} href={s.tiktok} target="_blank" rel="noreferrer">TikTok</a>
-          <a style={{ color: 'var(--nv-blue-600)' }} href={s.facebook} target="_blank" rel="noreferrer">Facebook</a>
-          <a style={{ color: 'var(--nv-blue-600)' }} href={s.x} target="_blank" rel="noreferrer">X</a>
-          <a style={{ color: 'var(--nv-blue-600)' }} href={s.instagram} target="_blank" rel="noreferrer">Instagram</a>
+      <div
+        className="container"
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: 12,
+          flexWrap: 'wrap',
+        }}
+      >
+        {/* Copyright in brand blue */}
+        <small style={{ color: 'var(--nv-blue-600)' }}>
+          © 2025 Turian Media Company
+        </small>
+
+        {/* Socials with guaranteed spacing */}
+        <nav aria-label="Social links" style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+          <a style={{ color: 'var(--nv-blue-600)' }} href={s.youtube}   target="_blank" rel="noopener noreferrer">YouTube</a>
+          <a style={{ color: 'var(--nv-blue-600)' }} href={s.tiktok}    target="_blank" rel="noopener noreferrer">TikTok</a>
+          <a style={{ color: 'var(--nv-blue-600)' }} href={s.facebook}  target="_blank" rel="noopener noreferrer">Facebook</a>
+          <a style={{ color: 'var(--nv-blue-600)' }} href={s.x}         target="_blank" rel="noopener noreferrer">X</a>
+          <a style={{ color: 'var(--nv-blue-600)' }} href={s.instagram} target="_blank" rel="noopener noreferrer">Instagram</a>
         </nav>
       </div>
     </footer>
   );
 }
+


### PR DESCRIPTION
## Summary
- fix footer copyright to always show 2025 in brand blue
- ensure social links are spaced, open in new tabs, and use noopener noreferrer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ba51bbb5e88329aecf71b75d18ecc0