### PR TITLE
feat: log assistant analytics and add viewer

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,23 @@
+import { supabase } from './supabase-client';
+
+type AnalyticsEvent = {
+  event: string;
+  from_page?: string | null;
+  to_page?: string | null;
+  text?: string | null;
+};
+
+export async function logEvent(payload: AnalyticsEvent) {
+  try {
+    await supabase.from('analytics').insert({
+      event: payload.event,
+      from_page: payload.from_page ?? null,
+      to_page: payload.to_page ?? null,
+      text: payload.text ?? null,
+    });
+  } catch (e) {
+    // non-blocking: never break UX if logging fails
+    console.warn('analytics log failed', e);
+  }
+}
+

--- a/src/pages/analytics.tsx
+++ b/src/pages/analytics.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase-client';
+
+type Row = {
+  id: string;
+  event: string;
+  from_page: string | null;
+  to_page: string | null;
+  text: string | null;
+  created_at: string;
+};
+
+export default function AnalyticsPage() {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const { data, error } = await supabase
+        .from('analytics')
+        .select('*')
+        .order('created_at', { ascending: false })
+        .limit(200);
+      if (!error && data) setRows(data as Row[]);
+      setLoading(false);
+    })();
+  }, []);
+
+  if (loading) return <div style={{ padding: 24 }}>Loading…</div>;
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>Turian Analytics (latest 200)</h1>
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr>
+            <th align="left">Time</th>
+            <th align="left">Event</th>
+            <th align="left">From</th>
+            <th align="left">To</th>
+            <th align="left">Text</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.id} style={{ borderTop: '1px solid #eee' }}>
+              <td>{new Date(r.created_at).toLocaleString()}</td>
+              <td>{r.event}</td>
+              <td>{r.from_page ?? ''}</td>
+              <td>{r.to_page ?? ''}</td>
+              <td>{r.text ?? ''}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -49,6 +49,8 @@ import About from './pages/About';
 import NotFound from './pages/NotFound';
 import RootLayout from './layouts/Root';
 import ZonesLayout from './layouts/Zones';
+import AnalyticsPage from './pages/analytics';
+import ProtectedRoute from './components/ProtectedRoute';
 
 export const router = createBrowserRouter([
   {
@@ -117,6 +119,7 @@ export const router = createBrowserRouter([
         { path: 'login', element: <LoginPage /> },
         { path: 'turian', element: <Turian /> },
         { path: 'profile', element: <ProfilePage /> },
+        { path: 'analytics', element: <ProtectedRoute component={AnalyticsPage} /> },
         { path: '404', element: <NotFound /> },
         { path: '*', element: <NotFound /> },
     ],


### PR DESCRIPTION
## Summary
- track assistant activity via reusable analytics util
- log open, message, navigate, and close events in TurianAssistant
- add simple protected analytics viewer page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Partial<Omit<{ id: string; user_id: string; name: string | null; ... }, "created_at" | "id" | "updated_at">>' is not assignable to parameter of type 'never'.)*

------
https://chatgpt.com/codex/tasks/task_e_68baffbed79c8329a5657b61ec092230