### PR TITLE
feat: unify navatar card and tabs

### DIFF
--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -1,34 +1,26 @@
-import type { ActiveNavatar } from "../lib/navatar/storage";
+import React from "react";
 
-export default function NavatarCard({ n }: { n: ActiveNavatar | null }) {
-  if (!n) return null;
+type Props = {
+  src?: string | null;
+  title?: string;
+  subtitle?: string;
+  className?: string;
+};
+
+export default function NavatarCard({ src, title = "My Navatar", subtitle, className }: Props) {
   return (
-    <div className="navatar-card">
-      <img src={n.imageUrl} alt={n.name} />
-      <div className="name">{n.name}</div>
-      <style>{`
-        .navatar-card {
-          display: inline-block;
-          border: 1px solid #e3e8ff;
-          border-radius: 14px;
-          padding: 10px;
-          background: #fff;
-        }
-        .navatar-card img {
-          width: 180px;
-          aspect-ratio: 3/4;
-          object-fit: cover;
-          border-radius: 10px;
-          background: #f3f6ff;
-          display: block;
-        }
-        .navatar-card .name {
-          margin-top: 8px;
-          font-weight: 700;
-          color: #1f4bff;
-          text-align: center;
-        }
-      `}</style>
-    </div>
+    <figure className={`nav-card ${className ?? ""}`}>
+      <div className="nav-card__img" aria-label={title}>
+        {src ? (
+          <img src={src} alt={title} />
+        ) : (
+          <div className="nav-card__placeholder">No photo</div>
+        )}
+      </div>
+      <figcaption className="nav-card__cap">
+        <strong>{title}</strong>
+        {subtitle ? <span> · {subtitle}</span> : null}
+      </figcaption>
+    </figure>
   );
 }

--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -1,28 +1,28 @@
-import { Link } from "react-router-dom";
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
 
-type Tab = "home" | "pick" | "upload" | "generate" | "mint" | "market";
+const TABS = [
+  { to: "/navatar", label: "My Navatar" },
+  { to: "/navatar/pick", label: "Pick" },
+  { to: "/navatar/upload", label: "Upload" },
+  { to: "/navatar/generate", label: "Generate" },
+  { to: "/navatar/mint", label: "NFT / Mint" },
+  { to: "/marketplace", label: "Marketplace" },
+];
 
-export default function NavatarTabs({ active }: { active: Tab }) {
-  const pill = (to: string, label: string, key: Tab) => (
-    <Link
-      key={key}
-      to={to}
-      className={`pill ${active === key ? "pill--active" : ""}`}
-      aria-current={active === key ? "page" : undefined}
-    >
-      {label}
-    </Link>
-  );
-
+export default function NavatarTabs() {
+  const { pathname } = useLocation();
   return (
-    <nav className="navatar-tabs" role="tablist" aria-label="Navatar sections">
-      {pill("/navatar", "My Navatar", "home")}
-      {pill("/navatar/pick", "Pick", "pick")}
-      {pill("/navatar/upload", "Upload", "upload")}
-      {pill("/navatar/generate", "Generate", "generate")}
-      {pill("/navatar/mint", "NFT / Mint", "mint")}
-      {pill("/navatar/marketplace", "Marketplace", "market")}
+    <nav className="nav-tabs" aria-label="Navatar actions">
+      {TABS.map(t => {
+        const active =
+          t.to === "/navatar" ? pathname === "/navatar" : pathname.startsWith(t.to);
+        return (
+          <Link key={t.to} to={t.to} className={`pill ${active ? "pill--active" : ""}`}>
+            {t.label}
+          </Link>
+        );
+      })}
     </nav>
   );
 }
-

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,14 +1,27 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
+import NavatarCard from "../../components/NavatarCard";
 import { saveActive } from "../../lib/localStorage";
+import "../../styles/navatar.css";
 
 export default function GenerateNavatarPage() {
   const [prompt, setPrompt] = useState("");
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
+  const [draftUrl, setDraftUrl] = useState<string | undefined>();
   const nav = useNavigate();
+
+  useEffect(() => {
+    if (!file) {
+      setDraftUrl(undefined);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setDraftUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
@@ -31,8 +44,12 @@ export default function GenerateNavatarPage() {
         items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Describe & Generate" }]}
       />
       <h1 className="center">Describe &amp; Generate</h1>
-      <NavatarTabs active="generate" />
-      <form onSubmit={onSave} className="center" style={{ maxWidth: 520, margin: "16px auto" }}>
+      <NavatarTabs />
+      <form
+        onSubmit={onSave}
+        style={{ maxWidth: 520, margin: "16px auto", display: "grid", justifyItems: "center", gap: 12 }}
+      >
+        <NavatarCard src={draftUrl} title={name || "My Navatar"} />
         <textarea
           rows={4}
           placeholder="Describe your Navatar (e.g., friendly water-buffalo spirit)…"
@@ -41,7 +58,7 @@ export default function GenerateNavatarPage() {
           onChange={(e) => setPrompt(e.target.value)}
         />
         <input
-          style={{ display: "block", width: "100%", margin: "8px 0" }}
+          style={{ display: "block", width: "100%" }}
           placeholder="Name (optional)"
           value={name}
           onChange={(e) => setName(e.target.value)}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,31 +1,21 @@
 import { useMemo } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
+import NavatarCard from "../../components/NavatarCard";
 import { loadActive } from "../../lib/localStorage";
+import "../../styles/navatar.css";
 
 export default function MyNavatarPage() {
-  const active = useMemo(() => loadActive<any>(), []);
+  const activeNavatar = useMemo(() => loadActive<any>(), []);
   return (
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
       <h1 className="center">My Navatar</h1>
-      <NavatarTabs active="home" />
+      <NavatarTabs />
 
-      {active?.imageDataUrl ? (
-        <div className="navatar-card">
-          <div className="img">
-            <img src={active.imageDataUrl} alt={active.name || "My Navatar"} />
-          </div>
-          <p className="center" style={{ fontWeight: 700, marginTop: 8 }}>
-            {active.name || "Turian"}
-          </p>
-        </div>
-      ) : (
-        <p className="center" style={{ marginTop: 16 }}>
-          No Navatar yet — <a href="/navatar/pick">Pick</a>, <a href="/navatar/upload">Upload</a>, or <a href="/navatar/generate">Generate</a>.
-        </p>
-      )}
+      <div style={{ marginTop: 8 }}>
+        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
+      </div>
     </main>
   );
 }
-

--- a/src/pages/navatar/marketplace.tsx
+++ b/src/pages/navatar/marketplace.tsx
@@ -1,5 +1,6 @@
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
+import "../../styles/navatar.css";
 
 export default function MarketplaceMakerPage() {
   return (
@@ -8,7 +9,7 @@ export default function MarketplaceMakerPage() {
         items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Marketplace" }]}
       />
       <h1 className="center">Marketplace Maker</h1>
-      <NavatarTabs active="market" />
+      <NavatarTabs />
       <div className="center" style={{ maxWidth: 560, margin: "16px auto" }}>
         <p>Mock up tees, plushies, stickers and more with your Navatar. (Coming soon.)</p>
         <a className="pill" href="/marketplace">Open Marketplace</a>

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -1,15 +1,23 @@
+import { useMemo } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
+import NavatarCard from "../../components/NavatarCard";
+import { loadActive } from "../../lib/localStorage";
+import "../../styles/navatar.css";
 
 export default function MintNavatarPage() {
+  const activeNavatar = useMemo(() => loadActive<any>(), []);
   return (
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "NFT / Mint" }]} />
-      <h1 className="center">Mint your Navatar</h1>
-      <NavatarTabs active="mint" />
-      <div className="center" style={{ maxWidth: 520, margin: "16px auto" }}>
-        <p>Minting is coming soon. In the meantime, you can make merch with your Navatar.</p>
-        <a className="pill pill--active" href="/navatar/marketplace">Go to Marketplace Maker</a>
+      <h1 className="center">NFT / Mint</h1>
+      <NavatarTabs />
+      <p style={{ textAlign: "center", maxWidth: 560, margin: "8px auto 20px" }}>
+        Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.
+      </p>
+      <div style={{ display: "grid", justifyItems: "center", gap: 12 }}>
+        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "My Navatar"} />
+        <a className="pill" href="/marketplace">Go to Marketplace</a>
       </div>
     </main>
   );

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -2,8 +2,10 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
+import NavatarCard from "../../components/NavatarCard";
 import { loadPublicNavatars, PublicNavatar } from "../../lib/navatar/publicList";
 import { saveActive } from "../../lib/localStorage";
+import "../../styles/navatar.css";
 
 export default function PickNavatarPage() {
   const [items, setItems] = useState<PublicNavatar[]>([]);
@@ -22,25 +24,20 @@ export default function PickNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Pick" }]} />
       <h1 className="center">Pick Navatar</h1>
-      <NavatarTabs active="pick" />
-      <div className="grid grid-cards">
+      <NavatarTabs />
+      <div className="nav-grid">
         {items.map((it) => (
           <button
             key={it.src}
-            className="navatar-card"
+            className="linklike"
             onClick={() => choose(it.src, it.name)}
             aria-label={`Pick ${it.name}`}
+            style={{ background: "none", border: 0, padding: 0, textAlign: "inherit" }}
           >
-            <div className="img">
-              <img src={it.src} alt={it.name} />
-            </div>
-            <p className="center" style={{ fontWeight: 700, marginTop: 8 }}>
-              {it.name}
-            </p>
+            <NavatarCard src={it.src} title={it.name} />
           </button>
         ))}
       </div>
-      <style>{`.grid-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px}`}</style>
     </main>
   );
 }

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,13 +1,26 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
+import NavatarCard from "../../components/NavatarCard";
 import { saveActive } from "../../lib/localStorage";
+import "../../styles/navatar.css";
 
 export default function UploadNavatarPage() {
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
+  const [previewUrl, setPreviewUrl] = useState<string | undefined>();
   const nav = useNavigate();
+
+  useEffect(() => {
+    if (!file) {
+      setPreviewUrl(undefined);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
@@ -26,11 +39,15 @@ export default function UploadNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Upload" }]} />
       <h1 className="center">Upload a Navatar</h1>
-      <NavatarTabs active="upload" />
-      <form onSubmit={onSave} className="center" style={{ maxWidth: 480, margin: "16px auto" }}>
+      <NavatarTabs />
+      <form
+        onSubmit={onSave}
+        style={{ display: "grid", justifyItems: "center", gap: 12, maxWidth: 480, margin: "16px auto" }}
+      >
+        <NavatarCard src={previewUrl} title={name || "My Navatar"} />
         <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
         <input
-          style={{ display: "block", width: "100%", margin: "8px 0" }}
+          style={{ display: "block", width: "100%" }}
           placeholder="Name (optional)"
           value={name}
           onChange={(e) => setName(e.target.value)}

--- a/src/styles/crumbs.css
+++ b/src/styles/crumbs.css
@@ -32,3 +32,6 @@
     margin-top: 0;
   }
 }
+
+.breadcrumbs a { color: #1e4ed8; font-weight: 600; }
+.breadcrumbs { color: #6882d9; }

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,119 +1,74 @@
-.Page { max-width: 1100px; margin: 0 auto; padding: 24px 16px; }
-
-.Breadcrumbs { margin: 8px 0 16px; font-size: 14px; }
-.Breadcrumbs a { color: #2563eb; text-decoration: none; }
-.Breadcrumbs a:hover { text-decoration: underline; }
-.Breadcrumbs span { color: #64748b; margin: 0 6px; }
-
-.Button { display:inline-flex; align-items:center; gap:8px; border-radius:10px; padding:10px 16px; background:#e5edff; color:#1e40af; border:1px solid #c7d2fe; }
-.Button.primary { background:#3b82f6; color:white; border-color:#3b82f6; }
-
-.ctaRow { margin: 12px 0 24px; }
-
-.CreatorGrid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-@media (max-width: 900px) {
-  .CreatorGrid { grid-template-columns: 1fr; }
+/* --- Pills: always horizontal & centered, wrap if needed --- */
+.nav-tabs {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;       /* stays horizontal; wraps when space runs out */
+  margin: 10px auto 18px;
 }
 
-.FormCard, .PreviewCard {
-  background:white; border:1px solid #e5e7eb; border-radius:14px; padding:16px;
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid #cfe0ff;
+  background: #f6f9ff;
+  color: #1e4ed8;
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 2px 0 rgba(0,0,0,.08);
+}
+.pill--active {
+  background: #1e4ed8;
+  color: #fff;
+  border-color: #1e4ed8;
 }
 
-.ChipRow { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:8px; }
-.Chip { border:1px solid #c7d2fe; background:#eef2ff; color:#1e3a8a; padding:8px 12px; border-radius:999px; }
-.Chip.active { background:#3b82f6; border-color:#3b82f6; color:white; }
+/* --- Card: single source of truth for size & fit --- */
+.nav-card {
+  --nav-card-w: 260px;    /* change this once to resize everywhere */
+  width: min(var(--nav-card-w), 88vw);
+  margin: 0 auto;
+  background: #ffffff;
+  border: 1px solid #e8eefc;
+  border-radius: 16px;
+  box-shadow: 0 6px 16px rgba(30,78,216,.06);
+}
 
-label { display:block; margin:10px 0; }
-input[type="text"], input[type="file"], textarea {
+.nav-card__img {
   width: 100%;
-  font-size: 16px; /* prevents iOS zoom */
-  border:1px solid #cbd5e1; border-radius:10px; padding:10px 12px;
-  background:white; color:#0f172a;
-}
-textarea { min-height: 96px; resize: vertical; }
-.Row { margin-top: 12px; }
-
-.CardCanvas {
-  width: 100%;
-  aspect-ratio: 3 / 4;
-  background: white;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
+  aspect-ratio: 3 / 4;     /* consistent portrait shape */
+  border-radius: 14px;
   overflow: hidden;
-  display:flex; align-items:center; justify-content:center;
+  background: #eef3ff;
 }
-.CardCanvas img { max-width: 100%; max-height: 100%; object-fit: contain; display:block; }
-.NoPhoto { color:#94a3b8; }
+.nav-card__img img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;     /* never crop uploads or picks */
+  display: block;
+}
+.nav-card__placeholder {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  color: #8aa2e6;
+  font-weight: 600;
+}
+.nav-card__cap {
+  padding: 8px 10px 10px;
+  text-align: center;
+  color: #1e40af;
+}
 
-.CardGrid {
-  display:grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+/* grid used by Pick page */
+.nav-grid {
+  display: grid;
   gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(min(200px, 46vw), 1fr));
+  align-items: start;
 }
-.NavatarCard { background:white; border:1px solid #e5e7eb; border-radius:14px; overflow:hidden; }
-.NavatarTitle { font-weight:700; padding:12px 12px 0; color:#1d4ed8; text-align:center; }
-.NavatarImg { height: 220px; display:flex; align-items:center; justify-content:center; padding:12px; }
-.NavatarImg img { max-width:100%; max-height:100%; object-fit:contain; }
-.NavatarMeta { padding:0 12px 12px; color:#64748b; font-size:12px; text-align:center; }
-.Error { color:#dc2626; }
-.muted { color:#64748b; font-weight:400; }
-
-/* Navatar tabs */
-.navatar-tabs{
-  display:flex;
-  justify-content:center;
-  gap:12px;
-  flex-wrap:nowrap;
-  overflow-x:auto;
-  -webkit-overflow-scrolling:touch;
-  padding:8px 8px 6px;
-}
-.navatar-tabs::-webkit-scrollbar{ display:none; }
-
-.pill{
-  border:1px solid #cfe0ff;
-  background:#f5f9ff;
-  color:#2457ff;
-  border-radius:999px;
-  padding:10px 14px;
-  font-weight:600;
-  white-space:nowrap;
-}
-.pill--active{
-  background:#2f5bff;
-  color:#fff;
-  border-color:#2f5bff;
-  box-shadow:0 3px 0 0 #cfd7ff;
-}
-
-/* Unified card sizing */
-.navatar-card{
-  width:min(420px, 88vw);
-  margin:16px auto;
-  background:#fff;
-  border:1px solid #e6e6e6;
-  border-radius:16px;
-  padding:12px;
-}
-.navatar-card .img{
-  width:100%;
-  aspect-ratio:3/4;
-  border-radius:12px;
-  background:#f1f5f9;
-  overflow:hidden;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-}
-.navatar-card .img img{
-  width:100%;
-  height:100%;
-  object-fit:contain;
-  display:block;
-}
-
-.center{text-align:center}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -19,8 +19,13 @@
 }
 
 /* Breadcrumbs and small labels */
-.nv-breadcrumbs,
-.nv-breadcrumbs a,
+.nv-breadcrumbs {
+  color: #6882d9;
+}
+.nv-breadcrumbs a {
+  color: #1e4ed8;
+  font-weight: 600;
+}
 .badge,
 .chip,
 .tag {


### PR DESCRIPTION
## Summary
- add reusable `NavatarCard` with fixed 3:4 portrait layout and placeholder
- center Navatar action tabs and highlight active path
- style breadcrumbs in brand blue

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc2fd470883298cf8a1c051d55ac9