### PR TITLE
Bring Turian the Durian to life (Groq + Netlify Function)

### DIFF
--- a/netlify/functions/turian-chat.js
+++ b/netlify/functions/turian-chat.js
@@ -1,0 +1,61 @@
+export async function handler(event) {
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, body: "Method Not Allowed" };
+  }
+
+  try {
+    const key = process.env.GROQ_API_KEY;
+    if (!key) {
+      return { statusCode: 500, body: "Missing GROQ_API_KEY" };
+    }
+
+    const { message, history } = JSON.parse(event.body || "{}");
+    if (!message || typeof message !== "string") {
+      return { statusCode: 400, body: "Missing 'message' string" };
+    }
+
+    const msgs = [
+      {
+        role: "system",
+        content:
+          "You are Turian the Durian, a playful guide of the Naturverse. Be friendly, curious, and funny; keep answers concise (2–6 sentences). Use the catchphrase 'Dee mak!' sometimes. No external links. Family-friendly.",
+      },
+      ...(Array.isArray(history) ? history : []).slice(-6),
+      { role: "user", content: message },
+    ];
+
+    const res = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "meta-llama/llama-3.1-8b-instruct",
+        messages: msgs,
+        temperature: 0.7,
+        max_tokens: 300,
+      }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      console.error("Groq error", res.status, text);
+      return { statusCode: 502, body: "Upstream error" };
+    }
+
+    const data = await res.json();
+    const reply =
+      data?.choices?.[0]?.message?.content ??
+      "Hmm… I’m a little stumped. Dee mak!";
+
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reply }),
+    };
+  } catch (err) {
+    console.error(err);
+    return { statusCode: 500, body: "Server error" };
+  }
+}

--- a/src/components/TurianChat.tsx
+++ b/src/components/TurianChat.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import "./turian.css";
+
+type Msg = { role: "user" | "assistant"; content: string };
+
+const OFFLINE_RESPONSES = [
+  "Howdy! I'm Turian the Durian. Ask me for tips, quests, or fun facts. Dee mak!",
+  "Seeds of curiosity grow big trees of wisdom. What do you want to explore?",
+  "Try a mini-quest: do one kind thing today and tell me how it felt. Dee mak!",
+];
+
+export default function TurianChat() {
+  const [messages, setMessages] = useState<Msg[]>([
+    { role: "assistant", content: OFFLINE_RESPONSES[0] },
+  ]);
+  const [input, setInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    scrollerRef.current?.scrollTo({ top: 999999, behavior: "smooth" });
+  }, [messages]);
+
+  async function send() {
+    const msg = input.trim();
+    if (!msg || busy) return;
+
+    setInput("");
+    const userMessage: Msg = { role: "user", content: msg };
+    const nextHistory: Msg[] = [...messages, userMessage];
+    setMessages(nextHistory);
+    setBusy(true);
+
+    try {
+      const res = await fetch("/.netlify/functions/turian-chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: msg,
+          history: nextHistory,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("bad status");
+      }
+
+      const data = (await res.json()) as { reply?: string };
+      const reply =
+        (data.reply || "").trim() ||
+        OFFLINE_RESPONSES[(Math.random() * OFFLINE_RESPONSES.length) | 0];
+
+      setMessages((m) => [...m, { role: "assistant", content: reply }]);
+    } catch (err) {
+      const fallback =
+        OFFLINE_RESPONSES[(Math.random() * OFFLINE_RESPONSES.length) | 0];
+      setMessages((m) => [
+        ...m,
+        {
+          role: "assistant",
+          content:
+            fallback +
+            " (I’m in offline mode right now, but I still love to chat!)",
+        },
+      ]);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function onKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      send();
+    }
+  }
+
+  return (
+    <div className="turian-card">
+      <h2 className="turian-title">Chat with Turian</h2>
+
+      <div className="turian-chat" ref={scrollerRef} aria-live="polite">
+        {messages.map((m, index) => (
+          <div key={index} className={`turian-row ${m.role}`}>
+            <div className="bubble">{m.content}</div>
+          </div>
+        ))}
+        {busy && (
+          <div className="turian-row assistant">
+            <div className="bubble typing" aria-label="Turian is typing">
+              <span className="dot" />
+              <span className="dot" />
+              <span className="dot" />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="turian-input">
+        <input
+          aria-label="Message Turian"
+          placeholder="Ask Turian something…"
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <button onClick={send} disabled={busy || !input.trim()}>
+          {busy ? "Sending…" : "Send"}
+        </button>
+      </div>
+
+      <p className="turian-footnote">
+        Uses a free demo model via a secure Netlify Function. If the model isn’t
+        reachable, Turian role-plays locally so the page never feels empty.
+      </p>
+    </div>
+  );
+}

--- a/src/components/turian.css
+++ b/src/components/turian.css
@@ -1,0 +1,123 @@
+.turian-card {
+  background: #f3f7ff;
+  border-radius: 18px;
+  padding: 16px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.06);
+  margin: 16px 24px 8px;
+}
+
+.turian-title {
+  text-align: center;
+  color: #2250ff;
+  margin: 4px 0 12px;
+}
+
+.turian-chat {
+  background: #ffffff;
+  border-radius: 16px;
+  height: 48vh;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid #e8ecff;
+}
+
+.turian-row {
+  display: flex;
+  margin: 10px 0;
+}
+
+.turian-row.user {
+  justify-content: flex-end;
+}
+
+.turian-row.assistant {
+  justify-content: flex-start;
+}
+
+.bubble {
+  max-width: min(80%, 720px);
+  padding: 10px 12px;
+  border-radius: 14px;
+  line-height: 1.3;
+  font-size: 15px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+}
+
+.user .bubble {
+  background: #2250ff;
+  color: #fff;
+  border-top-right-radius: 6px;
+}
+
+.assistant .bubble {
+  background: #f5f7ff;
+  color: #1a2b4b;
+  border-top-left-radius: 6px;
+  border: 1px solid #e8ecff;
+}
+
+.turian-input {
+  display: flex;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.turian-input input {
+  flex: 1;
+  border: 1px solid #dfe6ff;
+  border-radius: 12px;
+  padding: 12px 14px;
+  outline: none;
+}
+
+.turian-input input:focus {
+  border-color: #2250ff;
+  box-shadow: 0 0 0 3px rgba(34, 80, 255, 0.1);
+}
+
+.turian-input button {
+  border: none;
+  background: #2250ff;
+  color: #fff;
+  padding: 0 18px;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 6px 0 #bfcaff;
+  height: 44px;
+}
+
+.turian-input button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.typing {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.typing .dot {
+  width: 6px;
+  height: 6px;
+  background: #99aaff;
+  border-radius: 50%;
+  animation: t-bounce 1.1s infinite ease-in-out;
+}
+
+.typing .dot:nth-child(2) { animation-delay: .15s; }
+.typing .dot:nth-child(3) { animation-delay: .3s; }
+
+@keyframes t-bounce {
+  0%, 80%, 100% { transform: translateY(0); opacity: .6; }
+  40% { transform: translateY(-4px); opacity: 1; }
+}
+
+.turian-footnote {
+  margin-top: 10px;
+  text-align: center;
+  color: #667;
+  font-size: 12px;
+}

--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -1,23 +1,7 @@
-import React from "react";
+import TurianChat from "../components/TurianChat";
 import "./turian.css";
 
-/** Optional: drop-in hook you can wire later */
-function useTurianChat() {
-  // Wire this to your API route when ready
-  async function send(message: string): Promise<string> {
-    const res = await fetch("/api/turian-chat", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ message }),
-    });
-    const data = await res.json().catch(() => ({}));
-    return data?.reply ?? "";
-  }
-  return { send };
-}
-
 export default function Turian() {
-  // const { send } = useTurianChat(); // keep for later
   return (
     <main className="turian-page" role="main" aria-labelledby="turian-title">
       <nav className="turian-breadcrumb">
@@ -27,33 +11,12 @@ export default function Turian() {
       <header className="turian-hero">
         <h1 id="turian-title">Turian the Durian</h1>
         <p className="lead">
-          Ask for tips, quests, and facts. This is an offline demo—no external
-          calls or models yet.
+          Ask for tips, quests, and facts. Turian is standing by with cheerful
+          guidance.
         </p>
       </header>
 
-      {/* Status card (kept), chat fully removed */}
-      <section className="turian-card" aria-live="polite">
-        <div className="turian-card__title">Chat with Turian</div>
-        <p className="turian-card__text">Chat feature temporarily disabled.</p>
-      </section>
-
-      <p className="coming-soon">Live chat coming soon.</p>
-
-      {/* ------- When you’re ready, drop a new chat form here -------
-      <form className="turian-chat" onSubmit={async (e) => {
-        e.preventDefault();
-        const form = e.currentTarget as HTMLFormElement;
-        const input = form.querySelector("input[name='q']") as HTMLInputElement;
-        // const reply = await send(input.value);
-        // show reply in your UI
-        input.value = "";
-      }}>
-        <label htmlFor="turian-q" className="sr-only">Ask Turian</label>
-        <input id="turian-q" name="q" placeholder="Ask Turian anything…" />
-        <button type="submit" className="btn-primary">Ask</button>
-      </form>
-      ------------------------------------------------------------- */}
+      <TurianChat />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add a Netlify function that proxies chat completions to Groq with Turian-specific guardrails
- build a responsive TurianChat React component with an offline fallback and dedicated styling
- mount the new chat UI on the Turian page so visitors can talk to Turian directly

## Testing
- npm run typecheck *(fails: repository already contains numerous unresolved Next.js/Supabase type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cab4446478832994f00485fb0fc388