### PR TITLE
feat: add multi-Navatar support with gallery and card

### DIFF
--- a/src/components/HubPills.tsx
+++ b/src/components/HubPills.tsx
@@ -1,0 +1,30 @@
+import { Link, useLocation } from "react-router-dom";
+
+const TABS = [
+  { to: "/navatar", label: "My Navatar" },
+  { to: "/navatar/card", label: "Card" },
+  { to: "/navatar/pick", label: "Pick" },
+  { to: "/navatar/upload", label: "Upload" },
+  { to: "/navatar/generate", label: "Generate" },
+  { to: "/navatar/mint", label: "NFT / Mint" },
+  { to: "/navatar/marketplace", label: "Marketplace" },
+];
+
+export function HubPills({ isHub = false }: { isHub?: boolean }) {
+  const { pathname } = useLocation();
+  return (
+    <nav className={`pillbar ${isHub ? "hub" : "sub"}`} aria-label="Navatar actions">
+      {TABS.map((t) => {
+        const active = t.to === "/navatar" ? pathname === "/navatar" : pathname.startsWith(t.to);
+        return (
+          <Link key={t.to} to={t.to} className={`pill ${active ? "pill--active" : ""}`}>
+            {t.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+export default HubPills;
+

--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -4,66 +4,187 @@ export type NavatarRow = {
   id: string;
   user_id: string;
   name: string | null;
-  base_type: string;          // 'Animal' | 'Fruit' | 'Insect' | 'Spirit'
-  backstory: string | null;
-  image_path: string | null;  // storage key inside the 'avatars' bucket
+  image_path: string; // "public/navatars/<uid>/<uuid>.png"
+  is_primary: boolean;
   created_at: string;
-  updated_at: string;
+  url?: string; // signed
 };
 
+const BUCKET = "avatars";
+const SIGNED_URL_SECS = 3600;
+
+// helper: signed URL from storage path
+async function signedUrlFromPath(image_path: string) {
+  // strip "public/" because the bucket is avatars
+  const key = image_path.replace(/^public\//, "");
+  const { data, error } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUrl(key, SIGNED_URL_SECS);
+  if (error) throw error;
+  return data?.signedUrl ?? "";
+}
+
+// legacy helper: return a public URL for a stored path
 export function navatarImageUrl(image_path: string | null) {
   if (!image_path) return null;
-  // bucket is 'avatars'
-  const { data } = supabase.storage.from("avatars").getPublicUrl(image_path);
+  const key = image_path.replace(/^public\//, "");
+  const { data } = supabase.storage.from(BUCKET).getPublicUrl(key);
   return data?.publicUrl ?? null;
 }
 
-export async function listMyNavatars() {
-  const { data: { user }, error: uErr } = await supabase.auth.getUser();
-  if (uErr || !user) throw new Error("Not signed in");
+/** Return the user's primary navatar (or null). */
+export async function getMyNavatar(): Promise<NavatarRow | null> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
   const { data, error } = await supabase
-    .from("avatars")
+    .from("navatars")
+    .select("*")
+    .eq("user_id", user.id)
+    .eq("is_primary", true)
+    .maybeSingle();
+
+  if (error && error.code !== "PGRST116") throw error; // no rows
+  if (!data) return null;
+
+  return { ...data, url: await signedUrlFromPath(data.image_path) };
+}
+
+/** List all of the current user's navatars (with signed URLs). */
+export async function listMyNavatars(): Promise<NavatarRow[]> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from("navatars")
     .select("*")
     .eq("user_id", user.id)
     .order("created_at", { ascending: false });
+
   if (error) throw error;
-  return (data ?? []) as NavatarRow[];
+
+  return Promise.all(
+    (data ?? []).map(async (row) => ({
+      ...row,
+      url: await signedUrlFromPath(row.image_path),
+    }))
+  );
 }
 
-export async function saveNavatar(opts: {
-  name?: string;
-  base_type: "Animal" | "Fruit" | "Insect" | "Spirit";
-  backstory?: string;
-  file?: File | null;
-}) {
-  const { data: { user }, error: uErr } = await supabase.auth.getUser();
-  if (uErr || !user) throw new Error("Not signed in");
+/** Upload a new navatar image and create the DB row. */
+export async function uploadNavatar(file: File, name?: string) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not signed in");
 
-  let image_path: string | null = null;
+  const id = crypto.randomUUID();
+  const key = `public/navatars/${user.id}/${id}.png`;
 
-  if (opts.file) {
-    // create a deterministic file path
-    const ext = opts.file.name.split(".").pop() || "png";
-    const fileName = `${crypto.randomUUID()}.${ext}`;
-    image_path = `navatars/${user.id}/${fileName}`;
-    const { error: upErr } = await supabase
-      .storage.from("avatars")
-      .upload(image_path, opts.file, { upsert: false });
-    if (upErr) throw upErr;
-  }
+  const { error: upErr } = await supabase.storage
+    .from(BUCKET)
+    .upload(key.replace(/^public\//, ""), file, {
+      upsert: false,
+      contentType: file.type || "image/png",
+    });
+  if (upErr) throw upErr;
 
   const { data, error } = await supabase
-    .from("avatars")
-    .insert([{ 
-      name: opts.name ?? null,
-      base_type: opts.base_type,
-      backstory: opts.backstory ?? null,
-      image_path,
-    }])
-    .select()
+    .from("navatars")
+    .insert({
+      id,
+      user_id: user.id,
+      name: name ?? null,
+      image_path: key,
+      is_primary: true,
+    })
+    .select("*")
     .single();
 
   if (error) throw error;
-  return data as NavatarRow;
+
+  return { ...data, url: await signedUrlFromPath(key) } as NavatarRow;
+}
+
+export async function setPrimaryNavatar(id: string) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not signed in");
+
+  const { data, error } = await supabase
+    .from("navatars")
+    .update({ is_primary: true })
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .select("*")
+    .single();
+
+  if (error) throw error;
+  return {
+    ...(data as NavatarRow),
+    url: await signedUrlFromPath((data as NavatarRow).image_path),
+  };
+}
+
+export async function deleteNavatar(id: string) {
+  const { data: row, error: getErr } = await supabase
+    .from("navatars")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (getErr) throw getErr;
+  if (!row) return;
+
+  await supabase.storage
+    .from(BUCKET)
+    .remove([row.image_path.replace(/^public\//, "")]);
+  await supabase.from("navatars").delete().eq("id", id);
+}
+
+/** Card I/O (alignment -> kingdom) */
+export type NavatarCard = {
+  navatar_id: string;
+  name?: string | null;
+  species?: string | null;
+  kingdom?: string | null; // renamed
+  backstory?: string | null;
+  powers?: string[] | null;
+  traits?: string[] | null;
+};
+
+export async function saveCard(card: NavatarCard) {
+  const { data, error } = await supabase
+    .from("navatar_cards")
+    .upsert(card, { onConflict: "navatar_id" })
+    .select("*")
+    .single();
+  if (error) throw error;
+  return data as NavatarCard;
+}
+
+export async function loadCard(navatar_id: string) {
+  const { data, error } = await supabase
+    .from("navatar_cards")
+    .select("*")
+    .eq("navatar_id", navatar_id)
+    .maybeSingle();
+  if (error) throw error;
+  return data as NavatarCard | null;
+}
+
+/** @deprecated Use uploadNavatar instead */
+export async function saveNavatar(opts: {
+  name?: string;
+  base_type: string;
+  backstory?: string;
+  file?: File | null;
+}) {
+  if (!opts.file) throw new Error("File required");
+  return uploadNavatar(opts.file, opts.name);
 }
 

--- a/src/routes/navatar/card.tsx
+++ b/src/routes/navatar/card.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import HubPills from "../../components/HubPills";
+import { getMyNavatar, saveCard, loadCard } from "../../lib/navatar";
+import "../../styles/navatar.css";
+
+export default function NavatarCardPage() {
+  const [primary, setPrimary] = useState<any>(null);
+  const [form, setForm] = useState<any>({
+    name: "",
+    species: "",
+    kingdom: "",
+    backstory: "",
+    powers: "",
+    traits: "",
+  });
+
+  useEffect(() => {
+    (async () => {
+      const p = await getMyNavatar();
+      setPrimary(p);
+      if (p) {
+        const c = await loadCard(p.id);
+        if (c) {
+          setForm({
+            name: c.name ?? "",
+            species: c.species ?? "",
+            kingdom: c.kingdom ?? "",
+            backstory: c.backstory ?? "",
+            powers: (c.powers ?? []).join(", "),
+            traits: (c.traits ?? []).join(", "),
+          });
+        }
+      }
+    })();
+  }, []);
+
+  const onSave = async (e: any) => {
+    e.preventDefault();
+    if (!primary) return;
+    await saveCard({
+      navatar_id: primary.id,
+      name: form.name || null,
+      species: form.species || null,
+      kingdom: form.kingdom || null,
+      backstory: form.backstory || null,
+      powers: form.powers
+        ? form.powers.split(",").map((s: string) => s.trim()).filter(Boolean)
+        : [],
+      traits: form.traits
+        ? form.traits.split(",").map((s: string) => s.trim()).filter(Boolean)
+        : [],
+    });
+    alert("Saved ✓");
+  };
+
+  return (
+    <div className="container">
+      <HubPills /> {/* pills are auto-hidden on mobile for sub-pages */}
+      <h1>Character Card</h1>
+
+      <div className="two-col">
+        <div className="card-panel">
+          <h3 style={{ textAlign: "center" }}>My Navatar</h3>
+          <hr />
+          <p>
+            <strong>Backstory</strong>
+            <br />
+            {form.backstory || "No backstory yet."}
+          </p>
+          <p>
+            <strong>Powers</strong>
+            <br />
+            {form.powers || "—"}
+          </p>
+          <p>
+            <strong>Traits</strong>
+            <br />
+            {form.traits || "—"}
+          </p>
+        </div>
+
+        <form onSubmit={onSave} className="form">
+          <label>
+            Name
+            <input
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+            />
+          </label>
+          <label>
+            Species / Type
+            <input
+              value={form.species}
+              onChange={(e) => setForm({ ...form, species: e.target.value })}
+            />
+          </label>
+          <label>
+            Kingdom
+            <input
+              value={form.kingdom}
+              onChange={(e) => setForm({ ...form, kingdom: e.target.value })}
+            />
+          </label>
+          <label>
+            Backstory
+            <textarea
+              rows={5}
+              value={form.backstory}
+              onChange={(e) => setForm({ ...form, backstory: e.target.value })}
+            />
+          </label>
+          <label>
+            Powers (comma separated)
+            <input
+              value={form.powers}
+              onChange={(e) => setForm({ ...form, powers: e.target.value })}
+            />
+          </label>
+          <label>
+            Traits (comma separated)
+            <input
+              value={form.traits}
+              onChange={(e) => setForm({ ...form, traits: e.target.value })}
+            />
+          </label>
+          <button type="submit" className="btn primary">
+            Save
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -72,3 +72,71 @@
   grid-template-columns: repeat(auto-fill, minmax(min(200px, 46vw), 1fr));
   align-items: start;
 }
+
+/* shared card/image sizes */
+:root{
+  --navatar-w: 540px;
+  --navatar-ratio: 3/4;     /* width/height ratio */
+}
+
+.navatar-frame{
+  width: min(100%, var(--navatar-w));
+  aspect-ratio: var(--navatar-ratio);
+  border-radius: 20px;
+  overflow: hidden;
+  background: #f2f6ff;
+  box-shadow: 0 2px 18px rgba(16,44,190,.06);
+}
+.navatar-frame img{
+  width: 100%;
+  height: 100%;
+  object-fit: cover;        /* consistent crop */
+  display: block;
+  border: 0;
+}
+
+.card-panel{
+  width: min(100%, var(--navatar-w));
+  border-radius: 20px;
+  padding: 20px 22px;
+  background: #f7faff;
+  box-shadow: 0 2px 18px rgba(16,44,190,.06);
+}
+
+.gallery{
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+  gap: 12px;
+  max-width: min(100%, var(--navatar-w));
+}
+.gallery .thumb{
+  aspect-ratio: var(--navatar-ratio);
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  outline: 2px solid transparent;
+}
+.gallery .thumb.is-primary{ outline-color:#2f5aff; }
+.gallery .thumb img{ width:100%; height:100%; object-fit: cover; }
+
+.two-col{
+  display:grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px;
+}
+@media (max-width: 900px){
+  .two-col{ grid-template-columns: 1fr; }
+}
+
+/* 3-across on small screens when visible */
+.pillbar{
+  display:grid;
+  grid-template-columns: repeat(6, max-content);
+  gap: 10px;
+}
+@media (max-width: 640px){
+  .pillbar.hub{
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .pillbar.sub{ display:none; }
+}


### PR DESCRIPTION
## Summary
- support multiple Navatars with primary picker and signed URLs
- add HubPills navigation and character card page with Kingdom field
- standardize Navatar and card sizing with shared CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'next/link' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe357344483299ea0697f92a34bef