### PR TITLE
Add demo NaturBank send transfers

### DIFF
--- a/src/lib/naturbank.ts
+++ b/src/lib/naturbank.ts
@@ -1,4 +1,5 @@
 export type NaturTxType = 'grant' | 'spend';
+
 export interface NaturTx {
   id: string;
   at: number;
@@ -6,6 +7,7 @@ export interface NaturTx {
   amount: number;
   note?: string;
 }
+
 export interface NaturWallet {
   label: string;
   address: string;
@@ -13,29 +15,37 @@ export interface NaturWallet {
   txs: NaturTx[];
 }
 
+export function normalizeWalletId(raw: string): string {
+  return raw.trim().replace(/\s+/g, '').toLowerCase();
+}
+
 const KEY = (uid: string) => `naturbank:${uid}`;
+const storageKey = (uid: string) => KEY(normalizeWalletId(uid));
 
 export function loadWallet(uid: string, starting = 120): NaturWallet {
-  const raw = localStorage.getItem(KEY(uid));
+  const key = storageKey(uid);
+  const raw = localStorage.getItem(key);
   if (!raw) {
     const w: NaturWallet = { label: 'My Wallet', address: '', starting, txs: [] };
-    localStorage.setItem(KEY(uid), JSON.stringify(w));
+    localStorage.setItem(key, JSON.stringify(w));
     return w;
   }
   try {
     const parsed = JSON.parse(raw) as NaturWallet;
-    return { label: 'My Wallet', address: '', starting, txs: [], ...parsed };
+    const base: NaturWallet = { label: 'My Wallet', address: '', starting, txs: [] };
+    return { ...base, ...parsed };
   } catch {
     const w: NaturWallet = { label: 'My Wallet', address: '', starting, txs: [] };
-    localStorage.setItem(KEY(uid), JSON.stringify(w));
+    localStorage.setItem(key, JSON.stringify(w));
     return w;
   }
 }
 
 export function saveWallet(uid: string, partial: Partial<NaturWallet>) {
+  const key = storageKey(uid);
   const curr = loadWallet(uid);
   const next = { ...curr, ...partial };
-  localStorage.setItem(KEY(uid), JSON.stringify(next));
+  localStorage.setItem(key, JSON.stringify(next));
   return next;
 }
 
@@ -49,8 +59,71 @@ export function addTx(uid: string, tx: Omit<NaturTx, 'id' | 'at'>) {
   const at = Date.now();
   const w = loadWallet(uid);
   const next: NaturWallet = { ...w, txs: [{ id, at, ...tx }, ...w.txs] };
-  localStorage.setItem(KEY(uid), JSON.stringify(next));
+  localStorage.setItem(storageKey(uid), JSON.stringify(next));
   return next;
+}
+
+type TransferInput = {
+  fromUid: string;
+  to: string;
+  amount: number;
+  note?: string;
+  senderLabel?: string;
+};
+
+type TransferResult = {
+  sender: NaturWallet;
+  recipient: NaturWallet;
+  recipientId: string;
+  recipientLabel: string;
+};
+
+export function transferTo({ fromUid, to, amount, note, senderLabel }: TransferInput): TransferResult {
+  const trimmedRecipient = to.trim();
+  if (!trimmedRecipient) throw new Error('Enter a recipient');
+
+  if (!Number.isFinite(amount) || amount <= 0) throw new Error('Enter an amount greater than zero');
+
+  const senderId = normalizeWalletId(fromUid);
+  const recipientId = normalizeWalletId(trimmedRecipient);
+  if (!recipientId) throw new Error('Enter a recipient');
+  if (senderId === recipientId) throw new Error('You cannot send to yourself');
+
+  const senderBefore = loadWallet(senderId);
+  const senderBalance = balanceOf(senderBefore);
+  if (senderBalance < amount) throw new Error('Insufficient balance');
+
+  const senderNote = note?.trim() || undefined;
+  const cleanedSenderLabel = senderLabel?.trim();
+  const storedSenderLabel = senderBefore.label?.trim();
+  const senderLabelForNote =
+    (cleanedSenderLabel && cleanedSenderLabel !== 'My Wallet' && cleanedSenderLabel) ||
+    (storedSenderLabel && storedSenderLabel !== 'My Wallet' && storedSenderLabel) ||
+    fromUid.trim();
+
+  const recipientBefore = loadWallet(recipientId);
+  const recipientLabel = (() => {
+    const existing = recipientBefore.label && recipientBefore.label !== 'My Wallet'
+      ? recipientBefore.label
+      : null;
+    if (existing) return existing;
+    if (recipientId.startsWith('@')) return recipientId;
+    const cleaned = trimmedRecipient.replace(/\s+/g, ' ').trim();
+    return cleaned || recipientId;
+  })();
+
+  const sender = addTx(senderId, { type: 'spend', amount, note: senderNote });
+  let recipient = addTx(recipientId, {
+    type: 'grant',
+    amount,
+    note: `From ${senderLabelForNote}`,
+  });
+
+  if (!recipientBefore.label || recipientBefore.label === 'My Wallet') {
+    recipient = saveWallet(recipientId, { label: recipientLabel });
+  }
+
+  return { sender, recipient, recipientId, recipientLabel: recipient.label || recipientLabel };
 }
 
 export * from './naturbank/api';

--- a/src/pages/naturbank.css
+++ b/src/pages/naturbank.css
@@ -10,6 +10,18 @@ button { padding: .6rem .9rem; border-radius: 22px; border: none; background: #2
 button:disabled { opacity: .6; cursor: not-allowed; }
 .status { color:#2f63ff; font-weight:600; }
 .big { font-size: 2rem; font-weight: 800; }
+.send-panel { margin-top: 1.5rem; padding-top: 1.25rem; border-top: 1px solid #d9e3ff; display: grid; gap: 12px; }
+.send-panel h3 { margin: 0; font-size: 1.2rem; }
+.send-grid { display: grid; grid-template-columns: 2fr 1fr; gap: 12px; }
+.send-grid .send-note { grid-column: 1 / -1; }
+.send-btn { align-self: flex-start; display: inline-flex; align-items: center; gap: 8px; }
+.error { color: #d13a2f; font-weight: 600; margin: 0; }
+.spinner { width: 16px; height: 16px; border-radius: 50%; border: 2px solid rgba(255,255,255,.8); border-top-color: transparent; display: inline-block; animation: spin .8s linear infinite; }
+.send-panel .error { margin-top: -.25rem; }
+@media (max-width: 640px){
+  .send-grid { grid-template-columns: 1fr; }
+}
+@keyframes spin { to { transform: rotate(360deg); } }
 .table { display: grid; }
 .thead, .trow { display: grid; grid-template-columns: 1.2fr .8fr .6fr 1fr; gap: 10px; align-items: center; padding: .5rem 0; }
 .thead { font-weight: 700; opacity: .7; border-bottom: 1px solid #e5ecff; }


### PR DESCRIPTION
## Summary
- add local `transferTo` helper to normalize wallet ids, validate balances, and post paired grant/spend transactions
- extend the NaturBank demo page with a Send panel, inline validation, spinner state, and success toast messaging
- refresh NaturBank styles to support the new send layout and loading indicator

## Testing
- `npm run typecheck` *(fails: project expects Next.js/Supabase typings that are absent in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8d71cf748329a8e95dfd9ee831f2