### PR TITLE
Fix Character Card saving with real avatar UUID

### DIFF
--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -2,21 +2,24 @@ import { useEffect, useMemo, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
-import { loadActive } from "../../lib/localStorage";
-import { fetchMyCharacterCard } from "../../lib/navatar";
-import type { CharacterCard } from "../../lib/types";
+import {
+  loadActive,
+  fetchMyCharacterCard,
+  type CharacterCard,
+} from "../../lib/navatar";
+import { supabase } from "../../lib/supabase-client";
 import { Link } from "react-router-dom";
 import "../../styles/navatar.css";
 
 export default function MyNavatarPage() {
-  const activeNavatar = useMemo(() => loadActive<any>(), []);
+  const activeNavatar = useMemo(() => loadActive(), []);
   const [card, setCard] = useState<CharacterCard | null>(null);
 
   useEffect(() => {
     let alive = true;
     (async () => {
       try {
-        const c = await fetchMyCharacterCard();
+        const c = await fetchMyCharacterCard(supabase);
         if (alive) setCard(c);
       } catch {
         // ignore
@@ -35,7 +38,7 @@ export default function MyNavatarPage() {
       <div className="nv-hub-grid" style={{ marginTop: 8 }}>
         <section>
           <div className="nv-panel">
-            <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "Turian"} />
+            <NavatarCard src={activeNavatar?.image_url} title={activeNavatar?.title || "Turian"} />
           </div>
         </section>
 

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -3,23 +3,22 @@ import { Link } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
-import { loadActive } from "../../lib/localStorage";
-import { getActiveNavatar, getCardForAvatar } from "../../lib/navatar";
+import { loadActive, fetchMyCharacterCard, type CharacterCard } from "../../lib/navatar";
 import { supabase } from "../../lib/supabase-client";
 import "../../styles/navatar.css";
 
 export default function MintNavatarPage() {
-  const activeNavatar = useMemo(() => loadActive<any>(), []);
-  const [card, setCard] = useState<any>(null);
+  const activeNavatar = useMemo(() => loadActive(), []);
+  const [card, setCard] = useState<CharacterCard | null>(null);
 
   useEffect(() => {
     (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) return;
-      const { data: act } = await getActiveNavatar(user.id);
-      if (!act) return;
-      const { data: c } = await getCardForAvatar(act.id);
-      setCard(c);
+      try {
+        const c = await fetchMyCharacterCard(supabase);
+        setCard(c);
+      } catch {
+        // ignore
+      }
     })();
   }, []);
 
@@ -32,7 +31,7 @@ export default function MintNavatarPage() {
         Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.
       </p>
       <div style={{ display: "grid", justifyItems: "center", gap: 12 }}>
-        <NavatarCard src={activeNavatar?.imageDataUrl} title={activeNavatar?.name || "My Navatar"} />
+        <NavatarCard src={activeNavatar?.image_url} title={activeNavatar?.title || "My Navatar"} />
         <a className="pill" href="/marketplace">Go to Marketplace</a>
       </div>
 

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
 import { loadPublicNavatars, PublicNavatar } from "../../lib/navatar/publicList";
-import { saveActive } from "../../lib/localStorage";
+import { saveActiveFromRow } from "../../lib/navatar";
 import "../../styles/navatar.css";
 
 export default function PickNavatarPage() {
@@ -15,8 +15,14 @@ export default function PickNavatarPage() {
     loadPublicNavatars().then(setItems);
   }, []);
 
-  function choose(src: string, name: string) {
-    saveActive({ id: Date.now(), name, imageDataUrl: src, createdAt: Date.now() });
+  function choose(row: any) {
+    saveActiveFromRow({
+      id: row.id,
+      slug: row.slug,
+      name: row.name,
+      title: row.title,
+      image_url: row.src ?? row.image_url,
+    });
     nav("/navatar");
   }
 
@@ -26,15 +32,15 @@ export default function PickNavatarPage() {
       <h1 className="center">Pick Navatar</h1>
       <NavatarTabs />
       <div className="nav-grid">
-        {items.map((it) => (
+        {items.map((it: any) => (
           <button
-            key={it.src}
+            key={it.id ?? it.src}
             className="linklike"
-            onClick={() => choose(it.src, it.name)}
-            aria-label={`Pick ${it.name}`}
+            onClick={() => choose(it)}
+            aria-label={`Pick ${it.name ?? it.title}`}
             style={{ background: "none", border: 0, padding: 0, textAlign: "inherit" }}
           >
-            <NavatarCard src={it.src} title={it.name} />
+            <NavatarCard src={it.image_url ?? it.src} title={it.title ?? it.name} />
           </button>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- track selected Navatar by storing avatar UUID and metadata in localStorage
- guard and resolve invalid stored IDs when saving character cards
- upsert character cards on unique `(user_id, avatar_id)`

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68bc5ba0fc908329afe868b345fe739d