### PR TITLE
Hide Navatar pills on mobile

### DIFF
--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -14,7 +14,7 @@ const TABS = [
 export default function NavatarTabs({ sub = false }: { sub?: boolean }) {
   const { pathname } = useLocation();
   return (
-    <nav className={`nav-tabs${sub ? " nav-tabs--sub" : ""}`} aria-label="Navatar actions">
+    <nav className={`nav-tabs nav-pills${sub ? " nav-tabs--sub" : ""}`} aria-label="Navatar actions">
       {TABS.map(t => {
         const active =
           t.to === "/navatar" ? pathname === "/navatar" : pathname.startsWith(t.to);

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -31,6 +31,13 @@ export default function MyNavatarPage() {
     };
   }, [user?.id]);
 
+  useEffect(() => {
+    document.body.classList.add('page-navatar-home');
+    return () => {
+      document.body.classList.remove('page-navatar-home');
+    };
+  }, []);
+
   return (
     <main className="container page-pad">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -8,6 +8,19 @@
   margin: 10px auto 18px;
 }
 
+/* Hide pills on mobile; show on Navatar home */
+@media (max-width: 768px) {
+  .nav-pills {
+    display: none;
+  }
+
+  body.page-navatar-home .nav-pills {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+
 .pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- hide Navatar navigation pills on screens ≤768px
- restore pills on mobile for Navatar home via body class override

## Testing
- `npm run typecheck` *(fails: Argument of type ... is not assignable to parameter of type 'never')*


------
https://chatgpt.com/codex/tasks/task_e_68c79c0213248329809504af6174557f