### PR TITLE
Fix Navatar saving and preview styles

### DIFF
--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -1,0 +1,62 @@
+import { createClient } from '@supabase/supabase-js';
+
+export type NavatarRow = {
+  id: string;
+  user_id: string;
+  name: string | null;
+  base_type: 'Animal' | 'Fruit' | 'Insect' | 'Spirit';
+  backstory: string | null;
+  image_url: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export async function saveNavatar({
+  supabase,
+  userId,
+  name,
+  baseType,
+  backstory,
+  file,
+}: {
+  supabase: ReturnType<typeof createClient>;
+  userId: string;
+  name: string | null;
+  baseType: NavatarRow['base_type'];
+  backstory: string | null;
+  file: File | null;
+}) {
+  let image_url: string | null = null;
+
+  if (file) {
+    const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
+    const objectKey = `navatars/${userId}/${crypto.randomUUID()}.${ext}`;
+
+    const { error: upErr } = await supabase.storage.from('avatars').upload(objectKey, file, {
+      cacheControl: '3600',
+      upsert: false,
+      contentType: file.type || `image/${ext}`,
+    });
+
+    if (upErr) throw new Error(`upload_failed:${upErr.message}`);
+
+    const { data } = supabase.storage.from('avatars').getPublicUrl(objectKey);
+
+    image_url = data.publicUrl;
+  }
+
+  const { data: row, error: insErr } = await supabase
+    .from('avatars')
+    .insert({
+      user_id: userId,
+      name,
+      base_type: baseType,
+      backstory,
+      image_url,
+    })
+    .select()
+    .single();
+
+  if (insErr) throw new Error(`insert_failed:${insErr.message}`);
+  return row as NavatarRow;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import './main.css';
 import './styles/nvcard.css';
 import './app.css';
 import './styles/nv-sweep.css';
+import './styles/navatar.css';
 import ToastProvider from './components/Toast';
 import SkipLink from './components/SkipLink';
 import OfflineBanner from './components/OfflineBanner';
@@ -25,16 +26,16 @@ async function bootstrap() {
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       {/* Ensure auth context wraps the entire app so Home gets updates immediately */}
-        <AuthProvider initialSession={initialSession}>
-          <SkipLink />
-          <ToastProvider>
-            <OfflineBanner />
-            <BaseAuthProvider>
-              <App />
-            </BaseAuthProvider>
-          </ToastProvider>
-        </AuthProvider>
-      </React.StrictMode>,
+      <AuthProvider initialSession={initialSession}>
+        <SkipLink />
+        <ToastProvider>
+          <OfflineBanner />
+          <BaseAuthProvider>
+            <App />
+          </BaseAuthProvider>
+        </ToastProvider>
+      </AuthProvider>
+    </React.StrictMode>,
   );
 }
 

--- a/src/routes/navatar/index.tsx
+++ b/src/routes/navatar/index.tsx
@@ -1,23 +1,118 @@
-import { useState } from "react";
-const types = ["Animal","Fruit","Insect","Spirit"] as const;
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '@/lib/supabase-client';
+import { saveNavatar } from '@/lib/navatar';
+
+const types = ['Animal', 'Fruit', 'Insect', 'Spirit'] as const;
+
 export default function Navatar() {
-  const [sel,setSel] = useState<typeof types[number] | null>("Animal");
-    return (
-      <section className="space-y-4 navatar-page">
+  const [baseType, setBaseType] = useState<(typeof types)[number]>('Animal');
+  const [name, setName] = useState('');
+  const [backstory, setBackstory] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const navigate = useNavigate();
+
+  function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0] ?? null;
+    setFile(f);
+    setPreview(f ? URL.createObjectURL(f) : null);
+  }
+
+  async function onSave(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSaving(true);
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+    if (error || !user) {
+      alert('Please sign in to save your Navatar');
+      setSaving(false);
+      return;
+    }
+    try {
+      await saveNavatar({
+        supabase,
+        userId: user.id,
+        name: name.trim() || null,
+        baseType,
+        backstory: backstory.trim() || null,
+        file,
+      });
+      navigate('/navatar');
+    } catch (err) {
+      console.error(err);
+      alert('Could not save Navatar.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="space-y-4 navatar-page">
       <h2 className="text-2xl font-bold">Navatar Creator</h2>
-      <p className="text-gray-600">Choose a base type and generate a backstory later.</p>
-      <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-4">
-        {types.map(t=>(
-          <button key={t}
-            onClick={()=>setSel(t)}
-            className={"rounded border p-4 text-left " + (sel===t?"ring-2 ring-green-500":"")}>
-            <div className="font-semibold">{t}</div>
-            <div className="text-sm text-gray-600">Select</div>
+      <form onSubmit={onSave} className="space-y-4 navatar-form navatar-layout">
+        <div className="navatar-card">
+          <div className="navatar-preview">
+            {preview ? (
+              <img src={preview} alt="Navatar preview" />
+            ) : (
+              <div className="empty-preview">No photo</div>
+            )}
+          </div>
+        </div>
+        <div className="space-y-4">
+          <label className="block">
+            <span className="block text-sm font-medium">Name</span>
+            <input
+              className="w-full rounded border p-2"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </label>
+          <div>
+            <div className="mb-2 text-sm font-medium">Base type</div>
+            <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-4">
+              {types.map((t) => (
+                <button
+                  type="button"
+                  key={t}
+                  onClick={() => setBaseType(t)}
+                  className={
+                    'rounded border p-2 text-left ' +
+                    (baseType === t ? 'ring-2 ring-green-500' : '')
+                  }
+                >
+                  <div className="font-semibold">{t}</div>
+                  <div className="text-sm text-gray-600">Select</div>
+                </button>
+              ))}
+            </div>
+          </div>
+          <label className="block">
+            <span className="block text-sm font-medium">Backstory</span>
+            <textarea
+              className="w-full rounded border p-2"
+              rows={3}
+              value={backstory}
+              onChange={(e) => setBackstory(e.target.value)}
+            />
+          </label>
+          <label className="block">
+            <span className="block text-sm font-medium">Photo</span>
+            <input type="file" accept="image/*" onChange={onFile} />
+          </label>
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded border px-3 py-1 bg-green-600 text-white disabled:opacity-50"
+          >
+            {saving ? 'Saving...' : 'Save Navatar'}
           </button>
-        ))}
-      </div>
-      <div className="text-sm">Selected: <strong>{sel ?? "None"}</strong></div>
-      <button className="rounded border px-3 py-1 opacity-60 cursor-not-allowed">Save Navatar (stub)</button>
+        </div>
+      </form>
     </section>
   );
 }

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,0 +1,42 @@
+.navatar-card {
+  background: #fff;
+  border-radius: 16px;
+  border: 1px solid #e6ebff;
+  padding: 12px;
+}
+
+.navatar-preview {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #eef2ff;
+  aspect-ratio: 3 / 4;
+}
+
+.navatar-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+@media (max-width: 768px) {
+  .navatar-layout {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+  .navatar-preview {
+    max-width: 100%;
+  }
+}
+
+.navatar-form input,
+.navatar-form textarea,
+.navatar-form select {
+  font-size: 16px;
+}

--- a/supabase/avatars-policies.sql
+++ b/supabase/avatars-policies.sql
@@ -1,0 +1,58 @@
+-- RLS policies for public.avatars table and storage bucket
+
+-- Enable row level security on avatars table
+alter table public.avatars enable row level security;
+
+-- Select own rows
+create policy "avatars_select_own"
+  on public.avatars for select
+  to authenticated
+  using (user_id = auth.uid());
+
+-- Insert own rows
+create policy "avatars_insert_own"
+  on public.avatars for insert
+  to authenticated
+  with check (user_id = auth.uid());
+
+-- Update own rows
+create policy "avatars_update_own"
+  on public.avatars for update
+  to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+-- Storage policies for avatars bucket
+create policy "storage_upload_navats"
+  on storage.objects for insert
+  to authenticated
+  with check (
+    bucket_id = 'avatars'
+    and (storage.foldername(name))[1] = 'navatars'
+    and auth.uid() = uuid((storage.foldername(name))[2])
+  );
+
+create policy "storage_read_navats"
+  on storage.objects for select
+  to anon
+  using (bucket_id = 'avatars');
+
+create policy "storage_modify_own_navats"
+  on storage.objects for update
+  to authenticated
+  using (
+    bucket_id = 'avatars'
+    and auth.uid() = uuid((storage.foldername(name))[2])
+  )
+  with check (
+    bucket_id = 'avatars'
+    and auth.uid() = uuid((storage.foldername(name))[2])
+  );
+
+create policy "storage_delete_own_navats"
+  on storage.objects for delete
+  to authenticated
+  using (
+    bucket_id = 'avatars'
+    and auth.uid() = uuid((storage.foldername(name))[2])
+  );


### PR DESCRIPTION
## Summary
- add SQL policies for avatars table and storage
- implement saveNavatar helper and update navatar creation page
- style navatar preview for mobile and prevent iOS zoom

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0e626a988329a12f11758b651c74