### PR TITLE
Refactor Navatar tabs for desktop centering and mobile toggle

### DIFF
--- a/src/components/NavatarTabs.module.css
+++ b/src/components/NavatarTabs.module.css
@@ -1,36 +1,63 @@
-.tabs {
+/* Container keeps pills centered, wraps nicely, and adds breathing room. */
+.nvTabsWrap {
+  margin: 10px auto 6px;
+  max-width: 980px;
+  padding: 0 16px;
+}
+
+.nvTabs {
+  list-style: none;
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  margin: 8px 0 20px;
-  align-items: center;
+  justify-content: center;
+  gap: 12px 14px; /* row x column gap */
+  margin: 0;
+  padding: 0;
 }
 
-.pill {
-  display: inline-block;
-  padding: 10px 16px;
-  border-radius: 999px;
-  background: #eef3ff;
-  color: #1f3db3;
-  font-weight: 600;
-  text-decoration: none;
-  border: 1px solid #d9e3ff;
-}
-
-.pill:hover { background: #e6eeff; }
-.active { background: #2f54eb; color: #fff; }
-
-.hideOnMobile,
-.showOnMobile {
+/* Each pill sits in its own li so gaps stay even */
+.nvTabItem {
   display: flex;
 }
 
-/* Mobile behavior */
+/* Base pill */
+.pill,
+.pillActive {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  min-height: 40px;
+  border-radius: 9999px;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+  box-shadow: inset 0 -2px 0 rgba(0,0,0,0.06);
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+/* Default (inactive) look */
+.pill {
+  background: #eef2ff;         /* very light indigo */
+  color: #1e3a8a;               /* indigo-900 */
+  border: 1px solid #e5e7eb;    /* gray-200 */
+}
+.pill:hover {
+  box-shadow: inset 0 -2px 0 rgba(0,0,0,0.08), 0 1px 4px rgba(0,0,0,0.06);
+  transform: translateY(-1px);
+}
+
+/* Active page */
+.pillActive {
+  background: #3b82f6;          /* blue-500 */
+  color: white;
+  border: 1px solid #2563eb;     /* blue-600 */
+}
+
+/* Keep desktop pills visible everywhere, hide only on mobile for subpages */
 @media (max-width: 640px) {
-  .hideOnMobile {
+  .mobileHidden {
     display: none;
-  }
-  .showOnMobile {
-    display: flex;
   }
 }

--- a/src/components/NavatarTabs.tsx
+++ b/src/components/NavatarTabs.tsx
@@ -1,42 +1,42 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import styles from './NavatarTabs.module.css';
 
-type TabKey = 'my' | 'card' | 'pick' | 'upload' | 'generate' | 'mint' | 'marketplace';
+type Context = 'hub' | 'subpage';
 
-export function NavatarTabs({
-  active,
-  context = 'subpage',
-}: {
-  active: TabKey;
-  context?: 'hub' | 'subpage';
-}) {
-  const mobileClass = context === 'hub' ? styles.showOnMobile : styles.hideOnMobile;
+export default function NavatarTabs({ context = 'hub' }: { context?: Context }) {
+  const { pathname } = useLocation();
 
-  const base = '/navatar';
   const tabs = [
-    { key: 'my', to: `${base}`, label: 'My Navatar' },
-    { key: 'card', to: `${base}/card`, label: 'Card' },
-    { key: 'pick', to: `${base}/pick`, label: 'Pick' },
-    { key: 'upload', to: `${base}/upload`, label: 'Upload' },
-    { key: 'generate', to: `${base}/generate`, label: 'Generate' },
-    { key: 'mint', to: `${base}/mint`, label: 'NFT / Mint' },
-    { key: 'marketplace', to: `${base}/marketplace`, label: 'Marketplace' },
-  ] as const;
+    { to: '/navatar', label: 'My Navatar' },
+    { to: '/navatar/card', label: 'Card' },
+    { to: '/navatar/pick', label: 'Pick' },
+    { to: '/navatar/upload', label: 'Upload' },
+    { to: '/navatar/generate', label: 'Generate' },
+    { to: '/navatar/mint', label: 'NFT / Mint' },
+    { to: '/navatar/marketplace', label: 'Marketplace' },
+  ];
 
   return (
-    <nav className={`${styles.tabs} ${mobileClass}`}>
-      {tabs.map(t => (
-        <Link
-          key={t.key}
-          to={t.to}
-          className={`${styles.pill} ${active === t.key ? styles.active : ''}`}
-        >
-          {t.label}
-        </Link>
-      ))}
+    <nav
+      className={[
+        styles.nvTabsWrap,
+        context === 'subpage' ? styles.mobileHidden : '',
+      ].join(' ')}
+      aria-label="Navatar pages"
+    >
+      <ul className={styles.nvTabs}>
+        {tabs.map(t => {
+          const active = pathname === t.to;
+          return (
+            <li key={t.to} className={styles.nvTabItem}>
+              <Link className={active ? styles.pillActive : styles.pill} to={t.to}>
+                {t.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
     </nav>
   );
 }
 
-export default NavatarTabs;

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
-import { NavatarTabs } from "../../components/NavatarTabs";
+import NavatarTabs from "../../components/NavatarTabs";
 import { getMyAvatar, getMyCharacterCard, saveCharacterCard } from "../../lib/navatar";
 import { useAuthUser } from "../../lib/useAuthUser";
 import "../../styles/navatar.css";
@@ -96,8 +96,10 @@ export default function NavatarCardPage() {
   if (loading) {
     return (
       <main className="container page-pad">
-        <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
-        <h1 className="center page-title">Character Card</h1>
+        <div className="bcRow">
+          <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
+        </div>
+        <h1 className="pageTitle">Character Card</h1>
         <BackToMyNavatar />
         <p>Loading…</p>
       </main>
@@ -106,9 +108,11 @@ export default function NavatarCardPage() {
 
   return (
     <main className="container page-pad">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
-      <h1 className="center page-title">Character Card</h1>
-      <NavatarTabs active="card" context="subpage" />
+      <div className="bcRow">
+        <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Card" }]} />
+      </div>
+      <h1 className="pageTitle">Character Card</h1>
+      <NavatarTabs context="subpage" />
       <BackToMyNavatar />
       <form className="form-card" onSubmit={onSave} style={{ margin: "16px auto" }}>
         {err && <p className="Error">{err}</p>}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
-import { NavatarTabs } from "../../components/NavatarTabs";
+import NavatarTabs from "../../components/NavatarTabs";
 import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import "../../styles/navatar.css";
@@ -40,11 +40,13 @@ export default function GenerateNavatarPage() {
 
   return (
     <main className="container">
-      <Breadcrumbs
-        items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Describe & Generate" }]}
-      />
-      <h1 className="center">Describe &amp; Generate</h1>
-      <NavatarTabs active="generate" context="subpage" />
+      <div className="bcRow">
+        <Breadcrumbs
+          items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Describe & Generate" }]}
+        />
+      </div>
+      <h1 className="pageTitle">Describe &amp; Generate</h1>
+      <NavatarTabs context="subpage" />
       <BackToMyNavatar />
       <form
         onSubmit={onSave}

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
-import { NavatarTabs } from "../../components/NavatarTabs";
+import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
 import { getMyAvatar, getMyCharacterCard } from "../../lib/navatar";
 import type { CharacterCard } from "../../lib/navatar";
@@ -33,9 +33,11 @@ export default function MyNavatarPage() {
 
   return (
     <main className="container page-pad">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
-      <h1 className="center page-title">My Navatar</h1>
-      <NavatarTabs active="my" context="hub" />
+      <div className="bcRow">
+        <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }]} />
+      </div>
+      <h1 className="pageTitle">My Navatar</h1>
+      <NavatarTabs context="hub" />
       <div className="nv-hub-grid" style={{ marginTop: 8 }}>
         <section>
           <div className="nv-panel">

--- a/src/pages/navatar/marketplace.tsx
+++ b/src/pages/navatar/marketplace.tsx
@@ -1,16 +1,18 @@
 import Breadcrumbs from "../../components/Breadcrumbs";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
-import { NavatarTabs } from "../../components/NavatarTabs";
+import NavatarTabs from "../../components/NavatarTabs";
 import "../../styles/navatar.css";
 
 export default function NavatarMarketplacePage() {
   return (
     <main className="container">
-      <Breadcrumbs
-        items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Marketplace" }]}
-      />
-      <h1 className="center">Marketplace</h1>
-      <NavatarTabs active="marketplace" context="subpage" />
+      <div className="bcRow">
+        <Breadcrumbs
+          items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Marketplace" }]}
+        />
+      </div>
+      <h1 className="pageTitle">Marketplace</h1>
+      <NavatarTabs context="subpage" />
       <BackToMyNavatar />
       <div className="center" style={{ maxWidth: 560, margin: "16px auto" }}>
         <p>Mockups for tees, plushies, stickers and more are coming soon.</p>

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
-import { NavatarTabs } from "../../components/NavatarTabs";
+import NavatarTabs from "../../components/NavatarTabs";
 import { getCardForAvatar, navatarImageUrl } from "../../lib/navatar";
 import { getActiveNavatarId } from "../../lib/localNavatar";
 import { supabase } from "../../lib/supabase-client";
@@ -31,9 +31,11 @@ export default function MintNavatarPage() {
 
   return (
     <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "NFT / Mint" }]} />
-      <h1 className="center">NFT / Mint</h1>
-      <NavatarTabs active="mint" context="subpage" />
+      <div className="bcRow">
+        <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "NFT / Mint" }]} />
+      </div>
+      <h1 className="pageTitle">NFT / Mint</h1>
+      <NavatarTabs context="subpage" />
       <BackToMyNavatar />
       <p style={{ textAlign: "center", maxWidth: 560, margin: "8px auto 20px" }}>
         Coming soon: mint your Navatar on-chain. In the meantime, make merch with your Navatar on the Marketplace.

--- a/src/pages/navatar/pick.tsx
+++ b/src/pages/navatar/pick.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
-import { NavatarTabs } from "../../components/NavatarTabs";
+import NavatarTabs from "../../components/NavatarTabs";
 import { pickNavatar } from "../../lib/navatar";
 import { listNavatarImages } from "../../shared/storage";
 import { setActiveNavatarId } from "../../lib/localNavatar";
@@ -35,9 +35,11 @@ export default function PickNavatarPage() {
 
   return (
     <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Pick" }]} />
-      <h1 className="center">Pick Navatar</h1>
-      <NavatarTabs active="pick" context="subpage" />
+      <div className="bcRow">
+        <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Pick" }]} />
+      </div>
+      <h1 className="pageTitle">Pick Navatar</h1>
+      <NavatarTabs context="subpage" />
       <BackToMyNavatar />
       <div className="nav-grid">
         {items.map(it => (

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
-import { NavatarTabs } from "../../components/NavatarTabs";
+import NavatarTabs from "../../components/NavatarTabs";
 import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import "../../styles/navatar.css";
@@ -39,9 +39,11 @@ export default function UploadNavatarPage() {
 
   return (
     <main className="container">
-      <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Upload" }]} />
-      <h1 className="center">Upload a Navatar</h1>
-      <NavatarTabs active="upload" context="subpage" />
+      <div className="bcRow">
+        <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Upload" }]} />
+      </div>
+      <h1 className="pageTitle">Upload a Navatar</h1>
+      <NavatarTabs context="subpage" />
       <BackToMyNavatar />
       <form
         onSubmit={onSave}

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -1,3 +1,15 @@
+/* Heading spacing */
+.pageTitle {
+  margin-bottom: 6px;
+  text-align: center;
+}
+
+.bcRow {
+  margin: 0 auto 6px;
+  max-width: 980px;
+  padding: 0 16px;
+}
+
 /* --- Pills shared across Navatar pages --- */
 .pill {
   display: inline-flex;
@@ -65,6 +77,7 @@
 }
 
 /* Keep existing colors; enforce blue titles/links for the new page */
+.pageTitle,
 .page-title,
 .panel-title,
 .link,


### PR DESCRIPTION
## Summary
- Revamp `NavatarTabs` to compute active link from location and toggle mobile visibility via CSS class
- Introduce new tab layout styles for centered, evenly spaced pills with crisp active states
- Add shared `pageTitle`/`bcRow` spacing and update Navatar pages to apply new styling

## Testing
- ⚠️ `npm test` (script missing)
- ❌ `npm run typecheck` (fails: Argument of type 'Omit<...>' is not assignable)


------
https://chatgpt.com/codex/tasks/task_e_68c7a81f357c832986f923ee4c2a1aca