### PR TITLE
Align Navatar with Supabase avatars + fix Pick/Card/Upload

### DIFF
--- a/src/lib/navatarApi.ts
+++ b/src/lib/navatarApi.ts
@@ -1,0 +1,172 @@
+import { supabase } from "./supabase-client";
+
+export type AvatarRow = {
+  id: string;
+  user_id: string | null;
+  name: string | null;
+  image_url: string | null;
+  image_path: string | null;
+  thumbnail_url: string | null;
+  metadata: any | null;
+  is_public: boolean | null;
+  is_primary: boolean | null;
+  created_at?: string;
+};
+
+export type CharacterCard = {
+  id?: string;
+  user_id: string;
+  avatar_id: string | null;
+  name?: string | null;
+  species?: string | null;
+  kingdom?: string | null;
+  backstory?: string | null;
+  powers?: string[] | null;
+  traits?: string[] | null;
+};
+
+export async function getSessionUser() {
+  const { data, error } = await supabase.auth.getUser();
+  if (error || !data.user) throw error ?? new Error("Not signed in");
+  return data.user;
+}
+
+/** PUBLIC BROWSER LIST for Pick page */
+export async function listPublicAvatars(): Promise<AvatarRow[]> {
+  const { data, error } = await supabase
+    .from("avatars")
+    .select("id,name,image_url,thumbnail_url,image_path,is_public")
+    .eq("is_public", true)
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+  return (data ?? []) as AvatarRow[];
+}
+
+/** My primary avatar (for /navatar & /navatar/mint) */
+export async function getMyPrimaryAvatar(): Promise<AvatarRow | null> {
+  const user = await getSessionUser();
+  const { data, error } = await supabase
+    .from("avatars")
+    .select("*")
+    .eq("user_id", user.id)
+    .eq("is_primary", true)
+    .maybeSingle();
+  if (error && error.code !== "PGRST116") throw error;
+  return data ?? null;
+}
+
+/** Make selected avatar primary for me.
+ *  If it's a public stock avatar, duplicate a row for me; else toggle mine. */
+export async function pickAvatar(stock: AvatarRow): Promise<AvatarRow> {
+  const user = await getSessionUser();
+
+  // Clear any existing primary
+  await supabase
+    .from("avatars")
+    .update({ is_primary: false })
+    .eq("user_id", user.id)
+    .eq("is_primary", true);
+
+  if (stock.user_id === user.id) {
+    const { data, error } = await supabase
+      .from("avatars")
+      .update({ is_primary: true })
+      .eq("id", stock.id)
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  }
+
+  // Duplicate (reference same storage path/urls)
+  const insert = {
+    user_id: user.id,
+    name: stock.name,
+    image_url: stock.image_url,
+    image_path: stock.image_path,
+    thumbnail_url: stock.thumbnail_url,
+    metadata: stock.metadata,
+    is_public: false,
+    is_primary: true
+  };
+  const { data, error } = await supabase
+    .from("avatars")
+    .insert(insert)
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+/** Upload an image to storage bucket 'avatars' and create primary row */
+export async function uploadAvatar(file: File, name?: string): Promise<AvatarRow> {
+  const user = await getSessionUser();
+  const path = `${user.id}/${Date.now()}_${file.name}`;
+  const { error: upErr } = await supabase
+    .storage.from("avatars")
+    .upload(path, file, { upsert: false, contentType: file.type });
+  if (upErr) throw upErr;
+
+  const { data: urlData } = supabase.storage.from("avatars").getPublicUrl(path);
+
+  // Clear existing primary then insert
+  await supabase
+    .from("avatars")
+    .update({ is_primary: false })
+    .eq("user_id", user.id)
+    .eq("is_primary", true);
+
+  const { data, error } = await supabase
+    .from("avatars")
+    .insert({
+      user_id: user.id,
+      name: name ?? file.name.replace(/\.[^.]+$/, ""),
+      image_path: path,
+      image_url: urlData.publicUrl,
+      is_public: false,
+      is_primary: true
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+/** Save or update my character card for my current primary avatar */
+export async function saveCharacterCard(
+  card: Omit<CharacterCard, "user_id" | "avatar_id">
+) {
+  const user = await getSessionUser();
+  const avatar = await getMyPrimaryAvatar();
+  const payload: CharacterCard = {
+    user_id: user.id,
+    avatar_id: avatar ? avatar.id : null,
+    name: card.name ?? null,
+    species: card.species ?? null,
+    kingdom: card.kingdom ?? null,
+    backstory: card.backstory ?? null,
+    powers: card.powers ?? null,
+    traits: card.traits ?? null
+  };
+
+  // Upsert by user_id (works with migration above)
+  const { data, error } = await supabase
+    .from("character_cards")
+    .upsert(payload, { onConflict: "user_id" })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function getMyCharacterCard(): Promise<CharacterCard | null> {
+  const user = await getSessionUser();
+  const { data, error } = await supabase
+    .from("character_cards")
+    .select("*")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (error && error.code !== "PGRST116") throw error;
+  return data ?? null;
+}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,113 +1,77 @@
 import { useEffect, useState } from "react";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
-import NavatarCard from "../../components/NavatarCard";
-import { fetchMyCharacterCard, navatarImageUrl } from "../../lib/navatar";
-import { getActiveNavatarId } from "../../lib/localNavatar";
-import { supabase } from "../../lib/supabase-client";
-import type { CharacterCard } from "../../lib/types";
-import { Link } from "react-router-dom";
-import "../../styles/navatar.css";
+import { getMyPrimaryAvatar, getMyCharacterCard, AvatarRow, CharacterCard } from "@/lib/navatarApi";
 
-export default function MyNavatarPage() {
-  const [navatar, setNavatar] = useState<any | null>(null);
+export default function MyNavatar() {
+  const [avatar, setAvatar] = useState<AvatarRow | null>(null);
   const [card, setCard] = useState<CharacterCard | null>(null);
 
   useEffect(() => {
-    const activeId = getActiveNavatarId();
-    if (!activeId) return;
-
-    let alive = true;
     (async () => {
       try {
-        const { data } = await supabase
-          .from("avatars")
-          .select("id,name,image_path")
-          .eq("id", activeId)
-          .maybeSingle();
-        if (alive) setNavatar(data);
-      } catch {
-        // ignore
-      }
-      try {
-        const c = await fetchMyCharacterCard();
-        if (alive) setCard(c);
-      } catch {
-        // ignore
+        const a = await getMyPrimaryAvatar();
+        setAvatar(a);
+        const c = await getMyCharacterCard();
+        setCard(c);
+      } catch (e: any) {
+        alert(e.message);
       }
     })();
-    return () => {
-      alive = false;
-    };
   }, []);
 
   return (
-    <main className="container page-pad">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
-      <h1 className="center page-title">My Navatar</h1>
-      <NavatarTabs />
-      <div className="nv-hub-grid" style={{ marginTop: 8 }}>
-        <section>
-          <div className="nv-panel">
-            <NavatarCard src={navatarImageUrl(navatar?.image_path)} title={navatar?.name || "Turian"} />
-          </div>
-        </section>
+    <div className="container mx-auto px-4 pb-24">
+      <div className="text-sm text-blue-600 mb-2"><a href="/">Home</a> / Navatar</div>
+      <h1 className="text-3xl font-bold text-blue-700 mb-4">My Navatar</h1>
 
-        <aside className="nv-panel">
-          <div className="nv-title">Character Card</div>
-
-          {!card ? (
-            <p>
-              No card yet. <Link to="/navatar/card">Create Card</Link>
-            </p>
+      <div className="flex flex-wrap gap-8">
+        <div className="flex-1 min-w-[260px] max-w-[380px]">
+          {avatar ? (
+            <div className="rounded-2xl bg-white shadow p-3">
+              <img
+                src={avatar.image_url || ""}
+                alt={avatar.name || "Navatar"}
+                className="w-full h-[360px] object-cover rounded-xl bg-gray-50"
+              />
+              <div className="text-center font-semibold mt-2">{avatar.name}</div>
+            </div>
           ) : (
-            <dl className="nv-list">
-              {card.name && (
-                <>
-                  <dt>Name</dt>
-                  <dd>{card.name}</dd>
-                </>
-              )}
-              {card.species && (
-                <>
-                  <dt>Species</dt>
-                  <dd>{card.species}</dd>
-                </>
-              )}
-              {card.kingdom && (
-                <>
-                  <dt>Kingdom</dt>
-                  <dd>{card.kingdom}</dd>
-                </>
-              )}
-              {card.backstory && (
-                <>
-                  <dt>Backstory</dt>
-                  <dd>{card.backstory}</dd>
-                </>
-              )}
-              {card.powers && card.powers.length > 0 && (
-                <>
-                  <dt>Powers</dt>
-                  <dd>{card.powers.map(p => `— ${p}`).join("\n")}</dd>
-                </>
-              )}
-              {card.traits && card.traits.length > 0 && (
-                <>
-                  <dt>Traits</dt>
-                  <dd>{card.traits.map(t => `— ${t}`).join("\n")}</dd>
-                </>
-              )}
-            </dl>
+            <div className="text-gray-600">No Navatar yet. <a className="text-blue-600 underline" href="/navatar/pick">Pick</a> or <a className="text-blue-600 underline" href="/navatar/upload">Upload</a>.</div>
           )}
+        </div>
 
-          <div style={{ marginTop: 12 }}>
-            <Link to="/navatar/card" className="btn">
-              Edit Card
-            </Link>
+        <div className="flex-1 min-w-[260px] max-w-[480px]">
+          <div className="rounded-2xl bg-white shadow p-4">
+            <div className="text-xl font-semibold mb-3">Character Card</div>
+            {card ? (
+              <dl className="space-y-2 text-sm">
+                <div><dt className="font-medium">Name</dt><dd>{card.name}</dd></div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div><dt className="font-medium">Species</dt><dd>{card.species}</dd></div>
+                  <div><dt className="font-medium">Kingdom</dt><dd>{card.kingdom}</dd></div>
+                </div>
+                <div><dt className="font-medium">Backstory</dt><dd className="whitespace-pre-wrap">{card.backstory}</dd></div>
+                <div><dt className="font-medium">Powers</dt><dd>{(card.powers ?? []).join(', ')}</dd></div>
+                <div><dt className="font-medium">Traits</dt><dd>{(card.traits ?? []).join(', ')}</dd></div>
+            </dl>
+            ) : (
+              <div className="text-gray-600">No card yet. <a className="text-blue-600 underline" href="/navatar/card">Create Card</a>.</div>
+            )}
+            <div className="mt-4">
+              <a href="/navatar/card" className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Edit Card</a>
+            </div>
           </div>
-        </aside>
+        </div>
       </div>
-    </main>
+
+      <div className="mt-8 flex flex-wrap gap-3">
+        <a href="/navatar" className="px-4 py-2 bg-blue-600 text-white rounded">My Navatar</a>
+        <a href="/navatar/card" className="px-4 py-2 bg-blue-100 text-blue-700 rounded">Card</a>
+        <a href="/navatar/pick" className="px-4 py-2 bg-blue-100 text-blue-700 rounded">Pick</a>
+        <a href="/navatar/upload" className="px-4 py-2 bg-blue-100 text-blue-700 rounded">Upload</a>
+        <a href="/navatar/generate" className="px-4 py-2 bg-blue-100 text-blue-700 rounded">Generate</a>
+        <a href="/navatar/mint" className="px-4 py-2 bg-blue-100 text-blue-700 rounded">NFT / Mint</a>
+        <a href="/navatar/marketplace" className="px-4 py-2 bg-blue-100 text-blue-700 rounded">Marketplace</a>
+      </div>
+    </div>
   );
 }

--- a/supabase/migrations/20250912_navatar_alignment.sql
+++ b/supabase/migrations/20250912_navatar_alignment.sql
@@ -1,0 +1,49 @@
+-- One primary avatar per user
+create unique index if not exists unique_primary_avatar_per_user
+on public.avatars (user_id) where is_primary = true;
+
+-- Ensure character_cards belongs to a single user; enable ON CONFLICT (user_id)
+alter table public.character_cards
+  add column if not exists avatar_id uuid,
+  add constraint character_cards_user_unique unique (user_id);
+
+-- FK to avatars (optional but recommended)
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'character_cards_avatar_fkey'
+  ) then
+    alter table public.character_cards
+      add constraint character_cards_avatar_fkey
+      foreign key (avatar_id) references public.avatars(id)
+      on delete set null;
+  end if;
+end $$;
+
+-- RLS policies (idempotent)
+-- Avatars: read public or own; write own
+create policy if not exists "read public or own avatars"
+on public.avatars for select
+using (is_public = true or auth.uid() = user_id);
+
+create policy if not exists "insert own avatars"
+on public.avatars for insert
+with check (auth.uid() = user_id);
+
+create policy if not exists "update own avatars"
+on public.avatars for update
+using (auth.uid() = user_id);
+
+-- Character cards: user can manage own
+create policy if not exists "manage own character_card select"
+on public.character_cards for select
+using (auth.uid() = user_id);
+
+create policy if not exists "manage own character_card insert"
+on public.character_cards for insert
+with check (auth.uid() = user_id);
+
+create policy if not exists "manage own character_card update"
+on public.character_cards for update
+using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add Supabase migration enforcing one primary avatar per user and character card constraints
- introduce `navatarApi` for listing, selecting, uploading avatars and saving cards
- refactor Navatar pages (Pick, My Navatar, Card, Upload) to use Supabase avatars and Tailwind styling

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "created_at" | "id" | "updated_at">' is not assignable to parameter of type 'never[]'.)*

------
https://chatgpt.com/codex/tasks/task_e_68c30a01e3648329b19159187dab551d