### PR TITLE
feat: navatar card blue theming

### DIFF
--- a/src/components/NavatarPills.tsx
+++ b/src/components/NavatarPills.tsx
@@ -1,0 +1,48 @@
+import { Link } from "react-router-dom";
+
+export type Tab =
+  | "navatar"
+  | "card"
+  | "pick"
+  | "upload"
+  | "generate"
+  | "mint"
+  | "marketplace";
+
+const TABS: { to: string; label: string; key: Tab }[] = [
+  { to: "/navatar", label: "My Navatar", key: "navatar" },
+  { to: "/navatar/card", label: "Card", key: "card" },
+  { to: "/navatar/pick", label: "Pick", key: "pick" },
+  { to: "/navatar/upload", label: "Upload", key: "upload" },
+  { to: "/navatar/generate", label: "Generate", key: "generate" },
+  { to: "/navatar/mint", label: "NFT / Mint", key: "mint" },
+  { to: "/navatar/marketplace", label: "Marketplace", key: "marketplace" },
+];
+
+export default function NavatarPills({ active, color = "blue" }: { active: Tab; color?: "blue" | "gray" }) {
+  const activeStyle =
+    color === "blue"
+      ? { background: "var(--nv-blue-800)", color: "#fff", borderColor: "var(--nv-blue-800)" }
+      : { background: "#111827", color: "#fff", borderColor: "#111827" };
+  const idleStyle =
+    color === "blue"
+      ? {
+          background: "#fff",
+          color: "var(--nv-blue-800)",
+          border: "1px solid var(--nv-blue-200)",
+        }
+      : {
+          background: "#fff",
+          color: "#111827",
+          border: "1px solid #e5e7eb",
+        };
+  return (
+    <nav className="nav-tabs" aria-label="Navatar actions">
+      {TABS.map(t => (
+        <Link key={t.to} to={t.to} className="pill" style={t.key === active ? activeStyle : idleStyle}>
+          {t.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
+import NavatarPills from "../../components/NavatarPills";
 import { loadPrimaryNavatarId, loadCard, saveCard } from "../../lib/navatarCard";
 import "../../styles/navatar.css";
 
@@ -81,42 +81,45 @@ export default function NavatarCardPage() {
   return (
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
-      <h1 className="center">Character Card</h1>
-      <NavatarTabs />
-      <form onSubmit={onSave} style={{ maxWidth: 720, margin: "16px auto", display: "grid", gap: 12 }}>
+      <h1 className="center" style={{ color: "var(--nv-blue-900)" }}>Character Card</h1>
+      <NavatarPills active="card" color="blue" />
+      <form
+        onSubmit={onSave}
+        style={{ maxWidth: 720, margin: "16px auto", display: "grid", gap: 12, color: "var(--nv-blue-900)" }}
+      >
         <label>
           Name
-          <input value={form.name} onChange={onChange("name")} />
+          <input className="nv-input" value={form.name} onChange={onChange("name")} />
         </label>
 
         <label>
           Species / Type
-          <input value={form.species} onChange={onChange("species")} />
+          <input className="nv-input" value={form.species} onChange={onChange("species")} />
         </label>
 
         <label>
           Kingdom
-          <input value={form.kingdom} onChange={onChange("kingdom")} />
+          <input className="nv-input" value={form.kingdom} onChange={onChange("kingdom")} />
         </label>
 
         <label>
           Backstory
-          <textarea rows={6} value={form.backstory} onChange={onChange("backstory")} />
+          <textarea className="nv-input" rows={6} value={form.backstory} onChange={onChange("backstory")} />
         </label>
 
         <label>
           Powers (comma separated)
-          <input value={form.powers} onChange={onChange("powers")} />
+          <input className="nv-input" value={form.powers} onChange={onChange("powers")} />
         </label>
 
         <label>
           Traits (comma separated)
-          <input value={form.traits} onChange={onChange("traits")} />
+          <input className="nv-input" value={form.traits} onChange={onChange("traits")} />
         </label>
 
         <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
-          <Link to="/navatar" className="pill">Back to My Navatar</Link>
-          <button className="pill pill--active" type="submit" disabled={saving}>
+          <Link to="/navatar" className="nv-btn-outline">Back to My Navatar</Link>
+          <button className="nv-btn" type="submit" disabled={saving}>
             {saving ? "Saving…" : "Save"}
           </button>
         </div>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -113,3 +113,40 @@
 .nvrs-section.navatar .ccard li { line-height: 1.35; }
 .nvrs-section.navatar .ccard .label { font-weight: 700; }
 .nvrs-section.navatar .ccard .card__placeholder { color: #aaa; }
+
+/* --- Navatar Card blue form controls ------------------------------------- */
+.nv-input{
+  color: var(--nv-blue-900);
+  border: 1px solid var(--nv-blue-200);
+  background: #fff;
+  border-radius: 12px;
+  padding: .8rem 1rem;
+}
+.nv-input::placeholder{ color: var(--nv-blue-400); }
+.nv-input:focus{
+  outline: none;
+  border-color: var(--nv-blue-700);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--nv-blue-700) 20%, transparent);
+}
+
+.nv-btn{
+  background: var(--nv-blue-800);
+  color:#fff;
+  padding:.8rem 1.1rem;
+  border-radius:14px;
+  font-weight:700;
+}
+.nv-btn:hover{ background: var(--nv-blue-900); }
+
+.nv-btn-outline{
+  background:#fff;
+  color: var(--nv-blue-800);
+  border:1px solid var(--nv-blue-200);
+  padding:.8rem 1.1rem;
+  border-radius:14px;
+  font-weight:700;
+}
+.nv-btn-outline:hover{
+  border-color: var(--nv-blue-700);
+  color: var(--nv-blue-900);
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -3,14 +3,14 @@
   /* Brand blues */
   --nv-blue-50: #f2f6ff;
   --nv-blue-100: #e6efff;
-  --nv-blue-200: #cfe2ff;
+  --nv-blue-200: #dfe6ff;
   --nv-blue-300: #a9caff;
-  --nv-blue-400: #7eacff;
+  --nv-blue-400: #9bb0ff;
   --nv-blue-500: #3b82f6; /* primary */
   --nv-blue-600: #2463EB; /* existing brand blue (keep in sync) */
-  --nv-blue-700: #2D5CFF; /* active/focus ring */
-  --nv-blue-800: #1e479e;
-  --nv-blue-900: #173878;
+  --nv-blue-700: #3454ff; /* active/focus ring */
+  --nv-blue-800: #1e40ff;
+  --nv-blue-900: #0b3cff;
 
   /* Gradients (for primary buttons/chips) */
   --nv-grad-start: #2f6ceb;


### PR DESCRIPTION
## Summary
- add brand blue color tokens
- style card form controls and buttons with blue utilities
- tint Navatar card page and pills

## Testing
- `npm test` *(fails: command not found)*
- `npm run typecheck` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe8f545388329878987eaa5c37b64