### PR TITLE
feat(navatar): add character card page and storage

### DIFF
--- a/src/components/SubpagePills.tsx
+++ b/src/components/SubpagePills.tsx
@@ -1,0 +1,1 @@
+export const subpagePillRow = 'hidden md:flex gap-3 flex-wrap mb-6';

--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -67,3 +67,33 @@ export async function saveNavatar(opts: {
   return data as NavatarRow;
 }
 
+
+export type CharacterCard = {
+  name?: string;
+  species?: string;
+  kingdom?: string;
+  backstory?: string;
+  powers?: string[];
+  traits?: string[];
+};
+
+export async function getActiveNavatar(userId: string) {
+  return supabase
+    .from('avatars')
+    .select('id, name, image_path, card')
+    .eq('user_id', userId)
+    .eq('is_active', true)
+    .maybeSingle();
+}
+
+export async function updateActiveNavatarCard(userId: string, card: CharacterCard) {
+  const { data: active, error: findErr } = await getActiveNavatar(userId);
+  if (findErr) return { error: findErr };
+  if (!active) return { error: new Error('NO_ACTIVE_NAVATAR') };
+
+  return supabase
+    .from('avatars')
+    .update({ card })
+    .eq('id', active.id)
+    .eq('user_id', userId);
+}

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -1,126 +1,134 @@
-import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import { loadPrimaryNavatarId, loadCard, saveCard } from "../../lib/navatarCard";
-import "../../styles/navatar.css";
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import NavatarTabs from '../../components/NavatarTabs';
+import { useAuthUser } from '../../lib/useAuthUser';
+import { getActiveNavatar, updateActiveNavatarCard, CharacterCard } from '../../lib/navatar';
+import '../../styles/navatar.css';
 
-type Form = {
-  name: string;
-  species: string;
-  kingdom: string;
-  backstory: string;
-  powers: string;
-  traits: string;
-};
+const labelCls = 'text-blue-600 font-semibold';
+const inputCls =
+  'w-full rounded-lg border border-blue-200 bg-white/70 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400 text-blue-700 placeholder-blue-300';
 
 export default function NavatarCardPage() {
-  const [navatarId, setNavatarId] = useState<string | null>(null);
-  const [form, setForm] = useState<Form>({
-    name: "",
-    species: "",
-    kingdom: "",
-    backstory: "",
-    powers: "",
-    traits: "",
-  });
+  const nav = useNavigate();
+  const { user } = useAuthUser();
+  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [form, setForm] = useState<any>({});
 
   useEffect(() => {
+    let ignore = false;
     (async () => {
-      const id = await loadPrimaryNavatarId();
-      setNavatarId(id);
-      if (!id) return;
-      const card = await loadCard(id);
-      if (card) {
+      if (!user) { setLoading(false); return; }
+      const { data, error } = await getActiveNavatar(user.id);
+      if (ignore) return;
+      if (error) {
+        console.error(error);
+      } else if (data) {
+        setActiveId(data.id);
+        const card = (data.card ?? {}) as CharacterCard;
         setForm({
-          name: card.name ?? "",
-          species: card.species ?? "",
-          kingdom: card.kingdom ?? "",
-          backstory: card.backstory ?? "",
-          powers: (card.powers ?? []).join(", "),
-          traits: (card.traits ?? []).join(", "),
+          name: card.name ?? '',
+          species: card.species ?? '',
+          kingdom: card.kingdom ?? '',
+          backstory: card.backstory ?? '',
+          powers: card.powers ?? [],
+          traits: card.traits ?? [],
         });
       }
+      setLoading(false);
     })();
-  }, []);
+    return () => { ignore = true; };
+  }, [user]);
 
-  const onChange = (k: keyof Form) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
-    setForm(f => ({ ...f, [k]: e.target.value }));
+  const canSave = useMemo(() => !!activeId && !saving, [activeId, saving]);
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
-    if (!navatarId) {
-      alert("Please create or select a Navatar first.");
+    if (!activeId || !user) {
+      alert('Please create or select a Navatar first.');
       return;
     }
     setSaving(true);
-    try {
-      await saveCard({
-        navatar_id: navatarId,
-        name: form.name || null,
-        species: form.species || null,
-        kingdom: form.kingdom || null,
-        backstory: form.backstory || null,
-        powers: form.powers
-          ? form.powers.split(",").map(s => s.trim()).filter(Boolean)
-          : [],
-        traits: form.traits
-          ? form.traits.split(",").map(s => s.trim()).filter(Boolean)
-          : [],
-      });
-      alert("Saved ✓");
-    } catch (err: any) {
-      console.error(err);
-      alert(err.message ?? "Error saving card");
-    } finally {
-      setSaving(false);
+    const card: CharacterCard = {
+      name: form.name?.trim(),
+      species: form.species?.trim(),
+      kingdom: form.kingdom?.trim(),
+      backstory: form.backstory?.trim(),
+      powers: (Array.isArray(form.powers) ? form.powers : (form.powers ?? '').split(',')).map((s: string) => s.trim()).filter(Boolean),
+      traits: (Array.isArray(form.traits) ? form.traits : (form.traits ?? '').split(',')).map((s: string) => s.trim()).filter(Boolean),
+    };
+    const { error } = await updateActiveNavatarCard(user.id, card);
+    setSaving(false);
+    if (error) {
+      console.error(error);
+      alert(error.message);
+    } else {
+      nav('/navatar#card', { replace: true });
     }
   }
 
   return (
     <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
+      <Breadcrumbs items={[{ href: '/', label: 'Home' }, { href: '/navatar', label: 'Navatar' }, { label: 'Card' }]} />
       <h1 className="center">Character Card</h1>
-      <NavatarTabs />
-      <form onSubmit={onSave} style={{ maxWidth: 720, margin: "16px auto", display: "grid", gap: 12 }}>
-        <label>
-          Name
-          <input value={form.name} onChange={onChange("name")} />
-        </label>
+      <div className="hidden md:block"><NavatarTabs /></div>
+      {loading ? (
+        <p className="text-blue-500">Loading…</p>
+      ) : (
+        <form onSubmit={onSave} style={{ maxWidth: 720, margin: '16px auto', display: 'grid', gap: 12 }}>
+          {!activeId && (
+            <div className="rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-blue-700">
+              You don’t have an active Navatar.{' '}
+              <Link className="underline font-semibold" to="/navatar/pick">Pick</Link> or{' '}
+              <Link className="underline font-semibold" to="/navatar/upload">Upload</Link> one to save your card.
+            </div>
+          )}
 
-        <label>
-          Species / Type
-          <input value={form.species} onChange={onChange("species")} />
-        </label>
+          <label className={labelCls}>
+            Name
+              <input className={inputCls} value={form.name ?? ''} onChange={e => setForm((f: any) => ({ ...f, name: e.target.value }))} />
+          </label>
 
-        <label>
-          Kingdom
-          <input value={form.kingdom} onChange={onChange("kingdom")} />
-        </label>
+          <label className={labelCls}>
+            Species / Type
+              <input className={inputCls} value={form.species ?? ''} onChange={e => setForm((f: any) => ({ ...f, species: e.target.value }))} />
+          </label>
 
-        <label>
-          Backstory
-          <textarea rows={6} value={form.backstory} onChange={onChange("backstory")} />
-        </label>
+          <label className={labelCls}>
+            Kingdom
+              <input className={inputCls} value={form.kingdom ?? ''} onChange={e => setForm((f: any) => ({ ...f, kingdom: e.target.value }))} />
+          </label>
 
-        <label>
-          Powers (comma separated)
-          <input value={form.powers} onChange={onChange("powers")} />
-        </label>
+          <label className={labelCls}>
+            Backstory
+              <textarea rows={5} className={inputCls} value={form.backstory ?? ''} onChange={e => setForm((f: any) => ({ ...f, backstory: e.target.value }))} />
+          </label>
 
-        <label>
-          Traits (comma separated)
-          <input value={form.traits} onChange={onChange("traits")} />
-        </label>
+          <label className={labelCls}>
+            Powers (comma separated)
+            <input className={inputCls}
+              value={Array.isArray(form.powers) ? form.powers.join(', ') : (form.powers ?? '')}
+              onChange={e => setForm((f: any) => ({ ...f, powers: e.target.value }))} />
+          </label>
 
-        <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
-          <Link to="/navatar" className="pill">Back to My Navatar</Link>
-          <button className="pill pill--active" type="submit" disabled={saving}>
-            {saving ? "Saving…" : "Save"}
-          </button>
-        </div>
-      </form>
+          <label className={labelCls}>
+            Traits (comma separated)
+            <input className={inputCls}
+              value={Array.isArray(form.traits) ? form.traits.join(', ') : (form.traits ?? '')}
+              onChange={e => setForm((f: any) => ({ ...f, traits: e.target.value }))} />
+          </label>
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+            <Link to="/navatar" className="pill">Back to My Navatar</Link>
+            <button disabled={!canSave} className="pill pill--active" type="submit">
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </form>
+      )}
     </main>
   );
 }

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,21 +1,82 @@
-import { useMemo } from "react";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { loadActive } from "../../lib/localStorage";
-import "../../styles/navatar.css";
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import NavatarTabs from '../../components/NavatarTabs';
+import NavatarCard from '../../components/NavatarCard';
+import { useAuthUser } from '../../lib/useAuthUser';
+import { getActiveNavatar, navatarImageUrl, CharacterCard } from '../../lib/navatar';
+import '../../styles/navatar.css';
 
 export default function MyNavatarPage() {
-  const activeNavatar = useMemo(() => loadActive<any>(), []);
+  const { user } = useAuthUser();
+  const [loading, setLoading] = useState(true);
+  const [active, setActive] = useState<any | null>(null);
+
+  useEffect(() => {
+    let ignore = false;
+    (async () => {
+      if (!user) { setLoading(false); return; }
+      const { data, error } = await getActiveNavatar(user.id);
+      if (ignore) return;
+      if (!error) setActive(data);
+      setLoading(false);
+    })();
+    return () => { ignore = true; };
+  }, [user]);
+
+  const card: CharacterCard | null = (active?.card && Object.keys(active.card).length > 0) ? active.card : null;
+  const imageUrl = navatarImageUrl(active?.image_path ?? null);
+
   return (
     <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
+      <Breadcrumbs items={[{ href: '/', label: 'Home' }, { href: '/navatar', label: 'Navatar' }]} />
       <h1 className="center">My Navatar</h1>
       <NavatarTabs />
-
-      <div style={{ marginTop: 8 }}>
-        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
-      </div>
+      {loading ? (
+        <p>Loading…</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-start" style={{ marginTop: 8 }}>
+          <div>
+            <NavatarCard src={imageUrl} title={active?.name || 'Navatar'} />
+          </div>
+          <section id="card" className="rounded-2xl bg-white/70 border border-blue-200 p-5">
+            <h3 className="text-xl font-bold text-blue-700 mb-3">Character Card</h3>
+            {!card ? (
+              <p className="text-blue-700">
+                No card yet.{' '}
+                <Link to="/navatar/card" className="underline font-semibold">Create Card</Link>
+              </p>
+            ) : (
+              <div className="text-blue-800 space-y-3">
+                {card.name && <p><span className="font-semibold">Name:</span> {card.name}</p>}
+                {card.species && <p><span className="font-semibold">Species:</span> {card.species}</p>}
+                {card.kingdom && <p><span className="font-semibold">Kingdom:</span> {card.kingdom}</p>}
+                {card.backstory && (
+                  <div>
+                    <p className="font-semibold">Backstory</p>
+                    <p className="whitespace-pre-wrap">{card.backstory}</p>
+                  </div>
+                )}
+                {card.powers?.length ? (
+                  <div>
+                    <p className="font-semibold">Powers</p>
+                    <ul className="list-disc ml-6">{card.powers.map((p,i)=><li key={i}>{p}</li>)}</ul>
+                  </div>
+                ) : null}
+                {card.traits?.length ? (
+                  <div>
+                    <p className="font-semibold">Traits</p>
+                    <ul className="list-disc ml-6">{card.traits.map((t,i)=><li key={i}>{t}</li>)}</ul>
+                  </div>
+                ) : null}
+                <div className="pt-2">
+                  <Link to="/navatar/card" className="rounded-xl bg-white text-blue-700 border border-blue-200 px-4 py-2">Edit Card</Link>
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+      )}
     </main>
   );
 }

--- a/supabase/migrations/2025-10-22_add_card_to_avatars.sql
+++ b/supabase/migrations/2025-10-22_add_card_to_avatars.sql
@@ -1,0 +1,19 @@
+-- Add JSONB column to store character card on each avatar
+alter table public.avatars
+add column if not exists card jsonb default '{}'::jsonb;
+
+-- RLS: allow owners to update their own avatar.card
+-- (Idempotent policies: create only if not exists)
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public' and tablename='avatars' and policyname='avatars_update_own_card'
+  ) then
+    create policy "avatars_update_own_card"
+      on public.avatars
+      for update
+      using (auth.uid() = user_id)
+      with check (auth.uid() = user_id);
+  end if;
+end$$;


### PR DESCRIPTION
## Summary
- add migration and helpers to store character card JSON on avatars
- build `/navatar/card` subpage for editing card and hide pills on mobile
- display character card on My Navatar hub

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...> is not assignable to parameter of type 'never[]')*


------
https://chatgpt.com/codex/tasks/task_e_68bbff36dcb883299a776a001d7bd572