### PR TITLE
feat: add Turian assistant widget

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { SITE } from '@/lib/site';
 import "../styles/globals.css";
 import "../styles/nav.css";
+import "../styles/chat.css";
+import TurianAssistant from "../components/TurianAssistant";
 
 // ensure absolute URLs in SEO metadata
 export const metadata: Metadata = {
@@ -16,7 +18,11 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <TurianAssistant />
+      </body>
     </html>
   );
 }
+

--- a/components/TurianAssistant.tsx
+++ b/components/TurianAssistant.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type Msg = { role: 'user' | 'assistant'; content: string };
+
+function safelyHasSupabaseCookie(): boolean {
+  if (typeof document === 'undefined') return false;
+  try { return /(?:^|;\s)sb-/.test(document.cookie); } catch { return false; }
+}
+
+export default function TurianAssistant() {
+  const [open, setOpen] = useState(false);
+  const [msgs, setMsgs] = useState<Msg[]>([]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const zone = useMemo(() => {
+    if (typeof window === 'undefined') return 'home';
+    const seg = window.location.pathname.replace(/^\/+/,'').split('/')[0] || 'home';
+    return seg.toLowerCase();
+  }, []);
+
+  const send = useCallback(async () => {
+    const text = input.trim();
+    if (!text || sending) return;
+    setInput('');
+    setMsgs((m) => [...m, { role: 'user', content: text }]);
+    setSending(true);
+
+    try {
+      if (!safelyHasSupabaseCookie()) {
+        const hint = `You're in ${zone[0].toUpperCase() + zone.slice(1)}.\nPlease **create an account** or **Continue with Google** to get started.`;
+        setMsgs((m) => [...m, { role: 'assistant', content: hint }]);
+        return;
+      }
+
+      const res = await fetch('/.netlify/functions/chat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ zone, messages: [...msgs, { role: 'user', content: text }] }),
+      });
+
+      const data = res.ok ? await res.json() : null;
+      const reply =
+        data?.reply ??
+        `You're in ${zone}. Ask me about “languages”, “courses”, or “shop”.`;
+      setMsgs((m) => [...m, { role: 'assistant', content: reply }]);
+    } catch {
+      setMsgs((m) => [
+        ...m,
+        { role: 'assistant', content: `I couldn't reach the chat service. Try: "Where is languages?"` },
+      ]);
+    } finally {
+      setSending(false);
+    }
+  }, [input, sending, zone, msgs]);
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  return (
+    <>
+      <button aria-label="Ask Turian" className="turian-btn" onClick={() => setOpen((v) => !v)}>
+        <img src="/favicon-64x64.png" alt="" width={28} height={28} />
+      </button>
+
+      {open && (
+        <div className="turian-drawer" role="dialog" aria-label="Ask Turian">
+          <div className="turian-header">
+            <strong>Ask Turian</strong>
+            <button aria-label="Close" className="turian-close" onClick={() => setOpen(false)}>×</button>
+          </div>
+
+          <div className="turian-body">
+            {msgs.length === 0 && <div className="turian-tip">Try: “Where is languages?”</div>}
+            {msgs.map((m, i) => (
+              <div key={i} className={`turian-msg ${m.role}`}>
+                {m.role === 'user' ? 'You' : 'Turian'}: {m.content}
+              </div>
+            ))}
+          </div>
+
+          <div className="turian-inputrow">
+            <input
+              ref={inputRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && send()}
+              placeholder="Ask Turian…"
+              disabled={sending}
+            />
+            <button className="turian-send" onClick={send} disabled={sending}>
+              {sending ? '…' : 'Send'}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -1,0 +1,67 @@
+:root {
+  --nv-blue: #2563eb;
+  --nv-ring: rgba(37, 99, 235, 0.3);
+  --nv-bg: #ffffff;
+  --nv-text: #0f172a;
+}
+
+.turian-btn {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 60;
+  border: none;
+  border-radius: 9999px;
+  background: var(--nv-bg);
+  box-shadow: 0 8px 20px rgba(2, 6, 23, 0.15);
+  padding: 10px;
+  cursor: pointer;
+}
+
+.turian-drawer {
+  position: fixed;
+  right: 1rem;
+  bottom: 5.25rem;
+  z-index: 60;
+  width: min(420px, 92vw);
+  max-height: min(70vh, 560px);
+  background: var(--nv-bg);
+  color: var(--nv-text);
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.25);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.turian-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 14px; border-bottom: 1px solid rgba(15,23,42,.08);
+}
+
+.turian-close {
+  border: 0; background: var(--nv-blue); color: #fff;
+  width: 28px; height: 28px; border-radius: 8px; font-size: 18px; line-height: 1;
+}
+
+.turian-body { padding: 12px 14px; overflow: auto; display: flex; flex-direction: column; gap: 8px; }
+.turian-tip { opacity: .75; font-style: italic; }
+.turian-msg.user { font-weight: 600; }
+
+.turian-inputrow {
+  display: flex; gap: 8px; padding: 12px; border-top: 1px solid rgba(15,23,42,.08);
+}
+.turian-inputrow input {
+  flex: 1; border-radius: 12px; border: 1px solid rgba(15,23,42,.15); padding: 10px 12px; font-size: 16px;
+}
+.turian-inputrow input:focus { outline: none; box-shadow: 0 0 0 4px var(--nv-ring); border-color: var(--nv-blue); }
+.turian-send { background: var(--nv-blue); color: #fff; border: 0; border-radius: 12px; padding: 10px 14px; font-weight: 700; }
+.turian-send:disabled { opacity: .6; }
+
+@media (max-width: 480px) {
+  .turian-drawer {
+    right: .5rem; left: .5rem; bottom: 4.75rem;
+    width: auto; max-height: 62vh;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add client-only TurianAssistant component with simple chat flow
- mount assistant globally in layout and include chat styles
- style widget with brand-blue, mobile-friendly CSS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type ... is not assignable to parameter of type 'never' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9f9f99b88329813a01a3eca11b8f