### PR TITLE
Add global Turian assistant (floating chat) — Drop #1

### DIFF
--- a/netlify/functions/dev-chat.ts
+++ b/netlify/functions/dev-chat.ts
@@ -1,0 +1,42 @@
+import type { Handler } from "@netlify/functions";
+
+type Msg = { role: "user" | "assistant" | "system"; content: string };
+
+export const handler: Handler = async (event) => {
+  try {
+    const body = JSON.parse(event.body || "{}") as { messages?: Msg[]; path?: string };
+    const path = body.path || "/";
+    const last = body.messages?.slice().reverse().find(m => m.role === "user")?.content || "";
+
+    // Zone-aware canned replies for demos
+    const canned = (() => {
+      if (path.startsWith("/marketplace")) return "Marketplace is coming soon. We’ll list featured items, NFTs, and seasonal specials here.";
+      if (path.startsWith("/naturversity")) return "Naturversity offers lessons in languages, art, music and wellness. What would you like to learn?";
+      if (path.startsWith("/navatar")) return "Create, pick, or upload your Navatar. A generator option is coming soon!";
+      return "How can I help you explore The Naturverse?";
+    })();
+
+    // If you later set OLLAMA_URL in env, this block proxies to a local model
+    const OLLAMA = process.env.OLLAMA_URL;
+    if (OLLAMA) {
+      const res = await fetch(`${OLLAMA}/api/generate`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "llama3.1", prompt: `User: ${last}\nAssistant:`, stream: false }),
+      });
+      const data = await res.json();
+      const reply = data?.response || canned;
+      return ok({ reply });
+    }
+
+    // Default canned reply
+    const reply = last ? `${canned}\n\nYou asked: “${last}”` : canned;
+    return ok({ reply });
+  } catch (e: any) {
+    return { statusCode: 500, body: JSON.stringify({ error: e?.message || "error" }) };
+  }
+};
+
+function ok(payload: unknown) {
+  return { statusCode: 200, body: JSON.stringify(payload) };
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import NavBar from './NavBar';
+import TurianAssistant from './ai/TurianAssistant';
 
 type Props = { children: ReactNode; title?: ReactNode; breadcrumbs?: ReactNode };
 
@@ -14,6 +15,7 @@ export default function Layout({ title, breadcrumbs, children }: Props) {
           {children}
         </div>
       </main>
+      <TurianAssistant />
     </>
   );
 }

--- a/src/components/ai/ChatDrawer.tsx
+++ b/src/components/ai/ChatDrawer.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react';
+import { sendChat, type ChatMsg } from '../../lib/ai';
+import '../../styles/assistant.css';
+
+export default function ChatDrawer({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [msgs, setMsgs] = useState<ChatMsg[]>([]);
+  const [sending, setSending] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const path = typeof window !== 'undefined' ? window.location.pathname : '/';
+
+  useEffect(() => {
+    if (open && msgs.length === 0) {
+      setMsgs([{ role: 'assistant', content: 'Hi! I’m Turian 🦔 How can I help?' }]);
+    }
+  }, [open]);
+
+  async function onSend(e: React.FormEvent) {
+    e.preventDefault();
+    const text = inputRef.current?.value?.trim();
+    if (!text) return;
+    inputRef.current!.value = '';
+    const next = [...msgs, { role: 'user', content: text }];
+    setMsgs(next);
+    setSending(true);
+    try {
+      const { reply } = await sendChat(next, path);
+      setMsgs([...next, { role: 'assistant', content: reply }]);
+    } catch (err: any) {
+      setMsgs([...next, { role: 'assistant', content: 'Hmm, I had trouble replying. Try again!' }]);
+      console.warn(err);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className={`turian-drawer ${open ? 'open' : ''}`} role="dialog" aria-modal="true">
+      <header>
+        <strong>Turian Assistant</strong>
+        <button onClick={onClose} aria-label="Close">×</button>
+      </header>
+      <div className="msgs">
+        {msgs.map((m, i) => (
+          <div key={i} className={`msg ${m.role}`}>{m.content}</div>
+        ))}
+      </div>
+      <form onSubmit={onSend} className="composer">
+        <input ref={inputRef} placeholder={sending ? 'Thinking…' : 'Ask me anything…'} disabled={sending} />
+        <button disabled={sending}>Send</button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/ai/TurianAssistant.tsx
+++ b/src/components/ai/TurianAssistant.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+import ChatDrawer from './ChatDrawer';
+import '../../styles/assistant.css';
+
+export default function TurianAssistant() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button className="turian-fab" aria-label="Open assistant" onClick={() => setOpen(true)}>
+        <img src="/favicon-32x32.png" alt="" width={24} height={24} />
+      </button>
+      <ChatDrawer open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,11 @@
+export type ChatMsg = { role: "user" | "assistant" | "system"; content: string };
+
+export async function sendChat(messages: ChatMsg[], path: string) {
+  const res = await fetch("/.netlify/functions/dev-chat", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ messages, path }),
+  });
+  if (!res.ok) throw new Error(`Chat error: ${res.status}`);
+  return (await res.json()) as { reply: string };
+}

--- a/src/styles/assistant.css
+++ b/src/styles/assistant.css
@@ -1,0 +1,26 @@
+.turian-fab {
+  position: fixed; right: 1rem; bottom: 1rem; z-index: 10000;
+  border: 2px solid var(--nv-blue-300); background: #fff; border-radius: 999px;
+  width: 56px; height: 56px; box-shadow: 0 4px 12px rgba(0,0,0,.08);
+}
+.turian-fab:hover { transform: translateY(-1px); }
+
+.turian-drawer {
+  position: fixed; right: 1rem; bottom: 1rem; z-index: 10001;
+  width: min(420px, 92vw); height: min(65vh, 640px);
+  border: 2px solid var(--nv-blue-200); border-radius: 16px;
+  background: #fff; display: none; flex-direction: column; overflow: hidden;
+  box-shadow: 0 12px 24px rgba(0,0,0,.12);
+}
+.turian-drawer.open { display: flex; }
+.turian-drawer header {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: .75rem 1rem; border-bottom: 1px dashed var(--nv-blue-200);
+}
+.turian-drawer .msgs { padding: .75rem; gap: .5rem; display: flex; flex-direction: column; overflow: auto; }
+.turian-drawer .msg { padding: .5rem .75rem; border-radius: 12px; line-height: 1.35; }
+.turian-drawer .msg.user { align-self: flex-end; background: #eef3ff; border: 1px solid var(--nv-blue-200); }
+.turian-drawer .msg.assistant { align-self: flex-start; background: #fafafa; border: 1px solid #eee; }
+.turian-drawer .composer { display: flex; gap: .5rem; padding: .75rem; border-top: 1px dashed var(--nv-blue-200); }
+.turian-drawer input { flex: 1; padding: .6rem .8rem; border: 1px solid var(--nv-blue-200); border-radius: 10px; }
+.turian-drawer button { padding: .55rem .9rem; border-radius: 10px; border: 2px solid var(--nv-blue-300); background: #fff; }


### PR DESCRIPTION
## Summary
- Mount TurianAssistant globally in Layout
- Add client chat helper and UI components for floating assistant
- Provide Netlify function for canned or model-backed replies

## Testing
- `npm run typecheck` *(fails: existing TS errors)*

Label: codex

------
https://chatgpt.com/codex/tasks/task_e_68ba6fe0eed88329be24a1847e78d5db