### PR TITLE
Add Character Card hub + show card on My Navatar (no image size changes)

### DIFF
--- a/src/components/CharacterCardEditor.tsx
+++ b/src/components/CharacterCardEditor.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import type { NavatarCard } from '../lib/avatars';
+import '../styles/card.css';
+
+type Props = {
+  initial?: NavatarCard | null;
+  onSave: (card: NavatarCard) => Promise<void>;
+};
+
+export default function CharacterCardEditor({ initial, onSave }: Props) {
+  const [card, setCard] = useState<NavatarCard>(initial ?? {});
+  const [saving, setSaving] = useState(false);
+
+  const set = (k: keyof NavatarCard, v: any) =>
+    setCard(prev => ({ ...prev, [k]: v }));
+
+  const parseList = (s: string) =>
+    s.split(',').map(x => x.trim()).filter(Boolean);
+
+  return (
+    <div className="card-editor">
+      <div className="card-field">
+        <label>Name</label>
+        <input value={card.name ?? ''} onChange={e => set('name', e.target.value)} />
+      </div>
+      <div className="card-field">
+        <label>Species / Type</label>
+        <input value={card.species ?? ''} onChange={e => set('species', e.target.value)} />
+      </div>
+      <div className="card-field">
+        <label>Alignment</label>
+        <input value={card.alignment ?? ''} onChange={e => set('alignment', e.target.value)} />
+      </div>
+      <div className="card-field">
+        <label>Backstory</label>
+        <textarea value={card.backstory ?? ''} onChange={e => set('backstory', e.target.value)} />
+      </div>
+      <div className="card-field">
+        <label>Powers (comma separated)</label>
+        <input
+          value={(card.powers ?? []).join(', ')}
+          onChange={e => set('powers', parseList(e.target.value))}
+        />
+      </div>
+      <div className="card-field">
+        <label>Traits (comma separated)</label>
+        <input
+          value={(card.traits ?? []).join(', ')}
+          onChange={e => set('traits', parseList(e.target.value))}
+        />
+      </div>
+
+      <div className="card-actions">
+        <button className="btn" disabled>
+          AI: Suggest card (coming soon)
+        </button>
+        <button
+          className="btn primary"
+          disabled={saving}
+          onClick={async () => {
+            setSaving(true);
+            try { await onSave(card); alert('Character card saved.'); }
+            finally { setSaving(false); }
+          }}>
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CharacterCardPreview.tsx
+++ b/src/components/CharacterCardPreview.tsx
@@ -1,0 +1,31 @@
+import '../styles/card.css';
+import type { NavatarCard } from '../lib/avatars';
+
+export default function CharacterCardPreview({ card }: { card?: NavatarCard | null }) {
+  return (
+    <div className="navatar-card">
+      <div style={{ padding: '1rem 1rem .75rem' }}>
+        <h3 style={{ margin: 0 }}>{card?.name || 'My Navatar'}</h3>
+        <div style={{ color: '#6b7280', marginTop: 4 }}>
+          {[card?.species, card?.alignment].filter(Boolean).join(' • ') || '—'}
+        </div>
+      </div>
+      <div style={{ padding: '0 1rem 1rem' }}>
+        <strong>Backstory</strong>
+        <p style={{ marginTop: 6 }}>
+          {card?.backstory || 'No backstory yet.'}
+        </p>
+        <strong>Powers</strong>
+        <ul style={{ marginTop: 6 }}>
+          {(card?.powers?.length ? card.powers : ['—']).map((p, i) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+        <strong>Traits</strong>
+        <p style={{ marginTop: 6 }}>
+          {card?.traits?.join(', ') || '—'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -8,12 +8,13 @@ const TABS = [
   { to: "/navatar/generate", label: "Generate" },
   { to: "/navatar/mint", label: "NFT / Mint" },
   { to: "/navatar/marketplace", label: "Marketplace" },
+  { to: "/navatar/card", label: "Card" },
 ];
 
 export default function NavatarTabs() {
   const { pathname } = useLocation();
   return (
-    <nav className="nav-tabs" aria-label="Navatar actions">
+    <nav className="nav-pills" aria-label="Navatar actions">
       {TABS.map(t => {
         const active =
           t.to === "/navatar" ? pathname === "/navatar" : pathname.startsWith(t.to);

--- a/src/lib/avatars.ts
+++ b/src/lib/avatars.ts
@@ -1,0 +1,38 @@
+import { supabase } from './supabase-client';
+
+export type NavatarCard = {
+  name?: string;
+  species?: string;
+  alignment?: string;
+  backstory?: string;
+  powers?: string[];
+  traits?: string[];
+};
+
+type AvatarRow = {
+  id: string;
+  user_id: string;
+  image_url: string | null;
+  name: string | null;
+  card: NavatarCard | null;
+};
+
+export async function getMyAvatar(userId: string) {
+  const { data, error } = await supabase
+    .from('avatars')
+    .select('id,user_id,image_url,name,card')
+    .eq('user_id', userId)
+    .single();
+  if (error) throw error;
+  return data as AvatarRow;
+}
+
+export async function saveAvatarCard(userId: string, card: NavatarCard) {
+  const { data, error } = await supabase
+    .from('avatars')
+    .upsert({ user_id: userId, card }, { onConflict: 'user_id' })
+    .select('id,card')
+    .single();
+  if (error) throw error;
+  return data as AvatarRow | null;
+}

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
+import NavatarTabs from "../../components/NavatarTabs";
+import CharacterCardPreview from "../../components/CharacterCardPreview";
+import CharacterCardEditor from "../../components/CharacterCardEditor";
+import { getMyAvatar, saveAvatarCard, NavatarCard } from "../../lib/avatars";
+import { useAuth } from "../../lib/auth-context";
+import "../../styles/navatar.css";
+
+export default function CardPage() {
+  const { user } = useAuth();
+  const [card, setCard] = useState<NavatarCard | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    (async () => {
+      const row = await getMyAvatar(user.id);
+      setCard(row?.card ?? null);
+    })();
+  }, [user]);
+
+  async function handleSave(next: NavatarCard) {
+    if (!user) return;
+    await saveAvatarCard(user.id, next);
+    setCard(next);
+  }
+
+  return (
+    <main className="container">
+      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
+      <h1 className="center">Character Card</h1>
+      <NavatarTabs />
+
+      <div className="navatar-two-col" style={{ marginTop: "1rem" }}>
+        <CharacterCardPreview card={card} />
+        <CharacterCardEditor initial={card} onSave={handleSave} />
+      </div>
+    </main>
+  );
+}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,20 +1,44 @@
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { loadActive } from "../../lib/localStorage";
+import CharacterCardPreview from "../../components/CharacterCardPreview";
+import { getMyAvatar } from "../../lib/avatars";
+import { useAuth } from "../../lib/auth-context";
 import "../../styles/navatar.css";
 
 export default function MyNavatarPage() {
-  const activeNavatar = useMemo(() => loadActive<any>(), []);
+  const { user } = useAuth();
+  const [row, setRow] = useState<any>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    (async () => setRow(await getMyAvatar(user.id)))();
+  }, [user]);
+
   return (
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
       <h1 className="center">My Navatar</h1>
       <NavatarTabs />
 
-      <div style={{ marginTop: 8 }}>
-        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
+      <div className="navatar-two-col" style={{ marginTop: "1rem" }}>
+        <div className="navatar-card">
+          {row?.image_url ? (
+            <img className="navatar-img" src={row.image_url} alt={row?.name || 'My Navatar'} />
+          ) : (
+            <div className="navatar-img" style={{
+              background: '#f3f6ff',
+              display: 'grid',
+              placeItems: 'center',
+              color: '#9aa3b2'
+            }}>No photo</div>
+          )}
+          <div style={{ padding: '0.8rem 1rem 1rem', textAlign: 'center', fontWeight: 700 }}>
+            {row?.name || 'My Navatar'}
+          </div>
+        </div>
+
+        <CharacterCardPreview card={row?.card} />
       </div>
     </main>
   );

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -41,6 +41,7 @@ import NavatarUpload from './pages/navatar/upload';
 import NavatarGenerate from './pages/navatar/generate';
 import NavatarMint from './pages/navatar/mint';
 import NavatarMarketplace from './pages/navatar/marketplace';
+import NavatarCardPage from './pages/navatar/card';
 import PassportPage from './pages/passport';
 import LoginPage from './pages/Login';
 import Turian from './routes/turian';
@@ -127,6 +128,7 @@ export const router = createBrowserRouter([
           { path: 'generate', element: <NavatarGenerate /> },
           { path: 'mint', element: <NavatarMint /> },
           { path: 'marketplace', element: <NavatarMarketplace /> },
+          { path: 'card', element: <NavatarCardPage /> },
         ],
       },
         { path: 'passport', element: <PassportPage /> },

--- a/src/styles/card.css
+++ b/src/styles/card.css
@@ -1,0 +1,30 @@
+.card-editor {
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
+}
+.card-field {
+  margin: .6rem 0;
+}
+.card-field label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: .25rem;
+}
+.card-field input,
+.card-field textarea {
+  width: 100%;
+  border: 1px solid rgba(20,33,61,.15);
+  border-radius: 10px;
+  padding: .7rem .9rem;
+  outline: none;
+}
+.card-field textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+.card-actions {
+  margin-top: .9rem;
+  display: flex;
+  gap: .6rem;
+}

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,11 +1,16 @@
-/* --- Pills: always horizontal & centered, wrap if needed --- */
-.nav-tabs {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;       /* stays horizontal; wraps when space runs out */
+/* Pills: up to 3 across on narrow screens */
+.nav-pills {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: .75rem;
+  justify-items: center;
   margin: 10px auto 18px;
+}
+@media (max-width: 420px) {
+  .nav-pills { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (min-width: 768px) {
+  .nav-pills { display: flex; gap: .75rem; justify-content: center; flex-wrap: wrap; }
 }
 
 .pill {
@@ -71,4 +76,33 @@
   gap: 16px;
   grid-template-columns: repeat(auto-fill, minmax(min(200px, 46vw), 1fr));
   align-items: start;
+}
+
+/* Card container used across pages */
+.navatar-card {
+  width: 100%;
+  max-width: 420px;
+  margin: 0 auto;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 6px 18px rgba(20,33,61,.06);
+  overflow: hidden;
+  border: 1px solid rgba(20,33,61,.06);
+}
+
+/* The “perfect” image sizing you approved */
+.navatar-img {
+  width: 100%;
+  aspect-ratio: 3/4;
+  object-fit: cover;
+  display: block;
+}
+
+/* Two-column layout on desktop for My Navatar */
+.navatar-two-col {
+  display: grid;
+  gap: 1.25rem;
+}
+@media (min-width: 980px) {
+  .navatar-two-col { grid-template-columns: 1fr 1fr; justify-items: center; }
 }

--- a/supabase/migrations/2026-01-05-add-avatar-card.sql
+++ b/supabase/migrations/2026-01-05-add-avatar-card.sql
@@ -1,0 +1,3 @@
+-- one-time, idempotent
+alter table avatars
+add column if not exists card jsonb;


### PR DESCRIPTION
## Summary
- add Supabase helpers and migration to persist `avatars.card` JSON
- introduce character card editor and read-only preview components
- display Navatar and character card side-by-side and add `/navatar/card` hub with responsive pills

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type ... is not assignable to parameter of type 'never')*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react-swc')*

------
https://chatgpt.com/codex/tasks/task_e_68bbd2a5d0ec8329b7034bb492e79fe4