### PR TITLE
feat: improve Turian assistant widget

### DIFF
--- a/app/TurianAssistantWrapper.tsx
+++ b/app/TurianAssistantWrapper.tsx
@@ -1,9 +1,7 @@
 'use client';
 
 import TurianAssistant from '@/components/TurianAssistant';
-import { useUser } from '@supabase/auth-helpers-react';
 
 export default function TurianAssistantWrapper() {
-  const user = useUser();
-  return <TurianAssistant isAuthed={!!user} />;
+  return <TurianAssistant />;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,18 +6,15 @@ import { CartProvider } from './lib/cart';
 import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
 import TurianAssistant from './components/TurianAssistant';
-import { useAuth } from './lib/auth-context';
 import './styles/magic.css';
 // TEMP: disable interactions while we isolate the crash
 // import { initInteractions } from './init/interactions';
 import './init/runtime-logger'; // lightweight global error hooks
 
 export default function App() {
-  const { ready, user } = useAuth();
-  const isAuthed = ready && !!user;
   useEffect(() => {
-    // SAFE MODE: interactions temporarily disabled
-  }, []);
+      // SAFE MODE: interactions temporarily disabled
+    }, []);
   return (
     <CartProvider>
       <>
@@ -37,7 +34,7 @@ export default function App() {
           </div>
         </main>
         <ToasterListener />
-        <TurianAssistant isAuthed={isAuthed} />
+          <TurianAssistant />
       </>
     </CartProvider>
   );

--- a/src/components/TurianAssistant.tsx
+++ b/src/components/TurianAssistant.tsx
@@ -1,304 +1,181 @@
-"use client";
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { createClient } from "@supabase/supabase-js";
+import "./turian-assistant.css";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+type UiMsg = { role: "user" | "assistant" | "system"; content: string };
 
-/** Brand tokens (adjust if your blue is different) */
-const BRAND_BLUE = "#2563EB"; // Naturverse blue
-const RADIUS = 14;
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_ANON_KEY!
+);
 
-type TurianAssistantProps = {
-  /** When provided, this wins. If false, the widget won't render at all. */
-  isAuthed?: boolean;
+// simple, router-agnostic map (add/change paths to fit your site)
+const ROUTE_ALIASES: Record<string, string> = {
+  home: "/",
+  languages: "/languages",
+  language: "/languages",
+  course: "/languages",
+  courses: "/languages",
+  learn: "/learn",
+  play: "/play",
+  worlds: "/worlds",
+  zones: "/zones",
+  marketplace: "/marketplace",
+  market: "/marketplace",
+  shop: "/shop",
+  cart: "/cart",
+  profile: "/profile",
 };
 
-type ChatMsg = { role: "user" | "assistant"; content: string };
+function tryNavigateFromMessage(text: string) {
+  // “where is …”, “where are …”, “go to …”, “open …”
+  const m =
+    text.match(/^\s*(where\s+(is|are)\s+|go\s+to\s+|open\s+)(the\s+)?(.+?)\s*$/i) ||
+    text.match(/^\s*(languages|worlds|zones|courses|shop|cart|home)\s*$/i);
+  if (!m) return false;
 
-function getZone(pathname: string) {
-  // tiny helper so we can answer differently later (Home, Worlds, Zones, etc.)
-  const p = (pathname || "/").toLowerCase();
-  if (p.startsWith("/marketplace")) return "Marketplace";
-  if (p.startsWith("/naturversity")) return "Naturversity";
-  if (p.startsWith("/navatar")) return "Navatar";
-  if (p === "/" || p.startsWith("/home")) return "Home";
-  return "Site";
+  const key = (m[4] ?? m[1] ?? text).toLowerCase().trim();
+  // normalize simple plurals/spacing
+  const norm = key.replace(/[^a-z0-9 ]+/g, "").replace(/\s+/g, " ");
+  const target =
+    ROUTE_ALIASES[norm] ||
+    ROUTE_ALIASES[norm.replace(/s$/, "")] ||
+    ROUTE_ALIASES[norm.split(" ")[0]];
+  if (!target) return false;
+
+  // navigate without depending on a specific router
+  window.location.assign(target);
+  return true;
 }
 
-/** Dumb check: if a Supabase auth cookie exists, we treat as signed-in */
-function isSignedIn() {
-  try {
-    const hasCookie = document.cookie
-      .split("; ")
-      .some((c) => c.startsWith("sb-") && c.includes("auth"));
-    const hasStorage = Object.keys(localStorage).some(
-      (k) => k.startsWith("sb-") && k.endsWith("-auth-token"),
-    );
-    return hasCookie || hasStorage;
-  } catch {
-    return false;
-  }
+export default function TurianAssistant() {
+  // Auth-gated: show only when logged in
+  const [session, setSession] = useState<boolean>(false);
+  useEffect(() => {
+    let mounted = true;
+    supabase.auth.getSession().then(({ data }) => mounted && setSession(!!data.session));
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => setSession(!!s));
+    return () => {
+      mounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  if (!session) return null;
+
+  return createPortal(<AssistantUi />, document.body);
 }
 
-export default function TurianAssistant({
-  isAuthed,
-}: TurianAssistantProps) {
+function AssistantUi() {
   const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<UiMsg[]>([
+    { role: "system", content: 'Try: "Where is languages?"' },
+  ]);
   const [input, setInput] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [messages, setMessages] = useState<ChatMsg[]>([]);
-  const areaRef = useRef<HTMLDivElement>(null);
+  const [sending, setSending] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
 
-  const zone = useMemo(() => getZone(window.location.pathname), []);
-
+  // auto-scroll to latest
   useEffect(() => {
-    // starter tip so the box isn't empty
-    if (messages.length === 0) {
-      setMessages([
-        { role: "assistant", content: `Try: "Where is languages?"` },
-      ]);
-    }
-  }, []); // eslint-disable-line
-
-  useEffect(() => {
-    // keep scroll pinned to bottom on new content
-    const el = areaRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    const el = listRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
   }, [messages, open]);
 
-  const derived = useMemo(() => {
-    if (typeof isAuthed === "boolean") return isAuthed;
-    return isSignedIn();
-  }, [isAuthed]);
-
-  if (!derived) return null;
+  const canSend = useMemo(() => input.trim().length > 0 && !sending, [input, sending]);
 
   async function send() {
     const text = input.trim();
-    if (!text || busy) return;
+    if (!text) return;
 
-    // If logged out, show CTA and keep drawer open
-    if (!isSignedIn()) {
-      setMessages((m) => [
-        ...m,
-        { role: "user", content: text },
-        {
-          role: "assistant",
-          content:
-            "Please create an account or continue with Google to get started!",
-        },
-      ]);
-      setInput("");
-      return;
-    }
-
-    setBusy(true);
+    // local echo
     setMessages((m) => [...m, { role: "user", content: text }]);
     setInput("");
 
+    // “Where is …” -> navigate immediately
+    if (tryNavigateFromMessage(text)) {
+      setOpen(false);
+      return;
+    }
+
+    // otherwise call your Netlify function
+    setSending(true);
     try {
       const res = await fetch("/.netlify/functions/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          zone,
-          messages: [
-            // give the function a tiny bit of context
-            { role: "system", content: `You are Turian in ${zone}.` },
-            ...messages,
-            { role: "user", content: text },
-          ],
-        }),
+        body: JSON.stringify({ messages }),
       });
-
-      if (!res.ok) throw new Error(await res.text());
-      const json = (await res.json()) as { reply?: string };
-      setMessages((m) => [
-        ...m,
-        { role: "assistant", content: json.reply || "Okay!" },
-      ]);
+      const data = await res.json();
+      const reply: string =
+        data?.reply ?? "Sorry — I couldn't find that yet, try asking about languages, worlds, zones, or shop.";
+      setMessages((m) => [...m, { role: "assistant", content: reply }]);
     } catch (e) {
       setMessages((m) => [
         ...m,
-        { role: "assistant", content: "Something went wrong. Try again." },
+        { role: "assistant", content: "Network hiccup — please try again." },
       ]);
     } finally {
-      setBusy(false);
-    }
-    // IMPORTANT: we do NOT auto-close; the X is always visible
-  }
-
-  function onKey(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      send();
+      setSending(false);
     }
   }
 
   return (
     <>
-      {/* Floating button (bottom-right) */}
+      {/* Floating action button */}
       <button
+        className="turian-fab"
         aria-label="Ask Turian"
         onClick={() => setOpen(true)}
-        style={{
-          position: "fixed",
-          right: 16,
-          bottom: 16,
-          width: 56,
-          height: 56,
-          borderRadius: "50%",
-          background: "#ffffff",
-          border: `2px solid ${BRAND_BLUE}`,
-          boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
-          display: open ? "none" : "inline-flex",
-          alignItems: "center",
-          justifyContent: "center",
-          padding: 0,
-          cursor: "pointer",
-          zIndex: 90_000,
-        }}
       >
-        {/* Turian head from /public */}
         <img
-          src="/favicon-64x64.png"
+          src="/favicon-64x64.png" // use your round favicon (public/favicon-64x64.png)
           alt="Turian"
-          width={32}
-          height={32}
-          style={{ display: "block" }}
+          className="turian-fab__img"
+          draggable={false}
         />
       </button>
 
-      {/* Drawer */}
+      {/* Drawer / dialog */}
       {open && (
-        <div
-          role="dialog"
-          aria-label="Ask Turian"
-          style={{
-            position: "fixed",
-            right: 12,
-            bottom: 12,
-            width: "min(420px, 92vw)",
-            maxHeight: "72vh", // mobile-safe
-            background: "#fff",
-            border: "1px solid rgba(0,0,0,0.08)",
-            borderRadius: RADIUS,
-            boxShadow: "0 18px 40px rgba(0,0,0,0.22)",
-            zIndex: 90_001,
-            display: "flex",
-            flexDirection: "column",
-            overflow: "hidden",
-          }}
-        >
-          {/* Header */}
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 10,
-              background: BRAND_BLUE,
-              color: "#fff",
-              padding: "10px 12px",
-            }}
-          >
-            <img
-              src="/favicon-64x64.png"
-              alt="Turian"
-              width={20}
-              height={20}
-              style={{ borderRadius: 6, background: "#fff" }}
-            />
-            <strong style={{ fontWeight: 700 }}>Ask Turian</strong>
-            <div style={{ flex: 1 }} />
-            <button
-              aria-label="Close"
-              onClick={() => setOpen(false)}
-              style={{
-                background: "rgba(255,255,255,0.2)",
-                color: "#fff",
-                border: "none",
-                borderRadius: 8,
-                padding: "4px 8px",
-                cursor: "pointer",
-                fontWeight: 700,
-              }}
-            >
-              X
-            </button>
+        <div className="turian-dialog" role="dialog" aria-label="Ask Turian">
+          <div className="turian-dialog__header">
+            <div className="turian-dialog__title">
+              <img src="/favicon-32x32.png" alt="" />
+              <span>Ask Turian</span>
+            </div>
+            <button className="turian-dialog__close" onClick={() => setOpen(false)} aria-label="Close">×</button>
           </div>
 
-          {/* Messages */}
-          <div
-            ref={areaRef}
-            style={{
-              padding: 12,
-              overflow: "auto",
-              gap: 8,
-              display: "flex",
-              flexDirection: "column",
-              background: "#F8FAFC",
-            }}
-          >
+          <div ref={listRef} className="turian-dialog__messages">
             {messages.map((m, i) => (
-              <div
-                key={i}
-                style={{
-                  alignSelf: m.role === "user" ? "flex-end" : "flex-start",
-                  background: m.role === "user" ? BRAND_BLUE : "#fff",
-                  color: m.role === "user" ? "#fff" : "#111827",
-                  border: "1px solid rgba(0,0,0,0.06)",
-                  borderRadius: 12,
-                  padding: "8px 10px",
-                  maxWidth: "90%",
-                  whiteSpace: "pre-wrap",
-                }}
-              >
+              <div key={i} className={`msg msg--${m.role}`}>
                 {m.content}
               </div>
             ))}
           </div>
 
-          {/* Input row */}
-          <div
-            style={{
-              padding: 12,
-              borderTop: "1px solid rgba(0,0,0,0.08)",
-              display: "flex",
-              gap: 8,
-              background: "#fff",
+          <form
+            className="turian-dialog__input"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (canSend) void send();
             }}
           >
             <input
-              aria-label="Ask Turian"
-              placeholder="Ask Turian…"
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              onKeyDown={onKey}
-              disabled={busy}
-              style={{
-                flex: 1,
-                fontSize: 16,
-                padding: "10px 12px",
-                borderRadius: 10,
-                border: "1px solid rgba(0,0,0,0.12)",
-                outline: "none",
-              }}
+              placeholder="Ask Turian…"
+              // iOS zoom fix — keep at least 16px
+              inputMode="text"
+              autoComplete="off"
             />
-            <button
-              onClick={send}
-              disabled={busy || !input.trim()}
-              style={{
-                background: BRAND_BLUE,
-                color: "#fff",
-                border: "none",
-                borderRadius: 10,
-                padding: "10px 14px",
-                fontWeight: 700,
-                cursor: busy ? "default" : "pointer",
-                opacity: busy || !input.trim() ? 0.6 : 1,
-              }}
-            >
-              Send
+            <button disabled={!canSend} type="submit">
+              {sending ? "…" : "Send"}
             </button>
-          </div>
+          </form>
         </div>
       )}
     </>

--- a/src/components/turian-assistant.css
+++ b/src/components/turian-assistant.css
@@ -1,0 +1,128 @@
+/* High z-index so it sits above everything */
+.turian-fab {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 2147483000;
+  width: 64px;
+  height: 64px;
+  border: 0;
+  border-radius: 9999px;
+  background: var(--brand-blue, #2f6bff);
+  box-shadow: 0 8px 24px rgba(0,0,0,.18);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+.turian-fab__img {
+  width: 42px;
+  height: 42px;
+  border-radius: 9999px;           /* keep round */
+  pointer-events: none;
+}
+
+/* Drawer */
+.turian-dialog {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 2147483646;
+  width: min(420px, calc(100vw - 24px));
+  max-height: min(70vh, 560px);
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 16px 40px rgba(0,0,0,.22);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.turian-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--brand-blue, #2f6bff);
+  color: #fff;
+  padding: 12px 12px 12px 14px;
+}
+.turian-dialog__title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  font-size: 18px;
+}
+.turian-dialog__title img { width: 20px; height: 20px; border-radius: 50%; }
+
+.turian-dialog__close {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 0;
+  background: rgba(255,255,255,.2);
+  color: #fff;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.turian-dialog__messages {
+  padding: 12px;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  gap: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+.msg { 
+  border-radius: 12px; 
+  padding: 10px 12px; 
+  font-size: 15px; 
+  line-height: 1.35;
+  background: #f5f7ff;
+  color: #111827;
+}
+.msg--user {
+  align-self: flex-end;
+  background: var(--brand-blue, #2f6bff);
+  color: #fff;
+}
+
+.turian-dialog__input {
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px 12px;
+  background: #fff;
+  border-top: 1px solid #eef0f6;
+}
+.turian-dialog__input input {
+  flex: 1;
+  height: 44px;
+  padding: 0 12px;
+  border: 1px solid #e2e6f0;
+  border-radius: 12px;
+  font-size: 16px;           /* iOS no-zoom */
+}
+.turian-dialog__input button {
+  height: 44px;
+  min-width: 86px;
+  border: 0;
+  border-radius: 12px;
+  background: var(--brand-blue, #2f6bff);
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+}
+.turian-dialog__input button:disabled { opacity: .55; cursor: default; }
+
+/* Small screens: keep comfortable and non-intrusive */
+@media (max-width: 480px) {
+  .turian-fab { right: 12px; bottom: 12px; width: 60px; height: 60px; }
+  .turian-dialog {
+    right: 12px; bottom: 12px;
+    width: calc(100vw - 24px);
+    max-height: min(68vh, 520px);
+  }
+}
+


### PR DESCRIPTION
## Summary
- overhaul Turian assistant with Supabase-auth gate, portal-based drawer, and navigation shortcuts
- update wrapper and app entry to mount assistant without auth prop

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: Argument of type 'Partial<Omit<...>>' is not assignable to parameter of type 'never')


------
https://chatgpt.com/codex/tasks/task_e_68baeef0338083298e7d9ea52113d024