### PR TITLE
Add NaturShop demo to NaturBank

### DIFF
--- a/src/lib/naturshop.ts
+++ b/src/lib/naturshop.ts
@@ -1,0 +1,14 @@
+export type ShopItem = {
+  id: string;
+  name: string;
+  price: number; // in NATUR
+  emoji: string; // lightweight art
+  blurb?: string;
+};
+
+export const SHOP_ITEMS: ShopItem[] = [
+  { id: 'seed-pack', name: 'Seed Pack', price: 5, emoji: '🌱', blurb: 'Start something new.' },
+  { id: 'tree-token', name: 'Tree Token', price: 10, emoji: '🌳', blurb: 'Grow the grove.' },
+  { id: 'river-ride', name: 'River Ride', price: 15, emoji: '🛶', blurb: 'Glide downstream.' },
+  { id: 'sun-hat', name: 'Sun Hat', price: 8, emoji: '👒', blurb: 'Cool & shady.' },
+];

--- a/src/pages/naturbank.css
+++ b/src/pages/naturbank.css
@@ -48,3 +48,26 @@ button:disabled { opacity: .6; cursor: not-allowed; }
   opacity:0; pointer-events:none; transition:opacity .15s ease;
 }
 .toast.show { opacity:1; }
+
+/* NaturShop */
+.nb-shop { display:grid; gap:1rem; grid-template-columns: repeat(4, minmax(0,1fr)); }
+@media (max-width: 900px){ .nb-shop { grid-template-columns: repeat(2, minmax(0,1fr)); } }
+@media (max-width: 520px){ .nb-shop { grid-template-columns: 1fr; } }
+
+.nb-card {
+  background:#fff; border-radius:16px; padding:1rem;
+  box-shadow: 0 6px 24px rgba(44,62,80,.06), 0 1px 2px rgba(44,62,80,.06);
+}
+
+.nb-item-emoji { font-size:2.25rem; line-height:1; }
+.nb-item-name { font-weight:800; margin:.25rem 0 0; }
+.nb-item-blurb { opacity:.7; font-size:.9rem; margin:.15rem 0 .5rem; }
+.nb-item-price { font-weight:800; letter-spacing:.2px; }
+
+.nb-buy {
+  margin-top:.6rem; width:100%;
+  border-radius:999px; padding:.55rem .9rem; font-weight:800;
+  background:#2a55ff; color:#fff; border:none; cursor:pointer;
+  box-shadow:0 6px 0 rgba(42,85,255,.25);
+}
+.nb-buy:disabled { filter:saturate(.2) brightness(.95); cursor:not-allowed; }

--- a/src/pages/naturbank.tsx
+++ b/src/pages/naturbank.tsx
@@ -13,6 +13,7 @@ import {
   normalizeWalletId,
 } from '@/lib/naturbank';
 import type { NaturTx, RecentRecipient } from '@/lib/naturbank';
+import { SHOP_ITEMS } from '@/lib/naturshop';
 import { setTitle } from './_meta';
 import './naturbank.css';
 
@@ -120,9 +121,9 @@ export default function NaturBankPage() {
     setBusy(null);
   }
 
-  function spend(amount = 10) {
+  function spend(amount = 10, note = 'Shop demo') {
     setBusy('spend');
-    const w = addTx(uid, { type: 'spend', amount, note: 'Shop demo' });
+    const w = addTx(uid, { type: 'spend', amount, note });
     setTxs(w.txs);
     setBusy(null);
   }
@@ -279,6 +280,41 @@ export default function NaturBankPage() {
             </button>
             <small style={{ opacity: 0.7 }}>Balance: {fmt(balance)} NATUR</small>
           </div>
+        </div>
+      </section>
+
+      <section className="card" aria-labelledby="nb-shop-title">
+        <h3 id="nb-shop-title" style={{ marginTop: 0 }}>Shop</h3>
+        <p style={{ marginTop: '-.25rem', opacity: 0.75 }}>
+          Spend NATUR on small items to simulate purchases.
+        </p>
+        <div className="nb-shop">
+          {SHOP_ITEMS.map(item => {
+            const insufficient = balance < item.price;
+            const disabled = busy === 'spend' || insufficient;
+            const tooltip = disabled
+              ? insufficient
+                ? 'Insufficient balance'
+                : 'Processing purchase'
+              : `Buy ${item.name}`;
+            return (
+              <div className="nb-card" key={item.id} aria-label={`${item.name} card`}>
+                <div className="nb-item-emoji" aria-hidden="true">{item.emoji}</div>
+                <div className="nb-item-name">{item.name}</div>
+                {item.blurb && <div className="nb-item-blurb">{item.blurb}</div>}
+                <div className="nb-item-price">{fmt(item.price)} NATUR</div>
+                <button
+                  className="nb-buy"
+                  onClick={() => spend(item.price, item.name)}
+                  disabled={disabled}
+                  aria-disabled={disabled}
+                  title={tooltip}
+                >
+                  Buy
+                </button>
+              </div>
+            );
+          })}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add a shared NaturShop inventory list for demo items
- extend the NaturBank spend handler to accept item notes and render a Shop grid that reuses existing balance/transaction flows
- style the shop cards and responsive grid for the new section

## Testing
- npm run typecheck *(fails: repository lacks Next.js/Supabase type deps and has existing TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68caa2498a5c8329990c087deccdf474