### PR TITLE
Stabilize & mount global Turian assistant (demo replies)

### DIFF
--- a/src/components/ChatDrawer.tsx
+++ b/src/components/ChatDrawer.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState, FormEvent } from 'react';
+import styles from './assistant.module.css';
+import type { ChatMsg } from '../lib/chat';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  messages: ChatMsg[];
+  onSend: (text: string) => void;
+  sending: boolean;
+};
+
+export default function ChatDrawer({ open, onClose, messages, onSend, sending }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setText('');
+      inputRef.current?.focus();
+    }
+  }, [open]);
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const value = text.trim();
+    if (!value || sending) return;
+    onSend(value);
+    setText('');
+  }
+
+  return (
+    <div className={`${styles.drawer} ${open ? styles.open : ''}`} role="dialog" aria-modal="true">
+      <button className={styles.close} aria-label="Close" onClick={onClose}>
+        &times;
+      </button>
+      <div className={styles.messages}>
+        {messages.map((m, i) => (
+          <div key={i} className={m.role === 'user' ? styles.user : styles.assistant}>
+            {m.content}
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <input
+          ref={inputRef}
+          value={text}
+          onChange={e => setText(e.target.value)}
+          disabled={sending}
+          placeholder="Ask me anything"
+        />
+      </form>
+    </div>
+  );
+}
+

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import NavBar from './NavBar';
+import TurianAssistant from './TurianAssistant';
 
 type Props = { children: ReactNode; title?: ReactNode; breadcrumbs?: ReactNode };
 
@@ -14,6 +15,7 @@ export default function Layout({ title, breadcrumbs, children }: Props) {
           {children}
         </div>
       </main>
+      <TurianAssistant />
     </>
   );
 }

--- a/src/components/assistant.module.css
+++ b/src/components/assistant.module.css
@@ -1,0 +1,71 @@
+.float {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  z-index: 50;
+}
+
+.icon {
+  width: 3rem;
+  height: 3rem;
+}
+
+.drawer {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  max-width: 20rem;
+  max-height: 100vh;
+  background: #fff;
+  box-shadow: 0 -2px 8px rgba(0,0,0,0.2);
+  display: flex;
+  flex-direction: column;
+  transform: translateY(100%);
+  transition: transform 0.3s ease;
+  z-index: 50;
+}
+
+.open {
+  transform: translateY(0);
+}
+
+.close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2rem 1rem 1rem;
+}
+
+.user {
+  text-align: right;
+  margin-bottom: 0.5rem;
+}
+
+.assistant {
+  text-align: left;
+  margin-bottom: 0.5rem;
+}
+
+.form {
+  border-top: 1px solid #eee;
+  padding: 0.5rem;
+}
+
+.form input {
+  width: 100%;
+  padding: 0.5rem;
+}

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,0 +1,12 @@
+export type ChatMsg = { role: 'user' | 'assistant'; content: string };
+
+export async function sendChat(history: ChatMsg[], zone: string): Promise<string> {
+  const res = await fetch('/.netlify/functions/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ zone, messages: history }),
+  });
+  if (!res.ok) throw new Error('chat failed');
+  const data = await res.json();
+  return String(data.reply ?? '');
+}


### PR DESCRIPTION
## Summary
- add floating Turian assistant widget with mobile autoclose and zone detection
- wire chat drawer to Netlify function demo replies
- include placeholder Netlify handler with canned responses

## Testing
- `npm run typecheck` *(fails: Argument of type 'Partial<Omit<...' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8050c8308329ade54b929a52b3ba