### PR TITLE
feat: add p2p natur transfers

### DIFF
--- a/src/components/naturbank/SendCard.tsx
+++ b/src/components/naturbank/SendCard.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+
+type Props = {
+  onSend: (recipient: string, amount: number, note?: string) => Promise<void>;
+};
+
+export default function SendCard({ onSend }: Props) {
+  const [recipient, setRecipient] = useState('');
+  const [amount, setAmount] = useState(10);
+  const [note, setNote] = useState('');
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setPending(true);
+    setError(null);
+    try {
+      await onSend(recipient, amount, note);
+      setRecipient('');
+      setNote('');
+    } catch (err: any) {
+      setError(err.message ?? 'Failed');
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <section className="card">
+      <h3 className="h3">Send</h3>
+      <form onSubmit={handleSubmit} className="col gap">
+        <input
+          className="inp"
+          placeholder="Email or @handle"
+          value={recipient}
+          onChange={e => setRecipient(e.target.value)}
+        />
+        <input
+          className="inp"
+          type="number"
+          min={1}
+          value={amount}
+          onChange={e => setAmount(parseInt(e.target.value, 10) || 0)}
+          style={{ maxWidth: 100 }}
+        />
+        <input
+          className="inp"
+          placeholder="Note (optional)"
+          value={note}
+          onChange={e => setNote(e.target.value)}
+        />
+        {error && <p className="error">{error}</p>}
+        <button className="btn btn-primary" disabled={pending} type="submit">
+          Send
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/components/naturbank/WalletCard.tsx
+++ b/src/components/naturbank/WalletCard.tsx
@@ -25,7 +25,7 @@ export default function WalletCard({ wallet, onSave, onGrant, onSpend }: Props) 
           <label className="lbl">Address</label>
           <input
             className="inp"
-            placeholder="0x… or email handle"
+            placeholder="Email or @handle"
             value={addr}
             onChange={e => setAddr(e.target.value)}
           />

--- a/src/lib/naturbank/api.ts
+++ b/src/lib/naturbank/api.ts
@@ -82,3 +82,19 @@ export const spend = (
   amount = 10,
   note?: string
 ) => writeTxn(walletId, userId, 'spend', amount, note);
+
+export async function transferTo(
+  senderUserId: string,
+  recipient: string,
+  amount: number,
+  note?: string
+) {
+  const { data, error } = await supabase.rpc('natur_transfer', {
+    p_sender_user_id: senderUserId,
+    p_recipient: recipient,
+    p_amount: amount,
+    p_note: note ?? null,
+  });
+  if (error) throw error;
+  return data as { sender_balance: number; recipient_balance: number }[];
+}

--- a/src/routes/naturbank/index.tsx
+++ b/src/routes/naturbank/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import WalletCard from '../../components/naturbank/WalletCard';
+import SendCard from '../../components/naturbank/SendCard';
 import BalanceCard from '../../components/naturbank/BalanceCard';
 import TransactionsCard from '../../components/naturbank/TransactionsCard';
 import {
@@ -7,6 +8,7 @@ import {
   listTxns,
   grant,
   spend,
+  transferTo,
   saveWalletMeta,
   type Wallet,
   type Txn,
@@ -48,6 +50,12 @@ export default function NaturBankPage() {
     await refresh();
   };
 
+  const onSend = async (recipient: string, amount: number, note?: string) => {
+    if (!user) return;
+    await transferTo(user.id, recipient, amount, note);
+    await refresh();
+  };
+
   const styles = useMemo(() => ({
     page: { maxWidth: 920, margin: '0 auto' },
   }), []);
@@ -64,6 +72,7 @@ export default function NaturBankPage() {
       {wallet && (
         <>
           <WalletCard wallet={wallet} onSave={onSave} onGrant={onGrant} onSpend={onSpend} />
+          <SendCard onSend={onSend} />
           <BalanceCard balance={wallet.balance} />
         </>
       )}

--- a/supabase/migrations/2025-11-01-p2p-transfer.sql
+++ b/supabase/migrations/2025-11-01-p2p-transfer.sql
@@ -1,0 +1,94 @@
+-- P2P transfer support
+
+-- unique indexes for users
+create unique index if not exists users_email_unique on public.users (lower(email));
+create unique index if not exists users_username_unique on public.users (lower(username));
+
+-- ensure wallet helper
+create or replace function public.ensure_wallet(p_user_id uuid)
+returns uuid
+language plpgsql
+security definer
+as $$
+declare
+  wid uuid;
+begin
+  select id into wid from public.wallets where user_id = p_user_id;
+  if wid is null then
+    insert into public.wallets (user_id) values (p_user_id)
+    returning id into wid;
+  end if;
+  return wid;
+end;
+$$;
+
+-- atomic transfer function
+create or replace function public.natur_transfer(
+  p_sender_user_id uuid,
+  p_recipient text,
+  p_amount int,
+  p_note text default null
+)
+returns table(sender_balance int, recipient_balance int)
+language plpgsql
+security definer
+as $$
+declare
+  v_sender_wallet uuid;
+  v_recipient_user uuid;
+  v_recipient_wallet uuid;
+  v_clean text := trim(p_recipient);
+  v_is_handle boolean := left(trim(p_recipient),1)='@';
+begin
+  if p_amount is null or p_amount <= 0 then
+    raise exception 'Amount must be > 0';
+  end if;
+
+  -- resolve recipient by email or @handle (case-insensitive)
+  if v_is_handle then
+    select id into v_recipient_user
+    from public.users
+    where lower(username) = lower(substring(v_clean from 2));
+  else
+    select id into v_recipient_user
+    from public.users
+    where lower(email) = lower(v_clean);
+  end if;
+
+  if v_recipient_user is null then
+    raise exception 'Recipient not found';
+  end if;
+
+  if v_recipient_user = p_sender_user_id then
+    raise exception 'Cannot send to yourself';
+  end if;
+
+  -- wallets
+  v_sender_wallet    := public.ensure_wallet(p_sender_user_id);
+  v_recipient_wallet := public.ensure_wallet(v_recipient_user);
+
+  -- atomic block
+  perform pg_advisory_xact_lock( hashtextextended('natur_transfer',0) );
+
+  -- check funds
+  if (select balance from public.wallets where id = v_sender_wallet for update) < p_amount then
+    raise exception 'Insufficient balance';
+  end if;
+
+  -- write txns (triggers update balances)
+  insert into public.wallet_txns (user_id, wallet_id, type, amount, note)
+    values (p_sender_user_id, v_sender_wallet, 'spend', p_amount, coalesce(p_note,'send'));
+
+  insert into public.wallet_txns (user_id, wallet_id, type, amount, note)
+    values (v_recipient_user, v_recipient_wallet, 'grant', p_amount, coalesce(p_note,'receive'));
+
+  -- return new balances
+  return query
+  select s.balance, r.balance
+  from public.wallets s, public.wallets r
+  where s.id = v_sender_wallet and r.id = v_recipient_wallet;
+end;
+$$;
+
+revoke all on function public.natur_transfer(uuid,text,int,text) from public;
+grant execute on function public.natur_transfer(uuid,text,int,text) to authenticated;


### PR DESCRIPTION
## Summary
- add SQL functions for atomic Natur transfers
- support peer-to-peer send in NaturBank UI
- expose `transferTo` client helper

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b848acc08329bbf863b566bbd001