### PR TITLE
Add Turian chat page with Groq-backed Netlify function

### DIFF
--- a/netlify/functions/turian-chat.ts
+++ b/netlify/functions/turian-chat.ts
@@ -1,0 +1,79 @@
+import type { Handler } from "@netlify/functions";
+
+const SYSTEM_PROMPT = `You are Turian the Durian: a friendly, pun-loving forest guide in The Naturverse.
+Keep replies brief (2–6 sentences). Offer tips, quests, and fun facts about nature, creatures, and NATUR coins.
+Avoid promises about real purchases or on-chain actions; this environment is a demo.`;
+
+function offlineReply(user: string): string {
+  const lines = [
+    "🍃 Hey there! I'm Turian the Durian. What’s sprouting in your mind today?",
+    "Fun seed: mangroves can survive salty water—salty like my jokes. 😄",
+    "Quest idea: snap a photo of three different leaves and name their shapes.",
+    "If you're curious about NATUR, try earning by helping a friend—kindness compounds!"
+  ];
+  const tip = lines[Math.floor(Math.random() * lines.length)];
+  const echo = user ? `You said: “${user}”. Here’s a thought…` : "Here’s a thought…";
+  return `${echo}\n${tip}`;
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, body: "Method Not Allowed" };
+  }
+
+  const { messages } = JSON.parse(event.body || "{}") as {
+    messages: Array<{ role: "user" | "assistant" | "system"; content: string }>;
+  };
+
+  const apiKey = process.env.GROQ_API_KEY;
+
+  if (!apiKey) {
+    const lastUser = [...(messages || [])].reverse().find((m) => m.role === "user")?.content || "";
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reply: offlineReply(lastUser) })
+    };
+  }
+
+  try {
+    const resp = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        model: "llama-3.1-8b-instant",
+        temperature: 0.6,
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          ...(messages || []).slice(-20)
+        ]
+      })
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      return {
+        statusCode: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reply: offlineReply(""), error: text })
+      };
+    }
+
+    const data = await resp.json();
+    const reply = data?.choices?.[0]?.message?.content ?? offlineReply("");
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reply })
+    };
+  } catch (error: any) {
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reply: offlineReply(""), error: String(error?.message || error) })
+    };
+  }
+};

--- a/src/pages/turian.css
+++ b/src/pages/turian.css
@@ -1,113 +1,128 @@
-/* All styles are scoped to .turian-page so nothing leaks */
-.turian-page {
-  --nv-blue: var(--naturverse-blue, #2f6bff);
-  --nv-bg: #eef5ff;
-  --nv-white: #ffffff;
-  --nv-radius: 16px;
-  --nv-shadow: 0 6px 20px rgba(0, 40, 160, 0.08);
-
-  padding: 28px 0 60px;
-  background: transparent;
-  color: var(--nv-blue);
+.turian-wrap {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 24px 16px;
 }
 
-/* Breadcrumb */
-.turian-page .turian-breadcrumb {
-  margin: 0 24px 12px;
-  font-size: 15px;
-}
-.turian-page .turian-breadcrumb a {
-  color: var(--nv-blue) !important;
-  text-decoration: underline;
+.turian-hero {
+  background: #eef6ff;
+  border-radius: 14px;
+  padding: 16px 18px;
+  margin-bottom: 16px;
 }
 
-/* Hero */
-.turian-page .turian-hero {
-  margin: 0 24px 18px;
-  background: var(--nv-bg);
-  border-radius: var(--nv-radius);
-  padding: 22px 22px 18px;
-  box-shadow: var(--nv-shadow);
-}
-.turian-page h1 {
-  margin: 0 0 8px 0;
-  font-size: 34px;
-  line-height: 1.15;
-  color: var(--nv-blue) !important;
-}
-.turian-page .lead {
-  margin: 0;
-  font-weight: 500;
-  color: var(--nv-blue) !important;
+.turian-card {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 6px 18px rgba(27, 52, 132, 0.08);
+  padding: 16px;
 }
 
-/* Status card */
-.turian-page .turian-card {
-  margin: 16px 24px 8px;
-  background: var(--nv-white);
-  border-radius: var(--nv-radius);
-  box-shadow: var(--nv-shadow);
-  padding: 18px 20px;
-  text-align: left;              /* ensure left alignment */
-}
-.turian-page .turian-card__title {
-  font-weight: 800;
-  font-size: 20px;
-  margin-bottom: 6px;
-  color: var(--nv-blue) !important;
-}
-.turian-page .turian-card__text {
-  margin: 0;
-  color: var(--nv-blue) !important;
+.chat-box {
+  height: min(60vh, 520px);
+  overflow: auto;
+  background: #f9fbff;
+  border-radius: 12px;
+  padding: 12px;
+  margin-top: 8px;
 }
 
-/* “Coming soon” */
-.turian-page .coming-soon {
-  margin: 14px 24px 0;
-  font-weight: 700;
-  color: var(--nv-blue) !important;
+.row {
+  display: flex;
+  margin: 8px 0;
 }
 
-/* Optional future chat form (kept here but not rendered) */
-.turian-page .turian-chat {
-  margin: 18px 24px 0;
+.row.user {
+  justify-content: flex-end;
+}
+
+.bubble {
+  max-width: 75%;
+  padding: 10px 14px;
+  border-radius: 16px;
+  line-height: 1.35;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.04);
+}
+
+.row.assistant .bubble {
+  background: #ffffff;
+}
+
+.row.user .bubble {
+  background: #2f57eb;
+  color: #fff;
+}
+
+.bubble-dots {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #9aa9ff;
+  animation: pulse 1s infinite ease-in-out;
+}
+
+.dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes pulse {
+  0%,
+  80%,
+  100% {
+    opacity: 0.2;
+  }
+
+  40% {
+    opacity: 1;
+  }
+}
+
+.composer {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 12px;
-  align-items: center;
-  text-align: left;              /* NEVER centered again */
-}
-.turian-page .turian-chat input {
-  border-radius: 14px;
-  border: 2px solid rgba(47,107,255,0.28);
-  padding: 14px 16px;
-  font-size: 16px;
-  color: var(--nv-blue);
-  outline: none;
-  background: var(--nv-white);
-}
-.turian-page .turian-chat input::placeholder {
-  color: rgba(47, 107, 255, 0.75);
-}
-.turian-page .btn-primary {
-  background: var(--nv-blue);
-  color: var(--nv-white) !important;
-  border: none;
-  border-radius: 14px;
-  padding: 12px 18px;
-  font-weight: 800;
-  box-shadow: 0 6px 0 rgba(47, 107, 255, 0.35);
-  cursor: pointer;
-}
-.turian-page .btn-primary:active {
-  transform: translateY(1px);
-  box-shadow: 0 5px 0 rgba(47, 107, 255, 0.35);
+  gap: 10px;
+  margin-top: 12px;
 }
 
-/* Utility */
-.turian-page .sr-only {
-  position: absolute !important;
-  width: 1px; height: 1px;
-  padding: 0; margin: -1px; overflow: hidden;
-  clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+.composer input {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid #dde3f0;
+}
+
+.btn {
+  border: 0;
+  border-radius: 999px;
+  background: #2f57eb;
+  color: #fff;
+  font-weight: 700;
+  padding: 10px 18px;
+  box-shadow: 0 8px 0 rgba(21, 39, 132, 0.2);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.turian-note {
+  color: #5b6a7c;
+  text-align: center;
+  margin-top: 12px;
+}
+
+@media (max-width: 640px) {
+  .bubble {
+    max-width: 88%;
+  }
 }


### PR DESCRIPTION
## Summary
- add a Netlify function that proxies chat requests to Groq with an offline fallback
- replace the Turian page with an interactive chat UI that talks to the function
- restyle the Turian page for the new chat layout and typing indicators

## Testing
- npm run typecheck *(fails: repository still references Next.js-only imports and Supabase types that are currently unresolved)*

------
https://chatgpt.com/codex/tasks/task_e_68caaee6183c8329ae6b50c4af308648