### PR TITLE
Card polish + route + NFT tie-in

### DIFF
--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -32,60 +32,68 @@ export default function MyNavatarPage() {
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
       <h1 className="center page-title">My Navatar</h1>
       <NavatarTabs />
-
-      <div style={{ marginTop: 8 }}>
-        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
-      </div>
-
-      <section className="panel" style={{ marginTop: 16 }}>
-        <h3 className="panel-title">Character Card</h3>
-        {!card ? (
-          <p>
-            No card yet. <Link to="/navatar/card" className="link">Create Card</Link>
-          </p>
-        ) : (
-          <div className="cc-summary">
-            {card.name && (
-              <div>
-                <strong>Name:</strong> {card.name}
-              </div>
-            )}
-            {card.species && (
-              <div>
-                <strong>Species:</strong> {card.species}
-              </div>
-            )}
-            {card.kingdom && (
-              <div>
-                <strong>Kingdom:</strong> {card.kingdom}
-              </div>
-            )}
-            {card.backstory && (
-              <div className="mt-sm">
-                <strong>Backstory</strong>
-                <div>{card.backstory}</div>
-              </div>
-            )}
-            {card.powers && card.powers.length > 0 && (
-              <div className="mt-sm">
-                <strong>Powers</strong>
-                <div>— {card.powers.join(", ")}</div>
-              </div>
-            )}
-            {card.traits && card.traits.length > 0 && (
-              <div className="mt-sm">
-                <strong>Traits</strong>
-                <div>— {card.traits.join(", ")}</div>
-              </div>
-            )}
-            <div className="mt-md">
-              <Link to="/navatar/card" className="pill">
-                Edit Card
-              </Link>
-            </div>
+      <div className="nv-hub-grid" style={{ marginTop: 8 }}>
+        <section>
+          <div className="nv-panel">
+            <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
           </div>
-        )}
-      </section>
+        </section>
+
+        <aside className="nv-panel">
+          <div className="nv-title">Character Card</div>
+
+          {!card ? (
+            <p>
+              No card yet. <Link to="/navatar/card">Create Card</Link>
+            </p>
+          ) : (
+            <dl className="nv-list">
+              {card.name && (
+                <>
+                  <dt>Name</dt>
+                  <dd>{card.name}</dd>
+                </>
+              )}
+              {card.species && (
+                <>
+                  <dt>Species</dt>
+                  <dd>{card.species}</dd>
+                </>
+              )}
+              {card.kingdom && (
+                <>
+                  <dt>Kingdom</dt>
+                  <dd>{card.kingdom}</dd>
+                </>
+              )}
+              {card.backstory && (
+                <>
+                  <dt>Backstory</dt>
+                  <dd>{card.backstory}</dd>
+                </>
+              )}
+              {card.powers && card.powers.length > 0 && (
+                <>
+                  <dt>Powers</dt>
+                  <dd>{card.powers.map(p => `— ${p}`).join("\n")}</dd>
+                </>
+              )}
+              {card.traits && card.traits.length > 0 && (
+                <>
+                  <dt>Traits</dt>
+                  <dd>{card.traits.map(t => `— ${t}`).join("\n")}</dd>
+                </>
+              )}
+            </dl>
+          )}
+
+          <div style={{ marginTop: 12 }}>
+            <Link to="/navatar/card" className="btn">
+              Edit Card
+            </Link>
+          </div>
+        </aside>
+      </div>
     </main>
   );
 }

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -1,12 +1,28 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
 import { loadActive } from "../../lib/localStorage";
+import { getActiveNavatar, getCardForAvatar } from "../../lib/navatar";
+import { supabase } from "../../lib/supabase-client";
 import "../../styles/navatar.css";
 
 export default function MintNavatarPage() {
   const activeNavatar = useMemo(() => loadActive<any>(), []);
+  const [card, setCard] = useState<any>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+      const { data: act } = await getActiveNavatar(user.id);
+      if (!act) return;
+      const { data: c } = await getCardForAvatar(act.id);
+      setCard(c);
+    })();
+  }, []);
+
   return (
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "NFT / Mint" }]} />
@@ -19,6 +35,28 @@ export default function MintNavatarPage() {
         <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "My Navatar"} />
         <a className="pill" href="/marketplace">Go to Marketplace</a>
       </div>
+
+      {card ? (
+        <aside className="nv-panel" style={{ maxWidth: 480, margin: "20px auto 0" }}>
+          <div className="nv-title">Character Card</div>
+          <dl className="nv-list">
+            <dt>Name</dt><dd>{card.name}</dd>
+            <dt>Species</dt><dd>{card.species}</dd>
+            <dt>Kingdom</dt><dd>{card.kingdom}</dd>
+            <dt>Backstory</dt><dd>{card.backstory || "—"}</dd>
+            <dt>Powers</dt><dd>{card.powers?.map((p: string) => `— ${p}`).join("\n") || "—"}</dd>
+            <dt>Traits</dt><dd>{card.traits?.map((t: string) => `— ${t}`).join("\n") || "—"}</dd>
+          </dl>
+          <div style={{ marginTop: 12, textAlign: "center" }}>
+            <Link to="/navatar/card" className="btn">Edit Card</Link>
+          </div>
+        </aside>
+      ) : (
+        <div className="nv-panel" style={{ maxWidth: 480, margin: "20px auto 0" }}>
+          <div className="nv-title">Character Card</div>
+          <p>No card yet. <Link to="/navatar/card">Create Card</Link></p>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -118,3 +118,40 @@
 .page-pad {
   padding-bottom: 5rem;
 }
+
+/* Reuse across Navatar home, Card page, Mint preview */
+.nv-panel {
+  background: var(--nv-blue-50, #eef3ff);
+  border: 1px solid var(--nv-blue-200, #cfe0ff);
+  box-shadow: 0 6px 22px rgba(16, 51, 255, 0.06);
+  border-radius: 16px;
+  padding: 18px;
+}
+
+.nv-panel h3,
+.nv-panel .nv-title {
+  color: var(--nv-blue-800, #1e40af);
+  margin: 0 0 10px 0;
+  font-weight: 800;
+}
+
+.nv-list dt {
+  font-weight: 800;
+  color: var(--nv-blue-800, #1e40af);
+}
+.nv-list dd {
+  margin: 0 0 8px 0;
+}
+
+/* Hub layout: side-by-side desktop, stacked mobile */
+.nv-hub-grid {
+  display: grid;
+  gap: 22px;
+}
+@media (min-width: 960px) {
+  .nv-hub-grid {
+    grid-template-columns: 1fr 420px;
+    align-items: start;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add shared blue `nv-panel` style and responsive hub grid
- route character card saves to mint page tied to active Navatar
- show linked Character Card on mint and hub pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never')*


------
https://chatgpt.com/codex/tasks/task_e_68bc170d07e08329b069c91bfd256c70