### PR TITLE
feat: stabilize navatar auth user session loading

### DIFF
--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -6,13 +6,16 @@ import { loadActive } from "../../lib/localStorage";
 import { fetchMyCharacterCard } from "../../lib/navatar";
 import type { CharacterCard } from "../../lib/types";
 import { Link } from "react-router-dom";
+import useAuthUser from "../../lib/useAuthUser";
 import "../../styles/navatar.css";
 
 export default function MyNavatarPage() {
   const activeNavatar = useMemo(() => loadActive<any>(), []);
+  const { user, ready } = useAuthUser();
   const [card, setCard] = useState<CharacterCard | null>(null);
 
   useEffect(() => {
+    if (!user) return;
     let alive = true;
     (async () => {
       try {
@@ -25,7 +28,10 @@ export default function MyNavatarPage() {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [user]);
+
+  if (!ready) return <div style={{ padding: 16 }}>Loading…</div>;
+  if (!user) return <div style={{ padding: 16 }}>Please sign in.</div>;
 
   return (
     <main className="container page-pad">

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -5,23 +5,26 @@ import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
 import { loadActive } from "../../lib/localStorage";
 import { getActiveNavatar, getCardForAvatar } from "../../lib/navatar";
-import { supabase } from "../../lib/supabase-client";
+import useAuthUser from "../../lib/useAuthUser";
 import "../../styles/navatar.css";
 
 export default function MintNavatarPage() {
   const activeNavatar = useMemo(() => loadActive<any>(), []);
+  const { user, ready } = useAuthUser();
   const [card, setCard] = useState<any>(null);
 
   useEffect(() => {
+    if (!user) return;
     (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) return;
       const { data: act } = await getActiveNavatar(user.id);
       if (!act) return;
       const { data: c } = await getCardForAvatar(act.id);
       setCard(c);
     })();
-  }, []);
+  }, [user]);
+
+  if (!ready) return <div style={{ padding: 16 }}>Loading…</div>;
+  if (!user) return <div style={{ padding: 16 }}>Please sign in.</div>;
 
   return (
     <main className="container">


### PR DESCRIPTION
## Summary
- add `useAuthUser` hook to wait for Supabase session hydration
- use new hook on Navatar Card, Mint, and main pages to show loading/sign-in states and use authed `user.id`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68bc83cae1608329b332af001c9ce061