### PR TITLE
Persist NaturBank wallet and transactions in Supabase

### DIFF
--- a/src/components/naturbank/TransactionsCard.tsx
+++ b/src/components/naturbank/TransactionsCard.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { NaturTxn } from '../../shared/naturbank/types';
+import type { Txn } from '../../lib/naturbank';
 import { timeAgo } from '../../shared/naturbank/format';
 
-export default function TransactionsCard({ txns }: { txns: NaturTxn[] }) {
+export default function TransactionsCard({ txns }: { txns: Txn[] }) {
   return (
     <section className="card">
       <h3 className="h3">Transactions</h3>
@@ -16,8 +16,8 @@ export default function TransactionsCard({ txns }: { txns: NaturTxn[] }) {
           </div>
           {txns.map(t => (
             <div className="txn-row" key={t.id}>
-              <div>{timeAgo(t.ts)}</div>
-              <div className={t.type === 'grant' ? 'pill green' : 'pill gray'}>
+              <div>{timeAgo(new Date(t.created_at).getTime())}</div>
+              <div className={t.type === 'grant' ? 'pill blue' : 'pill red'}>
                 {t.type === 'grant' ? 'Grant' : 'Spend'}
               </div>
               <div>{t.type === 'grant' ? `+${t.amount}` : `-${t.amount}`}</div>

--- a/src/components/naturbank/WalletCard.tsx
+++ b/src/components/naturbank/WalletCard.tsx
@@ -1,16 +1,17 @@
 import React, { useState } from 'react';
-import { NaturWallet } from '../../shared/naturbank/types';
+import type { Wallet } from '../../lib/naturbank';
 
 type Props = {
-  wallet: NaturWallet;
-  onSave: (next: NaturWallet) => void;
-  onGrant: () => void;
-  onSpend: () => void;
+  wallet: Wallet;
+  onSave: (fields: { label: string; address: string }) => void;
+  onGrant: (note?: string) => void;
+  onSpend: (note?: string) => void;
 };
 
 export default function WalletCard({ wallet, onSave, onGrant, onSpend }: Props) {
   const [label, setLabel] = useState(wallet.label);
-  const [addr, setAddr] = useState(wallet.address);
+  const [addr, setAddr] = useState(wallet.address ?? '');
+  const [note, setNote] = useState('');
 
   return (
     <section className="card">
@@ -22,13 +23,40 @@ export default function WalletCard({ wallet, onSave, onGrant, onSpend }: Props) 
         </div>
         <div className="col">
           <label className="lbl">Address</label>
-          <input className="inp" placeholder="0x… or email handle" value={addr} onChange={e => setAddr(e.target.value)} />
+          <input
+            className="inp"
+            placeholder="0x… or email handle"
+            value={addr}
+            onChange={e => setAddr(e.target.value)}
+          />
         </div>
       </div>
-      <div className="row gap">
+      <div className="row gap wallet-actions">
+        <input
+          className="inp"
+          placeholder="Note (optional)"
+          value={note}
+          onChange={e => setNote(e.target.value)}
+        />
         <button className="btn" onClick={() => onSave({ label, address: addr })}>Save</button>
-        <button className="btn btn-primary" onClick={onGrant}>Grant +25 NATUR</button>
-        <button className="btn btn-danger" onClick={onSpend}>Spend −10 NATUR</button>
+        <button
+          className="btn btn-primary"
+          onClick={() => {
+            onGrant(note);
+            setNote('');
+          }}
+        >
+          Grant +25 NATUR
+        </button>
+        <button
+          className="btn btn-danger"
+          onClick={() => {
+            onSpend(note);
+            setNote('');
+          }}
+        >
+          Spend −10 NATUR
+        </button>
       </div>
       <p className="hint">Local demo mode.</p>
     </section>

--- a/src/lib/naturbank/api.ts
+++ b/src/lib/naturbank/api.ts
@@ -1,0 +1,84 @@
+import { supabase } from '../supabase-client';
+
+export type Wallet = {
+  id: string;
+  user_id: string;
+  label: string;
+  address: string | null;
+  balance: number;
+};
+
+export type Txn = {
+  id: string;
+  type: 'grant' | 'spend';
+  amount: number;
+  note?: string | null;
+  created_at: string;
+};
+
+export async function getOrCreateWallet(userId: string): Promise<Wallet> {
+  const { data: existing, error } = await supabase
+    .from('wallets')
+    .select('*')
+    .eq('user_id', userId)
+    .single();
+
+  if (!error && existing) return existing as Wallet;
+
+  const { data, error: insErr } = await supabase
+    .from('wallets')
+    .insert({ user_id: userId })
+    .select()
+    .single();
+  if (insErr) throw insErr;
+  return data as Wallet;
+}
+
+export async function saveWalletMeta(
+  walletId: string,
+  fields: Partial<Pick<Wallet, 'label' | 'address'>>
+) {
+  const { error } = await supabase
+    .from('wallets')
+    .update(fields)
+    .eq('id', walletId);
+  if (error) throw error;
+}
+
+export async function listTxns(walletId: string, userId: string): Promise<Txn[]> {
+  const { data, error } = await supabase
+    .from('wallet_txns')
+    .select('id,type,amount,note,created_at')
+    .eq('wallet_id', walletId)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return (data ?? []) as Txn[];
+}
+
+async function writeTxn(
+  walletId: string,
+  userId: string,
+  type: 'grant' | 'spend',
+  amount: number,
+  note?: string
+) {
+  const { error } = await supabase
+    .from('wallet_txns')
+    .insert({ wallet_id: walletId, user_id: userId, type, amount, note: note ?? null });
+  if (error) throw error;
+}
+
+export const grant = (
+  walletId: string,
+  userId: string,
+  amount = 25,
+  note?: string
+) => writeTxn(walletId, userId, 'grant', amount, note);
+
+export const spend = (
+  walletId: string,
+  userId: string,
+  amount = 10,
+  note?: string
+) => writeTxn(walletId, userId, 'spend', amount, note);

--- a/src/lib/naturbank/index.ts
+++ b/src/lib/naturbank/index.ts
@@ -1,0 +1,1 @@
+export * from './api';

--- a/src/styles/naturbank.css
+++ b/src/styles/naturbank.css
@@ -22,8 +22,8 @@
 .naturbank-page .txn-head { font-weight: 700; color:#445; font-size: 13px; }
 .naturbank-page .txn-row { background:#fff; padding:10px 12px; border-radius:10px; border:1px solid #e6ecf8; }
 .naturbank-page .pill { display:inline-block; padding:4px 10px; border-radius:999px; font-size:12px; }
-.naturbank-page .pill.green { background:#e6fffb; color:#006d75; }
-.naturbank-page .pill.gray  { background:#f5f5f5; color:#555; }
+.naturbank-page .pill.blue { background:#e6f4ff; color:#1d39c4; }
+.naturbank-page .pill.red  { background:#fff1f0; color:#cf1322; }
 
 @media (max-width: 640px) {
   .naturbank-page .txn-head { display: none; }

--- a/supabase/migrations/2025-10-30-naturbank-wallet.sql
+++ b/supabase/migrations/2025-10-30-naturbank-wallet.sql
@@ -1,0 +1,68 @@
+-- 1) Extension (if not already on)
+create extension if not exists "uuid-ossp";
+
+-- 2) Wallets
+create table if not exists public.wallets (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  label text not null default 'My Wallet',
+  address text,
+  balance integer not null default 120,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create unique index if not exists wallets_user_unique on public.wallets(user_id);
+
+-- 3) Transactions
+create table if not exists public.wallet_txns (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  wallet_id uuid not null references public.wallets(id) on delete cascade,
+  type text not null check (type in ('grant','spend')),
+  amount integer not null check (amount > 0),
+  note text,
+  created_at timestamptz not null default now()
+);
+create index if not exists wallet_txns_user_created_idx on public.wallet_txns(user_id, created_at desc);
+
+-- 4) RLS
+alter table public.wallets enable row level security;
+alter table public.wallet_txns enable row level security;
+
+create policy "wallets: owner read/write"
+on public.wallets
+for all
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy "txns: owner read"
+on public.wallet_txns
+for select
+using (auth.uid() = user_id);
+
+create policy "txns: owner insert"
+on public.wallet_txns
+for insert
+with check (auth.uid() = user_id);
+
+-- 5) Balance safety via trigger (keeps balance authoritative)
+create or replace function public.apply_wallet_txn()
+returns trigger as $$
+begin
+  if (tg_op = 'INSERT') then
+    if NEW.type = 'grant' then
+      update public.wallets set balance = balance + NEW.amount, updated_at = now()
+      where id = NEW.wallet_id and user_id = NEW.user_id;
+    elsif NEW.type = 'spend' then
+      update public.wallets set balance = balance - NEW.amount, updated_at = now()
+      where id = NEW.wallet_id and user_id = NEW.user_id;
+    end if;
+  end if;
+  return NEW;
+end;
+$$ language plpgsql security definer;
+
+drop trigger if exists trg_apply_wallet_txn on public.wallet_txns;
+create trigger trg_apply_wallet_txn
+after insert on public.wallet_txns
+for each row execute function public.apply_wallet_txn();


### PR DESCRIPTION
## Summary
- add Supabase migration for demo wallets and transactions with RLS and balance trigger
- add naturbank helper module to create wallets, save metadata, list and write transactions
- wire NaturBank UI to Supabase with persistent balance, notes, and color-coded transaction table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Argument of type 'Omit<{ id: string; user_id: string; name: string | null; base_type: string; backstory: string | null; image_url: string | null; created_at: string; updated_at: string; }, "created_at" | "id" | "updated_at">' is not assignable to parameter of type 'never[]'.)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b500b0b08329bd97671b535649c9