### PR TITLE
Navatar: add Marketplace stub page + wire Marketplace pill to /navatar/marketplace

### DIFF
--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -7,7 +7,7 @@ const TABS = [
   { to: "/navatar/upload", label: "Upload" },
   { to: "/navatar/generate", label: "Generate" },
   { to: "/navatar/mint", label: "NFT / Mint" },
-  { to: "/marketplace", label: "Marketplace" },
+  { to: "/navatar/marketplace", label: "Marketplace" },
 ];
 
 export default function NavatarTabs() {

--- a/src/pages/navatar/marketplace.tsx
+++ b/src/pages/navatar/marketplace.tsx
@@ -2,17 +2,18 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import "../../styles/navatar.css";
 
-export default function MarketplaceMakerPage() {
+export default function NavatarMarketplacePage() {
   return (
     <main className="container">
       <Breadcrumbs
         items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Marketplace" }]}
       />
-      <h1 className="center">Marketplace Maker</h1>
+      <h1 className="center">Marketplace</h1>
       <NavatarTabs />
       <div className="center" style={{ maxWidth: 560, margin: "16px auto" }}>
-        <p>Mock up tees, plushies, stickers and more with your Navatar. (Coming soon.)</p>
-        <a className="pill" href="/marketplace">Open Marketplace</a>
+        <p>Mockups for tees, plushies, stickers and more are coming soon.</p>
+        <p>You’ll be able to place your Navatar on products here, then purchase on the Marketplace.</p>
+        <a className="pill" href="/marketplace">Go to Marketplace</a>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- create a Navatar Marketplace stub page with breadcrumbs and call to action
- point the Navatar hub's Marketplace pill at `/navatar/marketplace`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS2345 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcd41cab8832980659e854f1951ad