### PR TITLE
Make Turian assistant login-aware (hide anon prompt when logged in)

### DIFF
--- a/src/components/TurianAssistant.tsx
+++ b/src/components/TurianAssistant.tsx
@@ -1,281 +1,140 @@
-"use client";
-
 import { useEffect, useMemo, useRef, useState } from "react";
 
-/** Brand tokens (adjust if your blue is different) */
-const BRAND_BLUE = "#2563EB"; // Naturverse blue
-const RADIUS = 14;
+// Minimal message shape used by the widget
+type Msg = { role: "user" | "assistant"; content: string };
 
-type ChatMsg = { role: "user" | "assistant"; content: string };
-
-function getZone(pathname: string) {
-  // tiny helper so we can answer differently later (Home, Worlds, Zones, etc.)
-  const p = (pathname || "/").toLowerCase();
-  if (p.startsWith("/marketplace")) return "Marketplace";
-  if (p.startsWith("/naturversity")) return "Naturversity";
-  if (p.startsWith("/navatar")) return "Navatar";
-  if (p === "/" || p.startsWith("/home")) return "Home";
-  return "Site";
-}
-
-/** Dumb check: if a Supabase auth cookie exists, we treat as signed-in */
-function isSignedIn() {
-  // Supabase sets "sb-" cookies; keep it simple and robust
-  return document.cookie.includes("sb-") || document.cookie.includes("supabase");
+// Simple signed-in detector: any Supabase auth cookie present
+function useIsLoggedIn() {
+  const [loggedIn, setLoggedIn] = useState(false);
+  useEffect(() => {
+    // Supabase sets cookies that start with sb- (e.g. sb-access-token)
+    const hasSb = document.cookie.split(";").some((c) => c.trim().startsWith("sb-"));
+    setLoggedIn(hasSb);
+  }, []);
+  return loggedIn;
 }
 
 export default function TurianAssistant() {
   const [open, setOpen] = useState(false);
+  const [pending, setPending] = useState(false);
   const [input, setInput] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [messages, setMessages] = useState<ChatMsg[]>([]);
-  const areaRef = useRef<HTMLDivElement>(null);
+  const [msgs, setMsgs] = useState<Msg[]>([
+    { role: "assistant", content: 'Try: "Where is languages?"' },
+  ]);
 
-  const zone = useMemo(() => getZone(window.location.pathname), []);
+  const isLoggedIn = useIsLoggedIn();
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    // starter tip so the box isn't empty
-    if (messages.length === 0) {
-      setMessages([
-        { role: "assistant", content: `Try: "Where is languages?"` },
-      ]);
-    }
-  }, []); // eslint-disable-line
+  // Use Turian head from /public (kept as-is in repo)
+  const avatarUrl = "/favicon-64x64.png";
 
-  useEffect(() => {
-    // keep scroll pinned to bottom on new content
-    const el = areaRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [messages, open]);
+  // simple zone hint using current path
+  const zoneHint = useMemo(() => {
+    const p = window.location.pathname.toLowerCase();
+    if (p.includes("navatar")) return "Navatar";
+    if (p.includes("naturbank")) return "NaturBank";
+    if (p.includes("market")) return "Marketplace";
+    if (p === "/" || p.includes("home")) return "Home";
+    return "Site";
+  }, []);
 
-  async function send() {
-    const text = input.trim();
-    if (!text || busy) return;
-
-    // If logged out, show CTA and keep drawer open
-    if (!isSignedIn()) {
-      setMessages((m) => [
-        ...m,
-        { role: "user", content: text },
-        {
-          role: "assistant",
-          content:
-            "Please create an account or continue with Google to get started!",
-        },
-      ]);
-      setInput("");
-      return;
-    }
-
-    setBusy(true);
-    setMessages((m) => [...m, { role: "user", content: text }]);
-    setInput("");
-
-    try {
-      const res = await fetch("/.netlify/functions/chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          zone,
-          messages: [
-            // give the function a tiny bit of context
-            { role: "system", content: `You are Turian in ${zone}.` },
-            ...messages,
-            { role: "user", content: text },
-          ],
-        }),
-      });
-
-      if (!res.ok) throw new Error(await res.text());
-      const json = (await res.json()) as { reply?: string };
-      setMessages((m) => [
-        ...m,
-        { role: "assistant", content: json.reply || "Okay!" },
-      ]);
-    } catch (e) {
-      setMessages((m) => [
-        ...m,
-        { role: "assistant", content: "Something went wrong. Try again." },
-      ]);
-    } finally {
-      setBusy(false);
-    }
-    // IMPORTANT: we do NOT auto-close; the X is always visible
+  async function sendToBot(history: Msg[]) {
+    const res = await fetch("/.netlify/functions/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        zone: zoneHint,
+        messages: history,
+      }),
+    });
+    if (!res.ok) throw new Error("Chat backend error");
+    const data = await res.json();
+    // Expecting { reply: string }
+    return (data?.reply as string) ?? "Hmm, I didn’t catch that.";
   }
 
-  function onKey(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      send();
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!input.trim() || pending) return;
+
+    const next: Msg[] = [...msgs, { role: "user", content: input.trim() }];
+    setMsgs(next);
+    setInput("");
+    setPending(true);
+
+    try {
+      // If not logged in, show the friendly sign-up nudge and stop.
+      if (!isLoggedIn) {
+        setMsgs([
+          ...next,
+          {
+            role: "assistant",
+            content:
+              "Please create an account or continue with Google to get started!",
+          },
+        ]);
+      } else {
+        const reply = await sendToBot(next);
+        setMsgs([...next, { role: "assistant", content: reply }]);
+      }
+    } catch {
+      setMsgs([
+        ...next,
+        { role: "assistant", content: "Something went wrong. Please try again." },
+      ]);
+    } finally {
+      setPending(false);
+      // keep drawer OPEN (as you requested); focus the input for quick follow-ups
+      inputRef.current?.focus();
     }
   }
 
   return (
     <>
-      {/* Floating button (bottom-right) */}
+      {/* FAB */}
       <button
         aria-label="Ask Turian"
+        className="turian-fab"
         onClick={() => setOpen(true)}
-        style={{
-          position: "fixed",
-          right: 16,
-          bottom: 16,
-          width: 56,
-          height: 56,
-          borderRadius: "50%",
-          background: "#ffffff",
-          border: `2px solid ${BRAND_BLUE}`,
-          boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
-          display: open ? "none" : "inline-flex",
-          alignItems: "center",
-          justifyContent: "center",
-          padding: 0,
-          cursor: "pointer",
-          zIndex: 90_000,
-        }}
       >
-        {/* Turian head from /public */}
-        <img
-          src="/favicon-64x64.png"
-          alt="Turian"
-          width={32}
-          height={32}
-          style={{ display: "block" }}
-        />
+        <img src={avatarUrl} alt="Turian" />
       </button>
 
       {/* Drawer */}
       {open && (
-        <div
-          role="dialog"
-          aria-label="Ask Turian"
-          style={{
-            position: "fixed",
-            right: 12,
-            bottom: 12,
-            width: "min(420px, 92vw)",
-            maxHeight: "72vh", // mobile-safe
-            background: "#fff",
-            border: "1px solid rgba(0,0,0,0.08)",
-            borderRadius: RADIUS,
-            boxShadow: "0 18px 40px rgba(0,0,0,0.22)",
-            zIndex: 90_001,
-            display: "flex",
-            flexDirection: "column",
-            overflow: "hidden",
-          }}
-        >
-          {/* Header */}
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 10,
-              background: BRAND_BLUE,
-              color: "#fff",
-              padding: "10px 12px",
-            }}
-          >
-            <img
-              src="/favicon-64x64.png"
-              alt="Turian"
-              width={20}
-              height={20}
-              style={{ borderRadius: 6, background: "#fff" }}
-            />
-            <strong style={{ fontWeight: 700 }}>Ask Turian</strong>
-            <div style={{ flex: 1 }} />
+        <div className="turian-drawer">
+          <div className="turian-header">
+            <img src={avatarUrl} alt="" />
+            <span>Ask Turian</span>
             <button
               aria-label="Close"
+              className="turian-close"
               onClick={() => setOpen(false)}
-              style={{
-                background: "rgba(255,255,255,0.2)",
-                color: "#fff",
-                border: "none",
-                borderRadius: 8,
-                padding: "4px 8px",
-                cursor: "pointer",
-                fontWeight: 700,
-              }}
             >
-              X
+              ×
             </button>
           </div>
 
-          {/* Messages */}
-          <div
-            ref={areaRef}
-            style={{
-              padding: 12,
-              overflow: "auto",
-              gap: 8,
-              display: "flex",
-              flexDirection: "column",
-              background: "#F8FAFC",
-            }}
-          >
-            {messages.map((m, i) => (
-              <div
-                key={i}
-                style={{
-                  alignSelf: m.role === "user" ? "flex-end" : "flex-start",
-                  background: m.role === "user" ? BRAND_BLUE : "#fff",
-                  color: m.role === "user" ? "#fff" : "#111827",
-                  border: "1px solid rgba(0,0,0,0.06)",
-                  borderRadius: 12,
-                  padding: "8px 10px",
-                  maxWidth: "90%",
-                  whiteSpace: "pre-wrap",
-                }}
-              >
+          <div className="turian-body">
+            {msgs.map((m, i) => (
+              <div key={i} className={`msg ${m.role}`}>
                 {m.content}
               </div>
             ))}
           </div>
 
-          {/* Input row */}
-          <div
-            style={{
-              padding: 12,
-              borderTop: "1px solid rgba(0,0,0,0.08)",
-              display: "flex",
-              gap: 8,
-              background: "#fff",
-            }}
-          >
+          <form className="turian-input" onSubmit={onSubmit}>
             <input
-              aria-label="Ask Turian"
-              placeholder="Ask Turian…"
+              ref={inputRef}
+              placeholder="Ask Turian..."
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              onKeyDown={onKey}
-              disabled={busy}
-              style={{
-                flex: 1,
-                fontSize: 16,
-                padding: "10px 12px",
-                borderRadius: 10,
-                border: "1px solid rgba(0,0,0,0.12)",
-                outline: "none",
-              }}
+              disabled={pending}
             />
-            <button
-              onClick={send}
-              disabled={busy || !input.trim()}
-              style={{
-                background: BRAND_BLUE,
-                color: "#fff",
-                border: "none",
-                borderRadius: 10,
-                padding: "10px 14px",
-                fontWeight: 700,
-                cursor: busy ? "default" : "pointer",
-                opacity: busy || !input.trim() ? 0.6 : 1,
-              }}
-            >
-              Send
+            <button type="submit" disabled={pending}>
+              {pending ? "…" : "Send"}
             </button>
-          </div>
+          </form>
         </div>
       )}
     </>

--- a/src/styles/chat.css
+++ b/src/styles/chat.css
@@ -1,0 +1,113 @@
+/* Floating button */
+.turian-fab {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  border: 2px solid #e5edff; /* soft outline */
+  background: #ffffff;
+  box-shadow: 0 6px 18px rgba(0,0,0,.12);
+  padding: 6px;
+  z-index: 1000;
+}
+.turian-fab img { width: 100%; height: 100%; border-radius: 999px; }
+
+/* Drawer */
+.turian-drawer {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  width: min(520px, calc(100vw - 24px));
+  max-height: min(70vh, 560px);
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 16px 48px rgba(0,0,0,.2);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 1001;
+}
+
+/* Header — brand blue and always-visible close button */
+.turian-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: #2e6bff;          /* brand blue */
+  color: #fff;
+  font-weight: 700;
+}
+.turian-header img {
+  width: 22px; height: 22px;
+  border-radius: 50%;
+}
+.turian-close {
+  margin-left: auto;
+  font-size: 18px;
+  line-height: 18px;
+  width: 32px; height: 32px;
+  border-radius: 8px;
+  background: rgba(255,255,255,.2);
+  color: #fff;
+  border: 0;
+}
+
+/* Body + messages */
+.turian-body {
+  padding: 12px;
+  gap: 8px;
+  display: grid;
+  overflow: auto;
+}
+.msg { 
+  padding: 10px 12px; 
+  border-radius: 12px; 
+  line-height: 1.35;
+}
+.msg.user {
+  justify-self: end;
+  background: #2e6bff;
+  color: #fff;
+}
+.msg.assistant {
+  justify-self: start;
+  background: #f2f6ff;
+  color: #102251;
+  border: 1px solid #e5edff;
+}
+
+/* Input row */
+.turian-input {
+  display: flex;
+  gap: 8px;
+  padding: 10px;
+  border-top: 1px solid #eef1ff;
+  background: #fff;
+}
+.turian-input input {
+  flex: 1;
+  border: 1px solid #dbe4ff;
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+.turian-input button {
+  border: 0;
+  border-radius: 10px;
+  padding: 0 16px;
+  background: #2e6bff;
+  color: #fff;
+  height: 40px;
+}
+
+@media (max-width: 420px) {
+  .turian-drawer {
+    right: 8px; left: 8px;
+    width: auto;
+    bottom: 8px;
+  }
+  .turian-close { position: static; } /* ensure visible, tap-friendly */
+}
+


### PR DESCRIPTION
## Summary
- detect Supabase auth cookies to decide if user is signed in
- show sign-up nudge only when logged out, otherwise send message to bot
- add responsive chat styles and keep close button accessible

## Testing
- `npm run typecheck` *(fails: Argument of type 'Partial<Omit...' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68baa83eaaa88329b4ed22ae78870063