### PR TITLE
Bring Turian to life (Vite/React + Netlify Functions, Groq)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,9 @@
 [build]
-  command = "npm install && npm run build"
+  command = "npm run build"
   publish = "dist"
 
 [functions]
+  node_bundler = "esbuild"
   directory = "netlify/functions"
 
 # SPA routing

--- a/netlify/functions/turian-chat.ts
+++ b/netlify/functions/turian-chat.ts
@@ -1,0 +1,60 @@
+import type { Handler } from "@netlify/functions";
+
+const MODEL = "llama-3.1-8b-instant";
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, body: "Method Not Allowed" };
+  }
+
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) {
+    return { statusCode: 500, body: "Missing GROQ_API_KEY" };
+  }
+
+  try {
+    const { messages } = JSON.parse(event.body || "{}") as {
+      messages: { role: "system" | "user" | "assistant"; content: string }[];
+    };
+
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return { statusCode: 400, body: "messages required" };
+    }
+
+    const last = messages[messages.length - 1]?.content || "";
+    if (last.length > 4000) {
+      return { statusCode: 413, body: "Message too long" };
+    }
+
+    const response = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        temperature: 0.7,
+        max_tokens: 400,
+        messages,
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return { statusCode: 502, body: text || "Groq error" };
+    }
+
+    const json = await response.json();
+    const content = json?.choices?.[0]?.message?.content ?? "…";
+
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Server error";
+    return { statusCode: 500, body: message };
+  }
+};

--- a/src/components/TurianChat.tsx
+++ b/src/components/TurianChat.tsx
@@ -1,0 +1,139 @@
+import type { KeyboardEvent } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import "./turian-chat.css";
+
+type Msg = { role: "user" | "assistant"; content: string };
+
+const SYSTEM_PROMPT =
+  "You are Turian the Durian, a cheerful Naturverse guide. " +
+  "Answer briefly (1-4 sentences), be playful but helpful, avoid claims that require real-world actions.";
+
+const LS_KEY = "naturverse_turian_chat_v1";
+const DEFAULT_GREETING: Msg = {
+  role: "assistant",
+  content: "Howdy! I'm Turian the Durian. Ask for tips, quests, or fun facts. 🥥🌿",
+};
+
+function offlineReply(input: string): string {
+  const tips = [
+    "Plant a tiny seed of kindness today.",
+    "Take three slow breaths—growth starts inside.",
+    "Spot one green thing nearby and smile at it.",
+    "Tiny steps beat perfect plans. What's one step?",
+  ];
+  const pick = tips[(input.length + tips.length) % tips.length];
+  return `Offline Turian here 🌱\n${pick}`;
+}
+
+export default function TurianChat() {
+  const [messages, setMessages] = useState<Msg[]>(() => {
+    if (typeof window === "undefined") return [DEFAULT_GREETING];
+    try {
+      const saved = window.localStorage.getItem(LS_KEY);
+      return saved ? (JSON.parse(saved) as Msg[]) : [DEFAULT_GREETING];
+    } catch {
+      return [DEFAULT_GREETING];
+    }
+  });
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(LS_KEY, JSON.stringify(messages));
+    }
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages]);
+
+  const apiMessages = useMemo(
+    () => [
+      { role: "system" as const, content: SYSTEM_PROMPT },
+      ...messages.map((message) => ({ role: message.role, content: message.content })),
+    ],
+    [messages],
+  );
+
+  async function send() {
+    const trimmed = input.trim();
+    if (!trimmed || loading) return;
+
+    const mine: Msg = { role: "user", content: trimmed };
+    setMessages((prev) => [...prev, mine]);
+    setInput("");
+    setLoading(true);
+
+    try {
+      const response = await fetch("/.netlify/functions/turian-chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: [...apiMessages, { role: "user", content: trimmed }] }),
+      });
+
+      let text: string;
+      if (response.ok) {
+        const json = await response.json();
+        text = String(json?.content ?? "").trim();
+      } else {
+        text = offlineReply(trimmed);
+      }
+
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: text || offlineReply(trimmed) },
+      ]);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: offlineReply(trimmed) },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      send();
+    }
+  }
+
+  return (
+    <div className="turian-card turian-chat-card">
+      <h3 className="turian-chat-title">Chat with Turian</h3>
+      <div className="turian-chat-scroll" ref={scrollRef} aria-live="polite">
+        {messages.map((message, index) => (
+          <div key={`${message.role}-${index}`} className={`turian-chat-bubble ${message.role}`}>
+            <p>{message.content}</p>
+          </div>
+        ))}
+        {loading && (
+          <div className="turian-chat-typing" aria-hidden="true">
+            <span />
+            <span />
+            <span />
+          </div>
+        )}
+      </div>
+
+      <div className="turian-chat-composer">
+        <input
+          aria-label="Message Turian"
+          placeholder="Ask Turian something…"
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <button className="turian-chat-send" onClick={send} disabled={loading || !input.trim()}>
+          {loading ? "Sending…" : "Send"}
+        </button>
+      </div>
+
+      <p className="turian-chat-footnote">
+        Uses a free demo model via a secure Netlify Function. If the model isn’t reachable,
+        Turian role-plays locally so the page never feels empty.
+      </p>
+    </div>
+  );
+}

--- a/src/components/turian-chat.css
+++ b/src/components/turian-chat.css
@@ -1,0 +1,124 @@
+.turian-chat-card {
+  background: var(--card, #fff);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 16px;
+  padding: 16px;
+  max-width: 960px;
+  margin: 0 auto;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.04);
+}
+
+.turian-chat-card .turian-chat-title {
+  text-align: center;
+  margin: 0 0 8px;
+}
+
+.turian-chat-card .turian-chat-scroll {
+  height: 40vh;
+  min-height: 280px;
+  overflow: auto;
+  background: #f7faff;
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.turian-chat-card .turian-chat-bubble {
+  max-width: 84%;
+  margin: 8px 0;
+  padding: 10px 12px;
+  border-radius: 14px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  word-break: break-word;
+}
+
+.turian-chat-card .turian-chat-bubble.user {
+  background: #2f6bff;
+  color: #fff;
+  margin-left: auto;
+  border-bottom-right-radius: 6px;
+}
+
+.turian-chat-card .turian-chat-bubble.assistant {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  color: #222;
+  margin-right: auto;
+  border-bottom-left-radius: 6px;
+}
+
+.turian-chat-card .turian-chat-typing {
+  display: inline-flex;
+  gap: 4px;
+  margin: 6px 10px;
+}
+
+.turian-chat-card .turian-chat-typing span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #8aa3ff;
+  opacity: 0.7;
+  animation: turian-chat-bounce 1s infinite ease-in-out;
+}
+
+.turian-chat-card .turian-chat-typing span:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.turian-chat-card .turian-chat-typing span:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes turian-chat-bounce {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.7);
+  }
+  40% {
+    transform: scale(1);
+  }
+}
+
+.turian-chat-card .turian-chat-composer {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.turian-chat-card .turian-chat-composer input {
+  flex: 1;
+  border-radius: 999px;
+  border: 1px solid #ccd7ff;
+  padding: 12px 14px;
+}
+
+.turian-chat-card .turian-chat-send {
+  border: 0;
+  border-radius: 999px;
+  padding: 12px 18px;
+  font-weight: 700;
+  background: #2f6bff;
+  color: #fff;
+  box-shadow: 0 6px 0 #b6c5ff;
+}
+
+.turian-chat-card .turian-chat-send:disabled {
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.turian-chat-card .turian-chat-footnote {
+  text-align: center;
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin-top: 8px;
+}
+
+@media (min-width: 768px) {
+  .turian-chat-card .turian-chat-scroll {
+    height: 52vh;
+  }
+}

--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -1,59 +1,25 @@
-import React from "react";
+import TurianChat from "../components/TurianChat";
 import "./turian.css";
 
-/** Optional: drop-in hook you can wire later */
-function useTurianChat() {
-  // Wire this to your API route when ready
-  async function send(message: string): Promise<string> {
-    const res = await fetch("/api/turian-chat", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ message }),
-    });
-    const data = await res.json().catch(() => ({}));
-    return data?.reply ?? "";
-  }
-  return { send };
-}
-
 export default function Turian() {
-  // const { send } = useTurianChat(); // keep for later
   return (
     <main className="turian-page" role="main" aria-labelledby="turian-title">
-      <nav className="turian-breadcrumb">
-        <a href="/">Home</a> <span>/</span> <span>Turian</span>
+      <nav className="turian-breadcrumb breadcrumbs" aria-label="Breadcrumb">
+        <a href="/">Home</a>
+        <span className="sep" aria-hidden>
+          /
+        </span>
+        <span>Turian</span>
       </nav>
 
       <header className="turian-hero">
         <h1 id="turian-title">Turian the Durian</h1>
         <p className="lead">
-          Ask for tips, quests, and facts. This is an offline demo—no external
-          calls or models yet.
+          Ask for tips, quests, and facts. Turian is standing by with cheerful guidance.
         </p>
       </header>
 
-      {/* Status card (kept), chat fully removed */}
-      <section className="turian-card" aria-live="polite">
-        <div className="turian-card__title">Chat with Turian</div>
-        <p className="turian-card__text">Chat feature temporarily disabled.</p>
-      </section>
-
-      <p className="coming-soon">Live chat coming soon.</p>
-
-      {/* ------- When you’re ready, drop a new chat form here -------
-      <form className="turian-chat" onSubmit={async (e) => {
-        e.preventDefault();
-        const form = e.currentTarget as HTMLFormElement;
-        const input = form.querySelector("input[name='q']") as HTMLInputElement;
-        // const reply = await send(input.value);
-        // show reply in your UI
-        input.value = "";
-      }}>
-        <label htmlFor="turian-q" className="sr-only">Ask Turian</label>
-        <input id="turian-q" name="q" placeholder="Ask Turian anything…" />
-        <button type="submit" className="btn-primary">Ask</button>
-      </form>
-      ------------------------------------------------------------- */}
+      <TurianChat />
     </main>
   );
 }

--- a/src/pages/turian.css
+++ b/src/pages/turian.css
@@ -1,113 +1,63 @@
-/* All styles are scoped to .turian-page so nothing leaks */
 .turian-page {
   --nv-blue: var(--naturverse-blue, #2f6bff);
   --nv-bg: #eef5ff;
-  --nv-white: #ffffff;
-  --nv-radius: 16px;
-  --nv-shadow: 0 6px 20px rgba(0, 40, 160, 0.08);
-
-  padding: 28px 0 60px;
+  padding: 32px 0 64px;
   background: transparent;
   color: var(--nv-blue);
 }
 
-/* Breadcrumb */
 .turian-page .turian-breadcrumb {
-  margin: 0 24px 12px;
+  margin: 0 auto 12px;
+  max-width: 960px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 15px;
 }
+
 .turian-page .turian-breadcrumb a {
   color: var(--nv-blue) !important;
   text-decoration: underline;
 }
 
-/* Hero */
-.turian-page .turian-hero {
-  margin: 0 24px 18px;
-  background: var(--nv-bg);
-  border-radius: var(--nv-radius);
-  padding: 22px 22px 18px;
-  box-shadow: var(--nv-shadow);
+.turian-page .turian-breadcrumb .sep {
+  opacity: 0.55;
+  color: var(--nv-blue);
 }
-.turian-page h1 {
-  margin: 0 0 8px 0;
-  font-size: 34px;
+
+.turian-page .turian-hero {
+  margin: 0 auto 20px;
+  max-width: 960px;
+  background: var(--nv-bg);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 8px 24px rgba(0, 40, 160, 0.08);
+  text-align: left;
+}
+
+.turian-page .turian-hero h1 {
+  margin: 0 0 8px;
+  font-size: clamp(2rem, 5vw, 2.75rem);
   line-height: 1.15;
   color: var(--nv-blue) !important;
 }
-.turian-page .lead {
+
+.turian-page .turian-hero .lead {
   margin: 0;
   font-weight: 500;
-  color: var(--nv-blue) !important;
+  color: rgba(23, 65, 160, 0.9);
 }
 
-/* Status card */
-.turian-page .turian-card {
-  margin: 16px 24px 8px;
-  background: var(--nv-white);
-  border-radius: var(--nv-radius);
-  box-shadow: var(--nv-shadow);
-  padding: 18px 20px;
-  text-align: left;              /* ensure left alignment */
-}
-.turian-page .turian-card__title {
-  font-weight: 800;
-  font-size: 20px;
-  margin-bottom: 6px;
-  color: var(--nv-blue) !important;
-}
-.turian-page .turian-card__text {
-  margin: 0;
-  color: var(--nv-blue) !important;
-}
+@media (max-width: 640px) {
+  .turian-page {
+    padding: 24px 0 48px;
+  }
 
-/* “Coming soon” */
-.turian-page .coming-soon {
-  margin: 14px 24px 0;
-  font-weight: 700;
-  color: var(--nv-blue) !important;
-}
+  .turian-page .turian-hero {
+    padding: 20px;
+  }
 
-/* Optional future chat form (kept here but not rendered) */
-.turian-page .turian-chat {
-  margin: 18px 24px 0;
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 12px;
-  align-items: center;
-  text-align: left;              /* NEVER centered again */
-}
-.turian-page .turian-chat input {
-  border-radius: 14px;
-  border: 2px solid rgba(47,107,255,0.28);
-  padding: 14px 16px;
-  font-size: 16px;
-  color: var(--nv-blue);
-  outline: none;
-  background: var(--nv-white);
-}
-.turian-page .turian-chat input::placeholder {
-  color: rgba(47, 107, 255, 0.75);
-}
-.turian-page .btn-primary {
-  background: var(--nv-blue);
-  color: var(--nv-white) !important;
-  border: none;
-  border-radius: 14px;
-  padding: 12px 18px;
-  font-weight: 800;
-  box-shadow: 0 6px 0 rgba(47, 107, 255, 0.35);
-  cursor: pointer;
-}
-.turian-page .btn-primary:active {
-  transform: translateY(1px);
-  box-shadow: 0 5px 0 rgba(47, 107, 255, 0.35);
-}
-
-/* Utility */
-.turian-page .sr-only {
-  position: absolute !important;
-  width: 1px; height: 1px;
-  padding: 0; margin: -1px; overflow: hidden;
-  clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+  .turian-page .turian-hero h1 {
+    font-size: 2.15rem;
+  }
 }


### PR DESCRIPTION
## Summary
- add a dedicated Netlify function that proxies chat completion requests to Groq using the GROQ_API_KEY
- build a TurianChat React experience with persisted history, typing indicator, and offline persona fallback for when the API is unreachable
- refresh the Turian page styles so the new chat mounts cleanly and ensure Netlify bundles functions with esbuild

## Testing
- `npm run build` *(fails: local environment cannot download @vitejs/plugin-react-swc from npm registry)*
- `npm run typecheck` *(fails: pre-existing Postgrest type definitions emit errors in navatar/passport/profile code)*

------
https://chatgpt.com/codex/tasks/task_e_68cab9ffe71883298b7a3beaab27f070