### PR TITLE
Fix Navatar active state and card display

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -1,62 +1,63 @@
-import React from 'react';
-import Img from './Img';
-
-export type CardData = {
-  id: string;
-  name: string;
-  realm: string;
-  species: string;
-  emoji: string;
-  color: string;
-  power: string;
-  motto: string;
-  avatarDataUrl?: string; // optional base64 image
-};
-
-export const CharacterCard: React.FC<{ data: CardData }> = ({ data }) => {
-  const { name, realm, species, emoji, color, power, motto, avatarDataUrl } = data;
-
+export default function CharacterCard({
+  card,
+  color = 'blue',
+  onEdit,
+}:{
+  card?: any;
+  color?: 'blue' | 'gray';
+  onEdit?: () => void;
+}) {
   return (
-    <div
-      className="nv-card"
-      style={{
-        border: `2px solid ${color || 'var(--nv-border)'}`,
-        boxShadow: '0 6px 20px rgba(0,0,0,.08)',
-      }}
-    >
-      <div className="nv-card__header" style={{ background: color || 'var(--nv-blue-50)' }}>
-        <div className="nv-card__emoji" aria-hidden>
-          {emoji || '🌱'}
-        </div>
-        <div className="nv-card__title">
-          <div className="nv-card__name">{name || 'Navatar'}</div>
-          <div className="nv-card__sub">
-            {species || 'Species'} · {realm || 'Realm'}
-          </div>
-        </div>
-      </div>
-
-      <div className="nv-card__body">
-        <div className="nv-card__avatar">
-          {avatarDataUrl ? (
-            <Img src={avatarDataUrl} alt={`${name} avatar`} />
-          ) : (
-            <div className="nv-card__avatar--placeholder">Add image</div>
+    <div className={`nv-card ${color === 'blue' ? 'nv-card-blue' : 'nv-card-gray'}`}>
+      {card ? (
+        <dl className="nv-list">
+          {card.name && (
+            <>
+              <dt>Name</dt>
+              <dd>{card.name}</dd>
+            </>
           )}
-        </div>
-        <dl className="nv-card__facts">
-          <div>
-            <dt>Power</dt>
-            <dd>{power || '—'}</dd>
-          </div>
-          <div>
-            <dt>Motto</dt>
-            <dd>{motto || '—'}</dd>
-          </div>
+          {card.species && (
+            <>
+              <dt>Species</dt>
+              <dd>{card.species}</dd>
+            </>
+          )}
+          {card.kingdom && (
+            <>
+              <dt>Kingdom</dt>
+              <dd>{card.kingdom}</dd>
+            </>
+          )}
+          {card.backstory && (
+            <>
+              <dt>Backstory</dt>
+              <dd>{card.backstory}</dd>
+            </>
+          )}
+          {card.powers && card.powers.length > 0 && (
+            <>
+              <dt>Powers</dt>
+              <dd>{card.powers.map((p: string) => `— ${p}`).join('\n')}</dd>
+            </>
+          )}
+          {card.traits && card.traits.length > 0 && (
+            <>
+              <dt>Traits</dt>
+              <dd>{card.traits.map((t: string) => `— ${t}`).join('\n')}</dd>
+            </>
+          )}
         </dl>
-      </div>
-
-      <div className="nv-card__footer">Naturverse • Character Card</div>
+      ) : (
+        <p>No card yet.</p>
+      )}
+      {onEdit && (
+        <div style={{ marginTop: 12, textAlign: 'center' }}>
+          <button className="btn" onClick={onEdit}>
+            {card ? 'Edit Card' : 'Create Card'}
+          </button>
+        </div>
+      )}
     </div>
   );
-};
+}

--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -1,22 +1,23 @@
-import React from "react";
+import NavatarImage from "./NavatarImage";
 
 type Props = {
   src?: string | null;
   title?: string;
   subtitle?: string;
   className?: string;
+  mode?: "contain" | "cover";
 };
 
-export default function NavatarCard({ src, title = "My Navatar", subtitle, className }: Props) {
+export default function NavatarCard({
+  src,
+  title = "My Navatar",
+  subtitle,
+  className,
+  mode = "contain",
+}: Props) {
   return (
     <figure className={`nav-card ${className ?? ""}`}>
-      <div className="nav-card__img" aria-label={title}>
-        {src ? (
-          <img src={src} alt={title} />
-        ) : (
-          <div className="nav-card__placeholder">No photo</div>
-        )}
-      </div>
+      <NavatarImage src={src} alt={title} mode={mode} />
       <figcaption className="nav-card__cap">
         <strong>{title}</strong>
         {subtitle ? <span> · {subtitle}</span> : null}

--- a/src/components/NavatarImage.tsx
+++ b/src/components/NavatarImage.tsx
@@ -1,0 +1,15 @@
+export default function NavatarImage({
+  src,
+  alt,
+  mode = 'contain',
+}: {
+  src?: string | null;
+  alt?: string;
+  mode?: 'contain' | 'cover';
+}) {
+  return (
+    <div className={`nv-img-wrap ${mode}`}>
+      {src ? <img src={src} alt={alt ?? 'Navatar'} /> : <div className="nv-img-ph" />}
+    </div>
+  );
+}

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -1,25 +1,27 @@
-import { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { loadActive } from "../../lib/localStorage";
-import { getActiveNavatar, getCardForAvatar } from "../../lib/navatar";
+import NavatarImage from "../../components/NavatarImage";
+import CharacterCard from "../../components/CharacterCard";
+import { getActiveNavatarWithCard, navatarImageUrl } from "../../lib/navatar";
 import { supabase } from "../../lib/supabase-client";
 import "../../styles/navatar.css";
 
 export default function MintNavatarPage() {
-  const activeNavatar = useMemo(() => loadActive<any>(), []);
+  const [navatar, setNavatar] = useState<any>(null);
   const [card, setCard] = useState<any>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       if (!user) return;
-      const { data: act } = await getActiveNavatar(user.id);
-      if (!act) return;
-      const { data: c } = await getCardForAvatar(act.id);
-      setCard(c);
+      const { navatar, card } = await getActiveNavatarWithCard(supabase, user.id);
+      setNavatar(navatar);
+      setCard(card);
     })();
   }, []);
 
@@ -32,31 +34,21 @@ export default function MintNavatarPage() {
         Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.
       </p>
       <div style={{ display: "grid", justifyItems: "center", gap: 12 }}>
-        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "My Navatar"} />
+        <NavatarImage
+          src={navatarImageUrl(navatar?.image_path ?? null)}
+          alt={navatar?.name ?? "Navatar"}
+          mode="contain"
+        />
         <a className="pill" href="/marketplace">Go to Marketplace</a>
       </div>
 
-      {card ? (
-        <aside className="nv-panel" style={{ maxWidth: 480, margin: "20px auto 0" }}>
-          <div className="nv-title">Character Card</div>
-          <dl className="nv-list">
-            <dt>Name</dt><dd>{card.name}</dd>
-            <dt>Species</dt><dd>{card.species}</dd>
-            <dt>Kingdom</dt><dd>{card.kingdom}</dd>
-            <dt>Backstory</dt><dd>{card.backstory || "—"}</dd>
-            <dt>Powers</dt><dd>{card.powers?.map((p: string) => `— ${p}`).join("\n") || "—"}</dd>
-            <dt>Traits</dt><dd>{card.traits?.map((t: string) => `— ${t}`).join("\n") || "—"}</dd>
-          </dl>
-          <div style={{ marginTop: 12, textAlign: "center" }}>
-            <Link to="/navatar/card" className="btn">Edit Card</Link>
-          </div>
-        </aside>
-      ) : (
-        <div className="nv-panel" style={{ maxWidth: 480, margin: "20px auto 0" }}>
-          <div className="nv-title">Character Card</div>
-          <p>No card yet. <Link to="/navatar/card">Create Card</Link></p>
-        </div>
-      )}
+      <div style={{ maxWidth: 480, margin: "20px auto 0" }}>
+        <CharacterCard
+          card={card ?? undefined}
+          color="blue"
+          onEdit={() => navigate("/navatar/card")}
+        />
+      </div>
     </main>
   );
 }

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -34,7 +34,7 @@ export default function PickNavatarPage() {
             aria-label={`Pick ${it.name}`}
             style={{ background: "none", border: 0, padding: 0, textAlign: "inherit" }}
           >
-            <NavatarCard src={it.src} title={it.name} />
+            <NavatarCard src={it.src} title={it.name} mode="cover" />
           </button>
         ))}
       </div>

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -155,3 +155,55 @@
   }
 }
 
+/* Character Card colors */
+.nv-card {
+  border-radius: 16px;
+  padding: 16px;
+}
+.nv-card-blue {
+  background: var(--nv-blue-50);
+  color: var(--nv-blue-900);
+}
+.nv-card-gray {
+  background: #f5f7fb;
+  color: #111827;
+}
+
+/* Navatar image framing */
+.nv-img-wrap {
+  width: 100%;
+  aspect-ratio: 3/4;
+  border-radius: 20px;
+  overflow: hidden;
+}
+.nv-img-wrap img {
+  width: 100%;
+  height: 100%;
+  object-position: center;
+  display: block;
+}
+.nv-img-wrap.contain img {
+  object-fit: contain;
+  background: #fff;
+}
+.nv-img-wrap.cover img {
+  object-fit: cover;
+}
+.nv-img-ph {
+  width: 100%;
+  height: 100%;
+  background: #eef3ff;
+}
+
+/* Hub responsive layout */
+.navatar-hub {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+}
+@media (min-width: 960px) {
+  .navatar-hub {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add helpers to manage active Navatar and related card
- show active Navatar and card on Hub and Mint using shared fetch
- unify card styling and image cropping with new components

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "created_at" | "id" | "updated_at">' is not assignable to parameter of type 'never[]'.)*

------
https://chatgpt.com/codex/tasks/task_e_68bc200cffc88329a7735382781053e8