### PR TITLE
Refactor Navatar flows with Supabase context and UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { router } from './router';
+import { NavatarProvider } from './lib/navatar-context';
 import { organizationLd, websiteLd } from './lib/jsonld';
 import { CartProvider } from './lib/cart';
 import ToasterListener from './components/Toaster';
@@ -33,7 +34,9 @@ export default function App() {
         />
         <main id="main" className="nv-page">
           <div className="container">
-            <RouterProvider router={router} />
+            <NavatarProvider>
+              <RouterProvider router={router} />
+            </NavatarProvider>
           </div>
         </main>
         <ToasterListener />

--- a/src/components/navatar/Breadcrumbs.tsx
+++ b/src/components/navatar/Breadcrumbs.tsx
@@ -1,0 +1,16 @@
+import { Link } from 'react-router-dom';
+
+export default function Breadcrumbs({ trail }: { trail: { to?: string; label: string }[] }) {
+  return (
+    <div className="text-sm text-blue-700 mb-3">
+      <Link to="/">Home</Link>
+      {trail.map((t, i) => (
+        <span key={i} className="ml-1">
+          {' / '}
+          {t.to ? <Link to={t.to}>{t.label}</Link> : <span>{t.label}</span>}
+        </span>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/navatar/NavTabs.tsx
+++ b/src/components/navatar/NavTabs.tsx
@@ -1,0 +1,32 @@
+import { Link, useLocation } from 'react-router-dom';
+
+const tabs = [
+  { to: '/navatar', label: 'My Navatar' },
+  { to: '/navatar/card', label: 'Card' },
+  { to: '/navatar/pick', label: 'Pick' },
+  { to: '/navatar/upload', label: 'Upload' },
+  { to: '/navatar/generate', label: 'Generate' },
+  { to: '/navatar/mint', label: 'NFT / Mint' },
+  { to: '/navatar/marketplace', label: 'Marketplace' },
+];
+
+export default function NavTabs() {
+  const { pathname } = useLocation();
+  return (
+    <div style={{ display:'flex', gap:12, flexWrap:'wrap', marginBottom:16 }}>
+      {tabs.map(t => {
+        const active = pathname === t.to;
+        return (
+          <Link
+            key={t.to}
+            to={t.to}
+            className={`px-4 py-2 rounded-full border ${active ? 'bg-blue-600 text-white' : 'bg-white text-blue-700'} shadow-sm`}
+          >
+            {t.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 /* center pages and avoid hugging the left edge */
 .nv-container {
   max-width: 1100px;
@@ -14,3 +18,6 @@
 .nv-nav {
   pointer-events: auto;
 }
+
+/* Navatar card sizing helpers */
+.navatar-card img { width: 100%; height: auto; border-radius: 0.75rem; }

--- a/src/lib/navatar-context.tsx
+++ b/src/lib/navatar-context.tsx
@@ -1,0 +1,172 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { supabase } from './supabase';
+
+export type CardData = {
+  name?: string;
+  species?: string;
+  kingdom?: string;
+  backstory?: string;
+  powers?: string[];   // comma-joined in UI
+  traits?: string[];   // comma-joined in UI
+};
+
+export type Navatar = {
+  id: string;            // uuid in DB
+  user_id: string;       // auth user
+  title: string;         // display name under the image
+  image_url: string;     // public URL (storage or /navatars/…)
+};
+
+type Ctx = {
+  userId: string | null;
+  active?: Navatar | null;
+  card?: CardData | null;
+  loading: boolean;
+  setActiveFromPick: (title: string, imageUrl: string) => Promise<void>;
+  setActiveFromUpload: (publicUrl: string, title?: string) => Promise<void>;
+  saveCard: (data: CardData) => Promise<void>;
+  refresh: () => Promise<void>;
+};
+
+const NavatarContext = createContext<Ctx | null>(null);
+export const useNavatar = () => {
+  const ctx = useContext(NavatarContext);
+  if (!ctx) throw new Error('useNavatar must be used within NavatarProvider');
+  return ctx;
+};
+
+const LS_KEY = 'active_avatar_id';
+
+export const NavatarProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [userId, setUserId] = useState<string | null>(null);
+  const [active, setActive] = useState<Navatar | null>(null);
+  const [card, setCard] = useState<CardData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // auth
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const { data } = await supabase.auth.getUser();
+      if (!mounted) return;
+      setUserId(data.user?.id ?? null);
+      setLoading(false);
+    })();
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, sess) => {
+      setUserId(sess?.user?.id ?? null);
+    });
+    return () => sub.subscription.unsubscribe();
+  }, []);
+
+  const fetchActive = async (uid: string) => {
+    const fromLS = localStorage.getItem(LS_KEY) || null;
+
+    // If LS has an id, try it first
+    if (fromLS) {
+      const { data, error } = await supabase
+        .from('avatars')
+        .select('id,user_id,title,image_url')
+        .eq('user_id', uid)
+        .eq('id', fromLS)
+        .maybeSingle();
+      if (!error && data) {
+        setActive(data as Navatar);
+        return data.id;
+      }
+    }
+
+    // Otherwise take the most recent for this user
+    const { data: rows } = await supabase
+      .from('avatars')
+      .select('id,user_id,title,image_url')
+      .eq('user_id', uid)
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    if (rows && rows.length) {
+      localStorage.setItem(LS_KEY, rows[0].id);
+      setActive(rows[0] as Navatar);
+      return rows[0].id as string;
+    }
+
+    setActive(null);
+    localStorage.removeItem(LS_KEY);
+    return null;
+  };
+
+  const fetchCard = async (uid: string, avatarId: string) => {
+    const { data } = await supabase
+      .from('character_cards')
+      .select('name,species,kingdom,backstory,powers,traits')
+      .eq('user_id', uid)
+      .eq('avatar_id', avatarId)
+      .maybeSingle();
+    if (data) {
+      setCard({
+        name: data.name ?? '',
+        species: data.species ?? '',
+        kingdom: data.kingdom ?? '',
+        backstory: data.backstory ?? '',
+        powers: Array.isArray(data.powers) ? data.powers : (data.powers ? String(data.powers).split(',').map(s => s.trim()).filter(Boolean) : []),
+        traits: Array.isArray(data.traits) ? data.traits : (data.traits ? String(data.traits).split(',').map(s => s.trim()).filter(Boolean) : []),
+      });
+    } else {
+      setCard(null);
+    }
+  };
+
+  const refresh = async () => {
+    if (!userId) return;
+    const id = await fetchActive(userId);
+    if (id) await fetchCard(userId, id);
+  };
+
+  useEffect(() => { if (userId) refresh(); }, [userId]);
+
+  const setActiveFromPick = async (title: string, imageUrl: string) => {
+    if (!userId) throw new Error('Please sign in');
+    const { data, error } = await supabase
+      .from('avatars')
+      .insert({ user_id: userId, title, image_url: imageUrl })
+      .select('id,user_id,title,image_url')
+      .single();
+    if (error) throw error;
+    localStorage.setItem(LS_KEY, data.id);
+    setActive(data as Navatar);
+    await fetchCard(userId, data.id);
+  };
+
+  const setActiveFromUpload = async (publicUrl: string, title?: string) => {
+    return setActiveFromPick(title ?? 'Uploaded', publicUrl);
+  };
+
+  const saveCard = async (data: CardData) => {
+    if (!userId || !active?.id) throw new Error('Please pick or upload a Navatar first.');
+    const payload = {
+      user_id: userId,
+      avatar_id: active.id,
+      name: data.name ?? '',
+      species: data.species ?? '',
+      kingdom: data.kingdom ?? '',
+      backstory: data.backstory ?? '',
+      powers: (data.powers ?? []).filter(Boolean),
+      traits: (data.traits ?? []).filter(Boolean),
+    };
+
+    // Upsert by composite key (user_id, avatar_id)
+    const { error } = await supabase
+      .from('character_cards')
+      .upsert(payload, { onConflict: 'user_id,avatar_id' });
+
+    if (error) throw error;
+    setCard(payload);
+  };
+
+  const value = useMemo<Ctx>(() => ({
+    userId, active, card, loading,
+    setActiveFromPick, setActiveFromUpload, saveCard, refresh,
+  }), [userId, active, card, loading]);
+
+  return <NavatarContext.Provider value={value}>{children}</NavatarContext.Provider>;
+};
+

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = import.meta.env.VITE_SUPABASE_URL!;
+const anon = import.meta.env.VITE_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(url, anon, {
+  auth: { persistSession: true, autoRefreshToken: true },
+});
+

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -1,166 +1,83 @@
-import { useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import { fetchMyCharacterCard, upsertCharacterCard } from "../../lib/navatar";
-import { getActiveNavatarId } from "../../lib/localNavatar";
-import { supabase } from "../../lib/supabase-client";
-import "../../styles/navatar.css";
+import { useEffect, useState } from 'react';
+import Breadcrumbs from '../../components/navatar/Breadcrumbs';
+import NavTabs from '../../components/navatar/NavTabs';
+import { useNavatar, CardData } from '../../lib/navatar-context';
 
-export default function NavatarCardPage() {
-  const nav = useNavigate();
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
+const empty: CardData = { name:'', species:'', kingdom:'', backstory:'', powers:[], traits:[] };
 
-  const [name, setName] = useState("");
-  const [species, setSpecies] = useState("");
-  const [kingdom, setKingdom] = useState("");
-  const [backstory, setBackstory] = useState("");
-  const [powers, setPowers] = useState("");
-  const [traits, setTraits] = useState("");
+export default function Card() {
+  const { active, card, saveCard, refresh } = useNavatar();
+  const [form, setForm] = useState<CardData>(empty);
 
-  useEffect(() => {
-    let alive = true;
-    (async () => {
-      try {
-        const card = await fetchMyCharacterCard();
-        if (card && alive) {
-          setName(card.name ?? "");
-          setSpecies(card.species ?? "");
-          setKingdom(card.kingdom ?? "");
-          setBackstory(card.backstory ?? "");
-          setPowers((card.powers ?? []).join(", "));
-          setTraits((card.traits ?? []).join(", "));
-        }
-      } catch (e: any) {
-        setErr(e.message ?? "Failed to load");
-      } finally {
-        if (alive) setLoading(false);
-      }
-    })();
-    return () => {
-      alive = false;
-    };
-  }, []);
+  useEffect(() => { if (card) setForm(card); }, [card]);
 
-  const canSave = useMemo(
-    () => [name, species, kingdom, backstory, powers, traits].some(v => v.trim().length > 0),
-    [name, species, kingdom, backstory, powers, traits]
-  );
-
-  async function onSave(e: React.FormEvent) {
-    e.preventDefault();
-    if (!canSave) return;
-    setSaving(true);
-    setErr(null);
-    try {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) {
-        alert("Please sign in.");
-        return;
-      }
-
-      const avatar_id = getActiveNavatarId();
-      if (!avatar_id) {
-        alert("Please create or select a Navatar first.");
-        return;
-      }
-
-      const powersArr = (powers || "")
-        .split(",")
-        .map(s => s.trim())
-        .filter(Boolean);
-
-      const traitsArr = (traits || "")
-        .split(",")
-        .map(s => s.trim())
-        .filter(Boolean);
-
-      const { error } = await upsertCharacterCard({
-        user_id: user.id,
-        avatar_id,
-        name,
-        species,
-        kingdom,
-        backstory,
-        powers: powersArr,
-        traits: traitsArr,
-      });
-      if (error) {
-        console.error(error);
-        setErr("Could not save your Character Card. Please try again.");
-        return;
-      }
-
-      nav("/navatar/mint");
-    } catch (e: any) {
-      console.error(e);
-      setErr(e.message ?? "Save failed");
-    } finally {
-      setSaving(false);
+  const update = (k: keyof CardData, v: string) => {
+    if (k === 'powers' || k === 'traits') {
+      setForm(f => ({ ...f, [k]: v.split(',').map(s => s.trim()).filter(Boolean) }));
+    } else {
+      setForm(f => ({ ...f, [k]: v }));
     }
-  }
+  };
 
-  if (loading) {
-    return (
-      <main className="container page-pad">
-        <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
-        <h1 className="center page-title">Character Card</h1>
-        <NavatarTabs sub />
-        <p>Loading…</p>
-      </main>
-    );
-  }
+  const onSave = async () => {
+    try {
+      await saveCard(form);
+      alert('Saved!');
+      await refresh();
+    } catch (e: any) {
+      alert(e.message ?? 'Failed to save');
+    }
+  };
 
   return (
-    <main className="container page-pad">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
-      <h1 className="center page-title">Character Card</h1>
-      <NavatarTabs sub />
-      <form className="form-card" onSubmit={onSave} style={{ margin: "16px auto" }}>
-        {err && <p className="Error">{err}</p>}
+    <div className="max-w-screen-md mx-auto px-4">
+      <Breadcrumbs trail={[{ to: '/navatar', label: 'Navatar' }, { label: 'Card' }]} />
+      <h1 className="text-4xl font-bold text-blue-700 mb-2">Character Card</h1>
+      <NavTabs />
+      {!active ? (
+        <div className="mt-4 text-blue-800">Please pick or upload a Navatar first.</div>
+      ) : (
+        <div className="rounded-2xl border bg-white p-4 shadow">
+          <div className="grid gap-3">
+            <label className="text-sm">Name
+              <input className="block w-full border rounded px-3 py-2"
+                value={form.name ?? ''} onChange={e => update('name', e.target.value)} />
+            </label>
 
-        <label>
-          Name
-          <input value={name} onChange={e => setName(e.target.value)} />
-        </label>
+            <label className="text-sm">Species / Type
+              <input className="block w-full border rounded px-3 py-2"
+                value={form.species ?? ''} onChange={e => update('species', e.target.value)} />
+            </label>
 
-        <label>
-          Species / Type
-          <input value={species} onChange={e => setSpecies(e.target.value)} />
-        </label>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <label className="text-sm">Kingdom
+                <input className="block w-full border rounded px-3 py-2"
+                  value={form.kingdom ?? ''} onChange={e => update('kingdom', e.target.value)} />
+              </label>
+              <label className="text-sm">Backstory
+                <textarea className="block w-full border rounded px-3 py-2"
+                  rows={3}
+                  value={form.backstory ?? ''} onChange={e => update('backstory', e.target.value)} />
+              </label>
+            </div>
 
-        <label>
-          Kingdom
-          <input value={kingdom} onChange={e => setKingdom(e.target.value)} />
-        </label>
+            <label className="text-sm">Powers (comma separated)
+              <input className="block w-full border rounded px-3 py-2"
+                value={(form.powers ?? []).join(', ')} onChange={e => update('powers', e.target.value)} />
+            </label>
 
-        <label>
-          Backstory
-          <textarea rows={5} value={backstory} onChange={e => setBackstory(e.target.value)} />
-        </label>
+            <label className="text-sm">Traits (comma separated)
+              <input className="block w-full border rounded px-3 py-2"
+                value={(form.traits ?? []).join(', ')} onChange={e => update('traits', e.target.value)} />
+            </label>
 
-        <label>
-          Powers (comma separated)
-          <input value={powers} onChange={e => setPowers(e.target.value)} />
-        </label>
-
-        <label>
-          Traits (comma separated)
-          <input value={traits} onChange={e => setTraits(e.target.value)} />
-        </label>
-
-        <div className="row gap" style={{ marginTop: 8 }}>
-          <Link to="/navatar" className="pill">
-            Back to My Navatar
-          </Link>
-          <button className="pill pill--active" disabled={!canSave || saving}>
-            {saving ? "Saving…" : "Save"}
-          </button>
+            <button onClick={onSave} className="mt-2 justify-self-start px-5 py-2 rounded-full bg-blue-600 text-white">
+              Save
+            </button>
+          </div>
         </div>
-      </form>
-    </main>
+      )}
+    </div>
   );
 }
 

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
+import Breadcrumbs from "../../components/navatar/Breadcrumbs";
+import NavTabs from "../../components/navatar/NavTabs";
 import NavatarCard from "../../components/NavatarCard";
 import { saveNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
@@ -38,15 +38,13 @@ export default function GenerateNavatarPage() {
   }
 
   return (
-    <main className="container">
-      <Breadcrumbs
-        items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Describe & Generate" }]}
-      />
-      <h1 className="center">Describe &amp; Generate</h1>
-      <NavatarTabs />
+    <div className="max-w-screen-md mx-auto px-4">
+      <Breadcrumbs trail={[{ to: '/navatar', label: 'Navatar' }, { label: 'Describe & Generate' }]} />
+      <h1 className="text-4xl font-bold text-blue-700 mb-2">Describe &amp; Generate</h1>
+      <NavTabs />
       <form
         onSubmit={onSave}
-        style={{ maxWidth: 520, margin: "16px auto", display: "grid", justifyItems: "center", gap: 12 }}
+        style={{ maxWidth: 520, margin: '16px auto', display: 'grid', justifyItems: 'center', gap: 12 }}
       >
         <NavatarCard src={draftUrl} title={name || "My Navatar"} />
         <textarea
@@ -70,7 +68,7 @@ export default function GenerateNavatarPage() {
       <p className="center" style={{ opacity: 0.8 }}>
         AI art & edit coming soon.
       </p>
-    </main>
+    </div>
   );
 }
 

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,113 +1,57 @@
-import { useEffect, useState } from "react";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { fetchMyCharacterCard, navatarImageUrl } from "../../lib/navatar";
-import { getActiveNavatarId } from "../../lib/localNavatar";
-import { supabase } from "../../lib/supabase-client";
-import type { CharacterCard } from "../../lib/types";
-import { Link } from "react-router-dom";
-import "../../styles/navatar.css";
+import Breadcrumbs from '../../components/navatar/Breadcrumbs';
+import NavTabs from '../../components/navatar/NavTabs';
+import { useNavatar } from '../../lib/navatar-context';
+import { Link } from 'react-router-dom';
 
-export default function MyNavatarPage() {
-  const [navatar, setNavatar] = useState<any | null>(null);
-  const [card, setCard] = useState<CharacterCard | null>(null);
-
-  useEffect(() => {
-    const activeId = getActiveNavatarId();
-    if (!activeId) return;
-
-    let alive = true;
-    (async () => {
-      try {
-        const { data } = await supabase
-          .from("avatars")
-          .select("id,name,image_path")
-          .eq("id", activeId)
-          .maybeSingle();
-        if (alive) setNavatar(data);
-      } catch {
-        // ignore
-      }
-      try {
-        const c = await fetchMyCharacterCard();
-        if (alive) setCard(c);
-      } catch {
-        // ignore
-      }
-    })();
-    return () => {
-      alive = false;
-    };
-  }, []);
+export default function MyNavatar() {
+  const { active, card } = useNavatar();
 
   return (
-    <main className="container page-pad">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
-      <h1 className="center page-title">My Navatar</h1>
-      <NavatarTabs />
-      <div className="nv-hub-grid" style={{ marginTop: 8 }}>
-        <section>
-          <div className="nv-panel">
-            <NavatarCard src={navatarImageUrl(navatar?.image_path)} title={navatar?.name || "Turian"} />
+    <div className="max-w-screen-md mx-auto px-4">
+      <Breadcrumbs trail={[{ label: 'Navatar' }]} />
+      <h1 className="text-4xl font-bold text-blue-700 mb-2">My Navatar</h1>
+      <NavTabs />
+
+      {!active ? (
+        <div className="mt-6 rounded-2xl border bg-white p-4 shadow">
+          <div className="text-blue-800">No Navatar yet.</div>
+          <div className="mt-2 flex gap-2">
+            <Link to="/navatar/pick" className="px-4 py-2 bg-blue-600 text-white rounded-full">Pick</Link>
+            <Link to="/navatar/upload" className="px-4 py-2 bg-white text-blue-700 border rounded-full">Upload</Link>
           </div>
-        </section>
-
-        <aside className="nv-panel">
-          <div className="nv-title">Character Card</div>
-
-          {!card ? (
-            <p>
-              No card yet. <Link to="/navatar/card">Create Card</Link>
-            </p>
-          ) : (
-            <dl className="nv-list">
-              {card.name && (
-                <>
-                  <dt>Name</dt>
-                  <dd>{card.name}</dd>
-                </>
-              )}
-              {card.species && (
-                <>
-                  <dt>Species</dt>
-                  <dd>{card.species}</dd>
-                </>
-              )}
-              {card.kingdom && (
-                <>
-                  <dt>Kingdom</dt>
-                  <dd>{card.kingdom}</dd>
-                </>
-              )}
-              {card.backstory && (
-                <>
-                  <dt>Backstory</dt>
-                  <dd>{card.backstory}</dd>
-                </>
-              )}
-              {card.powers && card.powers.length > 0 && (
-                <>
-                  <dt>Powers</dt>
-                  <dd>{card.powers.map(p => `— ${p}`).join("\n")}</dd>
-                </>
-              )}
-              {card.traits && card.traits.length > 0 && (
-                <>
-                  <dt>Traits</dt>
-                  <dd>{card.traits.map(t => `— ${t}`).join("\n")}</dd>
-                </>
-              )}
-            </dl>
-          )}
-
-          <div style={{ marginTop: 12 }}>
-            <Link to="/navatar/card" className="btn">
-              Edit Card
-            </Link>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          <div className="rounded-2xl border bg-white p-2 shadow">
+            <img src={active.image_url} alt={active.title} className="w-full rounded-xl" />
+            <div className="text-center font-semibold text-blue-800 mt-2">{active.title}</div>
           </div>
-        </aside>
-      </div>
-    </main>
+
+          <div className="rounded-2xl border bg-white p-4 shadow">
+            <div className="text-xl font-semibold text-blue-800 mb-2">Character Card</div>
+            {!card ? (
+              <div className="text-blue-700">
+                No card yet. <Link to="/navatar/card" className="underline">Create Card</Link>
+              </div>
+            ) : (
+              <div className="text-blue-900 space-y-1">
+                <div><span className="font-semibold">Name</span><div>{card.name}</div></div>
+                <div><span className="font-semibold">Species</span><div>{card.species}</div></div>
+                <div><span className="font-semibold">Kingdom</span><div>{card.kingdom}</div></div>
+                <div><span className="font-semibold">Backstory</span><div>{card.backstory}</div></div>
+                {!!card.powers?.length && (
+                  <div><span className="font-semibold">Powers</span><div>— {card.powers.join(', ')}</div></div>
+                )}
+                {!!card.traits?.length && (
+                  <div><span className="font-semibold">Traits</span><div>— {card.traits.join(', ')}</div></div>
+                )}
+                <Link to="/navatar/card" className="inline-block mt-2 px-4 py-2 rounded-full bg-blue-600 text-white">Edit Card</Link>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
+

--- a/src/pages/navatar/marketplace.tsx
+++ b/src/pages/navatar/marketplace.tsx
@@ -1,21 +1,22 @@
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import "../../styles/navatar.css";
+import Breadcrumbs from '../../components/navatar/Breadcrumbs';
+import NavTabs from '../../components/navatar/NavTabs';
 
-export default function NavatarMarketplacePage() {
+export default function Marketplace() {
   return (
-    <main className="container">
-      <Breadcrumbs
-        items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Marketplace" }]}
-      />
-      <h1 className="center">Marketplace</h1>
-      <NavatarTabs />
-      <div className="center" style={{ maxWidth: 560, margin: "16px auto" }}>
-        <p>Mockups for tees, plushies, stickers and more are coming soon.</p>
-        <p>You’ll be able to place your Navatar on products here, then purchase on the Marketplace.</p>
-        <a className="pill" href="/marketplace">Go to Marketplace</a>
+    <div className="max-w-screen-md mx-auto px-4">
+      <Breadcrumbs trail={[{ to: '/navatar', label: 'Navatar' }, { label: 'Marketplace' }]} />
+      <h1 className="text-4xl font-bold text-blue-700 mb-2">Marketplace (Coming Soon)</h1>
+      <NavTabs />
+      <p className="text-blue-900 mb-4">Mockups and merch generator preview will appear here.</p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-2xl border bg-gray-50 p-4 shadow h-64 flex items-end justify-center">
+            <div className="mb-2 font-semibold text-blue-800">Coming soon</div>
+          </div>
+        ))}
       </div>
-    </main>
+    </div>
   );
 }
 

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -1,68 +1,40 @@
-import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { getCardForAvatar, navatarImageUrl } from "../../lib/navatar";
-import { getActiveNavatarId } from "../../lib/localNavatar";
-import { supabase } from "../../lib/supabase-client";
-import "../../styles/navatar.css";
+import Breadcrumbs from '../../components/navatar/Breadcrumbs';
+import NavTabs from '../../components/navatar/NavTabs';
+import { useNavatar } from '../../lib/navatar-context';
+import { Link } from 'react-router-dom';
 
-export default function MintNavatarPage() {
-  const [navatar, setNavatar] = useState<any | null>(null);
-  const [card, setCard] = useState<any>(null);
-
-  useEffect(() => {
-    const activeId = getActiveNavatarId();
-    if (!activeId) return;
-
-    (async () => {
-      const { data } = await supabase
-        .from("avatars")
-        .select("id,name,image_path")
-        .eq("id", activeId)
-        .maybeSingle();
-      setNavatar(data);
-      const { data: c } = await getCardForAvatar(activeId);
-      setCard(c);
-    })();
-  }, []);
+export default function NFTMint() {
+  const { active, card } = useNavatar();
 
   return (
-    <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "NFT / Mint" }]} />
-      <h1 className="center">NFT / Mint</h1>
-      <NavatarTabs />
-      <p style={{ textAlign: "center", maxWidth: 560, margin: "8px auto 20px" }}>
+    <div className="max-w-screen-md mx-auto px-4">
+      <Breadcrumbs trail={[{ to: '/navatar', label: 'Navatar' }, { label: 'NFT / Mint' }]} />
+      <h1 className="text-4xl font-bold text-blue-700 mb-2">NFT / Mint</h1>
+      <NavTabs />
+      <p className="text-blue-900 mb-4">
         Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.
       </p>
-      <div style={{ display: "grid", justifyItems: "center", gap: 12 }}>
-        <NavatarCard src={navatarImageUrl(navatar?.image_path)} title={navatar?.name || "My Navatar"} />
-        <a className="pill" href="/marketplace">Go to Marketplace</a>
-      </div>
 
-      {card ? (
-        <aside className="nv-panel" style={{ maxWidth: 480, margin: "20px auto 0" }}>
-          <div className="nv-title">Character Card</div>
-          <dl className="nv-list">
-            <dt>Name</dt><dd>{card.name}</dd>
-            <dt>Species</dt><dd>{card.species}</dd>
-            <dt>Kingdom</dt><dd>{card.kingdom}</dd>
-            <dt>Backstory</dt><dd>{card.backstory || "—"}</dd>
-            <dt>Powers</dt><dd>{card.powers?.map((p: string) => `— ${p}`).join("\n") || "—"}</dd>
-            <dt>Traits</dt><dd>{card.traits?.map((t: string) => `— ${t}`).join("\n") || "—"}</dd>
-          </dl>
-          <div style={{ marginTop: 12, textAlign: "center" }}>
-            <Link to="/navatar/card" className="btn">Edit Card</Link>
-          </div>
-        </aside>
+      {!active ? (
+        <div className="text-blue-800">Pick or upload a Navatar first.</div>
       ) : (
-        <div className="nv-panel" style={{ maxWidth: 480, margin: "20px auto 0" }}>
-          <div className="nv-title">Character Card</div>
-          <p>No card yet. <Link to="/navatar/card">Create Card</Link></p>
+        <div className="rounded-2xl border bg-white p-4 shadow max-w-sm">
+          <img src={active.image_url} alt={active.title} className="w-full rounded-xl" />
+          <div className="text-center font-semibold text-blue-800 mt-2">{active.title}</div>
+          {card && (
+            <div className="text-blue-900 text-sm mt-3 space-y-1">
+              <div><b>Name</b> {card.name}</div>
+              <div><b>Species</b> {card.species}</div>
+              <div><b>Kingdom</b> {card.kingdom}</div>
+            </div>
+          )}
         </div>
       )}
-    </main>
+
+      <div className="mt-6">
+        <Link to="/navatar/marketplace" className="px-4 py-2 rounded-full bg-white text-blue-700 border">Go to Marketplace</Link>
+      </div>
+    </div>
   );
 }
 

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,63 +1,49 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { saveNavatar } from "../../lib/navatar";
-import { setActiveNavatarId } from "../../lib/localNavatar";
-import "../../styles/navatar.css";
+import { useState } from 'react';
+import { supabase } from '../../lib/supabase';
+import { useNavatar } from '../../lib/navatar-context';
+import NavTabs from '../../components/navatar/NavTabs';
+import Breadcrumbs from '../../components/navatar/Breadcrumbs';
 
-export default function UploadNavatarPage() {
+export default function Upload() {
+  const { setActiveFromUpload, userId } = useNavatar();
   const [file, setFile] = useState<File | null>(null);
-  const [name, setName] = useState("");
-  const [previewUrl, setPreviewUrl] = useState<string | undefined>();
-  const nav = useNavigate();
+  const [name, setName] = useState('');
 
-  useEffect(() => {
-    if (!file) {
-      setPreviewUrl(undefined);
-      return;
-    }
-    const url = URL.createObjectURL(file);
-    setPreviewUrl(url);
-    return () => URL.revokeObjectURL(url);
-  }, [file]);
+  const onUpload = async () => {
+    if (!userId) return alert('Please sign in');
+    if (!file) return alert('Choose a file');
+    const ext = file.name.split('.').pop();
+    const path = `${userId}/${Date.now()}.${ext}`;
 
-  async function onSave(e: React.FormEvent) {
-    e.preventDefault();
-    if (!file) return;
-    try {
-      const row = await saveNavatar({ name, base_type: "Animal", file });
-      setActiveNavatarId(row.id);
-      alert("Uploaded ✓");
-      nav("/navatar");
-    } catch {
-      alert("Upload failed");
-    }
-  }
+    const { error } = await supabase.storage.from('avatars').upload(path, file, {
+      upsert: false,
+      cacheControl: '3600',
+    });
+    if (error) return alert(`Upload failed: ${error.message}`);
+
+    const { data } = supabase.storage.from('avatars').getPublicUrl(path);
+    await setActiveFromUpload(data.publicUrl, name || file.name.replace(/\.[^.]+$/, ''));
+    alert('Uploaded!');
+  };
 
   return (
-    <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Upload" }]} />
-      <h1 className="center">Upload a Navatar</h1>
-      <NavatarTabs />
-      <form
-        onSubmit={onSave}
-        style={{ display: "grid", justifyItems: "center", gap: 12, maxWidth: 480, margin: "16px auto" }}
-      >
-        <NavatarCard src={previewUrl} title={name || "My Navatar"} />
-        <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+    <div className="max-w-screen-md mx-auto px-4">
+      <Breadcrumbs trail={[{ to: '/navatar', label: 'Navatar' }, { label: 'Upload' }]} />
+      <h1 className="text-4xl font-bold text-blue-700 mb-2">Upload</h1>
+      <NavTabs />
+      <div className="rounded-2xl border bg-white p-4 shadow">
+        <input type="file" accept="image/*" onChange={e => setFile(e.target.files?.[0] ?? null)} />
         <input
-          style={{ display: "block", width: "100%" }}
+          className="block mt-3 border rounded px-3 py-2 w-full"
           placeholder="Name (optional)"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={e => setName(e.target.value)}
         />
-        <button className="pill pill--active" type="submit">
+        <button onClick={onUpload} className="mt-4 px-5 py-2 rounded-full bg-blue-600 text-white">
           Save
         </button>
-      </form>
-    </main>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- add Supabase client and Navatar context for managing avatars and character cards
- rebuild Navatar pages with consistent styling and Supabase-backed pick/upload flows
- wrap router with NavatarProvider and add Tailwind base styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d51bfa708329818ace738e2dc051