### PR TITLE
Persist active Navatar on profile and show blue character cards

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -1,62 +1,31 @@
-import React from 'react';
-import Img from './Img';
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { getCharacterCard } from '../lib/navatar';
+import { supabase } from '../lib/supabase-client';
 
-export type CardData = {
-  id: string;
-  name: string;
-  realm: string;
-  species: string;
-  emoji: string;
-  color: string;
-  power: string;
-  motto: string;
-  avatarDataUrl?: string; // optional base64 image
-};
+export default function CharacterCard({ avatarId, color = 'blue' }: { avatarId: string; color?: 'blue' | 'gray' }) {
+  const [card, setCard] = useState<any>(null);
 
-export const CharacterCard: React.FC<{ data: CardData }> = ({ data }) => {
-  const { name, realm, species, emoji, color, power, motto, avatarDataUrl } = data;
+  useEffect(() => {
+    getCharacterCard(supabase, avatarId).then(setCard);
+  }, [avatarId]);
 
   return (
-    <div
-      className="nv-card"
-      style={{
-        border: `2px solid ${color || 'var(--nv-border)'}`,
-        boxShadow: '0 6px 20px rgba(0,0,0,.08)',
-      }}
-    >
-      <div className="nv-card__header" style={{ background: color || 'var(--nv-blue-50)' }}>
-        <div className="nv-card__emoji" aria-hidden>
-          {emoji || '🌱'}
-        </div>
-        <div className="nv-card__title">
-          <div className="nv-card__name">{name || 'Navatar'}</div>
-          <div className="nv-card__sub">
-            {species || 'Species'} · {realm || 'Realm'}
-          </div>
-        </div>
-      </div>
-
-      <div className="nv-card__body">
-        <div className="nv-card__avatar">
-          {avatarDataUrl ? (
-            <Img src={avatarDataUrl} alt={`${name} avatar`} />
-          ) : (
-            <div className="nv-card__avatar--placeholder">Add image</div>
-          )}
-        </div>
-        <dl className="nv-card__facts">
-          <div>
-            <dt>Power</dt>
-            <dd>{power || '—'}</dd>
-          </div>
-          <div>
-            <dt>Motto</dt>
-            <dd>{motto || '—'}</dd>
-          </div>
+    <section className={`card-shell ${color}`}>
+      <h3>Character Card</h3>
+      {card ? (
+        <dl className="kv">
+          <dt>Name</dt><dd>{card.name}</dd>
+          <dt>Species</dt><dd>{card.base_type}</dd>
+          <dt>Kingdom</dt><dd>{card.kingdom}</dd>
+          <dt>Backstory</dt><dd>{card.backstory}</dd>
+          <dt>Powers</dt><dd>{(card.powers ?? []).map((p: string) => `— ${p}`).join('\n')}</dd>
+          <dt>Traits</dt><dd>{(card.traits ?? []).map((t: string) => `— ${t}`).join('\n')}</dd>
         </dl>
-      </div>
-
-      <div className="nv-card__footer">Naturverse • Character Card</div>
-    </div>
+      ) : (
+        <p>No card yet.</p>
+      )}
+      <Link to="/navatar/card" className="btn-secondary">Edit Card</Link>
+    </section>
   );
-};
+}

--- a/src/components/NavatarImage.tsx
+++ b/src/components/NavatarImage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function NavatarImage({ src, alt }: { src: string; alt: string }) {
+  return (
+    <div className="navatar-frame">
+      <img src={src} alt={alt} loading="lazy" />
+    </div>
+  );
+}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,25 +1,30 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { loadActive } from "../../lib/localStorage";
-import { fetchMyCharacterCard } from "../../lib/navatar";
-import type { CharacterCard } from "../../lib/types";
+import CharacterCard from "../../components/CharacterCard";
+import NavatarImage from "../../components/NavatarImage";
+import { getActiveNavatarId, navatarImageUrl } from "../../lib/navatar";
+import { supabase } from "../../lib/supabase-client";
 import { Link } from "react-router-dom";
 import "../../styles/navatar.css";
 
 export default function MyNavatarPage() {
-  const activeNavatar = useMemo(() => loadActive<any>(), []);
-  const [card, setCard] = useState<CharacterCard | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [active, setActive] = useState<any>(null);
 
   useEffect(() => {
     let alive = true;
     (async () => {
-      try {
-        const c = await fetchMyCharacterCard();
-        if (alive) setCard(c);
-      } catch {
-        // ignore
+      const id = await getActiveNavatarId(supabase);
+      if (!alive) return;
+      setActiveId(id);
+      if (id) {
+        const { data } = await supabase
+          .from("avatars")
+          .select("*")
+          .eq("id", id)
+          .single();
+        if (alive) setActive(data);
       }
     })();
     return () => {
@@ -27,72 +32,27 @@ export default function MyNavatarPage() {
     };
   }, []);
 
+  if (!activeId || !active) {
+    return (
+      <main className="container page-pad">
+        <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
+        <h1 className="center page-title">My Navatar</h1>
+        <NavatarTabs />
+        <p className="center">
+          No Navatar yet. <Link to="/navatar/pick">Pick Navatar</Link>
+        </p>
+      </main>
+    );
+  }
+
   return (
     <main className="container page-pad">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
       <h1 className="center page-title">My Navatar</h1>
       <NavatarTabs />
-      <div className="nv-hub-grid" style={{ marginTop: 8 }}>
-        <section>
-          <div className="nv-panel">
-            <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
-          </div>
-        </section>
-
-        <aside className="nv-panel">
-          <div className="nv-title">Character Card</div>
-
-          {!card ? (
-            <p>
-              No card yet. <Link to="/navatar/card">Create Card</Link>
-            </p>
-          ) : (
-            <dl className="nv-list">
-              {card.name && (
-                <>
-                  <dt>Name</dt>
-                  <dd>{card.name}</dd>
-                </>
-              )}
-              {card.species && (
-                <>
-                  <dt>Species</dt>
-                  <dd>{card.species}</dd>
-                </>
-              )}
-              {card.kingdom && (
-                <>
-                  <dt>Kingdom</dt>
-                  <dd>{card.kingdom}</dd>
-                </>
-              )}
-              {card.backstory && (
-                <>
-                  <dt>Backstory</dt>
-                  <dd>{card.backstory}</dd>
-                </>
-              )}
-              {card.powers && card.powers.length > 0 && (
-                <>
-                  <dt>Powers</dt>
-                  <dd>{card.powers.map(p => `— ${p}`).join("\n")}</dd>
-                </>
-              )}
-              {card.traits && card.traits.length > 0 && (
-                <>
-                  <dt>Traits</dt>
-                  <dd>{card.traits.map(t => `— ${t}`).join("\n")}</dd>
-                </>
-              )}
-            </dl>
-          )}
-
-          <div style={{ marginTop: 12 }}>
-            <Link to="/navatar/card" className="btn">
-              Edit Card
-            </Link>
-          </div>
-        </aside>
+      <div className="navatar-hub" style={{ marginTop: 8 }}>
+        <NavatarImage src={navatarImageUrl(active.image_path) || ""} alt={active.name || "Navatar"} />
+        <CharacterCard avatarId={activeId} color="blue" />
       </div>
     </main>
   );

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -1,25 +1,29 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { loadActive } from "../../lib/localStorage";
-import { getActiveNavatar, getCardForAvatar } from "../../lib/navatar";
+import NavatarImage from "../../components/NavatarImage";
+import CharacterCard from "../../components/CharacterCard";
+import { getActiveNavatarId, navatarImageUrl } from "../../lib/navatar";
 import { supabase } from "../../lib/supabase-client";
 import "../../styles/navatar.css";
 
 export default function MintNavatarPage() {
-  const activeNavatar = useMemo(() => loadActive<any>(), []);
-  const [card, setCard] = useState<any>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [active, setActive] = useState<any>(null);
 
   useEffect(() => {
     (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) return;
-      const { data: act } = await getActiveNavatar(user.id);
-      if (!act) return;
-      const { data: c } = await getCardForAvatar(act.id);
-      setCard(c);
+      const id = await getActiveNavatarId(supabase);
+      setActiveId(id);
+      if (id) {
+        const { data } = await supabase
+          .from("avatars")
+          .select("*")
+          .eq("id", id)
+          .single();
+        setActive(data);
+      }
     })();
   }, []);
 
@@ -32,25 +36,14 @@ export default function MintNavatarPage() {
         Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.
       </p>
       <div style={{ display: "grid", justifyItems: "center", gap: 12 }}>
-        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "My Navatar"} />
+        {active && (
+          <NavatarImage src={navatarImageUrl(active.image_path) || ""} alt={active.name || "Navatar"} />
+        )}
         <a className="pill" href="/marketplace">Go to Marketplace</a>
       </div>
 
-      {card ? (
-        <aside className="nv-panel" style={{ maxWidth: 480, margin: "20px auto 0" }}>
-          <div className="nv-title">Character Card</div>
-          <dl className="nv-list">
-            <dt>Name</dt><dd>{card.name}</dd>
-            <dt>Species</dt><dd>{card.species}</dd>
-            <dt>Kingdom</dt><dd>{card.kingdom}</dd>
-            <dt>Backstory</dt><dd>{card.backstory || "—"}</dd>
-            <dt>Powers</dt><dd>{card.powers?.map((p: string) => `— ${p}`).join("\n") || "—"}</dd>
-            <dt>Traits</dt><dd>{card.traits?.map((t: string) => `— ${t}`).join("\n") || "—"}</dd>
-          </dl>
-          <div style={{ marginTop: 12, textAlign: "center" }}>
-            <Link to="/navatar/card" className="btn">Edit Card</Link>
-          </div>
-        </aside>
+      {activeId && active ? (
+        <CharacterCard avatarId={activeId} color="blue" />
       ) : (
         <div className="nv-panel" style={{ maxWidth: 480, margin: "20px auto 0" }}>
           <div className="nv-title">Character Card</div>
@@ -60,4 +53,3 @@ export default function MintNavatarPage() {
     </main>
   );
 }
-

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -3,20 +3,25 @@ import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
-import { loadPublicNavatars, PublicNavatar } from "../../lib/navatar/publicList";
-import { saveActive } from "../../lib/localStorage";
+import {
+  listMyNavatars,
+  navatarImageUrl,
+  setActiveNavatarId,
+  type NavatarRow,
+} from "../../lib/navatar";
+import { supabase } from "../../lib/supabase-client";
 import "../../styles/navatar.css";
 
 export default function PickNavatarPage() {
-  const [items, setItems] = useState<PublicNavatar[]>([]);
+  const [items, setItems] = useState<NavatarRow[]>([]);
   const nav = useNavigate();
 
   useEffect(() => {
-    loadPublicNavatars().then(setItems);
+    listMyNavatars().then(setItems).catch(() => setItems([]));
   }, []);
 
-  function choose(src: string, name: string) {
-    saveActive({ id: Date.now(), name, imageDataUrl: src, createdAt: Date.now() });
+  async function choose(id: string) {
+    await setActiveNavatarId(supabase, id);
     nav("/navatar");
   }
 
@@ -28,13 +33,13 @@ export default function PickNavatarPage() {
       <div className="nav-grid">
         {items.map((it) => (
           <button
-            key={it.src}
+            key={it.id}
             className="linklike"
-            onClick={() => choose(it.src, it.name)}
+            onClick={() => choose(it.id)}
             aria-label={`Pick ${it.name}`}
             style={{ background: "none", border: 0, padding: 0, textAlign: "inherit" }}
           >
-            <NavatarCard src={it.src} title={it.name} />
+            <NavatarCard src={navatarImageUrl(it.image_path)} title={it.name || "Navatar"} />
           </button>
         ))}
       </div>

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -155,3 +155,46 @@
   }
 }
 
+.navatar-frame {
+  width: min(100%, 480px);
+  aspect-ratio: 3 / 4;
+  border-radius: 24px;
+  background: #f6f8ff;
+  overflow: hidden;
+  margin-inline: auto;
+}
+.navatar-frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+@media (min-width: 992px) {
+  .navatar-hub {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 32px;
+    align-items: start;
+  }
+}
+
+.card-shell {
+  border-radius: 20px;
+  padding: 16px 18px;
+}
+
+.card-shell.blue {
+  background: var(--nv-blue-50);
+  border: 1px solid var(--nv-blue-200);
+  color: var(--nv-blue-900);
+}
+
+.kv dt {
+  font-weight: 800;
+  color: var(--nv-blue-800, #1e40af);
+}
+.kv dd {
+  margin: 0 0 8px 0;
+  white-space: pre-wrap;
+}
+

--- a/supabase/migrations/2026-01-01_active_avatar_and_character_cards.sql
+++ b/supabase/migrations/2026-01-01_active_avatar_and_character_cards.sql
@@ -1,0 +1,42 @@
+alter table public.profiles add column if not exists current_avatar_id uuid references public.avatars(id);
+
+do $$
+begin
+  if not exists (select 1 from pg_policies where policyname = 'profiles_update_active_avatar') then
+    create policy "profiles_update_active_avatar"
+      on public.profiles for update
+      using (auth.uid() = id)
+      with check (auth.uid() = id);
+  end if;
+end $$;
+
+create table if not exists public.character_cards (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id),
+  avatar_id uuid not null references public.avatars(id) on delete cascade,
+  name text,
+  base_type text,
+  kingdom text,
+  backstory text,
+  powers text[],
+  traits text[],
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  unique (user_id, avatar_id)
+);
+
+drop trigger if exists trg_character_cards_updated_at on public.character_cards;
+create trigger trg_character_cards_updated_at
+  before update on public.character_cards
+  for each row execute function public.set_updated_at();
+
+alter table public.character_cards enable row level security;
+do $$
+begin
+  if not exists (select 1 from pg_policies where policyname = 'character_cards_rw_own') then
+    create policy "character_cards_rw_own"
+      on public.character_cards for all
+      using (auth.uid() = user_id)
+      with check (auth.uid() = user_id);
+  end if;
+end $$;


### PR DESCRIPTION
## Summary
- Store active Navatar id in profile and expose helpers to get/set it
- Add `character_cards` table and RLS, plus a migration for active avatar column
- Unify Navatar hub, card, mint, and pick pages to use new `NavatarImage` and blue `CharacterCard`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_68bc226b1f048329ade89aee750733e5