### PR TITLE
Turian assistant — Drop #1a (force-mount + safe placement)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import './styles/magic.css';
 // TEMP: disable interactions while we isolate the crash
 // import { initInteractions } from './init/interactions';
 import './init/runtime-logger'; // lightweight global error hooks
+import TurianAssistant from './components/ai/TurianAssistant';
 
 export default function App() {
   useEffect(() => {
@@ -33,6 +34,7 @@ export default function App() {
           </div>
         </main>
         <ToasterListener />
+        <TurianAssistant />
       </>
     </CartProvider>
   );

--- a/src/components/ai/ChatDrawer.tsx
+++ b/src/components/ai/ChatDrawer.tsx
@@ -1,0 +1,48 @@
+import { FormEvent, useState } from 'react';
+import { sendTurianMessage } from '../../lib/ai';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function ChatDrawer({ open, onClose }: Props) {
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState<string[]>([]);
+
+  if (!open) return null;
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const msg = input.trim();
+    if (!msg) return;
+    setMessages((m) => [...m, msg]);
+    setInput('');
+    try {
+      const reply = await sendTurianMessage(msg);
+      setMessages((m) => [...m, reply]);
+    } catch {
+      setMessages((m) => [...m, 'Something went wrong.']);
+    }
+  }
+
+  return (
+    <div className="turian-drawer" role="dialog" aria-label="Turian assistant">
+      <button className="turian-close" aria-label="Close" onClick={onClose}>
+        ×
+      </button>
+      <div className="turian-messages">
+        {messages.map((m, i) => (
+          <p key={i}>{m}</p>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className="turian-form">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask Turian..."
+        />
+      </form>
+    </div>
+  );
+}

--- a/src/components/ai/TurianAssistant.tsx
+++ b/src/components/ai/TurianAssistant.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import ChatDrawer from './ChatDrawer';
+import '../../styles/assistant.css';
+
+export default function TurianAssistant() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        className="turian-fab"
+        aria-label="Open assistant"
+        data-testid="turian-fab"
+        style={{
+          position: 'fixed',
+          right: '1rem',
+          bottom: '1rem',
+          zIndex: 10000,
+          border: '2px solid var(--nv-blue-300)',
+          background: '#fff',
+          borderRadius: '999px',
+          width: 56,
+          height: 56,
+        }}
+        onClick={() => setOpen(true)}
+      >
+        <img src="/favicon-32x32.png" alt="" width={24} height={24} />
+      </button>
+      <ChatDrawer open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,12 @@
+export async function sendTurianMessage(message: string): Promise<string> {
+  const res = await fetch('/api/turian-chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message }),
+  });
+  if (!res.ok) {
+    throw new Error('Network response was not ok');
+  }
+  const data = await res.json();
+  return data.reply ?? '';
+}

--- a/src/styles/assistant.css
+++ b/src/styles/assistant.css
@@ -1,0 +1,41 @@
+.turian-drawer {
+  position: fixed;
+  right: 1rem;
+  bottom: 5rem;
+  width: min(90vw, 360px);
+  max-height: 80vh;
+  background: #fff;
+  border: 2px solid var(--nv-blue-300);
+  border-radius: 0.5rem;
+  z-index: 10000;
+  padding: 0.5rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+}
+
+.turian-close {
+  background: none;
+  border: none;
+  align-self: flex-end;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.turian-messages {
+  flex: 1;
+  overflow-y: auto;
+  margin-bottom: 0.5rem;
+}
+
+.turian-form input {
+  width: 100%;
+  border: 1px solid var(--nv-blue-300);
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
+}
+
+@media (max-width: 420px) {
+  .turian-fab { right: auto; left: 1rem; }
+  .turian-drawer { right: auto; left: 1rem; }
+}


### PR DESCRIPTION
## Summary
- Mount Turian assistant at the app root so the floating action button always renders
- Add inline fallback styles and chat drawer component for a robust assistant
- Add responsive positioning to avoid overlap with the Netlify preview bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba74333da08329a9f15e8f417e64c8