### PR TITLE
Navatar Hub — Marketplace-style top tabs (mobile-friendly) + layout polish

### DIFF
--- a/src/pages/Navatar/Hub.tsx
+++ b/src/pages/Navatar/Hub.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import { listMyNavatars, navatarImageUrl, NavatarRow } from '../../lib/navatar';
+import { Link, NavLink, Outlet, useLocation } from 'react-router-dom';
+import '../../styles/navatar.css';
+
+export default function Hub() {
+  const [rows, setRows] = useState<NavatarRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    listMyNavatars().then((r) => { if (mounted) { setRows(r); setLoading(false); } });
+    return () => { mounted = false; };
+  }, []);
+
+  const tabs = [
+    { to: '/navatar/create', label: 'Create' },
+    { to: '/navatar/pick',   label: 'Pick' },
+    { to: '/navatar/upload', label: 'Upload' }
+  ];
+
+  return (
+    <main className="nv-wrap">
+      <nav className="nv-breadcrumb">
+        <Link to="/">Home</Link> <span>/</span> <span>Navatar</span>
+      </nav>
+
+      <header className="nv-header">
+        <h1 className="nv-h1">Navatar</h1>
+
+        {/* Marketplace-style top tabs */}
+        <div className="nv-top-tabs" role="tablist" aria-label="Navatar sections">
+          <div className="nv-top-tabs-scroll">
+            {tabs.map(t => (
+              <NavLink
+                key={t.to}
+                to={t.to}
+                role="tab"
+                className={({isActive}) => 'nv-pill' + (isActive ? ' nv-pill-active' : '')}
+              >
+                {t.label}
+              </NavLink>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      {/* Sub-page content renders here */}
+      {(pathname === '/navatar') && (
+        <p className="nv-muted nv-intro">Choose a tab above to start, or browse your saved Navatars below.</p>
+      )}
+      <Outlet />
+
+      <section className="nv-section">
+        <div className="nv-section-head">
+          <h2 className="nv-h2">My Navatars</h2>
+        </div>
+
+        {loading && <p className="nv-muted">Loading…</p>}
+        {!loading && rows.length === 0 && <p className="nv-muted">No Navatars yet.</p>}
+
+        <div className="nv-grid">
+          {rows.map((r) => {
+            const url = navatarImageUrl(r.image_path);
+            return (
+              <div key={r.id} className="nv-card">
+                {url ? (
+                  <img src={url} alt={r.name ?? r.base_type ?? 'Navatar'} />
+                ) : (
+                  <div className="nv-ph">No photo</div>
+                )}
+                <div className="nv-card-meta">
+                  <div className="nv-card-title">{r.name ?? (r.base_type ?? 'Navatar')}</div>
+                  <div className="nv-card-sub">
+                    {(r.base_type ?? '—') + ' · ' + new Date(r.created_at).toLocaleDateString()}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,63 +1,60 @@
-.Page { max-width: 1100px; margin: 0 auto; padding: 24px 16px; }
+/* page shell */
+.nv-wrap { padding: 1rem; }
+.nv-breadcrumb { display:flex; gap:.5rem; color:#64748b; font-size:.9rem; }
+.nv-header { position:sticky; top:56px; background:#fff; z-index:5; padding-bottom:.5rem; }
+.nv-h1 { font-size:2rem; margin:.25rem 0 .5rem; }
+.nv-intro { margin:.25rem 0 .75rem; }
+.nv-muted { color:#6b7280; }
 
-.Breadcrumbs { margin: 8px 0 16px; font-size: 14px; }
-.Breadcrumbs a { color: #2563eb; text-decoration: none; }
-.Breadcrumbs a:hover { text-decoration: underline; }
-.Breadcrumbs span { color: #64748b; margin: 0 6px; }
-
-.Button { display:inline-flex; align-items:center; gap:8px; border-radius:10px; padding:10px 16px; background:#e5edff; color:#1e40af; border:1px solid #c7d2fe; }
-.Button.primary { background:#3b82f6; color:white; border-color:#3b82f6; }
-
-.ctaRow { margin: 12px 0 24px; }
-
-.CreatorGrid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-@media (max-width: 900px) {
-  .CreatorGrid { grid-template-columns: 1fr; }
-}
-
-.FormCard, .PreviewCard {
-  background:white; border:1px solid #e5e7eb; border-radius:14px; padding:16px;
-}
-
-.ChipRow { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:8px; }
-.Chip { border:1px solid #c7d2fe; background:#eef2ff; color:#1e3a8a; padding:8px 12px; border-radius:999px; }
-.Chip.active { background:#3b82f6; border-color:#3b82f6; color:white; }
-
-label { display:block; margin:10px 0; }
-input[type="text"], input[type="file"], textarea {
-  width: 100%;
-  font-size: 16px; /* prevents iOS zoom */
-  border:1px solid #cbd5e1; border-radius:10px; padding:10px 12px;
-  background:white; color:#0f172a;
-}
-textarea { min-height: 96px; resize: vertical; }
-.Row { margin-top: 12px; }
-
-.CardCanvas {
-  width: 100%;
-  aspect-ratio: 3 / 4;
-  background: white;
+/* TOP TABS – mirrors Marketplace look */
+.nv-top-tabs {
   border: 1px solid #e5e7eb;
   border-radius: 12px;
+  padding: .35rem;
+  background: #fff;
   overflow: hidden;
-  display:flex; align-items:center; justify-content:center;
 }
-.CardCanvas img { max-width: 100%; max-height: 100%; object-fit: contain; display:block; }
-.NoPhoto { color:#94a3b8; }
+.nv-top-tabs-scroll {
+  display: flex;
+  gap: .5rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.nv-top-tabs-scroll::-webkit-scrollbar { display: none; }
 
-.CardGrid {
-  display:grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 16px;
+.nv-pill {
+  padding: .45rem .8rem;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  border-radius: 999px;
+  text-decoration: none;
+  white-space: nowrap;
+  font-weight: 500;
+  font-size: .95rem;
 }
-.NavatarCard { background:white; border:1px solid #e5e7eb; border-radius:14px; overflow:hidden; }
-.NavatarTitle { font-weight:700; padding:12px 12px 0; color:#1d4ed8; text-align:center; }
-.NavatarImg { height: 220px; display:flex; align-items:center; justify-content:center; padding:12px; }
-.NavatarImg img { max-width:100%; max-height:100%; object-fit:contain; }
-.NavatarMeta { padding:0 12px 12px; color:#64748b; font-size:12px; text-align:center; }
-.Error { color:#dc2626; }
-.muted { color:#64748b; font-weight:400; }
+.nv-pill-active {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+}
+
+/* sections & cards */
+.nv-section { margin-top: 1rem; }
+.nv-section-head { display:flex; align-items:center; justify-content:space-between; }
+.nv-h2 { font-size:1.25rem; margin:.25rem 0 .5rem; }
+
+.nv-grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap:12px; }
+.nv-card { border:1px solid #e5e7eb; border-radius:12px; background:#fff; overflow:hidden; display:flex; flex-direction:column; }
+.nv-card img { width:100%; display:block; }
+.nv-card-meta { padding:.5rem .6rem; }
+.nv-card-title { font-weight:600; }
+.nv-card-sub { font-size:.85rem; color:#6b7280; }
+.nv-ph { height:160px; background:#f3f4f6; display:flex; align-items:center; justify-content:center; color:#9ca3af; }
+
+/* mobile tightening */
+@media (max-width: 640px) {
+  .nv-wrap { padding: .75rem; }
+  .nv-h1 { font-size: 1.6rem; }
+  .nv-grid { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap:10px; }
+  .nv-header { top: 52px; } /* adjust if your site header height differs */
+}


### PR DESCRIPTION
TARGET BRANCH
main642

SUMMARY
Moves the Navatar sub-tabs (Create / Pick / Upload) to a top tab bar that mirrors Marketplace. Tabs are pill buttons, horizontally arranged, scrollable on small screens, and sticky under the header. Also tightens spacing and ensures “My Navatars” sits below the tab bar on all viewports.

FILES CHANGED
	1.	src/pages/Navatar/Hub.tsx (layout changes)
	2.	src/styles/navatar.css (new tab bar styles + mobile polish)

TEST PLAN
	1.	Open /navatar on desktop and mobile:
	•	Tabs appear at the very top under the page title, matching Marketplace styling.
	•	Tabs are horizontally arranged and scrollable on narrow screens.
	•	The tab bar remains visible when you scroll (“sticky” below the site header).
	2.	Navigate to /navatar/create, /navatar/pick, /navatar/upload and confirm the active pill highlights.
	3.	Ensure “My Navatars” grid appears below the tabs with proper wrapping on mobile.

ROLLBACK
Revert this commit (only Hub.tsx + CSS modified).

NOTES
• Sticky offset top:56px assumes your main header height; tweak if your header is taller/shorter.
• No data or API behavior changed.

------
https://chatgpt.com/codex/tasks/task_e_68bb7fd484ac8329b36d562e5420bf38