### PR TITLE
feat: integrate supabase avatars

### DIFF
--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
-import { getMyAvatar, getCharacterCard, saveCharacterCard } from "../../lib/avatars";
+import { getCurrentAvatar, getMyCard, saveMyCard } from "../../shared/avatars";
 import { useAuthUser } from "../../lib/useAuthUser";
 import "../../styles/navatar.css";
 
@@ -26,18 +26,16 @@ export default function NavatarCardPage() {
     let alive = true;
     (async () => {
       try {
-        const { data: a } = await getMyAvatar(user.id);
+        const a = await getCurrentAvatar();
         if (alive) setAvatar(a || null);
-        if (a?.id) {
-          const { data: c } = await getCharacterCard(a.id);
-          if (c && alive) {
-            setName(c.name ?? "");
-            setSpecies(c.species ?? "");
-            setKingdom(c.kingdom ?? "");
-            setBackstory(c.backstory ?? "");
-            setPowers((c.powers ?? []).join(", "));
-            setTraits((c.traits ?? []).join(", "));
-          }
+        const c = await getMyCard();
+        if (c && alive) {
+          setName(c.name ?? "");
+          setSpecies(c.species ?? "");
+          setKingdom(c.kingdom ?? "");
+          setBackstory(c.backstory ?? "");
+          setPowers((c.powers ?? []).join(", "));
+          setTraits((c.traits ?? []).join(", "));
         }
       } catch (e: any) {
         setErr(e.message ?? "Failed to load");
@@ -68,17 +66,15 @@ export default function NavatarCardPage() {
 
       const powersArr = (powers || "")
         .split(",")
-        .map(s => s.trim())
+        .map((s) => s.trim())
         .filter(Boolean);
 
       const traitsArr = (traits || "")
         .split(",")
-        .map(s => s.trim())
+        .map((s) => s.trim())
         .filter(Boolean);
 
-      const { error } = await saveCharacterCard({
-        userId: user.id,
-        avatarId: avatar.id,
+      await saveMyCard({
         name,
         species,
         kingdom,
@@ -86,11 +82,6 @@ export default function NavatarCardPage() {
         powers: powersArr,
         traits: traitsArr,
       });
-      if (error) {
-        console.error(error);
-        setErr("Could not save your Character Card. Please try again.");
-        return;
-      }
 
       nav("/navatar/mint");
     } catch (e: any) {

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -2,9 +2,8 @@ import { useEffect, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
-import { getMyAvatar, getCharacterCard } from "../../lib/avatars";
+import { getCurrentAvatar, getMyCard, CharacterCard } from "../../shared/avatars";
 import { useAuthUser } from "../../lib/useAuthUser";
-import type { CharacterCard } from "../../lib/types";
 import { Link } from "react-router-dom";
 import "../../styles/navatar.css";
 
@@ -18,12 +17,10 @@ export default function MyNavatarPage() {
     let alive = true;
     (async () => {
       try {
-        const { data: my } = await getMyAvatar(user.id);
+        const my = await getCurrentAvatar();
         if (alive) setAvatar(my);
-        if (my?.id) {
-          const { data: c } = await getCharacterCard(my.id);
-          if (alive) setCard(c || null);
-        }
+        const c = await getMyCard();
+        if (alive) setCard(c || null);
       } catch {
         // ignore
       }

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -1,32 +1,33 @@
-import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
-import { loadPublicNavatars, PublicNavatar } from "../../lib/navatar/publicList";
-import { upsertMyAvatar } from "../../lib/avatars";
+import { pickStaticAvatar } from "../../shared/avatars";
 import { useAuthUser } from "../../lib/useAuthUser";
 import "../../styles/navatar.css";
 
+const images = Object.values(
+  import.meta.glob("/public/navatars/photos/*.{png,jpg,jpeg,webp,gif}", {
+    eager: true,
+    as: "url",
+  })
+) as string[];
+
 export default function PickNavatarPage() {
-  const [items, setItems] = useState<PublicNavatar[]>([]);
   const nav = useNavigate();
   const { user } = useAuthUser();
 
-  useEffect(() => {
-    loadPublicNavatars().then(setItems);
-  }, []);
-
-  async function choose(src: string, name: string) {
+  async function onPick(url: string) {
     try {
       if (!user) {
         alert("Please sign in.");
         return;
       }
-      await upsertMyAvatar(user.id, { image_url: src, name });
+      await pickStaticAvatar(url, url.split("/").pop() || "Navatar");
+      alert("Picked!");
       nav("/navatar");
-    } catch {
-      alert("Could not save Navatar.");
+    } catch (e: any) {
+      alert(`Pick failed: ${e.message}`);
     }
   }
 
@@ -36,17 +37,20 @@ export default function PickNavatarPage() {
       <h1 className="center">Pick Navatar</h1>
       <NavatarTabs />
       <div className="nav-grid">
-        {items.map((it) => (
-          <button
-            key={it.src}
-            className="linklike"
-            onClick={() => choose(it.src, it.name)}
-            aria-label={`Pick ${it.name}`}
-            style={{ background: "none", border: 0, padding: 0, textAlign: "inherit" }}
-          >
-            <NavatarCard src={it.src} title={it.name} />
-          </button>
-        ))}
+        {images.map((url) => {
+          const name = url.split("/").pop() || "Navatar";
+          return (
+            <button
+              key={url}
+              className="linklike"
+              onClick={() => onPick(url)}
+              aria-label={`Pick ${name}`}
+              style={{ background: "none", border: 0, padding: 0, textAlign: "inherit" }}
+            >
+              <NavatarCard src={url} title={name} />
+            </button>
+          );
+        })}
       </div>
     </main>
   );

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
-import { saveNavatar } from "../../lib/navatar";
+import { uploadAvatar } from "../../shared/avatars";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import "../../styles/navatar.css";
 
@@ -27,12 +27,12 @@ export default function UploadNavatarPage() {
     e.preventDefault();
     if (!file) return;
     try {
-      const row = await saveNavatar({ name, base_type: "Animal", file });
+      const row = await uploadAvatar(file, name);
       setActiveNavatarId(row.id);
-      alert("Uploaded ✓");
+      alert("Uploaded!");
       nav("/navatar");
-    } catch {
-      alert("Upload failed");
+    } catch (e: any) {
+      alert(`Upload failed: ${e.message}`);
     }
   }
 

--- a/src/shared/avatars.ts
+++ b/src/shared/avatars.ts
@@ -1,0 +1,113 @@
+import { supabase } from "../lib/supabase-client";
+
+export type AvatarRow = {
+  id: string;
+  user_id: string;
+  name: string | null;
+  image_url: string | null;
+  image_path: string | null;
+  is_primary: boolean | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export async function getUserId() {
+  const { data, error } = await supabase.auth.getUser();
+  if (error || !data.user) throw error ?? new Error("Not signed in");
+  return data.user.id;
+}
+
+export async function getCurrentAvatar(): Promise<AvatarRow | null> {
+  const userId = await getUserId();
+  const { data, error } = await supabase
+    .from("avatars")
+    .select("*")
+    .eq("user_id", userId)
+    .order("is_primary", { ascending: false })
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+export async function upsertPrimaryAvatar(fields: Partial<AvatarRow>) {
+  const userId = await getUserId();
+  const payload = {
+    user_id: userId,
+    is_primary: true,
+    updated_at: new Date().toISOString(),
+    ...fields,
+  };
+  const { data, error } = await supabase
+    .from("avatars")
+    .upsert(payload, { onConflict: "user_id" })
+    .select()
+    .single();
+  if (error) throw error;
+  return data as AvatarRow;
+}
+
+/** Picking from static /public/navatars/photos */
+export async function pickStaticAvatar(imageUrl: string, name?: string) {
+  return upsertPrimaryAvatar({
+    name: name ?? "Navatar",
+    image_url: imageUrl,
+    image_path: null,
+  });
+}
+
+/** Uploading a file to Storage then upserting DB row */
+export async function uploadAvatar(file: File, name?: string) {
+  const userId = await getUserId();
+  const path = `${userId}/${crypto.randomUUID()}-${file.name}`;
+  const { error: upErr } = await supabase.storage
+    .from("avatars")
+    .upload(path, file, { upsert: false, contentType: file.type });
+  if (upErr) throw upErr;
+
+  const { data: pub } = supabase.storage.from("avatars").getPublicUrl(path);
+  return upsertPrimaryAvatar({
+    name: name ?? file.name,
+    image_url: pub.publicUrl,
+    image_path: path,
+  });
+}
+
+/** Character card */
+export type CharacterCard = {
+  name?: string;
+  species?: string;
+  kingdom?: string;
+  backstory?: string;
+  powers?: string[];
+  traits?: string[];
+};
+
+export async function getMyCard() {
+  const userId = await getUserId();
+  const { data, error } = await supabase
+    .from("character_cards")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+export async function saveMyCard(card: CharacterCard) {
+  const userId = await getUserId();
+  const payload = {
+    user_id: userId,
+    ...card,
+    updated_at: new Date().toISOString(),
+  };
+  const { data, error } = await supabase
+    .from("character_cards")
+    .upsert(payload, { onConflict: "user_id" })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+


### PR DESCRIPTION
## Summary
- add shared Supabase avatar helpers for picking, uploading, and character cards
- load static avatar images directly from `/public/navatars/photos`
- wire navatar pages to use new helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<...>' is not assignable to parameter of type 'never[]')*


------
https://chatgpt.com/codex/tasks/task_e_68c64a6b9378832989ca72bd3ee7c6e0