### PR TITLE
Add Marketplace tabs and remove Wishlist from navigation

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,7 +9,6 @@ const PAGES = [
   '/zones',
   '/marketplace',
   '/cart',
-  '/wishlist',
   '/marketplace/checkout',
   '/naturversity',
   '/naturbank',

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -19,7 +19,6 @@ export default function NavBar() {
           <Link className="nv-link" href="/worlds">Worlds</Link>
           <Link className="nv-link" href="/zones">Zones</Link>
           <Link className="nv-link" href="/marketplace">Marketplace</Link>
-          <Link className="nv-link" href="/wishlist">Wishlist</Link>
           <Link className="nv-link" href="/naturversity">Naturversity</Link>
           <Link className="nv-link" href="/naturbank">NaturBank</Link>
           {/* Navatar is always enabled */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,7 +17,6 @@ export default function Header() {
           <Link to="/worlds">Worlds</Link>
           <Link to="/zones">Zones</Link>
           <Link to="/marketplace">Marketplace</Link>
-          <Link to="/wishlist">Wishlist</Link>
           <Link to="/naturversity">Naturversity</Link>
           <Link to="/naturbank">NaturBank</Link>
           <Link to="/navatar">Navatar</Link>

--- a/src/components/MarketTabs.tsx
+++ b/src/components/MarketTabs.tsx
@@ -1,0 +1,24 @@
+import { NavLink } from "react-router-dom";
+
+export default function MarketTabs() {
+  const tab = (to: string, label: string) => (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        "mk-tab" + (isActive ? " is-active" : "")
+      }
+      end
+    >
+      {label}
+    </NavLink>
+  );
+
+  return (
+    <div className="mk-tabs">
+      {tab("/marketplace", "Shop")}
+      {tab("/marketplace/nft", "NFT / Mint")}
+      {tab("/marketplace/specials", "Specials")}
+      {tab("/marketplace/wishlist", "Wishlist")}
+    </div>
+  );
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -39,7 +39,6 @@ export default function NavBar() {
           <Link to="/worlds">Worlds</Link>
           <Link to="/zones">Zones</Link>
           <Link to="/marketplace">Marketplace</Link>
-          <Link to="/wishlist">Wishlist</Link>
           <Link to="/naturversity">Naturversity</Link>
           <Link to="/naturbank">NaturBank</Link>
           <Link to="/navatar">Navatar</Link>
@@ -83,7 +82,6 @@ export default function NavBar() {
           <Link to="/worlds">Worlds</Link>
           <Link to="/zones">Zones</Link>
           <Link to="/marketplace">Marketplace</Link>
-          <Link to="/wishlist">Wishlist</Link>
           <Link to="/naturversity">Naturversity</Link>
           <Link to="/naturbank">NaturBank</Link>
           <Link to="/navatar">Navatar</Link>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -44,13 +44,6 @@ export default function SiteHeader() {
               Marketplace
             </NavLink>
             <NavLink
-              to="/wishlist"
-              className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
-              onClick={() => setOpen(false)}
-            >
-              Wishlist
-            </NavLink>
-            <NavLink
               to="/naturversity"
               className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
               onClick={() => setOpen(false)}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -77,7 +77,7 @@ export default function UserMenu() {
           </div>
           <a href="/profile" className="item">Profile</a>
           <a href="/passport" className="item">Passport</a>
-          <a href="/wishlist" className="item">Wishlist</a>
+          <a href="/marketplace/wishlist" className="item">Wishlist</a>
           <button
             className="item danger"
             onClick={async () => {

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -1,7 +1,7 @@
-import Breadcrumbs from "../../components/Breadcrumbs";
+import { Link } from "react-router-dom";
+import MarketTabs from "../../components/MarketTabs";
 import AddToCartButton from "../../components/AddToCartButton";
 import SaveButton from "../../components/SaveButton";
-import { Link } from "react-router-dom";
 import "../../styles/_cards.css";
 import "../../styles/marketplace.css";
 
@@ -11,11 +11,18 @@ const PRODUCTS = [
   { id:"stickers",     name:"Sticker Pack", price:6,  image:"/Marketplace/Stickerpack.png", href:"/marketplace/stickers" },
 ];
 
-export default function MarketplacePage(){
+export default function MarketplaceShop() {
   return (
-    <main id="main" data-page="marketplace" className="nvrs-section marketplace nv-secondary-scope">
-      <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Marketplace" }]} />
-      <h1 className="page-title">Marketplace</h1>
+    <main className="container">
+      <div className="mk-head">
+        <div className="mk-breadcrumbs">
+          <Link to="/">Home</Link> / <span>Marketplace</span>
+        </div>
+        <h1>Marketplace</h1>
+      </div>
+
+      <MarketTabs />
+
       <div className="mp-grid nv-card-grid">
         {PRODUCTS.map(p => (
           <article key={p.id} className="mp-card nv-card">

--- a/src/pages/marketplace/nft.tsx
+++ b/src/pages/marketplace/nft.tsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+import MarketTabs from "../../components/MarketTabs";
+import "../../styles/marketplace.css";
+
+export default function MarketplaceNFT() {
+  return (
+    <main className="container">
+      <div className="mk-head">
+        <div className="mk-breadcrumbs">
+          <Link to="/">Home</Link> / <Link to="/marketplace">Marketplace</Link> / <span>NFT / Mint</span>
+        </div>
+        <h1>Marketplace</h1>
+      </div>
+
+      <MarketTabs />
+      <p style={{ textAlign: "center", marginTop: "1.5rem" }}>
+        NFT / Mint — coming soon.
+      </p>
+    </main>
+  );
+}

--- a/src/pages/marketplace/specials.tsx
+++ b/src/pages/marketplace/specials.tsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+import MarketTabs from "../../components/MarketTabs";
+import "../../styles/marketplace.css";
+
+export default function MarketplaceSpecials() {
+  return (
+    <main className="container">
+      <div className="mk-head">
+        <div className="mk-breadcrumbs">
+          <Link to="/">Home</Link> / <Link to="/marketplace">Marketplace</Link> / <span>Specials</span>
+        </div>
+        <h1>Marketplace</h1>
+      </div>
+
+      <MarketTabs />
+      <p style={{ textAlign: "center", marginTop: "1.5rem" }}>
+        Specials — coming soon. Seasonal or limited-time offers will appear here.
+      </p>
+    </main>
+  );
+}

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+import MarketTabs from "../../components/MarketTabs";
+import "../../styles/marketplace.css";
+
+export default function MarketplaceWishlist() {
+  return (
+    <main className="container">
+      <div className="mk-head">
+        <div className="mk-breadcrumbs">
+          <Link to="/">Home</Link> / <Link to="/marketplace">Marketplace</Link> / <span>Wishlist</span>
+        </div>
+        <h1>Marketplace</h1>
+      </div>
+
+      <MarketTabs />
+      <p style={{ textAlign: "center", marginTop: "1.5rem" }}>
+        Wishlist — coming soon.
+      </p>
+    </main>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, Navigate } from 'react-router-dom';
 
 import Home from './pages/Home';
 import WorldsIndex from './routes/worlds';
@@ -16,10 +16,12 @@ import Observations from './pages/zones/Observations';
 import Community from './pages/zones/Community';
 import Culture from './pages/zones/Culture';
 import FutureZone from './pages/zones/Future';
-import MarketplacePage from './pages/marketplace';
+import MarketplaceShop from './pages/marketplace';
+import MarketplaceNFT from './pages/marketplace/nft';
+import MarketplaceSpecials from './pages/marketplace/specials';
+import MarketplaceWishlist from './pages/marketplace/wishlist';
 import ProductPage from './pages/marketplace/[slug]';
 import CartPage from './pages/cart';
-import WishlistPage from './pages/wishlist';
 import Naturversity from './pages/Naturversity';
 import Teachers from './pages/naturversity/Teachers';
 import Partners from './pages/naturversity/Partners';
@@ -77,12 +79,15 @@ export const router = createBrowserRouter([
       {
         path: 'marketplace',
         children: [
-          { index: true, element: <MarketplacePage /> },
+          { index: true, element: <MarketplaceShop /> },
+          { path: 'nft', element: <MarketplaceNFT /> },
+          { path: 'specials', element: <MarketplaceSpecials /> },
+          { path: 'wishlist', element: <MarketplaceWishlist /> },
           { path: ':slug', element: <ProductPage /> },
         ],
       },
       { path: 'cart', element: <CartPage /> },
-      { path: 'wishlist', element: <WishlistPage /> },
+      { path: 'wishlist', element: <Navigate to="/marketplace/wishlist" replace /> },
       {
         path: 'naturversity',
         element: <NaturversityLayout />,

--- a/src/styles/marketplace.css
+++ b/src/styles/marketplace.css
@@ -1,3 +1,36 @@
+/* Marketplace tab styles */
+.mk-head {
+  margin: 0 0 1rem 0;
+}
+.mk-breadcrumbs {
+  margin: 0 0 .75rem 0;
+  color: var(--nv-blue-500);
+}
+.mk-breadcrumbs a { color: inherit; }
+
+.mk-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+  justify-content: center;      /* centered on mobile */
+  margin: .5rem 0 1.25rem;
+}
+
+.mk-tab {
+  display: inline-block;
+  padding: .6rem .9rem;
+  border: 2px solid var(--nv-blue-200);
+  border-radius: .9rem;
+  text-decoration: none;
+  color: var(--nv-blue-700);
+  background: white;
+}
+
+.mk-tab.is-active {
+  border-color: var(--nv-blue-400);
+  box-shadow: 0 0 0 2px rgba(60,100,255,.06) inset;
+}
+
 /* Marketplace button consistency */
 .marketplace button,
 .marketplace .save-btn,


### PR DESCRIPTION
## Summary
- remove Wishlist from top navigation components
- add centered Marketplace tabs with Shop, NFT/Mint, Specials and Wishlist sections
- stub NFT/Mint, Specials and Wishlist pages with breadcrumbs and "coming soon" placeholders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ba60adf3108329a2a79bf9a6d1148c