### PR TITLE
feat: toggle navatar tabs by page context

### DIFF
--- a/src/components/NavatarTabs.module.css
+++ b/src/components/NavatarTabs.module.css
@@ -1,9 +1,9 @@
-/* Show on desktop/tablet, hide on phones */
 .tabs {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
   margin: 8px 0 20px;
+  align-items: center;
 }
 
 .pill {
@@ -20,7 +20,17 @@
 .pill:hover { background: #e6eeff; }
 .active { background: #2f54eb; color: #fff; }
 
-/* mobile: hide */
-@media (max-width: 768px) {
-  .tabs { display: none; }
+.hideOnMobile,
+.showOnMobile {
+  display: flex;
+}
+
+/* Mobile behavior */
+@media (max-width: 640px) {
+  .hideOnMobile {
+    display: none;
+  }
+  .showOnMobile {
+    display: flex;
+  }
 }

--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -1,35 +1,42 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styles from './NavatarTabs.module.css';
 
-export default function NavatarTabs() {
-  const { pathname } = useLocation();
-  const base = '/navatar';
+type TabKey = 'my' | 'card' | 'pick' | 'upload' | 'generate' | 'mint' | 'marketplace';
 
+export function NavatarTabs({
+  active,
+  context = 'subpage',
+}: {
+  active: TabKey;
+  context?: 'hub' | 'subpage';
+}) {
+  const mobileClass = context === 'hub' ? styles.showOnMobile : styles.hideOnMobile;
+
+  const base = '/navatar';
   const tabs = [
-    { to: `${base}`, label: 'My Navatar', match: (p:string) => p === base || p === `${base}/` },
-    { to: `${base}/card`, label: 'Card' },
-    { to: `${base}/pick`, label: 'Pick' },
-    { to: `${base}/upload`, label: 'Upload' },
-    { to: `${base}/generate`, label: 'Generate' },
-    { to: `${base}/mint`, label: 'NFT / Mint' },
-    { to: `${base}/marketplace`, label: 'Marketplace' },
-  ];
+    { key: 'my', to: `${base}`, label: 'My Navatar' },
+    { key: 'card', to: `${base}/card`, label: 'Card' },
+    { key: 'pick', to: `${base}/pick`, label: 'Pick' },
+    { key: 'upload', to: `${base}/upload`, label: 'Upload' },
+    { key: 'generate', to: `${base}/generate`, label: 'Generate' },
+    { key: 'mint', to: `${base}/mint`, label: 'NFT / Mint' },
+    { key: 'marketplace', to: `${base}/marketplace`, label: 'Marketplace' },
+  ] as const;
 
   return (
-    <nav className={styles.tabs}>
-      {tabs.map(t => {
-        const active = t.match ? t.match(pathname) : pathname.startsWith(t.to);
-        return (
-          <Link
-            key={t.to}
-            to={t.to}
-            className={`${styles.pill} ${active ? styles.active : ''}`}
-          >
-            {t.label}
-          </Link>
-        );
-      })}
+    <nav className={`${styles.tabs} ${mobileClass}`}>
+      {tabs.map(t => (
+        <Link
+          key={t.key}
+          to={t.to}
+          className={`${styles.pill} ${active === t.key ? styles.active : ''}`}
+        >
+          {t.label}
+        </Link>
+      ))}
     </nav>
   );
 }
+
+export default NavatarTabs;

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
+import { NavatarTabs } from "../../components/NavatarTabs";
 import { getMyAvatar, getMyCharacterCard, saveCharacterCard } from "../../lib/navatar";
 import { useAuthUser } from "../../lib/useAuthUser";
 import "../../styles/navatar.css";
@@ -107,6 +108,7 @@ export default function NavatarCardPage() {
     <main className="container page-pad">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
       <h1 className="center page-title">Character Card</h1>
+      <NavatarTabs active="card" context="subpage" />
       <BackToMyNavatar />
       <form className="form-card" onSubmit={onSave} style={{ margin: "16px auto" }}>
         {err && <p className="Error">{err}</p>}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
+import { NavatarTabs } from "../../components/NavatarTabs";
 import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import "../../styles/navatar.css";
@@ -43,6 +44,7 @@ export default function GenerateNavatarPage() {
         items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Describe & Generate" }]}
       />
       <h1 className="center">Describe &amp; Generate</h1>
+      <NavatarTabs active="generate" context="subpage" />
       <BackToMyNavatar />
       <form
         onSubmit={onSave}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarTabs from "../../components/NavatarTabs";
+import { NavatarTabs } from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
 import { getMyAvatar, getMyCharacterCard } from "../../lib/navatar";
 import type { CharacterCard } from "../../lib/navatar";
@@ -35,7 +35,7 @@ export default function MyNavatarPage() {
     <main className="container page-pad">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
       <h1 className="center page-title">My Navatar</h1>
-      <NavatarTabs />
+      <NavatarTabs active="my" context="hub" />
       <div className="nv-hub-grid" style={{ marginTop: 8 }}>
         <section>
           <div className="nv-panel">

--- a/src/pages/navatar/marketplace.tsx
+++ b/src/pages/navatar/marketplace.tsx
@@ -1,5 +1,6 @@
 import Breadcrumbs from "../../components/Breadcrumbs";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
+import { NavatarTabs } from "../../components/NavatarTabs";
 import "../../styles/navatar.css";
 
 export default function NavatarMarketplacePage() {
@@ -9,6 +10,7 @@ export default function NavatarMarketplacePage() {
         items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Marketplace" }]}
       />
       <h1 className="center">Marketplace</h1>
+      <NavatarTabs active="marketplace" context="subpage" />
       <BackToMyNavatar />
       <div className="center" style={{ maxWidth: 560, margin: "16px auto" }}>
         <p>Mockups for tees, plushies, stickers and more are coming soon.</p>

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
+import { NavatarTabs } from "../../components/NavatarTabs";
 import { getCardForAvatar, navatarImageUrl } from "../../lib/navatar";
 import { getActiveNavatarId } from "../../lib/localNavatar";
 import { supabase } from "../../lib/supabase-client";
@@ -32,6 +33,7 @@ export default function MintNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "NFT / Mint" }]} />
       <h1 className="center">NFT / Mint</h1>
+      <NavatarTabs active="mint" context="subpage" />
       <BackToMyNavatar />
       <p style={{ textAlign: "center", maxWidth: 560, margin: "8px auto 20px" }}>
         Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
+import { NavatarTabs } from "../../components/NavatarTabs";
 import { pickNavatar } from "../../lib/navatar";
 import { listNavatarImages } from "../../shared/storage";
 import { setActiveNavatarId } from "../../lib/localNavatar";
@@ -36,6 +37,7 @@ export default function PickNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Pick" }]} />
       <h1 className="center">Pick Navatar</h1>
+      <NavatarTabs active="pick" context="subpage" />
       <BackToMyNavatar />
       <div className="nav-grid">
         {items.map(it => (

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
+import { NavatarTabs } from "../../components/NavatarTabs";
 import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import "../../styles/navatar.css";
@@ -40,6 +41,7 @@ export default function UploadNavatarPage() {
     <main className="container">
       <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Upload" }]} />
       <h1 className="center">Upload a Navatar</h1>
+      <NavatarTabs active="upload" context="subpage" />
       <BackToMyNavatar />
       <form
         onSubmit={onSave}


### PR DESCRIPTION
## Summary
- make NavatarTabs accept active and page context to control mobile visibility
- scope NavatarTabs styles with showOnMobile/hideOnMobile helpers
- render tabs across Navatar sub-pages with correct context

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck` (fails: Argument of type 'Omit<...> is not assignable ...)

------
https://chatgpt.com/codex/tasks/task_e_68c7a506a0848329a2d1c1259527326b