### PR TITLE
feat: add Navatar card sub-hub with Supabase persistence

### DIFF
--- a/src/components/navatar/CardFrame.tsx
+++ b/src/components/navatar/CardFrame.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export function CardFrame({ children, title }: { children: React.ReactNode; title?: string }) {
+  return (
+    <div className="nv-card">
+      {title && <div className="nv-card-title">{title}</div>}
+      {children}
+    </div>
+  );
+}
+

--- a/src/components/navatar/CardReadout.tsx
+++ b/src/components/navatar/CardReadout.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { CardFrame } from './CardFrame';
+import type { UserCard } from '@/lib/supabase/navatar';
+
+export function CardReadout({ card }: { card: UserCard | null }) {
+  return (
+    <CardFrame title={card?.name || 'Character Card'}>
+      {card ? (
+        <div className="nv-card-body">
+          <dl>
+            {card.species && (
+              <>
+                <dt className="nv-label">Species</dt>
+                <dd>{card.species}</dd>
+              </>
+            )}
+            {card.kingdom && (
+              <>
+                <dt className="nv-label">Kingdom</dt>
+                <dd>{card.kingdom}</dd>
+              </>
+            )}
+            {card.backstory && (
+              <>
+                <dt className="nv-label">Backstory</dt>
+                <dd>{card.backstory}</dd>
+              </>
+            )}
+            {card.powers && card.powers.length > 0 && (
+              <>
+                <dt className="nv-label">Powers</dt>
+                <dd>{card.powers.join(', ')}</dd>
+              </>
+            )}
+            {card.traits && card.traits.length > 0 && (
+              <>
+                <dt className="nv-label">Traits</dt>
+                <dd>{card.traits.join(', ')}</dd>
+              </>
+            )}
+          </dl>
+        </div>
+      ) : (
+        <div className="nv-card-body">
+          <p>No card yet.</p>
+        </div>
+      )}
+    </CardFrame>
+  );
+}
+

--- a/src/components/navatar/Pills.tsx
+++ b/src/components/navatar/Pills.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+type Nav = { slug: string; to: string; label: string };
+
+const NAVATAR_TABS: Nav[] = [
+  { slug: 'my', to: '/navatar', label: 'My Navatar' },
+  { slug: 'card', to: '/navatar/card', label: 'Card' },
+  { slug: 'pick', to: '/navatar/pick', label: 'Pick' },
+  { slug: 'upload', to: '/navatar/upload', label: 'Upload' },
+  { slug: 'generate', to: '/navatar/generate', label: 'Generate' },
+  { slug: 'market', to: '/navatar/marketplace', label: 'Marketplace' },
+];
+
+type Props = {
+  hub: 'navatar';
+  active: string;
+  hideOnMobileSubpages?: boolean;
+};
+
+export function Pills({ hub, active, hideOnMobileSubpages }: Props) {
+  const items = hub === 'navatar' ? NAVATAR_TABS : [];
+  const hide = hideOnMobileSubpages && active !== 'my';
+  return (
+    <nav
+      className={`nav-tabs${hide ? ' nv-hide-mobile' : ''}`}
+      aria-label={`${hub} navigation`}
+    >
+      {items.map((t) => (
+        <Link
+          key={t.to}
+          to={t.to}
+          className={`pill${active === t.slug ? ' pill--active' : ''}`}
+        >
+          {t.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}
+

--- a/src/lib/supabase/navatar.ts
+++ b/src/lib/supabase/navatar.ts
@@ -1,0 +1,56 @@
+import { supabase } from '@/lib/supabase-client';
+
+export type UserNavatar = {
+  name?: string | null;
+  url: string;
+};
+
+export async function getUserNavatar(userId: string): Promise<UserNavatar | null> {
+  const { data, error } = await supabase
+    .from('user_navatar')
+    .select('name, url')
+    .eq('user_id', userId)
+    .single();
+  if (error && error.code !== 'PGRST116') throw error;
+  return (data as UserNavatar) ?? null;
+}
+
+export async function saveUserNavatar(
+  userId: string,
+  file: File,
+  name?: string
+): Promise<UserNavatar> {
+  const ext = file.name.split('.').pop() || 'png';
+  const path = `${userId}/current.${ext}`;
+  await supabase.storage.from('avatars').upload(path, file, { upsert: true });
+  const { data: { publicUrl } } = supabase.storage.from('avatars').getPublicUrl(path);
+  await supabase
+    .from('user_navatar')
+    .upsert({ user_id: userId, name: name ?? 'My Navatar', url: publicUrl }, { onConflict: 'user_id' });
+  return { url: publicUrl, name };
+}
+
+export type UserCard = {
+  user_id: string;
+  name?: string;
+  species?: string;
+  kingdom?: string;
+  backstory?: string;
+  powers?: string[];
+  traits?: string[];
+};
+
+export async function getUserCard(userId: string): Promise<UserCard | null> {
+  const { data, error } = await supabase
+    .from('navatar_cards')
+    .select('name,species,kingdom,backstory,powers,traits')
+    .eq('user_id', userId)
+    .single();
+  if (error && error.code !== 'PGRST116') throw error;
+  return (data as UserCard) ?? null;
+}
+
+export async function saveUserCard(card: UserCard) {
+  await supabase.from('navatar_cards').upsert(card, { onConflict: 'user_id' });
+}
+

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import { Pills } from '../../components/navatar/Pills';
+import { CardReadout } from '../../components/navatar/CardReadout';
+import { saveUserCard, getUserCard, type UserCard } from '@/lib/supabase/navatar';
+import { useAuth } from '@/lib/auth-context';
+import '../../styles/navatar.css';
+
+function formToCard(userId: string, fd: FormData): UserCard {
+  const get = (k: string) => fd.get(k)?.toString().trim() || undefined;
+  const split = (k: string) =>
+    get(k)
+      ?.split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  return {
+    user_id: userId,
+    name: get('name'),
+    species: get('species'),
+    kingdom: get('kingdom'),
+    backstory: get('backstory'),
+    powers: split('powers'),
+    traits: split('traits'),
+  };
+}
+
+export default function CardPage() {
+  const { user } = useAuth();
+  const [card, setCard] = useState<UserCard | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    getUserCard(user.id).then(setCard);
+  }, [user]);
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!user) return;
+    const data = formToCard(user.id, new FormData(e.currentTarget));
+    await saveUserCard(data);
+    setCard(data);
+  };
+
+  return (
+    <main className="container">
+      <Breadcrumbs items={[{ href: '/', label: 'Home' }, { href: '/navatar', label: 'Navatar' }, { label: 'Card' }]} />
+      <h1 className="nv-heading">Character Card</h1>
+      <Pills hub="navatar" active="card" hideOnMobileSubpages />
+      <div className="nv-two-col">
+        <CardReadout card={card} />
+        <form onSubmit={onSubmit} className="nv-form" style={{ display: 'grid', gap: 12 }}>
+          <label className="nv-label">Name<input name="name" defaultValue={card?.name} /></label>
+          <label className="nv-label">Species / Type<input name="species" defaultValue={card?.species} /></label>
+          <label className="nv-label">Kingdom<input name="kingdom" defaultValue={card?.kingdom} /></label>
+          <label className="nv-label">Backstory<textarea name="backstory" defaultValue={card?.backstory} /></label>
+          <label className="nv-label">Powers (comma separated)<input name="powers" defaultValue={card?.powers?.join(', ') || ''} /></label>
+          <label className="nv-label">Traits (comma separated)<input name="traits" defaultValue={card?.traits?.join(', ') || ''} /></label>
+          <div className="row end" style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+            <button className="pill" type="submit">Save</button>
+          </div>
+        </form>
+      </div>
+    </main>
+  );
+}
+

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,21 +1,39 @@
-import { useMemo } from "react";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { loadActive } from "../../lib/localStorage";
-import "../../styles/navatar.css";
+import { useEffect, useState } from 'react';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import { Pills } from '../../components/navatar/Pills';
+import { CardFrame } from '../../components/navatar/CardFrame';
+import { CardReadout } from '../../components/navatar/CardReadout';
+import { getUserNavatar, getUserCard, type UserNavatar, type UserCard } from '@/lib/supabase/navatar';
+import { useAuth } from '@/lib/auth-context';
+import '../../styles/navatar.css';
 
 export default function MyNavatarPage() {
-  const activeNavatar = useMemo(() => loadActive<any>(), []);
+  const { user } = useAuth();
+  const [navatar, setNavatar] = useState<UserNavatar | null>(null);
+  const [card, setCard] = useState<UserCard | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    getUserNavatar(user.id).then(setNavatar);
+    getUserCard(user.id).then(setCard);
+  }, [user]);
+
   return (
     <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
-      <h1 className="center">My Navatar</h1>
-      <NavatarTabs />
-
-      <div style={{ marginTop: 8 }}>
-        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
+      <Breadcrumbs items={[{ href: '/', label: 'Home' }, { href: '/navatar', label: 'Navatar' }]} />
+      <h1 className="nv-heading">My Navatar</h1>
+      <Pills hub="navatar" active="my" hideOnMobileSubpages />
+      <div className="nv-two-col">
+        <CardFrame title={navatar?.name ?? 'My Navatar'}>
+          {navatar?.url ? (
+            <img src={navatar.url} alt="My Navatar" />
+          ) : (
+            <div className="nav-card__placeholder">No photo</div>
+          )}
+        </CardFrame>
+        <CardReadout card={card} />
       </div>
     </main>
   );
 }
+

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -1,30 +1,36 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { loadPublicNavatars, PublicNavatar } from "../../lib/navatar/publicList";
-import { saveActive } from "../../lib/localStorage";
-import "../../styles/navatar.css";
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import { Pills } from '../../components/navatar/Pills';
+import { CardFrame } from '../../components/navatar/CardFrame';
+import { loadPublicNavatars, PublicNavatar } from '../../lib/navatar/publicList';
+import { saveUserNavatar } from '@/lib/supabase/navatar';
+import { useAuth } from '@/lib/auth-context';
+import '../../styles/navatar.css';
 
 export default function PickNavatarPage() {
   const [items, setItems] = useState<PublicNavatar[]>([]);
   const nav = useNavigate();
+  const { user } = useAuth();
 
   useEffect(() => {
     loadPublicNavatars().then(setItems);
   }, []);
 
-  function choose(src: string, name: string) {
-    saveActive({ id: Date.now(), name, imageDataUrl: src, createdAt: Date.now() });
-    nav("/navatar");
+  async function choose(src: string, name: string) {
+    if (!user) return;
+    const res = await fetch(src);
+    const blob = await res.blob();
+    const file = new File([blob], 'pick.png', { type: blob.type });
+    await saveUserNavatar(user.id, file, name);
+    nav('/navatar');
   }
 
   return (
     <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Pick" }]} />
-      <h1 className="center">Pick Navatar</h1>
-      <NavatarTabs />
+      <Breadcrumbs items={[{ href: '/', label: 'Home' }, { href: '/navatar', label: 'Navatar' }, { label: 'Pick' }]} />
+      <h1 className="nv-heading">Pick Navatar</h1>
+      <Pills hub="navatar" active="pick" hideOnMobileSubpages />
       <div className="nav-grid">
         {items.map((it) => (
           <button
@@ -32,9 +38,11 @@ export default function PickNavatarPage() {
             className="linklike"
             onClick={() => choose(it.src, it.name)}
             aria-label={`Pick ${it.name}`}
-            style={{ background: "none", border: 0, padding: 0, textAlign: "inherit" }}
+            style={{ background: 'none', border: 0, padding: 0, textAlign: 'inherit' }}
           >
-            <NavatarCard src={it.src} title={it.name} />
+            <CardFrame title={it.name}>
+              <img src={it.src} alt={it.name} />
+            </CardFrame>
           </button>
         ))}
       </div>

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,16 +1,18 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { saveActive } from "../../lib/localStorage";
-import "../../styles/navatar.css";
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import { Pills } from '../../components/navatar/Pills';
+import { CardFrame } from '../../components/navatar/CardFrame';
+import { saveUserNavatar } from '@/lib/supabase/navatar';
+import { useAuth } from '@/lib/auth-context';
+import '../../styles/navatar.css';
 
 export default function UploadNavatarPage() {
   const [file, setFile] = useState<File | null>(null);
-  const [name, setName] = useState("");
+  const [name, setName] = useState('');
   const [previewUrl, setPreviewUrl] = useState<string | undefined>();
   const nav = useNavigate();
+  const { user } = useAuth();
 
   useEffect(() => {
     if (!file) {
@@ -24,30 +26,30 @@ export default function UploadNavatarPage() {
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
-    if (!file) return;
-    const dataUrl = await new Promise<string>((res) => {
-      const r = new FileReader();
-      r.onload = () => res(String(r.result));
-      r.readAsDataURL(file);
-    });
-    saveActive({ id: Date.now(), name, imageDataUrl: dataUrl, createdAt: Date.now() });
-    alert("Uploaded ✓");
-    nav("/navatar");
+    if (!file || !user) return;
+    await saveUserNavatar(user.id, file, name);
+    nav('/navatar');
   }
 
   return (
     <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Upload" }]} />
-      <h1 className="center">Upload a Navatar</h1>
-      <NavatarTabs />
+      <Breadcrumbs items={[{ href: '/', label: 'Home' }, { href: '/navatar', label: 'Navatar' }, { label: 'Upload' }]} />
+      <h1 className="nv-heading">Upload a Navatar</h1>
+      <Pills hub="navatar" active="upload" hideOnMobileSubpages />
       <form
         onSubmit={onSave}
-        style={{ display: "grid", justifyItems: "center", gap: 12, maxWidth: 480, margin: "16px auto" }}
+        style={{ display: 'grid', justifyItems: 'center', gap: 12, maxWidth: 480, margin: '16px auto' }}
       >
-        <NavatarCard src={previewUrl} title={name || "My Navatar"} />
+        <CardFrame title={name || 'My Navatar'}>
+          {previewUrl ? (
+            <img src={previewUrl} alt="Preview" />
+          ) : (
+            <div className="nav-card__placeholder">No photo</div>
+          )}
+        </CardFrame>
         <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
         <input
-          style={{ display: "block", width: "100%" }}
+          style={{ display: 'block', width: '100%' }}
           placeholder="Name (optional)"
           value={name}
           onChange={(e) => setName(e.target.value)}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -36,6 +36,7 @@ import BankToken from './pages/naturbank/Token';
 import BankNFTs from './pages/naturbank/NFTs';
 import BankLearn from './pages/naturbank/Learn';
 import NavatarIndex from './pages/navatar';
+import NavatarCard from './pages/navatar/card';
 import NavatarPick from './pages/navatar/pick';
 import NavatarUpload from './pages/navatar/upload';
 import NavatarGenerate from './pages/navatar/generate';
@@ -122,6 +123,7 @@ export const router = createBrowserRouter([
         path: 'navatar',
         children: [
           { index: true, element: <NavatarIndex /> },
+          { path: 'card', element: <NavatarCard /> },
           { path: 'pick', element: <NavatarPick /> },
           { path: 'upload', element: <NavatarUpload /> },
           { path: 'generate', element: <NavatarGenerate /> },

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,10 +1,67 @@
+:root {
+  --nv-blue: #1e40af;
+  --nv-blue-ink: #1d4ed8;
+  --nav-card-w: clamp(260px, 32vw, 340px);
+}
+
+/* --- Shared card frame --- */
+.nv-card {
+  width: var(--nav-card-w);
+  aspect-ratio: 3 / 4;
+  border-radius: 16px;
+  background: #f1f5ff;
+  box-shadow: 0 8px 24px rgba(30, 64, 175, 0.08);
+  overflow: hidden;
+  margin-inline: auto;
+}
+.nv-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.nv-card-title {
+  padding: 6px 8px;
+  text-align: center;
+  font-weight: 600;
+  background: #eef3ff;
+}
+
+.nv-card-title,
+.nv-heading,
+.nv-label {
+  color: var(--nv-blue-ink);
+}
+
+.nv-card-body {
+  padding: 8px 12px;
+}
+
+.nv-two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+}
+
+@media (max-width: 640px) {
+  .nv-two-col {
+    display: block;
+  }
+  .nv-two-col > * {
+    margin-inline: auto;
+  }
+  .nv-hide-mobile {
+    display: none;
+  }
+}
+
 /* --- Pills: always horizontal & centered, wrap if needed --- */
 .nav-tabs {
   display: flex;
   justify-content: center;
   align-items: center;
   gap: 10px;
-  flex-wrap: wrap;       /* stays horizontal; wraps when space runs out */
+  flex-wrap: wrap;
   margin: 10px auto 18px;
 }
 
@@ -19,7 +76,7 @@
   color: #1e4ed8;
   text-decoration: none;
   font-weight: 600;
-  box-shadow: 0 2px 0 rgba(0,0,0,.08);
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.08);
 }
 .pill--active {
   background: #1e4ed8;
@@ -27,20 +84,20 @@
   border-color: #1e4ed8;
 }
 
-/* --- Card: single source of truth for size & fit --- */
+/* --- Legacy card styles (used elsewhere) --- */
 .nav-card {
-  --nav-card-w: 260px;    /* change this once to resize everywhere */
+  --nav-card-w: 260px;
   width: min(var(--nav-card-w), 88vw);
   margin: 0 auto;
   background: #ffffff;
   border: 1px solid #e8eefc;
   border-radius: 16px;
-  box-shadow: 0 6px 16px rgba(30,78,216,.06);
+  box-shadow: 0 6px 16px rgba(30, 78, 216, 0.06);
 }
 
 .nav-card__img {
   width: 100%;
-  aspect-ratio: 3 / 4;     /* consistent portrait shape */
+  aspect-ratio: 3 / 4;
   border-radius: 14px;
   overflow: hidden;
   background: #eef3ff;
@@ -48,7 +105,7 @@
 .nav-card__img img {
   width: 100%;
   height: 100%;
-  object-fit: contain;     /* never crop uploads or picks */
+  object-fit: contain;
   display: block;
 }
 .nav-card__placeholder {
@@ -72,3 +129,4 @@
   grid-template-columns: repeat(auto-fill, minmax(min(200px, 46vw), 1fr));
   align-items: start;
 }
+


### PR DESCRIPTION
## Summary
- add supabase helpers to store Navatar image and character card per user
- introduce Card sub-hub with form and readout; rename Alignment to Kingdom
- unify Navatar card sizing, mobile pills behaviour, and blue theme

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: TS errors in unrelated modules)


------
https://chatgpt.com/codex/tasks/task_e_68bbdc2a847c83299544c48d0ea3bc0d