### PR TITLE
feat: gate Turian assistant by auth

### DIFF
--- a/app/TurianAssistantWrapper.tsx
+++ b/app/TurianAssistantWrapper.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import TurianAssistant from '@/components/TurianAssistant';
+import { useUser } from '@supabase/auth-helpers-react';
+
+export default function TurianAssistantWrapper() {
+  const user = useUser();
+  return <TurianAssistant isAuthed={!!user} />;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { SITE } from '@/lib/site';
 import "../styles/globals.css";
 import "../styles/nav.css";
-import TurianAssistant from "@/components/TurianAssistant";
+import TurianAssistantWrapper from "./TurianAssistantWrapper";
 
 // ensure absolute URLs in SEO metadata
 export const metadata: Metadata = {
@@ -19,7 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body>
         {children}
-        <TurianAssistant />
+        <TurianAssistantWrapper />
       </body>
     </html>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,15 @@ import { CartProvider } from './lib/cart';
 import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
 import TurianAssistant from './components/TurianAssistant';
+import { useAuth } from './lib/auth-context';
 import './styles/magic.css';
 // TEMP: disable interactions while we isolate the crash
 // import { initInteractions } from './init/interactions';
 import './init/runtime-logger'; // lightweight global error hooks
 
 export default function App() {
+  const { ready, user } = useAuth();
+  const isAuthed = ready && !!user;
   useEffect(() => {
     // SAFE MODE: interactions temporarily disabled
   }, []);
@@ -34,7 +37,7 @@ export default function App() {
           </div>
         </main>
         <ToasterListener />
-        <TurianAssistant />
+        <TurianAssistant isAuthed={isAuthed} />
       </>
     </CartProvider>
   );


### PR DESCRIPTION
## Summary
- add optional auth override prop to TurianAssistant and hide widget when unauthenticated
- pass session auth state to TurianAssistant in React and Next.js roots

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type ... is not assignable to parameter of type 'never')*


------
https://chatgpt.com/codex/tasks/task_e_68bae3b8890c8329851699124f0e0770