### PR TITLE
feat: enhance navatar hub layout and styles

### DIFF
--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -1,28 +1,39 @@
 import React from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 
-const TABS = [
-  { to: "/navatar", label: "My Navatar" },
-  { to: "/navatar/pick", label: "Pick" },
-  { to: "/navatar/upload", label: "Upload" },
-  { to: "/navatar/generate", label: "Generate" },
-  { to: "/navatar/mint", label: "NFT / Mint" },
-  { to: "/navatar/marketplace", label: "Marketplace" },
+type TabKey =
+  | "my"
+  | "pick"
+  | "upload"
+  | "generate"
+  | "mint"
+  | "marketplace";
+
+const TABS: { to: string; label: string; key: TabKey }[] = [
+  { to: "/navatar", label: "My Navatar", key: "my" },
+  { to: "/navatar/pick", label: "Pick", key: "pick" },
+  { to: "/navatar/upload", label: "Upload", key: "upload" },
+  { to: "/navatar/generate", label: "Generate", key: "generate" },
+  { to: "/navatar/mint", label: "NFT / Mint", key: "mint" },
+  { to: "/navatar/marketplace", label: "Marketplace", key: "marketplace" },
 ];
 
-export default function NavatarTabs() {
-  const { pathname } = useLocation();
+interface Props {
+  active: TabKey;
+  variant?: "home" | "sub";
+}
+
+export default function NavatarTabs({ active, variant = "home" }: Props) {
   return (
-    <nav className="nav-tabs" aria-label="Navatar actions">
-      {TABS.map(t => {
-        const active =
-          t.to === "/navatar" ? pathname === "/navatar" : pathname.startsWith(t.to);
-        return (
-          <Link key={t.to} to={t.to} className={`pill ${active ? "pill--active" : ""}`}>
-            {t.label}
-          </Link>
-        );
-      })}
+    <nav
+      className={["nv-tabs", variant === "sub" ? "nv-tabs--sub" : ""].join(" ")}
+      aria-label="Navatar tabs"
+    >
+      {TABS.map((t) => (
+        <Link key={t.to} to={t.to} className={`pill ${active === t.key ? "pill--active" : ""}`}>
+          {t.label}
+        </Link>
+      ))}
     </nav>
   );
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -44,7 +44,7 @@ export default function GenerateNavatarPage() {
         items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Describe & Generate" }]}
       />
       <h1 className="center">Describe &amp; Generate</h1>
-      <NavatarTabs />
+      <NavatarTabs active="generate" variant="sub" />
       <form
         onSubmit={onSave}
         style={{ maxWidth: 520, margin: "16px auto", display: "grid", justifyItems: "center", gap: 12 }}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -3,6 +3,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
 import { loadActive } from "../../lib/localStorage";
+import { CharacterCardPreview } from "./pieces/CharacterCardPreview";
 import "../../styles/navatar.css";
 
 export default function MyNavatarPage() {
@@ -11,11 +12,17 @@ export default function MyNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
       <h1 className="center">My Navatar</h1>
-      <NavatarTabs />
+      <NavatarTabs active="my" variant="home" />
 
-      <div style={{ marginTop: 8 }}>
-        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
-      </div>
+      <section className="nv-two-col" style={{ marginTop: 8 }}>
+        <NavatarCard
+          className="navatar-card"
+          src={activeNavatar?.imageDataUrl}
+          title={activeNavatar?.name || "Turian"}
+        />
+
+        <CharacterCardPreview navatarId={activeNavatar?.id} />
+      </section>
     </main>
   );
 }

--- a/src/pages/navatar/marketplace.tsx
+++ b/src/pages/navatar/marketplace.tsx
@@ -9,7 +9,7 @@ export default function NavatarMarketplacePage() {
         items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Marketplace" }]}
       />
       <h1 className="center">Marketplace</h1>
-      <NavatarTabs />
+      <NavatarTabs active="marketplace" variant="sub" />
       <div className="center" style={{ maxWidth: 560, margin: "16px auto" }}>
         <p>Mockups for tees, plushies, stickers and more are coming soon.</p>
         <p>You’ll be able to place your Navatar on products here, then purchase on the Marketplace.</p>

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -11,7 +11,7 @@ export default function MintNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "NFT / Mint" }]} />
       <h1 className="center">NFT / Mint</h1>
-      <NavatarTabs />
+      <NavatarTabs active="mint" variant="sub" />
       <p style={{ textAlign: "center", maxWidth: 560, margin: "8px auto 20px" }}>
         Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.
       </p>

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -24,7 +24,7 @@ export default function PickNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Pick" }]} />
       <h1 className="center">Pick Navatar</h1>
-      <NavatarTabs />
+      <NavatarTabs active="pick" variant="sub" />
       <div className="nav-grid">
         {items.map((it) => (
           <button

--- a/src/pages/navatar/pieces/CharacterCardPreview.tsx
+++ b/src/pages/navatar/pieces/CharacterCardPreview.tsx
@@ -1,0 +1,19 @@
+import { useMemo } from "react";
+import { loadActive } from "../../../lib/localStorage";
+
+export function CharacterCardPreview({ navatarId }: { navatarId?: string }) {
+  const navatar = useMemo(() => loadActive<any>(), []);
+  return (
+    <aside className="card panel card-preview">
+      <h3 className="card-title">My Navatar</h3>
+      <dl className="card-fields">
+        <dt>Backstory</dt>
+        <dd>{navatar?.backstory || "No backstory yet."}</dd>
+        <dt>Powers</dt>
+        <dd>{navatar?.powers?.join(", ") || "—"}</dd>
+        <dt>Traits</dt>
+        <dd>{navatar?.traits?.join(", ") || "—"}</dd>
+      </dl>
+    </aside>
+  );
+}

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -39,7 +39,7 @@ export default function UploadNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Upload" }]} />
       <h1 className="center">Upload a Navatar</h1>
-      <NavatarTabs />
+      <NavatarTabs active="upload" variant="sub" />
       <form
         onSubmit={onSave}
         style={{ display: "grid", justifyItems: "center", gap: 12, maxWidth: 480, margin: "16px auto" }}

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,11 +1,30 @@
-/* --- Pills: always horizontal & centered, wrap if needed --- */
-.nav-tabs {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;       /* stays horizontal; wraps when space runs out */
-  margin: 10px auto 18px;
+:root {
+  --brand-blue: #2d5bff;
+ }
+
+/* Tabs: 3 across wrap + hide on subpages (mobile) */
+.nv-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  justify-items: center;
+  margin-bottom: 16px;
+}
+@media (min-width: 860px) {
+  .nv-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
+  }
+}
+.nv-tabs--sub {
+  display: none;
+}
+@media (min-width: 860px) {
+  .nv-tabs--sub {
+    display: flex;
+  }
 }
 
 .pill {
@@ -16,39 +35,39 @@
   border-radius: 999px;
   border: 1px solid #cfe0ff;
   background: #f6f9ff;
-  color: #1e4ed8;
+  color: var(--brand-blue);
   text-decoration: none;
   font-weight: 600;
-  box-shadow: 0 2px 0 rgba(0,0,0,.08);
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.08);
 }
 .pill--active {
-  background: #1e4ed8;
+  background: var(--brand-blue);
   color: #fff;
-  border-color: #1e4ed8;
+  border-color: var(--brand-blue);
 }
 
-/* --- Card: single source of truth for size & fit --- */
+/* Unified card sizing */
 .nav-card {
-  --nav-card-w: 260px;    /* change this once to resize everywhere */
-  width: min(var(--nav-card-w), 88vw);
+  width: 360px;
+  aspect-ratio: 3 / 4;
   margin: 0 auto;
   background: #ffffff;
   border: 1px solid #e8eefc;
-  border-radius: 16px;
-  box-shadow: 0 6px 16px rgba(30,78,216,.06);
+  border-radius: 18px;
+  box-shadow: 0 6px 16px rgba(30, 78, 216, 0.06);
 }
-
 .nav-card__img {
   width: 100%;
-  aspect-ratio: 3 / 4;     /* consistent portrait shape */
-  border-radius: 14px;
+  height: 100%;
+  aspect-ratio: 3 / 4;
+  border-radius: 18px;
   overflow: hidden;
   background: #eef3ff;
 }
 .nav-card__img img {
   width: 100%;
   height: 100%;
-  object-fit: contain;     /* never crop uploads or picks */
+  object-fit: cover;
   display: block;
 }
 .nav-card__placeholder {
@@ -62,13 +81,42 @@
 .nav-card__cap {
   padding: 8px 10px 10px;
   text-align: center;
-  color: #1e40af;
+  color: var(--brand-blue);
+}
+@media (max-width: 640px) {
+  .nav-card {
+    width: 100%;
+    max-width: 420px;
+  }
+}
+
+/* Two-column on desktop, single column on mobile */
+.nv-two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  align-items: start;
+}
+@media (max-width: 900px) {
+  .nv-two-col {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* grid used by Pick page */
 .nav-grid {
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(auto-fill, minmax(min(200px, 46vw), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(360px, 46vw), 1fr));
   align-items: start;
+}
+
+/* Blue everywhere (titles, labels, pills) */
+h1,
+h2,
+h3,
+.card-title,
+.nv-tabs .pill,
+.breadcrumb a {
+  color: var(--brand-blue);
 }


### PR DESCRIPTION
## Summary
- add variant-aware navatar tabs that hide on mobile subpages
- show character card preview alongside My Navatar
- unify navatar card sizing and apply brand blue styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd6e7cce08329af0109269b35e842