### PR TITLE
Make Turian assistant render reliably (App Router–safe)

### DIFF
--- a/src/components/ChatDrawer.tsx
+++ b/src/components/ChatDrawer.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useRef, type ReactNode } from 'react';
+import styles from './chat.module.css';
+
+export function ChatDrawer({
+  open,
+  onClose,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (!open) return;
+      const el = boxRef.current;
+      if (el && !el.contains(e.target as Node)) onClose();
+    }
+    function onEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onEsc);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onEsc);
+    };
+  }, [open, onClose]);
+
+  return (
+    <div className={`${styles.chat} ${open ? styles.open : ''}`} aria-hidden={!open}>
+      <div className={styles.box} ref={boxRef} role="dialog" aria-label="Turian chat">
+        <button className={styles.close} aria-label="Close chat" onClick={onClose}>
+          ×
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,9 @@
 import { ReactNode } from 'react';
 import NavBar from './NavBar';
+import dynamic from 'next/dynamic';
+
+// Load client component only on client to avoid any SSR hiccups
+const TurianAssistant = dynamic(() => import('./TurianAssistant'), { ssr: false });
 
 type Props = { children: ReactNode; title?: ReactNode; breadcrumbs?: ReactNode };
 
@@ -14,6 +18,7 @@ export default function Layout({ title, breadcrumbs, children }: Props) {
           {children}
         </div>
       </main>
+      <TurianAssistant />
     </>
   );
 }

--- a/src/components/TurianAssistant.tsx
+++ b/src/components/TurianAssistant.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ChatDrawer } from './ChatDrawer';
+import { sendChat, type ChatMsg } from '../lib/chat';
+import styles from './chat.module.css';
+
+const TURION_EMOJI = '🟢';
+
+export default function TurianAssistant() {
+  const [open, setOpen] = useState(false);
+  const [msgs, setMsgs] = useState<ChatMsg[]>([]);
+  const [text, setText] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const path = typeof window !== 'undefined' ? window.location.pathname : '/';
+  const isMobile =
+    typeof window !== 'undefined'
+      ? window.matchMedia('(max-width: 640px)').matches
+      : false;
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (open && inputRef.current) inputRef.current.focus();
+  }, [open]);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!text.trim() || busy) return;
+
+    const next = [...msgs, { role: 'user', content: text.trim() } as ChatMsg];
+    setMsgs(next);
+    setText('');
+    setBusy(true);
+
+    const replied = await sendChat(next, path);
+    setMsgs(replied.length ? replied : next);
+    setBusy(false);
+
+    if (isMobile) setTimeout(() => setOpen(false), 800);
+  }
+
+  return (
+    <>
+      <button
+        className={styles.fab}
+        aria-label='Open Turian assistant'
+        onClick={() => setOpen(true)}
+      >
+        {TURION_EMOJI}
+      </button>
+
+      <ChatDrawer open={open} onClose={() => setOpen(false)}>
+        <div className={styles.messages}>
+          {msgs.length === 0 ? (
+            <p className={styles.hint}>
+              Ask me about Worlds, Zones, Naturversity, Marketplace, or Navatars.
+            </p>
+          ) : (
+            msgs.map((m, i) => (
+              <div key={i} className={`${styles.msg} ${styles[m.role]}`}>
+                {m.content}
+              </div>
+            ))
+          )}
+          {busy && (
+            <div className={`${styles.msg} ${styles.assistant}`}>Thinking…</div>
+          )}
+        </div>
+
+        <form className={styles.form} onSubmit={onSubmit}>
+          <input
+            ref={inputRef}
+            className={styles.input}
+            placeholder='Ask Turian…'
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+          <button
+            className={styles.send}
+            disabled={busy || !text.trim()}
+            aria-label='Send'
+          >
+            ↩︎
+          </button>
+        </form>
+      </ChatDrawer>
+    </>
+  );
+}

--- a/src/components/chat.module.css
+++ b/src/components/chat.module.css
@@ -1,0 +1,72 @@
+.fab {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  border: 2px solid var(--nv-blue-300, #5b8cff);
+  background: white;
+  color: var(--nv-blue-600, #2a5bff);
+  box-shadow: 0 4px 12px rgba(0,0,0,.12);
+  z-index: 1000;
+}
+
+.chat { position: fixed; inset: 0; pointer-events: none; z-index: 1000; }
+.open { pointer-events: auto; }
+
+.box {
+  position: fixed;
+  right: .75rem;
+  bottom: 4.5rem;
+  width: min(92vw, 360px);
+  max-height: min(60vh, 420px);
+  background: #fff;
+  border: 2px solid var(--nv-blue-200, #9cb7ff);
+  border-radius: 12px;
+  padding: .75rem;
+  box-shadow: 0 8px 24px rgba(0,0,0,.16);
+  overflow: hidden;
+}
+
+.close {
+  position: absolute;
+  right: .35rem;
+  top: .15rem;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 0;
+  background: var(--nv-blue-600, #2a5bff);
+  color: #fff;
+  font-size: 18px;
+  line-height: 28px;
+}
+
+.messages {
+  overflow: auto;
+  padding-right: .25rem;
+  max-height: 300px;
+  margin: .5rem 0 .25rem 0;
+}
+
+.msg { margin: .25rem 0; }
+.user { color: var(--nv-blue-700, #1849ff); }
+.assistant { color: #111; }
+.hint { color: var(--nv-blue-600, #2a5bff); margin: .25rem 0; }
+
+.form { display: flex; gap: .5rem; }
+.input {
+  flex: 1;
+  border: 2px solid var(--nv-blue-300, #5b8cff);
+  border-radius: 10px;
+  padding: .5rem .6rem;
+  outline: none;
+}
+.send {
+  border: 0;
+  border-radius: 10px;
+  padding: 0 .75rem;
+  background: var(--nv-blue-600, #2a5bff);
+  color: white;
+}

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,0 +1,21 @@
+export type ChatMsg = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+export async function sendChat(msgs: ChatMsg[], path: string): Promise<ChatMsg[]> {
+  const message = msgs[msgs.length - 1]?.content ?? '';
+  try {
+    const res = await fetch('/.netlify/functions/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message, path }),
+    });
+    if (!res.ok) return msgs;
+    const data = await res.json().catch(() => ({}));
+    const reply = typeof data.reply === 'string' ? data.reply : '';
+    return reply ? [...msgs, { role: 'assistant', content: reply }] : msgs;
+  } catch {
+    return msgs;
+  }
+}

--- a/src/types/next-dynamic.d.ts
+++ b/src/types/next-dynamic.d.ts
@@ -1,0 +1,7 @@
+declare module 'next/dynamic' {
+  import type { ComponentType } from 'react';
+  export default function dynamic<T extends ComponentType<any>>(
+    loader: () => Promise<T>,
+    options?: { ssr?: boolean }
+  ): T;
+}


### PR DESCRIPTION
## Summary
- mark chat UI components as client-side and convert styles to a CSS module
- provide sendChat helper and dynamic layout hook for Turian assistant

## Testing
- `npm run typecheck` *(fails: Argument of type 'Partial<...>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68ba8afe147c832984a1a65d9c501a53