### PR TITLE
Mount global Turian assistant from root + resilient demo replies

### DIFF
--- a/netlify/functions/chat.ts
+++ b/netlify/functions/chat.ts
@@ -1,24 +1,31 @@
-// minimal ESM handler (no SDK) – uses OPENAI_API_KEY env
-export default async (req: Request) => {
-  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+import type { Handler } from '@netlify/functions';
+
+type Msg = { role: 'user' | 'assistant'; content: string };
+
+const canned = {
+  home: 'Welcome to The Naturverse! Try Worlds, Zones, or Marketplace.',
+  marketplace: 'Marketplace tabs: Shop, NFT/Mint, Specials, Wishlist.',
+  naturversity: 'Naturversity: Languages, Courses, Quizzes, Music.',
+  navatar: 'Navatar: Create, Pick, or Upload/Edit.',
+};
+
+export const handler: Handler = async (event) => {
   try {
-    const { message } = await req.json();
-    const body = {
-      model: "gpt-4o-mini",
-      input: [
-        { role: "system", content: "You are Turian, a friendly kid-safe nature guide. Keep replies <=80 words." },
-        { role: "user", content: String(message ?? "") }
-      ]
+    const { zone, messages } = JSON.parse(event.body ?? '{}') as {
+      zone?: keyof typeof canned;
+      messages?: Msg[];
     };
-    const r = await fetch("https://api.openai.com/v1/responses", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", "Authorization": `Bearer ${process.env.OPENAI_API_KEY}` },
-      body: JSON.stringify(body)
-    });
-    const j = await r.json();
-    const reply = j.output_text ?? "Hello from Turian!";
-    return new Response(JSON.stringify({ reply }), { headers: { "Content-Type": "application/json" } });
-  } catch (e:any) {
-    return new Response(JSON.stringify({ reply:"Turian is resting. Try again soon." }), { headers: { "Content-Type":"application/json" }, status: 200 });
+
+    const last = (messages ?? []).slice(-1)[0]?.content?.toLowerCase() || '';
+    let reply = canned[zone ?? 'home'];
+    if (last.includes('language')) reply = 'Naturversity → Languages.';
+    if (last.includes('course'))   reply = 'Naturversity → Courses.';
+    if (last.includes('shop'))     reply = 'Marketplace → Shop tab.';
+    if (last.includes('wishlist')) reply = 'Marketplace → Wishlist tab.';
+
+    return { statusCode: 200, body: JSON.stringify({ reply }) };
+  } catch {
+    return { statusCode: 200, body: JSON.stringify({ reply: 'Sorry—something went wrong. Try again.' }) };
   }
-}
+};
+

--- a/src/components/ChatDrawer.tsx
+++ b/src/components/ChatDrawer.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import styles from './assistant.module.css';
+import type { ChatMsg } from '../lib/chat';
+
+export default function ChatDrawer({
+  open,
+  onClose,
+  messages,
+  onSend,
+  sending,
+  placeholder,
+}: {
+  open: boolean;
+  onClose: () => void;
+  messages: ChatMsg[];
+  onSend: (text: string) => void;
+  sending: boolean;
+  placeholder: string;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) setTimeout(() => inputRef.current?.focus(), 50);
+  }, [open]);
+
+  useEffect(() => {
+    const onEsc = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
+    window.addEventListener('keydown', onEsc);
+    return () => window.removeEventListener('keydown', onEsc);
+  }, [onClose]);
+
+  return (
+    <div className={`${styles.drawer} ${open ? styles.open : ''}`} role="dialog" aria-modal="true">
+      <button className={styles.close} aria-label="Close" onClick={onClose}>×</button>
+
+      <div className={styles.messages}>
+        {messages.map((m, i) => (
+          <div key={i} className={m.role === 'user' ? styles.user : styles.bot}>
+            {m.content}
+          </div>
+        ))}
+      </div>
+
+      <form
+        className={styles.form}
+        onSubmit={(e) => {
+          e.preventDefault();
+          const val = inputRef.current?.value?.trim();
+          if (!val) return;
+          onSend(val);
+          if (inputRef.current) inputRef.current.value = '';
+        }}
+      >
+        <input
+          ref={inputRef}
+          className={styles.input}
+          type="text"
+          placeholder={placeholder}
+          aria-label="Message Turian"
+        />
+        <button className={styles.send} disabled={sending} type="submit">
+          {sending ? '…' : 'Send'}
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import NavBar from './NavBar';
+import TurianAssistant from './TurianAssistant';
 
 type Props = { children: ReactNode; title?: ReactNode; breadcrumbs?: ReactNode };
 
@@ -14,6 +15,7 @@ export default function Layout({ title, breadcrumbs, children }: Props) {
           {children}
         </div>
       </main>
+      <TurianAssistant />
     </>
   );
 }

--- a/src/components/TurianAssistant.tsx
+++ b/src/components/TurianAssistant.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useMemo, useState } from 'react';
+import ChatDrawer from './ChatDrawer';
+import styles from './assistant.module.css';
+import { sendChat, type ChatMsg } from '../lib/chat';
+import BrandMark from './BrandMark';
+
+type Zone = 'home' | 'naturversity' | 'marketplace' | 'navatar';
+
+function detectZone(path: string): Zone {
+  if (path.startsWith('/naturversity')) return 'naturversity';
+  if (path.startsWith('/marketplace'))  return 'marketplace';
+  if (path.startsWith('/navatar'))      return 'navatar';
+  return 'home';
+}
+
+export default function TurianAssistant() {
+  const [mounted, setMounted] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [zone, setZone] = useState<Zone>('home');
+  const [messages, setMessages] = useState<ChatMsg[]>([]);
+
+  useEffect(() => {
+    setMounted(true); // avoid SSR mismatch
+    try {
+      setZone(detectZone(window.location.pathname));
+    } catch { /* no-op */ }
+  }, []);
+
+  const placeholder = useMemo(() => 'Ask Turian…', []);
+
+  async function handleSend(text: string) {
+    const next = [...messages, { role: 'user', content: text }];
+    setMessages(next);
+    setSending(true);
+    try {
+      const reply = await sendChat(next, zone);
+      setMessages([...next, { role: 'assistant', content: reply }]);
+      // Auto collapse on small screens after a short delay
+      if (window.matchMedia('(max-width: 640px)').matches) {
+        setTimeout(() => setOpen(false), 600);
+      }
+    } catch {
+      setMessages([
+        ...next,
+        { role: 'assistant', content: 'Sorry—something went wrong. Try again.' },
+      ]);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  if (!mounted) return null;
+
+  return (
+    <>
+      <button
+        className={styles.float}
+        aria-label="Open Turian assistant"
+        onClick={() => setOpen(true)}
+      >
+        <span className={styles.iconWrap} aria-hidden>
+          <BrandMark />
+        </span>
+      </button>
+
+      <ChatDrawer
+        open={open}
+        onClose={() => setOpen(false)}
+        messages={messages}
+        onSend={handleSend}
+        sending={sending}
+        placeholder={placeholder}
+      />
+    </>
+  );
+}
+

--- a/src/components/assistant.module.css
+++ b/src/components/assistant.module.css
@@ -1,0 +1,108 @@
+.float {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  background: #ffffff;
+  border: 2px solid var(--nv-blue-400, #6ea8fe);
+  box-shadow: 0 6px 20px rgba(37, 74, 202, .18);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  z-index: 2147483000; /* above everything */
+}
+
+.iconWrap {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+}
+
+.drawer {
+  position: fixed;
+  right: 16px;
+  bottom: 86px;
+  width: min(520px, calc(100vw - 24px));
+  max-height: min(60vh, 520px);
+  background: #fff;
+  border: 2px solid var(--nv-blue-300, #9ec5fe);
+  border-radius: 14px;
+  box-shadow: 0 8px 30px rgba(37, 74, 202, .20);
+  padding: 10px 10px 12px;
+  transform: translateY(12px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .18s ease, transform .18s ease;
+  z-index: 2147483001;
+}
+
+.open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.close {
+  position: absolute;
+  right: 8px;
+  top: 6px;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 0;
+  background: var(--nv-blue-600, #2f6fed);
+  color: #fff;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.messages {
+  padding: 8px 4px 6px;
+  overflow: auto;
+  max-height: 58vh;
+}
+
+.user {
+  background: #eef4ff;
+  border: 1px solid var(--nv-blue-200, #bfd1ff);
+  border-radius: 12px;
+  padding: 8px 10px;
+  margin: 6px 0;
+}
+
+.bot {
+  background: #ffffff;
+  border: 1px dashed var(--nv-blue-300, #9ec5fe);
+  border-radius: 12px;
+  padding: 8px 10px;
+  margin: 6px 0;
+}
+
+.form {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.input {
+  flex: 1;
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid var(--nv-blue-300, #9ec5fe);
+  padding: 0 10px;
+}
+
+.send {
+  min-width: 70px;
+  height: 40px;
+  border-radius: 10px;
+  border: 0;
+  background: var(--nv-blue-600, #2f6fed);
+  color: #fff;
+  font-weight: 700;
+}
+

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,0 +1,35 @@
+export type ChatMsg = { role: 'user' | 'assistant'; content: string };
+
+const cannedByZone: Record<string, string> = {
+  home: 'Welcome to The Naturverse! Try Worlds, Zones, or Marketplace from the top.',
+  marketplace: 'Marketplace tabs: Shop (featured), NFT/Mint, Specials, Wishlist.',
+  naturversity: 'Naturversity hubs: Languages, Courses, Quizzes, Music.',
+  navatar: 'Navatar has Create, Pick Your Navatar, and Upload/Edit.',
+};
+
+export async function sendChat(history: ChatMsg[], zone: string): Promise<string> {
+  // Try Netlify function first…
+  try {
+    const res = await fetch('/.netlify/functions/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ zone, messages: history }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      return String(data.reply ?? '');
+    }
+  } catch {
+    /* fall through to local canned reply */
+  }
+
+  // …fallback so the demo *always* answers in previews or when functions aren’t available.
+  const last = history.at(-1)?.content.toLowerCase() ?? '';
+  let reply = cannedByZone[zone] ?? cannedByZone.home;
+  if (last.includes('language')) reply = 'Languages is in Naturversity → Languages.';
+  if (last.includes('course'))   reply = 'Courses are in Naturversity → Courses.';
+  if (last.includes('shop'))     reply = 'Open Marketplace → Shop tab.';
+  if (last.includes('wishlist')) reply = 'Wishlist is in Marketplace → Wishlist.';
+  return reply;
+}
+


### PR DESCRIPTION
## Summary
- Mount Turian assistant from root layout so it's always available
- Add chat drawer UI with mobile-friendly close behavior
- Implement Netlify function and client fallback for canned replies

## Testing
- `npm run typecheck` *(fails: Argument of type 'Partial<Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "created_at" | "id" | "updated_at">>' is not assignable to parameter of type 'never'.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba829070f88329b33e637e20bfa547