### PR TITLE
navatar: fix Pick flow, restore card sizing, add Marketplace stub tab

### DIFF
--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -1,6 +1,6 @@
 import { supabase } from "./supabase-client";
 import type { CharacterCard } from "./types";
-import { getActiveNavatarId } from "./localNavatar";
+import { getActiveNavatarId, setActiveNavatarId as saveActiveId } from "./localNavatar";
 
 export type NavatarRow = {
   id: string;
@@ -12,6 +12,10 @@ export type NavatarRow = {
   created_at: string;
   updated_at: string;
 };
+
+export function setActiveNavatarId(id: string) {
+  saveActiveId(id);
+}
 
 export function navatarImageUrl(image_path: string | null) {
   if (!image_path) return null;

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -49,7 +49,7 @@ export default function MyNavatarPage() {
       <div className="nv-hub-grid" style={{ marginTop: 8 }}>
         <section>
           <div className="nv-panel">
-            <NavatarCard src={navatarImageUrl(navatar?.image_path)} title={navatar?.name || "Turian"} />
+            <NavatarCard src={navatarImageUrl(navatar?.image_path)} title={navatar?.name || "My Navatar"} className="nav-card--fixed" />
           </div>
         </section>
 

--- a/src/pages/navatar/marketplace.tsx
+++ b/src/pages/navatar/marketplace.tsx
@@ -1,20 +1,14 @@
-import Breadcrumbs from "../../components/Breadcrumbs";
+import React from "react";
 import NavatarTabs from "../../components/NavatarTabs";
-import "../../styles/navatar.css";
 
-export default function NavatarMarketplacePage() {
+export default function NavatarMarketplaceStub() {
   return (
-    <main className="container">
-      <Breadcrumbs
-        items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Marketplace" }]}
-      />
-      <h1 className="center">Marketplace</h1>
+    <main className="container page-pad">
+      <h1 className="center page-title">Marketplace</h1>
       <NavatarTabs />
-      <div className="center" style={{ maxWidth: 560, margin: "16px auto" }}>
-        <p>Mockups for tees, plushies, stickers and more are coming soon.</p>
-        <p>You’ll be able to place your Navatar on products here, then purchase on the Marketplace.</p>
-        <a className="pill" href="/marketplace">Go to Marketplace</a>
-      </div>
+      <p className="center" style={{ opacity: 0.8 }}>
+        Mockups coming soon: create shirts, mugs, and posters with your active Navatar.
+      </p>
     </main>
   );
 }

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -36,9 +36,9 @@ export default function MintNavatarPage() {
       <p style={{ textAlign: "center", maxWidth: 560, margin: "8px auto 20px" }}>
         Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.
       </p>
-      <div style={{ display: "grid", justifyItems: "center", gap: 12 }}>
-        <NavatarCard src={navatarImageUrl(navatar?.image_path)} title={navatar?.name || "My Navatar"} />
-        <a className="pill" href="/marketplace">Go to Marketplace</a>
+      <div style={{ display: "grid", justifyItems: "center", gap: 12, margin: "16px auto" }}>
+        <NavatarCard src={navatarImageUrl(navatar?.image_path)} title={navatar?.name || "My Navatar"} className="nav-card--fixed" />
+        <a className="pill" href="/navatar/marketplace">Go to Marketplace</a>
       </div>
 
       {card ? (

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -1,52 +1,79 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
+import React, { useEffect, useState } from "react";
 import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { loadPublicNavatars, PublicNavatar } from "../../lib/navatar/publicList";
-import { saveNavatar } from "../../lib/navatar";
-import { setActiveNavatarId } from "../../lib/localNavatar";
+import { supabase } from "../../lib/supabase-client";
+import { setActiveNavatarId } from "../../lib/navatar";
+import { useNavigate } from "react-router-dom";
 import "../../styles/navatar.css";
 
+type AvatarRow = {
+  id: string;
+  name: string | null;
+  image_url: string | null;
+  created_at: string;
+};
+
 export default function PickNavatarPage() {
-  const [items, setItems] = useState<PublicNavatar[]>([]);
   const nav = useNavigate();
+  const [rows, setRows] = useState<AvatarRow[]>([]);
+  const [busy, setBusy] = useState(false);
 
   useEffect(() => {
-    loadPublicNavatars().then(setItems);
+    let alive = true;
+    (async () => {
+      const { data: auth } = await supabase.auth.getUser();
+      if (!auth.user) return;
+      const { data, error } = await supabase
+        .from("avatars")
+        .select("id,name,image_url,created_at")
+        .eq("user_id", auth.user.id)
+        .order("created_at", { ascending: false });
+      if (!alive) return;
+      if (!error && data) setRows(data as AvatarRow[]);
+    })();
+    return () => {
+      alive = false;
+    };
   }, []);
 
-  async function choose(src: string, name: string) {
-    try {
-      const res = await fetch(src);
-      const blob = await res.blob();
-      const file = new File([blob], "navatar.png", { type: blob.type });
-      const row = await saveNavatar({ name, base_type: "Animal", file });
-      setActiveNavatarId(row.id);
+  async function onPick(id: string) {
+    setBusy(true);
+    setActiveNavatarId(id);
+    // small tick so storage is flushed before navigate
+    setTimeout(() => {
       nav("/navatar");
-    } catch {
-      alert("Could not save Navatar.");
-    }
+    }, 10);
   }
 
   return (
-    <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Pick" }]} />
-      <h1 className="center">Pick Navatar</h1>
+    <main className="container page-pad">
+      <h1 className="center page-title">Pick</h1>
       <NavatarTabs />
-      <div className="nav-grid">
-        {items.map((it) => (
-          <button
-            key={it.src}
-            className="linklike"
-            onClick={() => choose(it.src, it.name)}
-            aria-label={`Pick ${it.name}`}
-            style={{ background: "none", border: 0, padding: 0, textAlign: "inherit" }}
-          >
-            <NavatarCard src={it.src} title={it.name} />
-          </button>
-        ))}
-      </div>
+
+      {!rows.length ? (
+        <p className="center" style={{ opacity: 0.8 }}>
+          You don’t have any Navatars yet. Try Upload or Generate.
+        </p>
+      ) : (
+        <div className="nv-grid">
+          {rows.map((a) => (
+            <button
+              key={a.id}
+              className="nav-card nav-card--button"
+              onClick={() => onPick(a.id)}
+              disabled={busy}
+              title="Set as active"
+            >
+              <div className="nav-card__img">
+                {/* eslint-disable-next-line jsx-a11y/alt-text */}
+                <img src={a.image_url || ""} alt={a.name || "Navatar"} />
+              </div>
+              <figcaption className="nav-card__cap">
+                <strong>{a.name || "Navatar"}</strong>
+              </figcaption>
+            </button>
+          ))}
+        </div>
+      )}
     </main>
   );
 }

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -28,50 +28,18 @@
 }
 
 /* --- Card: single source of truth for size & fit --- */
-.nav-card {
-  --nav-card-w: 260px;    /* change this once to resize everywhere */
-  width: min(var(--nav-card-w), 88vw);
-  margin: 0 auto;
-  background: #ffffff;
-  border: 1px solid #e8eefc;
-  border-radius: 16px;
-  box-shadow: 0 6px 16px rgba(30,78,216,.06);
-}
+.nav-card { width: 100%; max-width: 360px; margin: 0 auto; }
+.nav-card--fixed { width: 300px; }
 
-.nav-card__img {
-  width: 100%;
-  aspect-ratio: 3 / 4;     /* consistent portrait shape */
-  border-radius: 14px;
-  overflow: hidden;
-  background: #eef3ff;
-}
-.nav-card__img img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;     /* never crop uploads or picks */
-  display: block;
-}
-.nav-card__placeholder {
-  width: 100%;
-  height: 100%;
-  display: grid;
-  place-items: center;
-  color: #8aa2e6;
-  font-weight: 600;
-}
-.nav-card__cap {
-  padding: 8px 10px 10px;
-  text-align: center;
-  color: #1e40af;
-}
+.nav-card__img { width:100%; aspect-ratio: 3/4; background:#f4f6f8; display:grid; place-items:center; overflow:hidden; border-radius:14px; }
+.nav-card__img img { width:100%; height:100%; object-fit: cover; }
+.nav-card__placeholder { height: 400px; width: 300px; background:#f4f6f8; border-radius: 14px; }
+
+.nav-card--button { background: transparent; border: 0; padding: 0; cursor: pointer; }
+.nav-card__cap { text-align:center; padding:8px 0; }
 
 /* grid used by Pick page */
-.nav-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fill, minmax(min(200px, 46vw), 1fr));
-  align-items: start;
-}
+.nv-grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 16px; align-items:start; }
 
 /* Keep existing colors; enforce blue titles/links for the new page */
 .page-title,


### PR DESCRIPTION
## Summary
- allow setting active Navatar ID without refetching
- add in-app page to pick existing Navatars and stub marketplace tab
- keep Navatar cards a fixed size across pages and restore grid layout for selection

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `npm run typecheck` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c48259f08329a811d51743318eef