### PR TITLE
Add Navatar hub and avatar-backed storage

### DIFF
--- a/public/navatars/manifest.json
+++ b/public/navatars/manifest.json
@@ -1,0 +1,7 @@
+[
+  { "name": "Turian", "image": "/navatars/Turian.jpg" },
+  { "name": "Koala", "image": "/navatars/Koala.png" },
+  { "name": "Bald Eagle", "image": "/navatars/Baldeagle.png" },
+  { "name": "Pixie", "image": "/navatars/Pixie.png" },
+  { "name": "Tiger Sport", "image": "/navatars/Tigersport.png" }
+]

--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -1,44 +1,34 @@
-import React from "react";
-import type { Navatar } from "../types/navatar";
+import type { ActiveNavatar } from "../lib/navatar/storage";
 
-type Props = { navatar: Navatar };
-
-export default function NavatarCard({ navatar }: Props) {
+export default function NavatarCard({ n }: { n: ActiveNavatar | null }) {
+  if (!n) return null;
   return (
-    <article id="navatar-card" className="nv-card navatar-card character-card">
-      <header className="cc-head">
-        <span className="cc-name">{navatar.name || navatar.species}</span>
-        <span className="cc-meta">
-          {navatar.base} • {new Date(navatar.createdAt).toLocaleDateString()}
-        </span>
-      </header>
-
-      <div className="imageWrap">
-        {navatar.imageDataUrl ? (
-          <img
-            src={navatar.imageDataUrl}
-            alt={navatar.name || navatar.species}
-            loading="lazy"
-          />
-        ) : (
-          <div className="card__placeholder" aria-label="No photo">No photo</div>
-        )}
-      </div>
-
-      <dl className="cc-fields">
-        <div>
-          <dt>Species</dt>
-          <dd>{navatar.species}</dd>
-        </div>
-        <div>
-          <dt>Powers</dt>
-          <dd>{navatar.powers.join(" · ")}</dd>
-        </div>
-        <div>
-          <dt>Backstory</dt>
-          <dd>{navatar.backstory}</dd>
-        </div>
-      </dl>
-    </article>
+    <div className="navatar-card">
+      <img src={n.imageUrl} alt={n.name} />
+      <div className="name">{n.name}</div>
+      <style>{`
+        .navatar-card {
+          display: inline-block;
+          border: 1px solid #e3e8ff;
+          border-radius: 14px;
+          padding: 10px;
+          background: #fff;
+        }
+        .navatar-card img {
+          width: 180px;
+          aspect-ratio: 3/4;
+          object-fit: cover;
+          border-radius: 10px;
+          background: #f3f6ff;
+          display: block;
+        }
+        .navatar-card .name {
+          margin-top: 8px;
+          font-weight: 700;
+          color: #1f4bff;
+          text-align: center;
+        }
+      `}</style>
+    </div>
   );
 }

--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -1,0 +1,52 @@
+import { NavLink } from "react-router-dom";
+
+export default function NavatarTabs() {
+  const tab = (to: string, label: string) => (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        "nv-tab" + (isActive ? " is-active" : "")
+      }
+      end
+    >
+      {label}
+    </NavLink>
+  );
+
+  return (
+    <>
+      <div className="nv-tabs">
+        {tab("/navatar", "My Navatar")}
+        {tab("/navatar/pick", "Pick")}
+        {tab("/navatar/upload", "Upload")}
+        {tab("/navatar/generate", "Generate")}
+        {tab("/marketplace", "Marketplace")}
+      </div>
+      <style>{`
+        .nv-tabs {
+          display: flex;
+          flex-wrap: wrap;
+          gap: .75rem;
+          justify-content: center;
+          margin: .5rem 0 1.25rem;
+          overflow-x: auto;
+          padding-bottom: .25rem;
+        }
+        .nv-tab {
+          display: inline-block;
+          padding: .6rem .9rem;
+          border: 2px solid var(--nv-blue-200);
+          border-radius: .9rem;
+          text-decoration: none;
+          color: var(--nv-blue-700);
+          background: #fff;
+          white-space: nowrap;
+        }
+        .nv-tab.is-active {
+          border-color: var(--nv-blue-400);
+          box-shadow: 0 0 0 2px rgba(60,100,255,.06) inset;
+        }
+      `}</style>
+    </>
+  );
+}

--- a/src/lib/navatar/storage.ts
+++ b/src/lib/navatar/storage.ts
@@ -1,0 +1,25 @@
+export type ActiveNavatar = {
+  id: string;
+  name: string;
+  imageUrl: string;
+  createdAt: number;
+};
+
+const KEY = "naturverse.navatar.active.v1";
+
+export function getActive(): ActiveNavatar | null {
+  try {
+    return JSON.parse(localStorage.getItem(KEY) || "null");
+  } catch {
+    return null;
+  }
+}
+
+export function setActive(n: ActiveNavatar | null) {
+  try {
+    if (n) localStorage.setItem(KEY, JSON.stringify(n));
+    else localStorage.removeItem(KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/navatar/useSupabase.ts
+++ b/src/lib/navatar/useSupabase.ts
@@ -1,0 +1,34 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_ANON_KEY!
+);
+
+// Table names & storage buckets are **avatars**
+export async function saveAvatarRow(payload: any) {
+  // e.g., { user_id, name, image_url, meta }
+  return await supabase.from("avatars").insert(payload).select().single();
+}
+
+export async function listAvatarsByUser(userId: string) {
+  return await supabase
+    .from("avatars")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+}
+
+// Storage bucket also **avatars**
+export async function uploadAvatarImage(userId: string, file: File) {
+  const path = `${userId}/${Date.now()}-${file.name}`;
+  const { data, error } = await supabase
+    .storage
+    .from("avatars")
+    .upload(path, file, { upsert: false });
+  if (error) throw error;
+  const { data: pub } = await supabase.storage
+    .from("avatars")
+    .getPublicUrl(path);
+  return pub.publicUrl; // public URL for card
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
+import NavatarTabs from "../../components/NavatarTabs";
+import { setActive } from "../../lib/navatar/storage";
+import { uploadAvatarImage, saveAvatarRow } from "../../lib/navatar/useSupabase";
+import { useNavigate } from "react-router-dom";
+
+export default function NavatarGenerate() {
+  const [file, setFile] = useState<File | null>(null);
+  const [desc, setDesc] = useState("");
+  const nav = useNavigate();
+
+  async function onSave() {
+    if (!file) return; // for now, require a file
+    const userId = "anon";
+    const publicUrl = await uploadAvatarImage(userId, file);
+    setActive({
+      id: crypto.randomUUID(),
+      name: desc || "Generated",
+      imageUrl: publicUrl,
+      createdAt: Date.now(),
+    });
+    await saveAvatarRow({ user_id: userId, name: desc, image_url: publicUrl, meta: { from: "generate" } });
+    nav("/navatar");
+  }
+
+  return (
+    <div className="container">
+      <Breadcrumbs
+        items={[
+          { href: "/", label: "Home" },
+          { href: "/navatar", label: "Navatar" },
+          { label: "Generate" },
+        ]}
+      />
+      <h1 className="center">Generate a Navatar</h1>
+      <NavatarTabs />
+
+      <div className="form">
+        <textarea
+          placeholder="Describe your Navatar"
+          value={desc}
+          onChange={(e) => setDesc(e.target.value)}
+        />
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+        />
+        <button onClick={onSave} disabled={!file}>
+          Save
+        </button>
+      </div>
+
+      <style>{`
+        .center{text-align:center}
+        .form{max-width:520px;margin:16px auto;display:grid;gap:10px}
+        textarea{border:1px solid #c9d6ff;border-radius:10px;padding:10px}
+        input{border:1px solid #c9d6ff;border-radius:10px;padding:10px}
+        button{background:#1f4bff;color:#fff;border:none;border-radius:10px;padding:12px;font-weight:700}
+      `}</style>
+    </div>
+  );
+}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,0 +1,20 @@
+import Breadcrumbs from "../../components/Breadcrumbs";
+import NavatarTabs from "../../components/NavatarTabs";
+import NavatarCard from "../../components/NavatarCard";
+import { getActive } from "../../lib/navatar/storage";
+
+export default function MyNavatar() {
+  const active = getActive();
+  return (
+    <div className="container">
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { label: "Navatar" }]} />
+      <h1 className="center">My Navatar</h1>
+      <NavatarTabs />
+      <div className="center">
+        <NavatarCard n={active} />
+        {!active && <p>No Navatar yet — Pick, Upload, or Generate above.</p>}
+      </div>
+      <style>{`.center{text-align:center}`}</style>
+    </div>
+  );
+}

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
+import NavatarTabs from "../../components/NavatarTabs";
+import { setActive } from "../../lib/navatar/storage";
+import { useNavigate } from "react-router-dom";
+
+type PublicNavatar = { name: string; image: string };
+
+export default function NavatarPick() {
+  const [items, setItems] = useState<PublicNavatar[]>([]);
+  const nav = useNavigate();
+
+  useEffect(() => {
+    // served by your repo’s public tree: public/navatars/manifest.json
+    fetch("/navatars/manifest.json")
+      .then((r) => r.json())
+      .then(setItems)
+      .catch(() => setItems([]));
+  }, []);
+
+  function choose(it: PublicNavatar) {
+    setActive({
+      id: crypto.randomUUID(),
+      name: it.name,
+      imageUrl: it.image,
+      createdAt: Date.now(),
+    });
+    nav("/navatar"); // back to hub
+  }
+
+  return (
+    <div className="container">
+      <Breadcrumbs
+        items={[
+          { href: "/", label: "Home" },
+          { href: "/navatar", label: "Navatar" },
+          { label: "Pick" },
+        ]}
+      />
+      <h1 className="center">Pick Navatar</h1>
+      <NavatarTabs />
+
+      <ul className="grid">
+        {items.map((it) => (
+          <li
+            key={it.image}
+            className="card"
+            onClick={() => choose(it)}
+            role="button"
+            tabIndex={0}
+          >
+            <img src={it.image} alt={it.name} />
+            <div className="name">{it.name}</div>
+          </li>
+        ))}
+      </ul>
+
+      <style>{`
+        .center{text-align:center}
+        .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:16px;padding:0}
+        .card{list-style:none;border:1px solid #e3e8ff;border-radius:14px;padding:10px;background:#fff;cursor:pointer}
+        .card img{width:100%;aspect-ratio:3/4;object-fit:cover;border-radius:10px;background:#f3f6ff;display:block}
+        .name{margin-top:8px;font-weight:700;color:#1f4bff;text-align:center}
+      `}</style>
+    </div>
+  );
+}

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
+import NavatarTabs from "../../components/NavatarTabs";
+import { setActive } from "../../lib/navatar/storage";
+import { uploadAvatarImage, saveAvatarRow } from "../../lib/navatar/useSupabase";
+import { useNavigate } from "react-router-dom";
+
+export default function NavatarUpload() {
+  const [file, setFile] = useState<File | null>(null);
+  const [name, setName] = useState("");
+  const nav = useNavigate();
+
+  async function onSave() {
+    if (!file) return;
+    const userId = "anon"; // replace with real auth id when available
+    const publicUrl = await uploadAvatarImage(userId, file);
+    setActive({
+      id: crypto.randomUUID(),
+      name,
+      imageUrl: publicUrl,
+      createdAt: Date.now(),
+    });
+    await saveAvatarRow({ user_id: userId, name, image_url: publicUrl, meta: {} });
+    nav("/navatar");
+  }
+
+  return (
+    <div className="container">
+      <Breadcrumbs
+        items={[
+          { href: "/", label: "Home" },
+          { href: "/navatar", label: "Navatar" },
+          { label: "Upload" },
+        ]}
+      />
+      <h1 className="center">Upload a Navatar</h1>
+      <NavatarTabs />
+
+      <div className="form">
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+        />
+        <input
+          placeholder="Name (optional)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button onClick={onSave} disabled={!file}>
+          Save
+        </button>
+      </div>
+
+      <style>{`
+        .center{text-align:center}
+        .form{max-width:520px;margin:16px auto;display:grid;gap:10px}
+        input{border:1px solid #c9d6ff;border-radius:10px;padding:10px}
+        button{background:#1f4bff;color:#fff;border:none;border-radius:10px;padding:12px;font-weight:700}
+      `}</style>
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -35,8 +35,10 @@ import BankWallet from './pages/naturbank/Wallet';
 import BankToken from './pages/naturbank/Token';
 import BankNFTs from './pages/naturbank/NFTs';
 import BankLearn from './pages/naturbank/Learn';
-import NavatarHome from './routes/navatar';
-import NavatarCreate from './routes/navatar/create';
+import NavatarIndex from './pages/navatar';
+import NavatarPick from './pages/navatar/pick';
+import NavatarUpload from './pages/navatar/upload';
+import NavatarGenerate from './pages/navatar/generate';
 import PassportPage from './pages/passport';
 import LoginPage from './pages/Login';
 import Turian from './routes/turian';
@@ -114,8 +116,15 @@ export const router = createBrowserRouter([
       { path: 'contact', element: <Contact /> },
       { path: 'accessibility', element: <Accessibility /> },
       { path: 'about', element: <About /> },
-      { path: 'navatar', element: <NavatarHome /> },
-      { path: 'navatar/create', element: <NavatarCreate /> },
+      {
+        path: 'navatar',
+        children: [
+          { index: true, element: <NavatarIndex /> },
+          { path: 'pick', element: <NavatarPick /> },
+          { path: 'upload', element: <NavatarUpload /> },
+          { path: 'generate', element: <NavatarGenerate /> },
+        ],
+      },
         { path: 'passport', element: <PassportPage /> },
         { path: 'auth/callback', element: <AuthCallback /> },
         { path: 'login', element: <LoginPage /> },


### PR DESCRIPTION
## Summary
- Replace navatar data layer with Supabase `avatars` table and storage bucket
- Add Navatar hub, pick, upload, and generate pages with horizontal tabs and blue breadcrumbs
- Read public navatar manifest for pick list and redirect back to `/navatar` after saves

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bbb640f4048329b84e40a4f7e233ff