### PR TITLE
Restore circular Turian chat FAB

### DIFF
--- a/src/components/TurianAssistant.css
+++ b/src/components/TurianAssistant.css
@@ -1,0 +1,33 @@
+/* Floating action button (FAB) */
+.turian-fab {
+  position: fixed;
+  right: clamp(12px, 3vw, 20px);
+  bottom: clamp(12px, 3vw, 20px);
+  width: 56px;
+  height: 56px;
+  border-radius: 9999px;
+  border: 3px solid var(--brand-blue, #2F63FF); /* blue ring */
+  background: #fff;                               /* clear/white center */
+  display: grid;
+  place-items: center;
+  box-shadow: 0 6px 16px rgba(0,0,0,.18);
+  z-index: 9999;                                  /* above page chrome */
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.turian-fab img {
+  width: 70%;
+  height: 70%;
+  object-fit: contain;         /* prevents the “rounded square” look */
+  border-radius: 50%;          /* keep the mascot circular */
+  image-rendering: auto;       /* avoid pixelation on mobile */
+}
+
+/* reduce motion ripple-ish feedback */
+.turian-fab:active { transform: translateY(1px); }
+
+/* keep mobile safe area clear */
+@supports (padding: max(0px)) {
+  .turian-fab { right: max(12px, env(safe-area-inset-right)); bottom: max(12px, env(safe-area-inset-bottom)); }
+}

--- a/src/components/TurianAssistant.tsx
+++ b/src/components/TurianAssistant.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import "./TurianAssistant.css";
 
 /** Brand tokens (adjust if your blue is different) */
 const BRAND_BLUE = "#2563EB"; // Naturverse blue
@@ -135,37 +136,22 @@ export default function TurianAssistant({
 
   return (
     <>
-      {/* Floating button (bottom-right) */}
-      <button
-        aria-label="Ask Turian"
-        onClick={() => setOpen(true)}
-        style={{
-          position: "fixed",
-          right: 16,
-          bottom: 16,
-          width: 56,
-          height: 56,
-          borderRadius: "50%",
-          background: "#ffffff",
-          border: `2px solid ${BRAND_BLUE}`,
-          boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
-          display: open ? "none" : "inline-flex",
-          alignItems: "center",
-          justifyContent: "center",
-          padding: 0,
-          cursor: "pointer",
-          zIndex: 90_000,
-        }}
-      >
-        {/* Turian head from /public */}
-        <img
-          src="/favicon-64x64.png"
-          alt="Turian"
-          width={32}
-          height={32}
-          style={{ display: "block" }}
-        />
-      </button>
+        {/* Floating button (bottom-right) */}
+        {!open && (
+          <button
+            type="button"
+            className="turian-fab"
+            aria-label="Open Turian chat"
+            onClick={() => setOpen(true)}
+          >
+            <img
+              src="/favicon-64x64.png"
+              alt="Turian"
+              decoding="async"
+              loading="eager"
+            />
+          </button>
+        )}
 
       {/* Drawer */}
       {open && (


### PR DESCRIPTION
## Summary
- style: add TurianAssistant.css for floating action button styling
- feat: replace inline FAB markup with `.turian-fab` button and mascot image

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next' and other declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68baf20857208329b00d7d4e82aae783