### PR TITLE
Hide Navatar Pills on Mobile, Keep Breadcrumbs

### DIFF
--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -8,6 +8,13 @@
   margin: 10px auto 18px;
 }
 
+/* Hide pills on small screens */
+@media (max-width: 767px) {
+  .nav-tabs {
+    display: none;
+  }
+}
+
 .pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- hide Navatar tab pills on small screens via CSS

## Testing
- `npm run typecheck` *(fails: Argument of type 'Omit<...> is not assignable to parameter of type 'never[]')*

------
https://chatgpt.com/codex/tasks/task_e_68c798233f1c832997e907dc97544511