### PR TITLE
Unify Character Card + Fix Pick Cropping + Show Card on NFT/Mint

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -1,62 +1,41 @@
-import React from 'react';
-import Img from './Img';
+import React from "react";
+import type { CharacterCard } from "../lib/types";
 
-export type CardData = {
-  id: string;
-  name: string;
-  realm: string;
-  species: string;
-  emoji: string;
-  color: string;
-  power: string;
-  motto: string;
-  avatarDataUrl?: string; // optional base64 image
-};
-
-export const CharacterCard: React.FC<{ data: CardData }> = ({ data }) => {
-  const { name, realm, species, emoji, color, power, motto, avatarDataUrl } = data;
-
+export default function CharacterCardView({ card }: { card?: CharacterCard | null }) {
   return (
-    <div
-      className="nv-card"
-      style={{
-        border: `2px solid ${color || 'var(--nv-border)'}`,
-        boxShadow: '0 6px 20px rgba(0,0,0,.08)',
-      }}
-    >
-      <div className="nv-card__header" style={{ background: color || 'var(--nv-blue-50)' }}>
-        <div className="nv-card__emoji" aria-hidden>
-          {emoji || '🌱'}
-        </div>
-        <div className="nv-card__title">
-          <div className="nv-card__name">{name || 'Navatar'}</div>
-          <div className="nv-card__sub">
-            {species || 'Species'} · {realm || 'Realm'}
-          </div>
-        </div>
-      </div>
+    <div className="nv-card">
+      <h3 className="nv-card-title">Character Card</h3>
 
-      <div className="nv-card__body">
-        <div className="nv-card__avatar">
-          {avatarDataUrl ? (
-            <Img src={avatarDataUrl} alt={`${name} avatar`} />
-          ) : (
-            <div className="nv-card__avatar--placeholder">Add image</div>
+      {card ? (
+        <div className="nv-card-body">
+          <p><b>Name:</b> {card.name}</p>
+          <p><b>Species:</b> {card.species}</p>
+          <p><b>Kingdom:</b> {card.kingdom}</p>
+
+          {!!card.backstory && (
+            <>
+              <p><b>Backstory</b></p>
+              <p>{card.backstory}</p>
+            </>
+          )}
+
+          {!!card.powers?.length && (
+            <>
+              <p><b>Powers</b></p>
+              <ul>{card.powers.map((p, i) => <li key={i}>— {p}</li>)}</ul>
+            </>
+          )}
+
+          {!!card.traits?.length && (
+            <>
+              <p><b>Traits</b></p>
+              <ul>{card.traits.map((t, i) => <li key={i}>— {t}</li>)}</ul>
+            </>
           )}
         </div>
-        <dl className="nv-card__facts">
-          <div>
-            <dt>Power</dt>
-            <dd>{power || '—'}</dd>
-          </div>
-          <div>
-            <dt>Motto</dt>
-            <dd>{motto || '—'}</dd>
-          </div>
-        </dl>
-      </div>
-
-      <div className="nv-card__footer">Naturverse • Character Card</div>
+      ) : (
+        <div className="nv-card-empty">No card yet.</div>
+      )}
     </div>
   );
-};
+}

--- a/src/components/NavatarImage.tsx
+++ b/src/components/NavatarImage.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export default function NavatarImage({
+  src,
+  alt,
+  maxHeight = 440,
+}: { src?: string | null; alt?: string; maxHeight?: number }) {
+  return (
+    <div className="nv-image-frame" style={{ maxHeight }}>
+      {/* Use <img> so object-fit is respected everywhere */}
+      <img className="nv-image" src={src ?? ""} alt={alt ?? "Navatar"} />
+    </div>
+  );
+}

--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -128,3 +128,22 @@ export async function getCardForAvatar(avatarId: string) {
     .single();
 }
 
+
+export async function getActiveNavatarWithCard(userId: string) {
+  const { data: active } = await supabase
+    .from("avatars")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("is_active", true)
+    .maybeSingle();
+
+  if (!active) return { avatar: null, card: null };
+
+  const { data: card } = await supabase
+    .from("character_cards")
+    .select("*")
+    .eq("avatar_id", active.id)
+    .maybeSingle();
+
+  return { avatar: active, card: (card as unknown as CharacterCard) ?? null };
+}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
+import NavatarImage from "../../components/NavatarImage";
+import CharacterCardView from "../../components/CharacterCard";
 import { loadActive } from "../../lib/localStorage";
 import { fetchMyCharacterCard } from "../../lib/navatar";
 import type { CharacterCard } from "../../lib/types";
@@ -35,57 +36,12 @@ export default function MyNavatarPage() {
       <div className="nv-hub-grid" style={{ marginTop: 8 }}>
         <section>
           <div className="nv-panel">
-            <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
+            <NavatarImage src={activeNavatar?.imageDataUrl} alt={activeNavatar?.name} />
           </div>
         </section>
 
         <aside className="nv-panel">
-          <div className="nv-title">Character Card</div>
-
-          {!card ? (
-            <p>
-              No card yet. <Link to="/navatar/card">Create Card</Link>
-            </p>
-          ) : (
-            <dl className="nv-list">
-              {card.name && (
-                <>
-                  <dt>Name</dt>
-                  <dd>{card.name}</dd>
-                </>
-              )}
-              {card.species && (
-                <>
-                  <dt>Species</dt>
-                  <dd>{card.species}</dd>
-                </>
-              )}
-              {card.kingdom && (
-                <>
-                  <dt>Kingdom</dt>
-                  <dd>{card.kingdom}</dd>
-                </>
-              )}
-              {card.backstory && (
-                <>
-                  <dt>Backstory</dt>
-                  <dd>{card.backstory}</dd>
-                </>
-              )}
-              {card.powers && card.powers.length > 0 && (
-                <>
-                  <dt>Powers</dt>
-                  <dd>{card.powers.map(p => `— ${p}`).join("\n")}</dd>
-                </>
-              )}
-              {card.traits && card.traits.length > 0 && (
-                <>
-                  <dt>Traits</dt>
-                  <dd>{card.traits.map(t => `— ${t}`).join("\n")}</dd>
-                </>
-              )}
-            </dl>
-          )}
+          <CharacterCardView card={card} />
 
           <div style={{ marginTop: 12 }}>
             <Link to="/navatar/card" className="btn">

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -1,25 +1,24 @@
-import { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { loadActive } from "../../lib/localStorage";
-import { getActiveNavatar, getCardForAvatar } from "../../lib/navatar";
+import NavatarImage from "../../components/NavatarImage";
+import CharacterCardView from "../../components/CharacterCard";
+import { getActiveNavatarWithCard } from "../../lib/navatar";
 import { supabase } from "../../lib/supabase-client";
+import type { CharacterCard } from "../../lib/types";
 import "../../styles/navatar.css";
 
 export default function MintNavatarPage() {
-  const activeNavatar = useMemo(() => loadActive<any>(), []);
-  const [card, setCard] = useState<any>(null);
+  const [avatar, setAvatar] = useState<any>(null);
+  const [card, setCard] = useState<CharacterCard | null>(null);
 
   useEffect(() => {
     (async () => {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
-      const { data: act } = await getActiveNavatar(user.id);
-      if (!act) return;
-      const { data: c } = await getCardForAvatar(act.id);
-      setCard(c);
+      const { avatar, card } = await getActiveNavatarWithCard(user.id);
+      setAvatar(avatar);
+      setCard(card);
     })();
   }, []);
 
@@ -32,31 +31,13 @@ export default function MintNavatarPage() {
         Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.
       </p>
       <div style={{ display: "grid", justifyItems: "center", gap: 12 }}>
-        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "My Navatar"} />
+        <NavatarImage src={avatar?.image_url} alt={avatar?.name} />
         <a className="pill" href="/marketplace">Go to Marketplace</a>
       </div>
 
-      {card ? (
-        <aside className="nv-panel" style={{ maxWidth: 480, margin: "20px auto 0" }}>
-          <div className="nv-title">Character Card</div>
-          <dl className="nv-list">
-            <dt>Name</dt><dd>{card.name}</dd>
-            <dt>Species</dt><dd>{card.species}</dd>
-            <dt>Kingdom</dt><dd>{card.kingdom}</dd>
-            <dt>Backstory</dt><dd>{card.backstory || "—"}</dd>
-            <dt>Powers</dt><dd>{card.powers?.map((p: string) => `— ${p}`).join("\n") || "—"}</dd>
-            <dt>Traits</dt><dd>{card.traits?.map((t: string) => `— ${t}`).join("\n") || "—"}</dd>
-          </dl>
-          <div style={{ marginTop: 12, textAlign: "center" }}>
-            <Link to="/navatar/card" className="btn">Edit Card</Link>
-          </div>
-        </aside>
-      ) : (
-        <div className="nv-panel" style={{ maxWidth: 480, margin: "20px auto 0" }}>
-          <div className="nv-title">Character Card</div>
-          <p>No card yet. <Link to="/navatar/card">Create Card</Link></p>
-        </div>
-      )}
+      <div style={{ maxWidth: 480, margin: "20px auto 0" }}>
+        <CharacterCardView card={card} />
+      </div>
     </main>
   );
 }

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
+import NavatarImage from "../../components/NavatarImage";
 import { loadPublicNavatars, PublicNavatar } from "../../lib/navatar/publicList";
 import { saveActive } from "../../lib/localStorage";
 import "../../styles/navatar.css";
@@ -34,7 +34,12 @@ export default function PickNavatarPage() {
             aria-label={`Pick ${it.name}`}
             style={{ background: "none", border: 0, padding: 0, textAlign: "inherit" }}
           >
-            <NavatarCard src={it.src} title={it.name} />
+            <figure className="nav-card">
+              <NavatarImage src={it.src} alt={it.name} maxHeight={260} />
+              <figcaption className="nav-card__cap">
+                <strong>{it.name}</strong>
+              </figcaption>
+            </figure>
           </button>
         ))}
       </div>

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -155,3 +155,39 @@
   }
 }
 
+
+/* Image framing/cropping — used by Pick/MyNavatar/Mint */
+.nv-image-frame {
+  width: 100%;
+  border-radius: 20px;
+  overflow: hidden;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.nv-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain; /* prevent cut-off */
+}
+
+/* Blue card shell (shared) */
+.nv-card {
+  background: #f7f9ff;
+  border: 1px solid var(--nv-blue-200);
+  border-radius: 20px;
+  padding: 16px 20px;
+}
+.nv-card-title {
+  color: var(--nv-blue-800);
+  font-size: 1.25rem;
+  margin: 0 0 12px;
+}
+.nv-card-body p { margin: 6px 0; }
+.nv-card-body ul { margin: 4px 0 0 0; padding-left: 18px; }
+.nv-card-empty {
+  color: #506; 
+  opacity: 0.7;
+}
+


### PR DESCRIPTION
## Summary
- add reusable `NavatarImage` for consistent avatar sizing
- add blue-themed `CharacterCardView` and reuse on My Navatar and Mint pages
- update Pick grid to avoid image cropping and use new image component
- fetch active avatar with card via new `getActiveNavatarWithCard`

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "created_at" | "id" | "updated_at">' is not assignable to parameter of type 'never[]'.)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1cf3c6e08329873a96a1741233d8