### PR TITLE
Add local NaturBank demo

### DIFF
--- a/src/components/naturbank/BalanceCard.tsx
+++ b/src/components/naturbank/BalanceCard.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { fmtNatur } from '../../shared/naturbank/format';
+
+export default function BalanceCard({ balance }: { balance: number }) {
+  return (
+    <section className="card">
+      <h3 className="h3">Balance</h3>
+      <div className="center big">{fmtNatur(balance)}</div>
+      <p className="hint">Starting demo balance: 120. Transactions apply on top.</p>
+    </section>
+  );
+}

--- a/src/components/naturbank/TransactionsCard.tsx
+++ b/src/components/naturbank/TransactionsCard.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { NaturTxn } from '../../shared/naturbank/types';
+import { timeAgo } from '../../shared/naturbank/format';
+
+export default function TransactionsCard({ txns }: { txns: NaturTxn[] }) {
+  return (
+    <section className="card">
+      <h3 className="h3">Transactions</h3>
+
+      {txns.length === 0 ? (
+        <p className="muted">No activity yet. Use the grant/spend buttons to simulate flow.</p>
+      ) : (
+        <div className="txn-table">
+          <div className="txn-head">
+            <div>Date</div><div>Type</div><div>Amount</div><div>Note</div>
+          </div>
+          {txns.map(t => (
+            <div className="txn-row" key={t.id}>
+              <div>{timeAgo(t.ts)}</div>
+              <div className={t.type === 'grant' ? 'pill green' : 'pill gray'}>
+                {t.type === 'grant' ? 'Grant' : 'Spend'}
+              </div>
+              <div>{t.type === 'grant' ? `+${t.amount}` : `-${t.amount}`}</div>
+              <div className="muted">{t.note || '—'}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/naturbank/WalletCard.tsx
+++ b/src/components/naturbank/WalletCard.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { NaturWallet } from '../../shared/naturbank/types';
+
+type Props = {
+  wallet: NaturWallet;
+  onSave: (next: NaturWallet) => void;
+  onGrant: () => void;
+  onSpend: () => void;
+};
+
+export default function WalletCard({ wallet, onSave, onGrant, onSpend }: Props) {
+  const [label, setLabel] = useState(wallet.label);
+  const [addr, setAddr] = useState(wallet.address);
+
+  return (
+    <section className="card">
+      <h3 className="h3">Wallet</h3>
+      <div className="row">
+        <div className="col">
+          <label className="lbl">Label</label>
+          <input className="inp" value={label} onChange={e => setLabel(e.target.value)} />
+        </div>
+        <div className="col">
+          <label className="lbl">Address</label>
+          <input className="inp" placeholder="0x… or email handle" value={addr} onChange={e => setAddr(e.target.value)} />
+        </div>
+      </div>
+      <div className="row gap">
+        <button className="btn" onClick={() => onSave({ label, address: addr })}>Save</button>
+        <button className="btn btn-primary" onClick={onGrant}>Grant +25 NATUR</button>
+        <button className="btn btn-danger" onClick={onSpend}>Spend −10 NATUR</button>
+      </div>
+      <p className="hint">Local demo mode.</p>
+    </section>
+  );
+}

--- a/src/routes/naturbank/index.tsx
+++ b/src/routes/naturbank/index.tsx
@@ -1,37 +1,55 @@
-import HubCard from '../../components/HubCard';
-import HubGrid from '../../components/HubGrid';
+import React, { useMemo, useState } from 'react';
+import WalletCard from '../../components/naturbank/WalletCard';
+import BalanceCard from '../../components/naturbank/BalanceCard';
+import TransactionsCard from '../../components/naturbank/TransactionsCard';
+import { NaturBankState, NaturTxn } from '../../shared/naturbank/types';
+import { applyTxn, loadState, saveState } from '../../shared/naturbank/storage';
 
-export default function Naturbank() {
+function uuid() {
+  return crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+}
+
+export default function NaturBankPage() {
+  const [state, setState] = useState<NaturBankState>(() => loadState());
+
+  // actions
+  const saveWallet = (next: NaturBankState['wallet']) => {
+    const updated = { ...state, wallet: next };
+    setState(updated); saveState(updated);
+  };
+
+  const addTxn = (type: 'grant' | 'spend', amount: number, note?: string) => {
+    const txn: NaturTxn = { id: uuid(), ts: Date.now(), type, amount, note };
+    const updated = applyTxn(state, txn);
+    setState(updated); saveState(updated);
+  };
+
+  const onGrant = () => addTxn('grant', 25, 'Demo grant');
+  const onSpend = () => addTxn('spend', 10, 'Demo spend');
+
+  // simple page styles (scoped)
+  const styles = useMemo(() => ({
+    page: { maxWidth: 920, margin: '0 auto' },
+  }), []);
+
   return (
-    <section className="space-y-6 naturbank-page">
-      <h2 className="text-2xl font-bold">Naturbank</h2>
-      <HubGrid>
-        <HubCard
-          to="/naturbank/wallet"
-          title="Wallet"
-          sub="Create custodial wallet & view address."
-          emoji="🪙"
-        />
-        <HubCard
-          to="/naturbank/token"
-          title="NATUR Token"
-          sub="Earnings, redemptions, and ledger."
-          emoji="🪙"
-        />
-        <HubCard
-          to="/naturbank/nfts"
-          title="NFTs"
-          sub="Mint navatar cards & collectibles."
-          emoji="🖼️"
-        />
-        <HubCard
-          to="/naturbank/learn"
-          title="Learn"
-          sub="Crypto basics & safety guides."
-          emoji="📘"
-        />
-      </HubGrid>
-      <p className="text-sm text-gray-500 mt-2">Demo address (placeholder) shown in Wallet.</p>
-    </section>
+    <main className="naturbank-page" style={styles.page}>
+      <nav className="breadcrumbs">
+        <a href="/">Home</a> <span>/</span> <span className="current">NaturBank</span>
+      </nav>
+
+      <h1 className="title">NaturBank</h1>
+      <p className="muted center">Local demo mode.</p>
+
+      <WalletCard wallet={state.wallet} onSave={saveWallet} onGrant={onGrant} onSpend={onSpend} />
+      <BalanceCard balance={state.balance} />
+      <TransactionsCard txns={state.txns} />
+
+      <section className="card">
+        <p className="muted">
+          Coming soon: real wallet connect, custodial accounts, on-chain mints, and marketplace redemption.
+        </p>
+      </section>
+    </main>
   );
 }

--- a/src/shared/naturbank/format.ts
+++ b/src/shared/naturbank/format.ts
@@ -1,0 +1,12 @@
+export const fmtNatur = (n: number) => `${n} NATUR`;
+
+export const timeAgo = (ts: number) => {
+  const s = Math.max(1, Math.floor((Date.now() - ts) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+};

--- a/src/shared/naturbank/storage.ts
+++ b/src/shared/naturbank/storage.ts
@@ -1,0 +1,36 @@
+import { NaturBankState, NaturTxn } from './types';
+
+const KEY = 'naturbank_demo_v1';
+
+const DEFAULT_STATE: NaturBankState = {
+  balance: 120,
+  wallet: { label: 'My Wallet', address: '' },
+  txns: [],
+};
+
+export function loadState(): NaturBankState {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return DEFAULT_STATE;
+    const parsed = JSON.parse(raw) as NaturBankState;
+    // cheap guards
+    if (!parsed || typeof parsed.balance !== 'number') return DEFAULT_STATE;
+    return parsed;
+  } catch {
+    return DEFAULT_STATE;
+  }
+}
+
+export function saveState(next: NaturBankState) {
+  localStorage.setItem(KEY, JSON.stringify(next));
+}
+
+export function applyTxn(state: NaturBankState, txn: NaturTxn): NaturBankState {
+  const delta = txn.type === 'grant' ? txn.amount : -txn.amount;
+  const balance = Math.max(0, state.balance + delta);
+  return {
+    ...state,
+    balance,
+    txns: [txn, ...state.txns].slice(0, 200), // simple cap
+  };
+}

--- a/src/shared/naturbank/types.ts
+++ b/src/shared/naturbank/types.ts
@@ -1,0 +1,20 @@
+export type NaturTxnType = 'grant' | 'spend';
+
+export interface NaturTxn {
+  id: string;             // uuid
+  ts: number;             // epoch ms
+  type: NaturTxnType;
+  amount: number;         // positive numbers; sign implied by type
+  note?: string;
+}
+
+export interface NaturWallet {
+  label: string;
+  address: string;        // 0x.. or email/handle for now
+}
+
+export interface NaturBankState {
+  balance: number;
+  wallet: NaturWallet;
+  txns: NaturTxn[];
+}

--- a/src/styles/naturbank.css
+++ b/src/styles/naturbank.css
@@ -1,4 +1,33 @@
-.naturbank-page { max-width: 640px; margin: auto; padding: 20px; }
-.naturbank-page .btn { margin: 12px 0; }
-.naturbank-page .txs ul { list-style: none; padding: 0; }
-.naturbank-page .txs li { padding: 6px 0; border-bottom: 1px solid #eee; }
+/* naturbank helpers */
+.naturbank-page .card { background: #f3f6fb; border-radius: 14px; padding: 16px 18px; margin: 16px 0; }
+.naturbank-page .h3 { margin: 0 0 10px; font-size: 18px; font-weight: 700; color: #2f54eb; }
+.naturbank-page .row { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+.naturbank-page .col { flex: 1 1 280px; min-width: 240px; }
+.naturbank-page .lbl { display:block; font-size: 12px; color:#6b7a99; margin-bottom: 6px; }
+.naturbank-page .inp { width: 100%; border: 1px solid #dbe3f3; border-radius: 10px; padding: 10px 12px; font-size: 14px; }
+.naturbank-page .btn { border: 1px solid #dbe3f3; border-radius: 999px; padding: 8px 12px; background: #fff; }
+.naturbank-page .btn-primary { background: #2f54eb; color: #fff; border-color: #2f54eb; }
+.naturbank-page .btn-danger { background: #f5222d; color: #fff; border-color: #f5222d; }
+.naturbank-page .center { text-align: center; }
+.naturbank-page .big { font-size: 24px; font-weight: 800; color: #0f172a; }
+.naturbank-page .hint, .naturbank-page .muted { color:#7a8aaa; font-size:12px; margin: 8px 0 0; }
+.naturbank-page .breadcrumbs { margin: 8px 0 8px; color:#8aa; font-size:14px; }
+.naturbank-page .breadcrumbs .current { font-weight: 700; color:#1f3161; }
+.naturbank-page .title { font-size: 28px; margin: 8px 0 4px; color:#1f3161; }
+
+.naturbank-page .txn-table { display: grid; gap: 8px; }
+.naturbank-page .txn-head, .naturbank-page .txn-row {
+  display: grid; grid-template-columns: 120px 90px 90px 1fr; gap: 10px; align-items: center;
+}
+.naturbank-page .txn-head { font-weight: 700; color:#445; font-size: 13px; }
+.naturbank-page .txn-row { background:#fff; padding:10px 12px; border-radius:10px; border:1px solid #e6ecf8; }
+.naturbank-page .pill { display:inline-block; padding:4px 10px; border-radius:999px; font-size:12px; }
+.naturbank-page .pill.green { background:#e6fffb; color:#006d75; }
+.naturbank-page .pill.gray  { background:#f5f5f5; color:#555; }
+
+@media (max-width: 640px) {
+  .naturbank-page .txn-head { display: none; }
+  .naturbank-page .txn-row { grid-template-columns: 1fr 1fr; }
+  .naturbank-page .txn-row > :nth-child(1) { grid-column: 1 / 3; font-size:12px; color:#7a8aaa; }
+  .naturbank-page .txn-row > :nth-child(4) { grid-column: 1 / 3; }
+}


### PR DESCRIPTION
## Summary
- replace NaturBank page with client-only demo featuring wallet form, balance, and transactions feed
- persist demo state in localStorage and wire grant/spend actions
- add scoped styles for NaturBank components

## Testing
- ⚠️ `npm test` *(missing script)*
- ❌ `npm run typecheck`
- ⚠️ `npm run build` *(missing @vitejs/plugin-react-swc)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b1a38bc88329bc3c9acfdc8ff28c