### PR TITLE
feat: add assistant deep link navigation

### DIFF
--- a/src/routes/zones/index.tsx
+++ b/src/routes/zones/index.tsx
@@ -10,12 +10,15 @@ export default function Zones() {
         <Breadcrumbs />
         <h1>Zones</h1>
         <div className="cards grid-gap">
-        {ZONES.map((z) => (
-          <a key={z.href} className="card" href={z.href}>
-            <h2>{z.title}</h2>
-            <p>{z.blurb}</p>
-          </a>
-        ))}
+        {ZONES.map((z) => {
+          const id = z.href.split("/").pop();
+          return (
+            <a key={z.href} className="card" href={z.href}>
+              <h2 id={id}>{z.title}</h2>
+              <p>{z.blurb}</p>
+            </a>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- make Turian Assistant understand "take me to" phrases and deep link to routes or in-page anchors
- add IDs on Zones tiles so hash navigation can scroll to sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'Partial<...>' is not assignable to parameter of type 'never')*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react-swc')*

------
https://chatgpt.com/codex/tasks/task_e_68baf498bed8832991b750cd0873f069