### PR TITLE
feat: add global Turian chat assistant

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { SITE } from '@/lib/site';
 import "../styles/globals.css";
 import "../styles/nav.css";
+import "../styles/chat.css";
+import TurianAssistant from "@/components/TurianAssistant";
 
 // ensure absolute URLs in SEO metadata
 export const metadata: Metadata = {
@@ -16,7 +18,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <TurianAssistant />
+      </body>
     </html>
   );
 }

--- a/src/components/TurianAssistant.tsx
+++ b/src/components/TurianAssistant.tsx
@@ -1,0 +1,136 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+type Msg = { role: "user" | "assistant"; content: string };
+
+function looksSignedIn() {
+  // Supabase sets cookies starting with sb-; cheap, non-blocking check
+  return typeof document !== "undefined" && /(?:^|;\s)sb-/.test(document.cookie);
+}
+
+export default function TurianAssistant() {
+  const [open, setOpen] = useState(false);
+  const [msgs, setMsgs] = useState<Msg[]>([]);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // zone hint (simple: first URL segment)
+  const zone = useMemo(() => {
+    const p = typeof window !== "undefined" ? window.location.pathname : "/";
+    const seg = p.replace(/^\/+/, "").split("/")[0] || "home";
+    return seg.toLowerCase();
+  }, []);
+
+  const send = useCallback(async () => {
+    if (!input.trim() || sending) return;
+    const userText = input.trim();
+    setInput("");
+    setMsgs((m) => [...m, { role: "user", content: userText }]);
+    setSending(true);
+
+    try {
+      // When logged out, reply with onboarding prompt locally and stop.
+      if (!looksSignedIn()) {
+        const hint =
+          `You're in ${zone.charAt(0).toUpperCase() + zone.slice(1)}.\n` +
+          `Please **create an account** or **Continue with Google** to get started.`;
+        setMsgs((m) => [...m, { role: "assistant", content: hint }]);
+        setSending(false);
+        return;
+      }
+
+      const res = await fetch("/.netlify/functions/chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          zone,
+          messages: [...msgs, { role: "user", content: userText }],
+        }),
+      });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      const reply: string =
+        data?.reply ??
+        `You're in ${zone}. Ask me about “languages”, “courses”, or “shop”.`;
+      setMsgs((m) => [...m, { role: "assistant", content: reply }]);
+    } catch {
+      setMsgs((m) => [
+        ...m,
+        {
+          role: "assistant",
+          content:
+            `I couldn't reach the chat service. You're in ${zone}. Try “Where is languages?”`,
+        },
+      ]);
+    } finally {
+      setSending(false);
+      // Important: keep drawer **open** after reply; do not auto-close.
+    }
+  }, [input, msgs, sending, zone]);
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  return (
+    <>
+      {/* Floating button */}
+      <button
+        aria-label="Ask Turian"
+        className="turian-btn"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <img
+          src="/favicon-64x64.png" /* swap to any Turian head in /public */
+          alt=""
+          width={28}
+          height={28}
+          style={{ display: "block" }}
+        />
+      </button>
+
+      {/* Drawer */}
+      {open && (
+        <div className="turian-drawer" role="dialog" aria-label="Ask Turian">
+          <div className="turian-header">
+            <strong>Ask Turian</strong>
+            <button
+              aria-label="Close"
+              className="turian-close"
+              onClick={() => setOpen(false)}
+            >
+              ×
+            </button>
+          </div>
+
+          <div className="turian-body">
+            {msgs.length === 0 && (
+              <div className="turian-tip">Try: “Where is languages?”</div>
+            )}
+            {msgs.map((m, i) => (
+              <div key={i} className={`turian-msg ${m.role}`}>
+                {m.role === "user" ? "You" : "Turian"}: {m.content}
+              </div>
+            ))}
+          </div>
+
+          <div className="turian-inputrow">
+            <input
+              ref={inputRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && send()}
+              placeholder="Ask Turian…"
+              disabled={sending}
+            />
+            <button className="turian-send" onClick={send} disabled={sending}>
+              {sending ? "…" : "Send"}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -1,0 +1,124 @@
+:root {
+  --nv-blue: #2563eb; /* brand-blue */
+  --nv-blue-700: #1d4ed8;
+  --nv-ring: rgba(37, 99, 235, 0.3);
+  --nv-bg: #ffffff;
+  --nv-text: #0f172a;
+}
+
+.turian-btn {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 60;
+  border: none;
+  border-radius: 9999px;
+  background: var(--nv-bg);
+  box-shadow: 0 8px 20px rgba(2, 6, 23, 0.15);
+  padding: 10px;
+  cursor: pointer;
+}
+
+.turian-btn:focus-visible {
+  outline: 2px solid var(--nv-blue);
+  outline-offset: 2px;
+}
+
+.turian-drawer {
+  position: fixed;
+  right: 1rem;
+  bottom: 5.25rem; /* floats above button */
+  z-index: 60;
+  width: min(420px, 92vw);
+  max-height: min(70vh, 560px);
+  background: var(--nv-bg);
+  color: var(--nv-text);
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.25);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.turian-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  background: var(--nv-bg);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.turian-close {
+  appearance: none;
+  border: none;
+  background: var(--nv-blue);
+  color: #fff;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.turian-body {
+  padding: 12px 14px;
+  overflow: auto;
+  gap: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+.turian-tip {
+  opacity: 0.75;
+  font-style: italic;
+}
+
+.turian-msg.user { font-weight: 600; }
+.turian-msg.assistant { }
+
+.turian-inputrow {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  background: var(--nv-bg);
+}
+
+.turian-inputrow input {
+  flex: 1;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  padding: 10px 12px;
+  font-size: 16px;
+}
+
+.turian-inputrow input:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px var(--nv-ring);
+  border-color: var(--nv-blue);
+}
+
+.turian-send {
+  background: var(--nv-blue);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.turian-send:disabled { opacity: 0.6; }
+
+@media (max-width: 480px) {
+  .turian-drawer {
+    right: 0.5rem;
+    left: 0.5rem;
+    width: auto;
+    bottom: 4.75rem;
+    max-height: 62vh; /* prevents “blowing up” */
+  }
+}
+


### PR DESCRIPTION
## Summary
- mount Turian chat assistant globally with Vite-friendly React component
- style chat UI with brand colors and mobile-friendly drawer
- keep chat open after responses and prompt sign-in when logged out

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Partial<...>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68ba9d35127c83299622cef0051a4b2a