### PR TITLE
Restore Navatar tabs and persist active navatar ID

### DIFF
--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -1,25 +1,36 @@
-import React from "react";
 import { Link, useLocation } from "react-router-dom";
 
-const TABS = [
-  { to: "/navatar", label: "My Navatar" },
-  { to: "/navatar/card", label: "Card" },
-  { to: "/navatar/pick", label: "Pick" },
-  { to: "/navatar/upload", label: "Upload" },
-  { to: "/navatar/generate", label: "Generate" },
-  { to: "/navatar/mint", label: "NFT / Mint" },
-  { to: "/navatar/marketplace", label: "Marketplace" },
+export type TabKey =
+  | "navatar"
+  | "card"
+  | "pick"
+  | "upload"
+  | "generate"
+  | "mint"
+  | "marketplace";
+
+const TABS: { to: string; label: string; key: TabKey }[] = [
+  { to: "/navatar", label: "My Navatar", key: "navatar" },
+  { to: "/navatar/card", label: "Card", key: "card" },
+  { to: "/navatar/pick", label: "Pick", key: "pick" },
+  { to: "/navatar/upload", label: "Upload", key: "upload" },
+  { to: "/navatar/generate", label: "Generate", key: "generate" },
+  { to: "/navatar/mint", label: "NFT / Mint", key: "mint" },
+  { to: "/navatar/marketplace", label: "Marketplace", key: "marketplace" },
 ];
 
-export default function NavatarTabs({ sub = false }: { sub?: boolean }) {
+export default function NavatarTabs() {
   const { pathname } = useLocation();
   return (
-    <nav className={`nav-tabs${sub ? " nav-tabs--sub" : ""}`} aria-label="Navatar actions">
+    <nav className="nav-tabs" aria-label="Navatar actions">
       {TABS.map(t => {
-        const active =
-          t.to === "/navatar" ? pathname === "/navatar" : pathname.startsWith(t.to);
+        const active = pathname === t.to;
         return (
-          <Link key={t.to} to={t.to} className={`pill ${active ? "pill--active" : ""}`}>
+          <Link
+            key={t.to}
+            to={t.to}
+            className={"pill" + (active ? " pill--active" : "")}
+          >
             {t.label}
           </Link>
         );
@@ -27,3 +38,4 @@ export default function NavatarTabs({ sub = false }: { sub?: boolean }) {
     </nav>
   );
 }
+

--- a/src/lib/localNavatar.ts
+++ b/src/lib/localNavatar.ts
@@ -1,0 +1,16 @@
+const KEY = "nv.activeNavatarId";
+
+export function loadActive(): string | null {
+  try {
+    return localStorage.getItem(KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function saveActive(id: string) {
+  try {
+    localStorage.setItem(KEY, id);
+  } catch {}
+}
+

--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -31,6 +31,20 @@ export async function listMyNavatars() {
   return (data ?? []) as NavatarRow[];
 }
 
+export async function getMyLatestAvatar(): Promise<{ id: string } | null> {
+  const { data: { user }, error: uErr } = await supabase.auth.getUser();
+  if (uErr || !user) return null;
+  const { data, error } = await supabase
+    .from("avatars")
+    .select("id")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error && (error as any).code !== "PGRST116") throw error;
+  return (data as { id: string }) ?? null;
+}
+
 export async function saveNavatar(opts: {
   name?: string;
   base_type: "Animal" | "Fruit" | "Insect" | "Spirit";

--- a/src/lib/navatar/publicList.ts
+++ b/src/lib/navatar/publicList.ts
@@ -1,4 +1,4 @@
-export type PublicNavatar = { name: string; src: string };
+export type PublicNavatar = { id: string; name: string; src: string };
 
 function labelFromFilename(f: string) {
   const base = f.replace(/\.[a-z0-9]+$/i, "");
@@ -12,10 +12,16 @@ export async function loadPublicNavatars(): Promise<PublicNavatar[]> {
     const res = await fetch("/navatars/manifest.json", { cache: "no-store" });
     if (res.ok) {
       const files: string[] = await res.json();
-      return files.map((f) => ({ name: labelFromFilename(f), src: `/navatars/${f}` }));
+      return files.map((f) => {
+        const id = f.replace(/\.[a-z0-9]+$/i, "");
+        return { id, name: labelFromFilename(f), src: `/navatars/${f}` };
+      });
     }
   } catch {}
   const fallback = ["turian.png", "koala.png", "bald-eagle.png", "pixie.png", "tiger.png"];
-  return fallback.map((f) => ({ name: labelFromFilename(f), src: `/navatars/${f}` }));
+  return fallback.map((f) => {
+    const id = f.replace(/\.[a-z0-9]+$/i, "");
+    return { id, name: labelFromFilename(f), src: `/navatars/${f}` };
+  });
 }
 

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -2,7 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
-import { fetchMyCharacterCard, getActiveNavatar, upsertCharacterCard } from "../../lib/navatar";
+import { fetchMyCharacterCard, upsertCharacterCard } from "../../lib/navatar";
+import { loadActive } from "../../lib/localNavatar";
 import { supabase } from "../../lib/supabase-client";
 import "../../styles/navatar.css";
 
@@ -57,15 +58,15 @@ export default function NavatarCardPage() {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) throw new Error("Please sign in");
 
-      const { data: active } = await getActiveNavatar(user.id);
-      if (!active) {
-        alert("Please create or select a Navatar first.");
+      const avatarId = loadActive();
+      if (!avatarId) {
+        alert("Please pick or upload a Navatar first.");
         return;
       }
 
       const { error } = await upsertCharacterCard({
         user_id: user.id,
-        avatar_id: active.id,
+        avatar_id: avatarId,
         name,
         species,
         kingdom,
@@ -93,7 +94,7 @@ export default function NavatarCardPage() {
       <main className="container page-pad">
         <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
         <h1 className="center page-title">Character Card</h1>
-        <NavatarTabs sub />
+        <NavatarTabs />
         <p>Loading…</p>
       </main>
     );
@@ -103,7 +104,7 @@ export default function NavatarCardPage() {
     <main className="container page-pad">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
       <h1 className="center page-title">Character Card</h1>
-      <NavatarTabs sub />
+      <NavatarTabs />
       <form className="form-card" onSubmit={onSave} style={{ margin: "16px auto" }}>
         {err && <p className="Error">{err}</p>}
 

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -2,14 +2,15 @@ import { useEffect, useMemo, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
-import { loadActive } from "../../lib/localStorage";
-import { fetchMyCharacterCard } from "../../lib/navatar";
+import { loadActive as loadActiveNav } from "../../lib/localStorage";
+import { loadActive as loadActiveId, saveActive as saveActiveId } from "../../lib/localNavatar";
+import { fetchMyCharacterCard, getMyLatestAvatar } from "../../lib/navatar";
 import type { CharacterCard } from "../../lib/types";
 import { Link } from "react-router-dom";
 import "../../styles/navatar.css";
 
 export default function MyNavatarPage() {
-  const activeNavatar = useMemo(() => loadActive<any>(), []);
+  const activeNavatar = useMemo(() => loadActiveNav<any>(), []);
   const [card, setCard] = useState<CharacterCard | null>(null);
 
   useEffect(() => {
@@ -25,6 +26,16 @@ export default function MyNavatarPage() {
     return () => {
       alive = false;
     };
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      const current = loadActiveId();
+      if (!current) {
+        const latest = await getMyLatestAvatar();
+        if (latest?.id) saveActiveId(latest.id);
+      }
+    })();
   }, []);
 
   return (

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -4,7 +4,8 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
 import { loadPublicNavatars, PublicNavatar } from "../../lib/navatar/publicList";
-import { saveActive } from "../../lib/localStorage";
+import { saveActive as saveActiveId } from "../../lib/localNavatar";
+import { saveActive as saveActiveNav } from "../../lib/localStorage";
 import "../../styles/navatar.css";
 
 export default function PickNavatarPage() {
@@ -15,8 +16,14 @@ export default function PickNavatarPage() {
     loadPublicNavatars().then(setItems);
   }, []);
 
-  function choose(src: string, name: string) {
-    saveActive({ id: Date.now(), name, imageDataUrl: src, createdAt: Date.now() });
+  function choose(navatar: PublicNavatar) {
+    saveActiveId(navatar.id);
+    saveActiveNav({
+      id: navatar.id,
+      name: navatar.name,
+      imageDataUrl: navatar.src,
+      createdAt: Date.now(),
+    });
     nav("/navatar");
   }
 
@@ -26,11 +33,11 @@ export default function PickNavatarPage() {
       <h1 className="center">Pick Navatar</h1>
       <NavatarTabs />
       <div className="nav-grid">
-        {items.map((it) => (
+        {items.map(it => (
           <button
-            key={it.src}
+            key={it.id}
             className="linklike"
-            onClick={() => choose(it.src, it.name)}
+            onClick={() => choose(it)}
             aria-label={`Pick ${it.name}`}
             style={{ background: "none", border: 0, padding: 0, textAlign: "inherit" }}
           >


### PR DESCRIPTION
## Summary
- Rebuild NavatarTabs component for consistent pill navigation across Navatar pages
- Persist active Navatar ID in localStorage and hydrate from latest avatar when missing
- Ensure Card saving uses active ID and update Navatar pick flow accordingly

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit...' is not assignable to parameter of type 'never[]', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6f30abb483299e871a719e6aced3