### PR TITLE
feat: add navatar hub with local storage

### DIFF
--- a/public/navatars/manifest.json
+++ b/public/navatars/manifest.json
@@ -1,0 +1,5 @@
+[
+  "Owl.png",
+  "hank.png",
+  "Turian.jpg"
+]

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,73 +1,18 @@
-import { Link, useLocation } from "react-router-dom";
-import * as React from "react";
+import { Link } from "react-router-dom";
+import "./breadcrumbs.css";
 
-type Crumb = { label: string; href?: string };
-
-const LABELS: Record<string, string> = {
-  "": "Home",
-  worlds: "Worlds",
-  naturversity: "Naturversity",
-  languages: "Languages",
-  zones: "Zones",
-  marketplace: "Marketplace",
-  naturbank: "NaturBank",
-  navatar: "Navatar",
-  passport: "Passport",
-  turian: "Turian",
-  profile: "Profile",
-  "arcade": "Arcade",
-  "music": "Music",
-  "wellness": "Wellness",
-  "creator-lab": "Creator Lab",
-  community: "Community",
-  culture: "Culture",
-  future: "Future",
-  observations: "Observations",
-  quizzes: "Quizzes",
-  stories: "Stories",
-};
-
-export function Breadcrumbs(props: { items?: Crumb[] }) {
-  const location = useLocation();
-
-  // Allow explicit items to override auto mode when needed
-  const items: Crumb[] = React.useMemo(() => {
-    if (props.items?.length) return props.items;
-
-    const parts = location.pathname.replace(/^\/+|\/+$/g, "").split("/");
-    const acc: Crumb[] = [];
-    let path = "";
-
-    // Always include Home
-    acc.push({ label: "Home", href: "/" });
-
-    parts.forEach((seg, i) => {
-      if (!seg) return;
-      path += `/${seg}`;
-      const label = LABELS[seg.toLowerCase()] ?? seg.replace(/-/g, " ");
-      const isLast = i === parts.length - 1;
-      acc.push({ label, href: isLast ? undefined : path });
-    });
-
-    return acc;
-  }, [location.pathname, props.items]);
-
-  if (items.length <= 1) return null;
-
+export default function Breadcrumbs({ items = [] }:{
+  items?: {href?: string; label: string}[];
+}) {
+  if (items.length === 0) return null;
   return (
-    <nav aria-label="Breadcrumb" className="nv-breadcrumbs">
-      <ol>
-        {items.map((c, i) => {
-          const isLast = i === items.length - 1;
-          return (
-            <li key={`${c.label}-${i}`} aria-current={isLast ? "page" : undefined}>
-              {c.href && !isLast ? <Link to={c.href}>{c.label}</Link> : <span>{c.label}</span>}
-              {!isLast && <span className="sep"> / </span>}
-            </li>
-          );
-        })}
-      </ol>
+    <nav aria-label="Breadcrumb" className="crumbs">
+      {items.map((it, i) => (
+        <span key={i} className="crumb">
+          {it.href ? <Link to={it.href}>{it.label}</Link> : <span>{it.label}</span>}
+          {i < items.length - 1 && " / "}
+        </span>
+      ))}
     </nav>
   );
 }
-export default Breadcrumbs;

--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -1,62 +1,18 @@
-import React from 'react';
-import Img from './Img';
+import type { Navatar } from "../lib/navatar/types";
+import "./characterCard.css";
 
-export type CardData = {
-  id: string;
-  name: string;
-  realm: string;
-  species: string;
-  emoji: string;
-  color: string;
-  power: string;
-  motto: string;
-  avatarDataUrl?: string; // optional base64 image
-};
-
-export const CharacterCard: React.FC<{ data: CardData }> = ({ data }) => {
-  const { name, realm, species, emoji, color, power, motto, avatarDataUrl } = data;
-
+export default function CharacterCard({navatar}:{navatar: Navatar | null}) {
   return (
-    <div
-      className="nv-card"
-      style={{
-        border: `2px solid ${color || 'var(--nv-border)'}`,
-        boxShadow: '0 6px 20px rgba(0,0,0,.08)',
-      }}
-    >
-      <div className="nv-card__header" style={{ background: color || 'var(--nv-blue-50)' }}>
-        <div className="nv-card__emoji" aria-hidden>
-          {emoji || '🌱'}
-        </div>
-        <div className="nv-card__title">
-          <div className="nv-card__name">{name || 'Navatar'}</div>
-          <div className="nv-card__sub">
-            {species || 'Species'} · {realm || 'Realm'}
-          </div>
-        </div>
+    <div className="card">
+      <div className="card-img">
+        {navatar?.imageDataUrl
+          ? <img src={navatar.imageDataUrl} alt={navatar.name || "My Navatar"} />
+          : <div className="empty">No photo</div>}
       </div>
-
-      <div className="nv-card__body">
-        <div className="nv-card__avatar">
-          {avatarDataUrl ? (
-            <Img src={avatarDataUrl} alt={`${name} avatar`} />
-          ) : (
-            <div className="nv-card__avatar--placeholder">Add image</div>
-          )}
-        </div>
-        <dl className="nv-card__facts">
-          <div>
-            <dt>Power</dt>
-            <dd>{power || '—'}</dd>
-          </div>
-          <div>
-            <dt>Motto</dt>
-            <dd>{motto || '—'}</dd>
-          </div>
-        </dl>
+      <div className="card-meta">
+        <div className="name">{navatar?.name || "My Navatar"}</div>
+        <div className="date">{navatar ? new Date(navatar.createdAt).toLocaleDateString() : ""}</div>
       </div>
-
-      <div className="nv-card__footer">Naturverse • Character Card</div>
     </div>
   );
-};
+}

--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -1,0 +1,25 @@
+import { NavLink } from "react-router-dom";
+import "./navatarTabs.css";
+
+const TABS = [
+  { to: "/navatar", label: "My Navatar" },
+  { to: "/navatar/pick", label: "Pick" },
+  { to: "/navatar/upload", label: "Upload" },
+  { to: "/navatar/generate", label: "Generate" },
+  { to: "/navatar/mint", label: "NFT / Mint" },
+  { to: "/navatar/marketplace", label: "Marketplace" },
+];
+
+export default function NavatarTabs() {
+  return (
+    <div className="nv-tabs">
+      {TABS.map(t => (
+        <NavLink key={t.to} to={t.to} className={({isActive}) =>
+          "nv-pill" + (isActive ? " is-active" : "")
+        }>
+          {t.label}
+        </NavLink>
+      ))}
+    </div>
+  );
+}

--- a/src/components/breadcrumbs.css
+++ b/src/components/breadcrumbs.css
@@ -1,0 +1,2 @@
+.crumbs{display:block;margin:0 auto 10px;max-width:980px;text-align:center}
+.crumbs a,.crumbs span{color:#1d4ed8;text-decoration:underline;text-underline-offset:3px}

--- a/src/components/characterCard.css
+++ b/src/components/characterCard.css
@@ -1,0 +1,8 @@
+.card{width:280px;border-radius:16px;border:1px solid #e5e7eb;padding:10px;background:#fff}
+.card-img{width:100%;aspect-ratio:3/4;border-radius:12px;overflow:hidden;background:#f1f5f9;
+  display:flex;align-items:center;justify-content:center}
+.card-img img{max-width:100%;max-height:100%;object-fit:contain;display:block}
+.card .empty{color:#94a3b8}
+.card-meta{display:flex;justify-content:space-between;align-items:center;margin-top:8px}
+.name{font-weight:700}
+.date{color:#64748b;font-size:.9rem}

--- a/src/components/navatarTabs.css
+++ b/src/components/navatarTabs.css
@@ -1,0 +1,11 @@
+.nv-tabs{
+  display:flex;flex-wrap:wrap;gap:10px;justify-content:center;
+  margin:12px auto 20px;max-width:980px
+}
+.nv-pill{
+  display:inline-block;padding:10px 14px;border-radius:999px;
+  border:2px solid #c7d2fe;background:#eef2ff;color:#1e3a8a;
+  text-decoration:none;font-weight:600;box-shadow:0 3px 0 #d1d5db;
+}
+.nv-pill.is-active{background:#2563eb;color:#fff;border-color:#2563eb}
+@media (max-width:640px){ .nv-pill{padding:8px 12px} }

--- a/src/lib/navatar/storage.ts
+++ b/src/lib/navatar/storage.ts
@@ -1,0 +1,21 @@
+import type { Navatar } from "./types";
+
+const ACTIVE_KEY = "navatar.active";
+const LIB_KEY = "navatar.library";
+
+export function loadActive(): Navatar | null {
+  try { return JSON.parse(localStorage.getItem(ACTIVE_KEY) || "null"); }
+  catch { return null; }
+}
+
+export function saveActive(n: Navatar) {
+  localStorage.setItem(ACTIVE_KEY, JSON.stringify(n));
+  const lib = loadLibrary();
+  const next = [n, ...lib.filter(x => x.id !== n.id)].slice(0, 100);
+  localStorage.setItem(LIB_KEY, JSON.stringify(next));
+}
+
+export function loadLibrary(): Navatar[] {
+  try { return JSON.parse(localStorage.getItem(LIB_KEY) || "[]"); }
+  catch { return []; }
+}

--- a/src/lib/navatar/types.ts
+++ b/src/lib/navatar/types.ts
@@ -1,0 +1,10 @@
+export type Navatar = {
+  id: string;
+  name?: string;
+  imageDataUrl?: string; // active image
+  createdAt: number;
+};
+
+export function newId() {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,0 +1,50 @@
+import { useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Breadcrumbs from "../../components/Breadcrumbs";
+import NavatarTabs from "../../components/NavatarTabs";
+import CharacterCard from "../../components/CharacterCard";
+import { Navatar, newId } from "../../lib/navatar/types";
+import { saveActive } from "../../lib/navatar/storage";
+import "./navatarPage.css";
+
+// This is a lightweight stub UI for describe/edit flows.
+// (Hook up your real image service later; for now it just saves the uploaded/edited image.)
+
+export default function GenerateNavatar() {
+  const nav = useNavigate();
+  const [desc, setDesc] = useState("");
+  const [preview, setPreview] = useState<string|undefined>();
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0]; if (!f) return;
+    const reader = new FileReader();
+    reader.onload = () => setPreview(String(reader.result));
+    reader.readAsDataURL(f);
+  }
+
+  function save() {
+    const n: Navatar = { id:newId(), name: desc.trim() || "My Navatar", imageDataUrl: preview, createdAt: Date.now() };
+    saveActive(n);
+    alert("Saved ✓");
+    nav("/navatar");
+  }
+
+  return (
+    <div className="nv-wrap">
+      <h1 className="nv-title">Describe & Generate</h1>
+      <Breadcrumbs items={[{href:"/",label:"Home"},{href:"/navatar",label:"Navatar"},{label:"Describe & Generate"}]} />
+      <NavatarTabs/>
+
+      <div className="gen">
+        <CharacterCard navatar={preview ? {id:"tmp", createdAt:Date.now(), name:desc, imageDataUrl:preview}: null}/>
+        <div className="gen-form">
+          <textarea value={desc} onChange={e=>setDesc(e.target.value)} placeholder="Describe your Navatar (e.g., leaf spirit with bamboo crown)…"/>
+          <input type="file" accept="image/*" ref={fileRef} onChange={onFile}/>
+          <button className="primary" disabled={!preview && !desc.trim()} onClick={save}>Save</button>
+          <small className="hint">Upload a selfie or image to edit; generation hook can be added later.</small>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
+import NavatarTabs from "../../components/NavatarTabs";
+import CharacterCard from "../../components/CharacterCard";
+import { loadActive } from "../../lib/navatar/storage";
+import type { Navatar } from "../../lib/navatar/types";
+import "./navatarPage.css";
+
+export default function NavatarHome() {
+  const [me, setMe] = useState<Navatar|null>(null);
+  useEffect(()=>{ setMe(loadActive()); },[]);
+
+  return (
+    <div className="nv-wrap">
+      <h1 className="nv-title">My Navatar</h1>
+      <Breadcrumbs items={[{href:"/",label:"Home"},{href:"/navatar",label:"Navatar"},{label:"My Navatar"}]} />
+      <NavatarTabs/>
+      <section className="nv-body">
+        <CharacterCard navatar={me}/>
+        <p className="nv-help">
+          {me ? "Set Active or make merch from tabs above."
+              : "No Navatar yet — pick, upload, or generate one above."}
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/navatar/marketplace.tsx
+++ b/src/pages/navatar/marketplace.tsx
@@ -1,0 +1,16 @@
+import Breadcrumbs from "../../components/Breadcrumbs";
+import NavatarTabs from "../../components/NavatarTabs";
+import { Link } from "react-router-dom";
+import "./navatarPage.css";
+
+export default function NavatarMarket() {
+  return (
+    <div className="nv-wrap">
+      <h1 className="nv-title">Marketplace</h1>
+      <Breadcrumbs items={[{href:"/",label:"Home"},{href:"/navatar",label:"Navatar"},{label:"Marketplace"}]} />
+      <NavatarTabs/>
+      <p className="nv-help">Create plushies, tees and more with your Navatar.</p>
+      <Link to="/marketplace" className="primary">Open Marketplace</Link>
+    </div>
+  );
+}

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -1,0 +1,16 @@
+import Breadcrumbs from "../../components/Breadcrumbs";
+import NavatarTabs from "../../components/NavatarTabs";
+import "./navatarPage.css";
+import { Link } from "react-router-dom";
+
+export default function Mint() {
+  return (
+    <div className="nv-wrap">
+      <h1 className="nv-title">Mint your Navatar as an NFT</h1>
+      <Breadcrumbs items={[{href:"/",label:"Home"},{href:"/navatar",label:"Navatar"},{label:"NFT / Mint"}]} />
+      <NavatarTabs/>
+      <p className="nv-help">Coming soon. In the meantime, make merch with your Navatar.</p>
+      <Link to="/marketplace" className="primary">Marketplace</Link>
+    </div>
+  );
+}

--- a/src/pages/navatar/navatarPage.css
+++ b/src/pages/navatar/navatarPage.css
@@ -1,0 +1,16 @@
+.nv-wrap{max-width:980px;margin:0 auto;padding:10px 16px}
+.nv-title{font-size:2.2rem;line-height:1.1;margin:8px 0 6px;text-align:center;color:#1d4ed8}
+.nv-body{display:flex;gap:24px;justify-content:center;align-items:flex-start;flex-wrap:wrap}
+.nv-help{color:#475569;text-align:center;margin-top:10px}
+.form{display:flex;flex-direction:column;gap:10px;max-width:520px;margin:0 auto}
+.form input[type="file"]{padding:8px;border:1px solid #e5e7eb;border-radius:10px;background:#fff}
+.form input{padding:10px;border:1px solid #e5e7eb;border-radius:10px}
+.primary{display:inline-block;text-align:center;padding:12px 18px;border-radius:12px;
+  background:#2563eb;color:#fff;border:none;text-decoration:none;font-weight:700;box-shadow:0 4px 0 #c7d2fe}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:14px}
+.pick{border:1px solid #e5e7eb;border-radius:12px;padding:8px;background:#fff}
+.pick img{width:100%;height:220px;object-fit:cover;border-radius:8px;display:block}
+.gen{display:flex;gap:20px;flex-wrap:wrap;justify-content:center}
+.gen-form{display:flex;flex-direction:column;gap:10px;min-width:280px;max-width:420px}
+.gen-form textarea{min-height:120px;padding:10px;border:1px solid #e5e7eb;border-radius:10px}
+.hint{color:#64748b}

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Breadcrumbs from "../../components/Breadcrumbs";
+import NavatarTabs from "../../components/NavatarTabs";
+import { newId, Navatar } from "../../lib/navatar/types";
+import { saveActive } from "../../lib/navatar/storage";
+import "./navatarPage.css";
+
+type Manifest = string[]; // filenames in /navatars
+
+export default function PickNavatar() {
+  const nav = useNavigate();
+  const [files, setFiles] = useState<string[]>([]);
+
+  useEffect(()=>{
+    fetch("/navatars/manifest.json").then(r=>r.json()).then((m:Manifest)=>setFiles(m)).catch(()=>setFiles([]));
+  },[]);
+
+  function choose(src:string) {
+    const n: Navatar = { id:newId(), name:"My Navatar", imageDataUrl: src, createdAt:Date.now() };
+    saveActive(n);
+    alert("Set as active ✓");
+    nav("/navatar");
+  }
+
+  return (
+    <div className="nv-wrap">
+      <h1 className="nv-title">Pick Navatar</h1>
+      <Breadcrumbs items={[{href:"/",label:"Home"},{href:"/navatar",label:"Navatar"},{label:"Pick"}]} />
+      <NavatarTabs/>
+      <div className="grid">
+        {files.map(fn => {
+          const url = `/navatars/${fn}`;
+          return (
+            <button key={fn} className="pick" onClick={()=>choose(url)}>
+              <img src={url} alt={fn} />
+            </button>
+          );
+        })}
+        {files.length===0 && <p>No images found in <code>public/navatars</code>.</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Breadcrumbs from "../../components/Breadcrumbs";
+import NavatarTabs from "../../components/NavatarTabs";
+import { Navatar, newId } from "../../lib/navatar/types";
+import { saveActive } from "../../lib/navatar/storage";
+import "./navatarPage.css";
+
+export default function UploadNavatar() {
+  const nav = useNavigate();
+  const [name, setName] = useState("");
+
+  function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0]; if (!f) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const n: Navatar = { id:newId(), name: name || "My Navatar", imageDataUrl:String(reader.result), createdAt:Date.now() };
+      saveActive(n);
+      alert("Uploaded ✓");
+      nav("/navatar");
+    };
+    reader.readAsDataURL(f);
+  }
+
+  return (
+    <div className="nv-wrap">
+      <h1 className="nv-title">Upload a Navatar</h1>
+      <Breadcrumbs items={[{href:"/",label:"Home"},{href:"/navatar",label:"Navatar"},{label:"Upload"}]} />
+      <NavatarTabs/>
+      <div className="form">
+        <input type="file" accept="image/*" onChange={onFile}/>
+        <input placeholder="Name (optional)" value={name} onChange={e=>setName(e.target.value)} />
+        <button className="primary" onClick={()=>{ /* no-op: submit handled on file select */ }}>Save</button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/zones/creator-lab.tsx
+++ b/src/pages/zones/creator-lab.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { Breadcrumbs } from "../../components/Breadcrumbs";
+import Breadcrumbs from "../../components/Breadcrumbs";
 import NvCard from "../../components/NvCard";
 import { setTitle } from "../_meta";
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -35,8 +35,12 @@ import BankWallet from './pages/naturbank/Wallet';
 import BankToken from './pages/naturbank/Token';
 import BankNFTs from './pages/naturbank/NFTs';
 import BankLearn from './pages/naturbank/Learn';
-import NavatarHome from './routes/navatar';
-import NavatarCreate from './routes/navatar/create';
+import NavatarHome from './pages/navatar';
+import PickNavatar from './pages/navatar/pick';
+import UploadNavatar from './pages/navatar/upload';
+import GenerateNavatar from './pages/navatar/generate';
+import Mint from './pages/navatar/mint';
+import NavatarMarket from './pages/navatar/marketplace';
 import PassportPage from './pages/passport';
 import LoginPage from './pages/Login';
 import Turian from './routes/turian';
@@ -115,7 +119,11 @@ export const router = createBrowserRouter([
       { path: 'accessibility', element: <Accessibility /> },
       { path: 'about', element: <About /> },
       { path: 'navatar', element: <NavatarHome /> },
-      { path: 'navatar/create', element: <NavatarCreate /> },
+      { path: 'navatar/pick', element: <PickNavatar /> },
+      { path: 'navatar/upload', element: <UploadNavatar /> },
+      { path: 'navatar/generate', element: <GenerateNavatar /> },
+      { path: 'navatar/mint', element: <Mint /> },
+      { path: 'navatar/marketplace', element: <NavatarMarket /> },
         { path: 'passport', element: <PassportPage /> },
         { path: 'auth/callback', element: <AuthCallback /> },
         { path: 'login', element: <LoginPage /> },


### PR DESCRIPTION
## Summary
- add Navatar types and local storage helpers
- introduce Navatar hub with tabs and multiple pages
- wire new routes and manifest for public navatars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Partial<Omit<...>>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68bbb278f6448329b7a4be26cfcca43e