### PR TITLE
feat: add navatar marketplace stub and mobile tabs

### DIFF
--- a/src/components/BlueBreadcrumbs.tsx
+++ b/src/components/BlueBreadcrumbs.tsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+
+type Item = { label: string; to?: string };
+
+export function BlueBreadcrumbs({ items }: { items: Item[] }) {
+  return (
+    <nav aria-label="Breadcrumb" className="breadcrumbs">
+      <ol>
+        {items.map((c, i) => {
+          const isLast = i === items.length - 1;
+          return (
+            <li key={`${c.label}-${i}`} aria-current={isLast ? "page" : undefined} style={{ display: "inline" }}>
+              {c.to && !isLast ? <Link to={c.to}>{c.label}</Link> : <span>{c.label}</span>}
+              {!isLast && <span> / </span>}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -1,25 +1,9 @@
-import React from "react";
-
-type Props = {
-  src?: string | null;
-  title?: string;
-  subtitle?: string;
-  className?: string;
-};
-
-export default function NavatarCard({ src, title = "My Navatar", subtitle, className }: Props) {
+export function NavatarCard({ src, title }: { src?: string; title?: string }) {
   return (
-    <figure className={`nav-card ${className ?? ""}`}>
-      <div className="nav-card__img" aria-label={title}>
-        {src ? (
-          <img src={src} alt={title} />
-        ) : (
-          <div className="nav-card__placeholder">No photo</div>
-        )}
-      </div>
-      <figcaption className="nav-card__cap">
-        <strong>{title}</strong>
-        {subtitle ? <span> · {subtitle}</span> : null}
+    <figure className="nv-card nv-character">
+      {src ? <img src={src} alt={title || "My Navatar"} /> : <div className="nv-empty">No photo</div>}
+      <figcaption style={{ textAlign:"center", fontWeight:700, color:"#1e46ff", padding:"10px 4px" }}>
+        {title ?? "My Navatar"}
       </figcaption>
     </figure>
   );

--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -1,28 +1,56 @@
-import React from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
+import { useEffect, useRef, useState } from "react";
 
-const TABS = [
-  { to: "/navatar", label: "My Navatar" },
-  { to: "/navatar/pick", label: "Pick" },
-  { to: "/navatar/upload", label: "Upload" },
-  { to: "/navatar/generate", label: "Generate" },
-  { to: "/navatar/mint", label: "NFT / Mint" },
-  { to: "/marketplace", label: "Marketplace" },
-];
+type TabKey = "home" | "pick" | "upload" | "generate" | "mint" | "marketplace";
+export function NavatarTabs({ active }: { active: TabKey }) {
+  const all = [
+    { key: "home",        label: "My Navatar", to: "/navatar" },
+    { key: "pick",        label: "Pick",        to: "/navatar/pick" },
+    { key: "upload",      label: "Upload",      to: "/navatar/upload" },
+    { key: "generate",    label: "Generate",    to: "/navatar/generate" },
+    { key: "mint",        label: "NFT / Mint",  to: "/navatar/mint" },
+    { key: "marketplace", label: "Marketplace", to: "/navatar/marketplace" },
+  ] as const;
 
-export default function NavatarTabs() {
-  const { pathname } = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const moreRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (!moreRef.current?.contains(e.target as Node)) setMenuOpen(false);
+    };
+    document.addEventListener("click", onClick);
+    return () => document.removeEventListener("click", onClick);
+  }, []);
+
+  const activeTab = all.find(t => t.key === active)!;
+  const rest = all.filter(t => t.key !== active);
+
   return (
-    <nav className="nav-tabs" aria-label="Navatar actions">
-      {TABS.map(t => {
-        const active =
-          t.to === "/navatar" ? pathname === "/navatar" : pathname.startsWith(t.to);
-        return (
-          <Link key={t.to} to={t.to} className={`pill ${active ? "pill--active" : ""}`}>
+    <div className="nv-tabs">
+      {/* Desktop / tablet: all tabs inline */}
+      <div className="nv-tabs-row nv-only-wide">
+        {all.map(t => (
+          <Link key={t.key} to={t.to} className={`nv-tab ${t.key===active ? "is-active": ""}`}>
             {t.label}
           </Link>
-        );
-      })}
-    </nav>
+        ))}
+      </div>
+
+      {/* Mobile: only active + More */}
+      <div className="nv-tabs-row nv-only-narrow">
+        <Link to={activeTab.to} className="nv-tab is-active">{activeTab.label}</Link>
+        <div ref={moreRef} className="nv-more">
+          <button className="nv-tab" aria-haspopup="menu" onClick={()=>setMenuOpen(v=>!v)}>…</button>
+          {menuOpen && (
+            <div className="nv-more-menu" role="menu">
+              {rest.map(t => (
+                <Link role="menuitem" key={t.key} to={t.to} className="nv-more-item">{t.label}</Link>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from "react";
+
+export function PageShell({ children }: { children: ReactNode }) {
+  return <main className="container">{children}</main>;
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
+import { BlueBreadcrumbs } from "../../components/BlueBreadcrumbs";
+import { PageShell } from "../../components/PageShell";
+import { NavatarTabs } from "../../components/NavatarTabs";
+import { NavatarCard } from "../../components/NavatarCard";
 import { saveActive } from "../../lib/localStorage";
 import "../../styles/navatar.css";
 
@@ -39,12 +40,12 @@ export default function GenerateNavatarPage() {
   }
 
   return (
-    <main className="container">
-      <Breadcrumbs
-        items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Describe & Generate" }]}
+    <PageShell>
+      <BlueBreadcrumbs
+        items={[{ label: "Home", to: "/" }, { label: "Navatar", to: "/navatar" }, { label: "Describe & Generate", to: "/navatar/generate" }]}
       />
-      <h1 className="center">Describe &amp; Generate</h1>
-      <NavatarTabs />
+      <h1 className="nv-heading">Describe &amp; Generate</h1>
+      <NavatarTabs active="generate" />
       <form
         onSubmit={onSave}
         style={{ maxWidth: 520, margin: "16px auto", display: "grid", justifyItems: "center", gap: 12 }}
@@ -64,14 +65,14 @@ export default function GenerateNavatarPage() {
           onChange={(e) => setName(e.target.value)}
         />
         <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
-        <button className="pill pill--active" type="submit" style={{ marginTop: 8 }}>
+        <button className="nv-button" type="submit" style={{ marginTop: 8 }}>
           Save
         </button>
       </form>
-      <p className="center" style={{ opacity: 0.8 }}>
+      <p className="nv-muted" style={{ textAlign: "center" }}>
         AI art & edit coming soon.
       </p>
-    </main>
+    </PageShell>
   );
 }
 

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,21 +1,22 @@
 import { useMemo } from "react";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
+import { BlueBreadcrumbs } from "../../components/BlueBreadcrumbs";
+import { PageShell } from "../../components/PageShell";
+import { NavatarTabs } from "../../components/NavatarTabs";
+import { NavatarCard } from "../../components/NavatarCard";
 import { loadActive } from "../../lib/localStorage";
 import "../../styles/navatar.css";
 
 export default function MyNavatarPage() {
   const activeNavatar = useMemo(() => loadActive<any>(), []);
   return (
-    <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
-      <h1 className="center">My Navatar</h1>
-      <NavatarTabs />
+    <PageShell>
+      <BlueBreadcrumbs items={[{ label: "Home", to: "/" }, { label: "Navatar", to: "/navatar" }]} />
+      <h1 className="nv-heading">My Navatar</h1>
+      <NavatarTabs active="home" />
 
       <div style={{ marginTop: 8 }}>
         <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
       </div>
-    </main>
+    </PageShell>
   );
 }

--- a/src/pages/navatar/marketplace.tsx
+++ b/src/pages/navatar/marketplace.tsx
@@ -1,20 +1,26 @@
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import "../../styles/navatar.css";
+import { Link } from "react-router-dom";
+import { BlueBreadcrumbs } from "../../components/BlueBreadcrumbs";
+import { PageShell } from "../../components/PageShell";
+import { NavatarTabs } from "../../components/NavatarTabs";
 
-export default function MarketplaceMakerPage() {
+export default function NavatarMarketplaceStub() {
   return (
-    <main className="container">
-      <Breadcrumbs
-        items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Marketplace" }]}
+    <PageShell>
+      <BlueBreadcrumbs
+        items={[
+          { label: "Home", to: "/" },
+          { label: "Navatar", to: "/navatar" },
+          { label: "Marketplace", to: "/navatar/marketplace" },
+        ]}
       />
-      <h1 className="center">Marketplace Maker</h1>
-      <NavatarTabs />
-      <div className="center" style={{ maxWidth: 560, margin: "16px auto" }}>
-        <p>Mock up tees, plushies, stickers and more with your Navatar. (Coming soon.)</p>
-        <a className="pill" href="/marketplace">Open Marketplace</a>
+      <h1 className="nv-heading">Marketplace</h1>
+      <NavatarTabs active="marketplace" />
+
+      <div className="nv-card nv-center" style={{ maxWidth: 720 }}>
+        <p className="nv-lead">Mockups for tees, plushies, stickers and more are coming soon.</p>
+        <p className="nv-muted">You’ll be able to place your Navatar on products here, then purchase on the Marketplace.</p>
+        <Link className="nv-button" to="/marketplace">Go to Marketplace</Link>
       </div>
-    </main>
+    </PageShell>
   );
 }
-

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -1,25 +1,23 @@
-import { useMemo } from "react";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { loadActive } from "../../lib/localStorage";
-import "../../styles/navatar.css";
+import { Link } from "react-router-dom";
+import { BlueBreadcrumbs } from "../../components/BlueBreadcrumbs";
+import { PageShell } from "../../components/PageShell";
+import { NavatarTabs } from "../../components/NavatarTabs";
 
-export default function MintNavatarPage() {
-  const activeNavatar = useMemo(() => loadActive<any>(), []);
+export default function NavatarMintStub() {
   return (
-    <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "NFT / Mint" }]} />
-      <h1 className="center">NFT / Mint</h1>
-      <NavatarTabs />
-      <p style={{ textAlign: "center", maxWidth: 560, margin: "8px auto 20px" }}>
-        Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.
-      </p>
-      <div style={{ display: "grid", justifyItems: "center", gap: 12 }}>
-        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "My Navatar"} />
-        <a className="pill" href="/marketplace">Go to Marketplace</a>
+    <PageShell>
+      <BlueBreadcrumbs items={[
+        { label:"Home", to:"/" },
+        { label:"Navatar", to:"/navatar" },
+        { label:"NFT / Mint", to:"/navatar/mint" },
+      ]}/>
+      <h1 className="nv-heading">Mint your Navatar</h1>
+      <NavatarTabs active="mint" />
+      <div className="nv-card nv-center" style={{ maxWidth: 720 }}>
+        <p className="nv-lead">NFT minting is coming soon.</p>
+        <p className="nv-muted">In the meantime, you can browse merch in the shop.</p>
+        <Link className="nv-button" to="/marketplace">Go to Marketplace</Link>
       </div>
-    </main>
+    </PageShell>
   );
 }
-

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
+import { BlueBreadcrumbs } from "../../components/BlueBreadcrumbs";
+import { PageShell } from "../../components/PageShell";
+import { NavatarTabs } from "../../components/NavatarTabs";
+import { NavatarCard } from "../../components/NavatarCard";
 import { loadPublicNavatars, PublicNavatar } from "../../lib/navatar/publicList";
 import { saveActive } from "../../lib/localStorage";
 import "../../styles/navatar.css";
@@ -21,11 +22,11 @@ export default function PickNavatarPage() {
   }
 
   return (
-    <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Pick" }]} />
-      <h1 className="center">Pick Navatar</h1>
-      <NavatarTabs />
-      <div className="nav-grid">
+    <PageShell>
+      <BlueBreadcrumbs items={[{ label: "Home", to: "/" }, { label: "Navatar", to: "/navatar" }, { label: "Pick", to: "/navatar/pick" }]} />
+      <h1 className="nv-heading">Pick Navatar</h1>
+      <NavatarTabs active="pick" />
+      <div className="nv-grid">
         {items.map((it) => (
           <button
             key={it.src}
@@ -38,7 +39,7 @@ export default function PickNavatarPage() {
           </button>
         ))}
       </div>
-    </main>
+    </PageShell>
   );
 }
 

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
+import { BlueBreadcrumbs } from "../../components/BlueBreadcrumbs";
+import { PageShell } from "../../components/PageShell";
+import { NavatarTabs } from "../../components/NavatarTabs";
+import { NavatarCard } from "../../components/NavatarCard";
 import { saveActive } from "../../lib/localStorage";
 import "../../styles/navatar.css";
 
@@ -36,10 +37,10 @@ export default function UploadNavatarPage() {
   }
 
   return (
-    <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Upload" }]} />
-      <h1 className="center">Upload a Navatar</h1>
-      <NavatarTabs />
+    <PageShell>
+      <BlueBreadcrumbs items={[{ label: "Home", to: "/" }, { label: "Navatar", to: "/navatar" }, { label: "Upload", to: "/navatar/upload" }]} />
+      <h1 className="nv-heading">Upload a Navatar</h1>
+      <NavatarTabs active="upload" />
       <form
         onSubmit={onSave}
         style={{ display: "grid", justifyItems: "center", gap: 12, maxWidth: 480, margin: "16px auto" }}
@@ -52,11 +53,11 @@ export default function UploadNavatarPage() {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <button className="pill pill--active" type="submit">
+        <button className="nv-button" type="submit">
           Save
         </button>
       </form>
-    </main>
+    </PageShell>
   );
 }
 

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,74 +1,46 @@
-/* --- Pills: always horizontal & centered, wrap if needed --- */
-.nav-tabs {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;       /* stays horizontal; wraps when space runs out */
-  margin: 10px auto 18px;
+/* Tabs */
+.nv-tabs { display:block; margin: 8px 0 16px; }
+.nv-tabs-row { display:flex; gap:12px; justify-content:center; align-items:center; }
+.nv-tab { padding:10px 16px; border-radius:20px; border:1px solid #cfe0ff; text-decoration:none; color:#1e46ff; background:#f3f7ff; }
+.nv-tab.is-active { color:#fff; background:#1e46ff; border-color:#1e46ff; }
+.nv-more { position:relative; }
+.nv-more-menu { position:absolute; top:44px; right:0; background:#fff; border:1px solid #dde7ff; border-radius:12px; box-shadow:0 6px 18px rgba(0,0,0,.06); min-width:180px; padding:6px; z-index:15; }
+.nv-more-item { display:block; padding:8px 12px; color:#1e46ff; text-decoration:none; border-radius:8px; }
+.nv-more-item:hover { background:#f3f7ff; }
+
+/* Responsive visibility */
+@media (max-width: 640px) {
+  .nv-only-wide { display:none; }
+}
+@media (min-width: 641px) {
+  .nv-only-narrow { display:none; }
 }
 
-.pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 14px;
-  border-radius: 999px;
-  border: 1px solid #cfe0ff;
-  background: #f6f9ff;
-  color: #1e4ed8;
-  text-decoration: none;
-  font-weight: 600;
-  box-shadow: 0 2px 0 rgba(0,0,0,.08);
-}
-.pill--active {
-  background: #1e4ed8;
-  color: #fff;
-  border-color: #1e4ed8;
-}
+/* Card + image sizing kept consistent everywhere */
+.nv-card { background:#fff; border:1px solid #e8eefc; border-radius:16px; padding:16px; }
+.nv-center { margin: 0 auto; text-align:center; }
 
-/* --- Card: single source of truth for size & fit --- */
-.nav-card {
-  --nav-card-w: 260px;    /* change this once to resize everywhere */
-  width: min(var(--nav-card-w), 88vw);
-  margin: 0 auto;
-  background: #ffffff;
-  border: 1px solid #e8eefc;
+.nv-character {
+  width: clamp(240px, 90vw, 360px);
+  aspect-ratio: 3/4;
   border-radius: 16px;
-  box-shadow: 0 6px 16px rgba(30,78,216,.06);
-}
-
-.nav-card__img {
-  width: 100%;
-  aspect-ratio: 3 / 4;     /* consistent portrait shape */
-  border-radius: 14px;
   overflow: hidden;
-  background: #eef3ff;
+  box-shadow: 0 4px 16px rgba(0,0,0,.06);
+  margin-inline:auto;
 }
-.nav-card__img img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;     /* never crop uploads or picks */
-  display: block;
-}
-.nav-card__placeholder {
-  width: 100%;
-  height: 100%;
-  display: grid;
-  place-items: center;
-  color: #8aa2e6;
-  font-weight: 600;
-}
-.nav-card__cap {
-  padding: 8px 10px 10px;
-  text-align: center;
-  color: #1e40af;
-}
+.nv-character img { width:100%; height:100%; object-fit:cover; }
+.nv-empty { display:grid; place-items:center; width:100%; height:100%; background:#f3f7ff; color:#8aa2e6; font-weight:600; }
 
-/* grid used by Pick page */
-.nav-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fill, minmax(min(200px, 46vw), 1fr));
-  align-items: start;
-}
+/* Headings / breadcrumbs (blue) */
+.nv-heading { text-align:center; color:#1e46ff; margin: 8px 0 12px; }
+.nv-lead { font-weight:600; color:#1e46ff; }
+.nv-muted { color:#6b7bb8; }
+
+.breadcrumbs a, .breadcrumbs { color:#1e46ff; }
+.breadcrumbs a:hover { text-decoration: underline; }
+
+/* Buttons */
+.nv-button { display:inline-block; padding:10px 16px; border-radius:20px; border:1px solid #1e46ff; background:#1e46ff; color:#fff; text-decoration:none; }
+
+/* Grid for pick page */
+.nv-grid { display:grid; gap:16px; grid-template-columns: repeat(auto-fill, minmax(min(200px, 46vw), 1fr)); align-items:start; }


### PR DESCRIPTION
## Summary
- add Navatar marketplace and mint stub pages with breadcrumbs and CTAs
- implement responsive NavatarTabs with mobile "More" menu
- create unified NavatarCard and blue breadcrumbs styling

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68bbc8c8f9e88329aedc84f37326daea