### PR TITLE
feat: add character card sub-page

### DIFF
--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -11,10 +11,10 @@ const TABS = [
   { to: "/navatar/marketplace", label: "Marketplace" },
 ];
 
-export default function NavatarTabs() {
+export default function NavatarTabs({ sub = false }: { sub?: boolean }) {
   const { pathname } = useLocation();
   return (
-    <nav className="nav-tabs" aria-label="Navatar actions">
+    <nav className={`nav-tabs${sub ? " nav-tabs--sub" : ""}`} aria-label="Navatar actions">
       {TABS.map(t => {
         const active =
           t.to === "/navatar" ? pathname === "/navatar" : pathname.startsWith(t.to);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -114,3 +114,17 @@ export type CatalogSection = {
 export type WishlistItem = CatalogItem & {
   wishedAt: Date;
 };
+
+export type CharacterCard = {
+  id: string;
+  user_id: string;
+  navatar_id: string | null;
+  name: string | null;
+  species: string | null;
+  kingdom: string | null;
+  backstory: string | null;
+  powers: string[] | null;
+  traits: string[] | null;
+  created_at: string;
+  updated_at: string;
+};

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,21 +1,91 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
 import { loadActive } from "../../lib/localStorage";
+import { fetchMyCharacterCard } from "../../lib/navatar";
+import type { CharacterCard } from "../../lib/types";
+import { Link } from "react-router-dom";
 import "../../styles/navatar.css";
 
 export default function MyNavatarPage() {
   const activeNavatar = useMemo(() => loadActive<any>(), []);
+  const [card, setCard] = useState<CharacterCard | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const c = await fetchMyCharacterCard();
+        if (alive) setCard(c);
+      } catch {
+        // ignore
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
   return (
-    <main className="container">
+    <main className="container page-pad">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
-      <h1 className="center">My Navatar</h1>
+      <h1 className="center page-title">My Navatar</h1>
       <NavatarTabs />
 
       <div style={{ marginTop: 8 }}>
         <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
       </div>
+
+      <section className="panel" style={{ marginTop: 16 }}>
+        <h3 className="panel-title">Character Card</h3>
+        {!card ? (
+          <p>
+            No card yet. <Link to="/navatar/card" className="link">Create Card</Link>
+          </p>
+        ) : (
+          <div className="cc-summary">
+            {card.name && (
+              <div>
+                <strong>Name:</strong> {card.name}
+              </div>
+            )}
+            {card.species && (
+              <div>
+                <strong>Species:</strong> {card.species}
+              </div>
+            )}
+            {card.kingdom && (
+              <div>
+                <strong>Kingdom:</strong> {card.kingdom}
+              </div>
+            )}
+            {card.backstory && (
+              <div className="mt-sm">
+                <strong>Backstory</strong>
+                <div>{card.backstory}</div>
+              </div>
+            )}
+            {card.powers && card.powers.length > 0 && (
+              <div className="mt-sm">
+                <strong>Powers</strong>
+                <div>— {card.powers.join(", ")}</div>
+              </div>
+            )}
+            {card.traits && card.traits.length > 0 && (
+              <div className="mt-sm">
+                <strong>Traits</strong>
+                <div>— {card.traits.join(", ")}</div>
+              </div>
+            )}
+            <div className="mt-md">
+              <Link to="/navatar/card" className="pill">
+                Edit Card
+              </Link>
+            </div>
+          </div>
+        )}
+      </section>
     </main>
   );
 }

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -72,3 +72,49 @@
   grid-template-columns: repeat(auto-fill, minmax(min(200px, 46vw), 1fr));
   align-items: start;
 }
+
+/* Keep existing colors; enforce blue titles/links for the new page */
+.page-title,
+.panel-title,
+.link,
+.btn {
+  color: var(--nv-blue-600);
+}
+
+/* Sub-page pill bar: hidden on mobile, visible ≥ md */
+.nav-tabs--sub {
+  display: none;
+}
+@media (min-width: 768px) {
+  .nav-tabs--sub {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+}
+
+/* Form spacing */
+.form-card {
+  max-width: 720px;
+}
+.form-card label {
+  display: block;
+  margin: 0 0 0.75rem;
+  color: var(--nv-blue-700);
+  font-weight: 600;
+}
+.form-card input,
+.form-card textarea {
+  width: 100%;
+}
+.row.gap {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+/* Ensure bottom buttons are tappable on mobile (not hidden by footer) */
+.page-pad {
+  padding-bottom: 5rem;
+}


### PR DESCRIPTION
## Summary
- add CharacterCard type and Supabase helpers for persistence
- new /navatar/card route with blue-themed form and mobile-friendly pills
- show saved card summary on My Navatar page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: type errors in existing code)


------
https://chatgpt.com/codex/tasks/task_e_68bbef9ba710832991888a1fdae95ca4