### PR TITLE
Enhance TurianAssistant with navigation intents + analytics

### DIFF
--- a/src/data/assistantMap.ts
+++ b/src/data/assistantMap.ts
@@ -1,0 +1,11 @@
+export const assistantMap = {
+  languages: { path: "/languages", synonyms: ["language", "phrases", "words"] },
+  worlds: { path: "/worlds", synonyms: ["kingdoms", "map", "adventure"] },
+  zones: { path: "/zones", synonyms: ["activities", "areas", "sections"] },
+  marketplace: { path: "/marketplace", synonyms: ["shop", "store", "buy"] },
+  music: { path: "/zones#music", synonyms: ["songs", "karaoke", "beats"] },
+  wellness: { path: "/zones#w", synonyms: ["yoga", "stretching", "mindfulness"] },
+  arcade: { path: "/zones#a", synonyms: ["games", "mini games", "play"] },
+  stories: { path: "/zones#stories", synonyms: ["adventures", "quests"] },
+  creator: { path: "/zones#creator", synonyms: ["lab", "maker", "art"] },
+};

--- a/supabase/migrations/2025-09-01-add_analytics_table.sql
+++ b/supabase/migrations/2025-09-01-add_analytics_table.sql
@@ -1,0 +1,8 @@
+create table if not exists analytics (
+  id uuid primary key default gen_random_uuid(),
+  event text not null,
+  from_page text,
+  to_page text,
+  text text,
+  created_at timestamp default now()
+);


### PR DESCRIPTION
## Summary
- map user phrases to paths with synonyms for core sections
- log assistant navigation events to Supabase
- add migration for analytics table

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bafcc5637083299a6db9914319821f