### PR TITLE
Navatar “Card” sub-page + preview (blue), save → NFT, no other layout changes

### DIFF
--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,20 +1,56 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
 import { loadActive } from "../../lib/localStorage";
+import { getCard, loadPrimaryNavatarId } from "../../lib/card";
 import "../../styles/navatar.css";
 
 export default function MyNavatarPage() {
   const activeNavatar = useMemo(() => loadActive<any>(), []);
+  const [card, setCard] = useState<any>(null);
+
+  useEffect(() => {
+    (async () => {
+      const id = await loadPrimaryNavatarId();
+      if (!id) return;
+      try {
+        setCard(await getCard(id));
+      } catch (err) {
+        console.warn(err);
+      }
+    })();
+  }, []);
+
   return (
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
       <h1 className="center">My Navatar</h1>
       <NavatarTabs />
 
-      <div style={{ marginTop: 8 }}>
+      <div className="nav-stack" style={{ marginTop: 8 }}>
         <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
+
+        <div className="char-card">
+          <h3>Character Card</h3>
+          {card ? (
+            <dl className="char-card__dl">
+              <div><strong>Name</strong><div>{card.name ?? "—"}</div></div>
+              <div><strong>Species</strong><div>{card.species ?? "—"}</div></div>
+              <div><strong>Kingdom</strong><div>{card.kingdom ?? "—"}</div></div>
+              <div><strong>Backstory</strong><div className="pre">{card.backstory || "—"}</div></div>
+              <div><strong>Powers</strong><div className="pre">{(card.powers || []).length ? (card.powers || []).map((p: string) => <div key={p}>— {p}</div>) : "—"}</div></div>
+              <div><strong>Traits</strong><div className="pre">{(card.traits || []).length ? (card.traits || []).map((t: string) => <div key={t}>— {t}</div>) : "—"}</div></div>
+            </dl>
+          ) : (
+            <div>No card yet. <Link to="/navatar/card">Create Card</Link></div>
+          )}
+
+          <div style={{ marginTop: 16 }}>
+            <Link to="/navatar/card" className="pill">Edit Card</Link>
+          </div>
+        </div>
       </div>
     </main>
   );

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -72,3 +72,35 @@
   grid-template-columns: repeat(auto-fill, minmax(min(200px, 46vw), 1fr));
   align-items: start;
 }
+
+/* layout for My Navatar + Character Card preview */
+.nav-stack {
+  display: grid;
+  gap: 24px;
+}
+@media (min-width: 768px) {
+  .nav-stack {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+}
+
+.char-card {
+  border: 1px solid #cfe0ff;
+  background: #f6f9ff;
+  border-radius: 16px;
+  padding: 24px;
+  color: #1e40af;
+}
+.char-card h3 {
+  margin-top: 0;
+  color: #1e40af;
+  font-weight: 800;
+  margin-bottom: 12px;
+}
+.char-card__dl div {
+  margin-bottom: 8px;
+}
+.char-card .pre {
+  white-space: pre-wrap;
+}

--- a/supabase/migrations/2025-09-06_000_card_table.sql
+++ b/supabase/migrations/2025-09-06_000_card_table.sql
@@ -1,0 +1,47 @@
+-- Character cards for a user's selected Navatar
+create table if not exists public.character_cards (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  navatar_id uuid not null references public.avatars(id) on delete cascade,
+  name text,
+  species text,
+  kingdom text,
+  backstory text,
+  powers text[],        -- comma list stored as array
+  traits text[],        -- comma list stored as array
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (user_id, navatar_id)
+);
+
+alter table public.character_cards enable row level security;
+
+-- owner can read/write their own cards
+create policy "card_select_own"
+on public.character_cards for select
+using (auth.uid() = user_id);
+
+create policy "card_insert_own"
+on public.character_cards for insert
+with check (auth.uid() = user_id);
+
+create policy "card_update_own"
+on public.character_cards for update
+using (auth.uid() = user_id);
+
+create policy "card_delete_own"
+on public.character_cards for delete
+using (auth.uid() = user_id);
+
+-- trigger to keep updated_at fresh
+create or replace function public.touch_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now(); 
+  return new;
+end$$;
+
+drop trigger if exists trg_touch_character_cards on public.character_cards;
+create trigger trg_touch_character_cards
+before update on public.character_cards
+for each row execute function public.touch_updated_at();


### PR DESCRIPTION
## Summary
- add `character_cards` table and row level security policies
- create shared helpers to load and save character cards
- introduce Navatar Card page that upserts to Supabase and redirects to mint
- show Character Card preview alongside My Navatar hub

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type ... is not assignable to parameter of type 'never' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf75946408329b640733e651e40e7