### PR TITLE
feat(navatar): polish hub navigation and placeholder

### DIFF
--- a/src/components/AvatarPlaceholder.tsx
+++ b/src/components/AvatarPlaceholder.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function AvatarPlaceholder({ title = 'No photo' }: { title?: string }) {
+  // Inline SVG (no binary asset)
+  return (
+    <div
+      aria-label={title}
+      style={{
+        width: '100%',
+        aspectRatio: '3/4',
+        display: 'grid',
+        placeItems: 'center',
+        borderRadius: 16,
+        background: 'linear-gradient(180deg,#f5f8ff,#eef3ff)',
+        border: '1px solid #e3e9ff',
+        color: '#94a3b8',
+        fontWeight: 700,
+      }}
+    >
+      {title}
+    </div>
+  );
+}

--- a/src/components/BackToMyNavatar.tsx
+++ b/src/components/BackToMyNavatar.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function BackToMyNavatar() {
+  return (
+    <div style={{ margin: '8px 0 16px' }}>
+      <Link to="/navatar" style={{ fontWeight: 700, color: '#1f3db3', textDecoration: 'none' }}>
+        ← Back to My Navatar
+      </Link>
+    </div>
+  );
+}

--- a/src/components/NavatarCard.tsx
+++ b/src/components/NavatarCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import AvatarPlaceholder from './AvatarPlaceholder';
 
 type Props = {
   src?: string | null;
@@ -14,7 +15,7 @@ export default function NavatarCard({ src, title = "My Navatar", subtitle, class
         {src ? (
           <img src={src} alt={title} />
         ) : (
-          <div className="nav-card__placeholder">No photo</div>
+          <AvatarPlaceholder title={title} />
         )}
       </div>
       <figcaption className="nav-card__cap">

--- a/src/components/NavatarTabs.module.css
+++ b/src/components/NavatarTabs.module.css
@@ -1,0 +1,26 @@
+/* Show on desktop/tablet, hide on phones */
+.tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 8px 0 20px;
+}
+
+.pill {
+  display: inline-block;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: #eef3ff;
+  color: #1f3db3;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid #d9e3ff;
+}
+
+.pill:hover { background: #e6eeff; }
+.active { background: #2f54eb; color: #fff; }
+
+/* mobile: hide */
+@media (max-width: 768px) {
+  .tabs { display: none; }
+}

--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -1,25 +1,31 @@
-import React from "react";
-import { Link, useLocation } from "react-router-dom";
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import styles from './NavatarTabs.module.css';
 
-const TABS = [
-  { to: "/navatar", label: "My Navatar" },
-  { to: "/navatar/card", label: "Card" },
-  { to: "/navatar/pick", label: "Pick" },
-  { to: "/navatar/upload", label: "Upload" },
-  { to: "/navatar/generate", label: "Generate" },
-  { to: "/navatar/mint", label: "NFT / Mint" },
-  { to: "/navatar/marketplace", label: "Marketplace" },
-];
-
-export default function NavatarTabs({ sub = false }: { sub?: boolean }) {
+export default function NavatarTabs() {
   const { pathname } = useLocation();
+  const base = '/navatar';
+
+  const tabs = [
+    { to: `${base}`, label: 'My Navatar', match: (p:string) => p === base || p === `${base}/` },
+    { to: `${base}/card`, label: 'Card' },
+    { to: `${base}/pick`, label: 'Pick' },
+    { to: `${base}/upload`, label: 'Upload' },
+    { to: `${base}/generate`, label: 'Generate' },
+    { to: `${base}/mint`, label: 'NFT / Mint' },
+    { to: `${base}/marketplace`, label: 'Marketplace' },
+  ];
+
   return (
-    <nav className={`nav-tabs nav-pills${sub ? " nav-tabs--sub" : ""}`} aria-label="Navatar actions">
-      {TABS.map(t => {
-        const active =
-          t.to === "/navatar" ? pathname === "/navatar" : pathname.startsWith(t.to);
+    <nav className={styles.tabs}>
+      {tabs.map(t => {
+        const active = t.match ? t.match(pathname) : pathname.startsWith(t.to);
         return (
-          <Link key={t.to} to={t.to} className={`pill ${active ? "pill--active" : ""}`}>
+          <Link
+            key={t.to}
+            to={t.to}
+            className={`${styles.pill} ${active ? styles.active : ''}`}
+          >
             {t.label}
           </Link>
         );

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
+import BackToMyNavatar from "../../components/BackToMyNavatar";
 import { getMyAvatar, getMyCharacterCard, saveCharacterCard } from "../../lib/navatar";
 import { useAuthUser } from "../../lib/useAuthUser";
 import "../../styles/navatar.css";
@@ -97,7 +97,7 @@ export default function NavatarCardPage() {
       <main className="container page-pad">
         <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
         <h1 className="center page-title">Character Card</h1>
-        <NavatarTabs sub />
+        <BackToMyNavatar />
         <p>Loading…</p>
       </main>
     );
@@ -107,7 +107,7 @@ export default function NavatarCardPage() {
     <main className="container page-pad">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
       <h1 className="center page-title">Character Card</h1>
-      <NavatarTabs sub />
+      <BackToMyNavatar />
       <form className="form-card" onSubmit={onSave} style={{ margin: "16px auto" }}>
         {err && <p className="Error">{err}</p>}
 

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
+import BackToMyNavatar from "../../components/BackToMyNavatar";
 import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import "../../styles/navatar.css";
@@ -43,7 +43,7 @@ export default function GenerateNavatarPage() {
         items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Describe & Generate" }]}
       />
       <h1 className="center">Describe &amp; Generate</h1>
-      <NavatarTabs />
+      <BackToMyNavatar />
       <form
         onSubmit={onSave}
         style={{ maxWidth: 520, margin: "16px auto", display: "grid", justifyItems: "center", gap: 12 }}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -31,13 +31,6 @@ export default function MyNavatarPage() {
     };
   }, [user?.id]);
 
-  useEffect(() => {
-    document.body.classList.add('page-navatar-home');
-    return () => {
-      document.body.classList.remove('page-navatar-home');
-    };
-  }, []);
-
   return (
     <main className="container page-pad">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />

--- a/src/pages/navatar/marketplace.tsx
+++ b/src/pages/navatar/marketplace.tsx
@@ -1,5 +1,5 @@
 import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
+import BackToMyNavatar from "../../components/BackToMyNavatar";
 import "../../styles/navatar.css";
 
 export default function NavatarMarketplacePage() {
@@ -9,7 +9,7 @@ export default function NavatarMarketplacePage() {
         items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Marketplace" }]}
       />
       <h1 className="center">Marketplace</h1>
-      <NavatarTabs />
+      <BackToMyNavatar />
       <div className="center" style={{ maxWidth: 560, margin: "16px auto" }}>
         <p>Mockups for tees, plushies, stickers and more are coming soon.</p>
         <p>You’ll be able to place your Navatar on products here, then purchase on the Marketplace.</p>

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
+import BackToMyNavatar from "../../components/BackToMyNavatar";
 import { getCardForAvatar, navatarImageUrl } from "../../lib/navatar";
 import { getActiveNavatarId } from "../../lib/localNavatar";
 import { supabase } from "../../lib/supabase-client";
@@ -32,7 +32,7 @@ export default function MintNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "NFT / Mint" }]} />
       <h1 className="center">NFT / Mint</h1>
-      <NavatarTabs />
+      <BackToMyNavatar />
       <p style={{ textAlign: "center", maxWidth: 560, margin: "8px auto 20px" }}>
         Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.
       </p>

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
-import { listNavatars, pickNavatar } from "../../lib/navatar";
+import BackToMyNavatar from "../../components/BackToMyNavatar";
+import { pickNavatar } from "../../lib/navatar";
+import { listNavatarImages } from "../../shared/storage";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useAuthUser } from "../../lib/useAuthUser";
 import "../../styles/navatar.css";
@@ -14,7 +15,7 @@ export default function PickNavatarPage() {
   const { user } = useAuthUser();
 
   useEffect(() => {
-    listNavatars().then(setItems).catch(() => setItems([]));
+    listNavatarImages().then(setItems).catch(() => setItems([]));
   }, []);
 
   async function choose(item: { path: string; name: string }) {
@@ -35,7 +36,7 @@ export default function PickNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Pick" }]} />
       <h1 className="center">Pick Navatar</h1>
-      <NavatarTabs />
+      <BackToMyNavatar />
       <div className="nav-grid">
         {items.map(it => (
           <button

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
+import BackToMyNavatar from "../../components/BackToMyNavatar";
 import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import "../../styles/navatar.css";
@@ -40,7 +40,7 @@ export default function UploadNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Upload" }]} />
       <h1 className="center">Upload a Navatar</h1>
-      <NavatarTabs />
+      <BackToMyNavatar />
       <form
         onSubmit={onSave}
         style={{ display: "grid", justifyItems: "center", gap: 12, maxWidth: 480, margin: "16px auto" }}

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,0 +1,25 @@
+import { supabase } from '../lib/supabase-client';
+
+const IMAGE_EXT = ['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg'];
+
+export async function listNavatarImages() {
+  const path = 'navatars';
+  const { data, error } = await supabase
+    .storage
+    .from('avatars')
+    .list(path, { limit: 200, sortBy: { column: 'name', order: 'asc' } });
+
+  if (error) throw error;
+
+  return (data ?? [])
+    .filter(item => item.id) // keep files only
+    .filter(item => {
+      const n = item.name.toLowerCase();
+      return IMAGE_EXT.some(ext => n.endsWith(ext));
+    })
+    .map(item => {
+      const fullPath = `${path}/${item.name}`;
+      const { data: pub } = supabase.storage.from('avatars').getPublicUrl(fullPath);
+      return { name: item.name, url: pub.publicUrl, path: fullPath };
+    });
+}

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,26 +1,4 @@
-/* --- Pills: always horizontal & centered, wrap if needed --- */
-.nav-tabs {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;       /* stays horizontal; wraps when space runs out */
-  margin: 10px auto 18px;
-}
-
-/* Hide pills on mobile; show on Navatar home */
-@media (max-width: 768px) {
-  .nav-pills {
-    display: none;
-  }
-
-  body.page-navatar-home .nav-pills {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-}
-
+/* --- Pills shared across Navatar pages --- */
 .pill {
   display: inline-flex;
   align-items: center;
@@ -92,19 +70,6 @@
 .link,
 .btn {
   color: var(--nv-blue-600);
-}
-
-/* Sub-page pill bar: hidden on mobile, visible ≥ md */
-.nav-tabs--sub {
-  display: none;
-}
-@media (min-width: 768px) {
-  .nav-tabs--sub {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-  }
 }
 
 /* Form spacing */


### PR DESCRIPTION
## Summary
- show Navatar hub pills on desktop while hiding them on mobile
- add breadcrumb back link on Navatar subpages
- filter Navatar pick list to images only and add placeholder for missing avatar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a15450608329a52e659b99109b9b