### PR TITLE
Add global Turian assistant (floating chat) with swappable dev AI

### DIFF
--- a/netlify/functions/dev-chat.ts
+++ b/netlify/functions/dev-chat.ts
@@ -1,0 +1,61 @@
+import type { Handler } from '@netlify/functions';
+
+type Msg = { role: 'user' | 'assistant' | 'system'; content: string };
+
+const OLLAMA_URL = process.env.OLLAMA_URL; // e.g. http://localhost:11434
+
+async function ollamaChat(messages: Msg[]) {
+  // Minimal proxy to Ollama's chat API (if available)
+  const res = await fetch(`${OLLAMA_URL}/api/chat`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'llama3.1', messages }),
+  });
+  if (!res.ok) throw new Error('ollama error');
+  const json = await res.json();
+  const reply: string = json?.message?.content ?? '…';
+  return reply;
+}
+
+function cannedReply(path: string, lastUser: string) {
+  // Simple, zone-aware helper text for demos
+  const byZone: Record<string, string> = {
+    '/marketplace': `You're in Marketplace. You can browse "Shop", "NFT/Mint", and "Specials". \
+Try "What can I buy?"`,
+    '/navatar': `You're in Navatar. Use Create (generator), Pick (from library), or Upload (camera). \
+Try "Help me make a scooter Navatar!"`,
+    '/naturversity': `You're in Naturversity. Ask for languages, courses, or tips. \
+Try "Teach me 'hello' in Thai."`,
+  };
+
+  const zoneTip =
+    Object.entries(byZone).find(([key]) => path.startsWith(key))?.[1] ??
+    `You're on The Naturverse. Ask about Worlds, Zones, or getting started.`;
+
+  return `${zoneTip}
+
+You said: "${lastUser}"
+Tip: You can ask me to navigate (e.g., "take me to Marketplace Specials") or explain a feature.`;
+}
+
+export const handler: Handler = async (event) => {
+  try {
+    const body = JSON.parse(event.body || '{}') as { messages: Msg[]; path?: string };
+    const lastUser = [...(body.messages ?? [])].reverse().find(m => m.role === 'user')?.content ?? '';
+    const path = body.path ?? '/';
+
+    // If local + Ollama is configured, use it; otherwise use canned replies.
+    if (OLLAMA_URL && (process.env.NETLIFY_LOCAL || process.env.CONTEXT === 'dev')) {
+      try {
+        const reply = await ollamaChat(body.messages ?? []);
+        return Response.json({ reply });
+      } catch {
+        // fall through to canned
+      }
+    }
+    const reply = cannedReply(path, lastUser);
+    return Response.json({ reply });
+  } catch (err: any) {
+    return Response.json({ reply: `Oops, I hit a snag: ${err?.message ?? err}` }, { status: 200 });
+  }
+};

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import NavBar from './NavBar';
+import TurianAssistant from './ai/TurianAssistant';
 
 type Props = { children: ReactNode; title?: ReactNode; breadcrumbs?: ReactNode };
 
@@ -14,6 +15,7 @@ export default function Layout({ title, breadcrumbs, children }: Props) {
           {children}
         </div>
       </main>
+      <TurianAssistant />
     </>
   );
 }

--- a/src/components/ai/ChatDrawer.tsx
+++ b/src/components/ai/ChatDrawer.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from 'react';
+import { chat, type ChatMessage } from '../../lib/ai';
+import '../../styles/assistant.css';
+
+export default function ChatDrawer({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    { role: 'assistant', content: 'Hi! I’m Turian. Ask me about whatever’s on this page.' },
+  ]);
+  const [input, setInput] = useState('');
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (open) setTimeout(() => scrollRef.current?.scrollTo(0, 999999), 0);
+  }, [open, messages.length]);
+
+  async function send() {
+    const text = input.trim();
+    if (!text) return;
+    setInput('');
+    const next = [...messages, { role: 'user', content: text }];
+    setMessages(next);
+    try {
+      const reply = await chat(next, { path: window.location.pathname });
+      setMessages([...next, { role: 'assistant', content: reply }]);
+    } catch (err: any) {
+      setMessages([...next, { role: 'assistant', content: `Error: ${err?.message ?? err}` }]);
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <section className="turian-drawer" role="dialog" aria-label="Turian assistant">
+      <div className="turian-header">
+        <div className="turian-title">
+          <img src="/favicon-32x32.png" alt="" width={20} height={20} />
+          Turian Assistant
+        </div>
+        <button onClick={onClose} aria-label="Close">Close ✕</button>
+      </div>
+
+      <div ref={scrollRef} className="turian-body">
+        {messages.map((m, i) => (
+          <div key={i} className={`turian-msg ${m.role === 'user' ? 'me' : 'ai'}`}>{m.content}</div>
+        ))}
+      </div>
+
+      <form
+        className="turian-input"
+        onSubmit={(e) => {
+          e.preventDefault();
+          send();
+        }}
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask about this page, navigation, or features…"
+        />
+        <button type="submit">Send</button>
+      </form>
+    </section>
+  );
+}

--- a/src/components/ai/TurianAssistant.tsx
+++ b/src/components/ai/TurianAssistant.tsx
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+import ChatDrawer from './ChatDrawer';
+import '../../styles/assistant.css';
+
+export default function TurianAssistant() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        className="turian-fab"
+        aria-label="Open Turian assistant"
+        onClick={() => setOpen(true)}
+      >
+        <img src="/favicon-32x32.png" alt="" />
+      </button>
+      <ChatDrawer open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,12 @@
+export type ChatMessage = { role: 'user' | 'assistant' | 'system'; content: string };
+
+export async function chat(messages: ChatMessage[], extra?: { path?: string }) {
+  const res = await fetch('/.netlify/functions/dev-chat', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ messages, path: extra?.path ?? window.location.pathname }),
+  });
+  if (!res.ok) throw new Error(`chat failed: ${res.status}`);
+  const data = (await res.json()) as { reply: string };
+  return data.reply;
+}

--- a/src/styles/assistant.css
+++ b/src/styles/assistant.css
@@ -1,0 +1,89 @@
+.turian-fab {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 9999;
+  border: 2px solid var(--nv-blue-300);
+  background: white;
+  border-radius: 999px;
+  width: 52px;
+  height: 52px;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.08);
+}
+
+.turian-fab img {
+  width: 28px;
+  height: 28px;
+}
+
+.turian-drawer {
+  position: fixed;
+  inset: auto 0 0 0;
+  height: min(70vh, 560px);
+  background: #fff;
+  border-top: 2px solid var(--nv-blue-200);
+  box-shadow: 0 -10px 30px rgba(0,0,0,0.08);
+  z-index: 9998;
+  display: flex;
+  flex-direction: column;
+}
+
+.turian-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+  padding: .75rem 1rem;
+  border-bottom: 1px dashed var(--nv-blue-200);
+}
+
+.turian-title {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  font-weight: 700;
+  color: var(--nv-blue-700);
+}
+
+.turian-body {
+  padding: .75rem 1rem;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+
+.turian-msg {
+  max-width: 80%;
+  padding: .5rem .75rem;
+  border-radius: .75rem;
+  border: 1px solid var(--nv-blue-200);
+}
+
+.turian-msg.me { margin-left: auto; }
+.turian-msg.ai { background: #f7faff; }
+
+.turian-input {
+  display: flex;
+  gap: .5rem;
+  padding: .75rem 1rem;
+  border-top: 1px dashed var(--nv-blue-200);
+}
+
+.turian-input input {
+  flex: 1;
+  padding: .65rem .75rem;
+  border: 1px solid var(--nv-blue-300);
+  border-radius: .5rem;
+}
+
+.turian-input button {
+  padding: .65rem .9rem;
+  border-radius: .5rem;
+  border: 1px solid var(--nv-blue-400);
+  background: var(--nv-blue-50);
+  color: var(--nv-blue-700);
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- add global floating Turian head button and chat drawer component
- create small API layer and Netlify function to provide canned replies or proxy to Ollama
- include assistant styles and mount TurianAssistant in Layout for global access

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck` (fails: type errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68ba6c5af3d48329b77cad3c3dc30be0