### PR TITLE
feat: restore assistant navigation

### DIFF
--- a/src/components/TurianAssistant.tsx
+++ b/src/components/TurianAssistant.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { maybeNavigateFrom } from "@/lib/assistant/maybeNavigateFrom";
 
 /** Brand tokens (adjust if your blue is different) */
 const BRAND_BLUE = "#2563EB"; // Naturverse blue
@@ -90,9 +91,26 @@ export default function TurianAssistant({
       return;
     }
 
-    setBusy(true);
     setMessages((m) => [...m, { role: "user", content: text }]);
     setInput("");
+
+    const href = maybeNavigateFrom(text);
+    if (href) {
+      setMessages((m) => [
+        ...m,
+        {
+          role: "assistant",
+          content: `On it! Taking you to ${href.replace("/", "")}…`,
+        },
+      ]);
+      setOpen(false);
+      setTimeout(() => {
+        window.location.href = href;
+      }, 150);
+      return;
+    }
+
+    setBusy(true);
 
     try {
       const res = await fetch("/.netlify/functions/chat", {

--- a/src/lib/assistant/maybeNavigateFrom.ts
+++ b/src/lib/assistant/maybeNavigateFrom.ts
@@ -1,0 +1,76 @@
+const toPath = (slug: string) => {
+  switch (slug) {
+    case "home":
+      return "/";
+    case "zones":
+      return "/zones";
+    case "languages":
+      return "/languages";
+    case "music":
+      return "/zones#music";
+    case "arcade":
+      return "/zones#arcade";
+    case "wellness":
+      return "/zones#wellness";
+    case "creator-lab":
+    case "creator":
+    case "lab":
+      return "/zones#creator-lab";
+    case "stories":
+      return "/zones#stories";
+    case "marketplace":
+    case "shop":
+    case "store":
+      return "/marketplace";
+    case "worlds":
+      return "/worlds";
+    case "cart":
+      return "/cart";
+    case "profile":
+    case "account":
+      return "/account";
+    default:
+      return null;
+  }
+};
+
+export function maybeNavigateFrom(input: string): string | null {
+  if (!input) return null;
+  // normalize
+  const text = input
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, " ")
+    .trim();
+
+  // common phrasings
+  const targets = [
+    "languages",
+    "zones",
+    "music",
+    "arcade",
+    "wellness",
+    "creator-lab",
+    "creator",
+    "lab",
+    "stories",
+    "marketplace",
+    "shop",
+    "store",
+    "worlds",
+    "cart",
+    "profile",
+    "account",
+    "home",
+  ];
+
+  for (const t of targets) {
+    // match exact word in the sentence (e.g., "where is languages", "take me to music")
+    const re = new RegExp(`\\b(${t.replace("-", "\\-")})\\b`);
+    if (re.test(text)) {
+      const path = toPath(t);
+      if (path) return path;
+    }
+  }
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- add helper to map intent slugs to paths
- route user prompts locally before calling chat API

## Testing
- `npm test` *(fails: Missing script)*
- `npm run typecheck` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68baf8e7f1cc8329a6f7f9a5f55ff8d2