### PR TITLE
Stabilize Turian chat connectivity and mobile layout

### DIFF
--- a/netlify/functions/turian-chat.ts
+++ b/netlify/functions/turian-chat.ts
@@ -1,32 +1,135 @@
 import type { Handler } from "@netlify/functions";
 
-const MODEL = "llama-3.1-8b-instant";
+type ChatRole = "system" | "user" | "assistant";
 
-export const handler: Handler = async (event) => {
-  if (event.httpMethod !== "POST") {
-    return { statusCode: 405, body: "Method Not Allowed" };
+type ChatMessage = {
+  role: ChatRole;
+  content: string;
+};
+
+const MODEL = "meta-llama/llama-3.1-8b-instant";
+const API_URL = "https://api.groq.com/openai/v1/chat/completions";
+const REQUEST_TIMEOUT_MS = 20_000;
+
+const fallbackOrigin =
+  process.env.PUBLIC_ORIGIN ??
+  process.env.SITE_URL ??
+  process.env.URL ??
+  process.env.DEPLOY_PRIME_URL ??
+  process.env.DEPLOY_URL ??
+  "http://localhost:8888";
+
+const allowedOrigins = [
+  fallbackOrigin,
+  process.env.PUBLIC_URL,
+  process.env.PUBLIC_ORIGIN,
+  process.env.SITE_URL,
+  process.env.URL,
+  process.env.DEPLOY_PRIME_URL,
+  process.env.DEPLOY_URL,
+  "http://localhost:8888",
+  "http://127.0.0.1:8888",
+  "http://localhost:5173",
+  "http://127.0.0.1:5173",
+].filter((value, index, array): value is string => {
+  return Boolean(value) && array.indexOf(value) === index;
+});
+
+const allowedOriginSet = new Set(allowedOrigins);
+
+const baseCorsHeaders = {
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Allow-Methods": "OPTIONS,GET,POST",
+  Vary: "Origin",
+};
+
+type CorsResult = {
+  allowed: boolean;
+  headers: Record<string, string>;
+};
+
+function resolveCors(originHeader?: string): CorsResult {
+  const headers = { ...baseCorsHeaders };
+
+  if (!originHeader) {
+    if (allowedOrigins[0]) {
+      headers["Access-Control-Allow-Origin"] = allowedOrigins[0];
+    }
+    return { allowed: true, headers };
   }
 
-  const apiKey = process.env.GROQ_API_KEY;
-  if (!apiKey) {
-    return { statusCode: 500, body: "Missing GROQ_API_KEY" };
+  if (allowedOriginSet.has(originHeader)) {
+    headers["Access-Control-Allow-Origin"] = originHeader;
+    return { allowed: true, headers };
   }
+
+  return { allowed: false, headers };
+}
+
+function jsonResponse(
+  statusCode: number,
+  body: Record<string, unknown> | string,
+  headers: Record<string, string>,
+) {
+  return {
+    statusCode,
+    headers: {
+      ...headers,
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  };
+}
+
+function readBody(eventBody: string | null | undefined) {
+  if (!eventBody) return {};
 
   try {
-    const { messages } = JSON.parse(event.body || "{}") as {
-      messages: { role: "system" | "user" | "assistant"; content: string }[];
-    };
+    return JSON.parse(eventBody) as unknown;
+  } catch {
+    return {};
+  }
+}
 
-    if (!Array.isArray(messages) || messages.length === 0) {
-      return { statusCode: 400, body: "messages required" };
-    }
+function sanitizeMessages(input: unknown): ChatMessage[] | null {
+  if (!Array.isArray(input)) return null;
 
-    const last = messages[messages.length - 1]?.content || "";
-    if (last.length > 4000) {
-      return { statusCode: 413, body: "Message too long" };
-    }
+  const trimmed = input
+    .map((message) => {
+      if (!message || typeof message !== "object") return null;
+      const role = (message as ChatMessage).role;
+      const content = (message as ChatMessage).content;
 
-    const response = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+      if (role !== "system" && role !== "user" && role !== "assistant") {
+        return null;
+      }
+
+      if (typeof content !== "string") {
+        return null;
+      }
+
+      const safeContent = content.trim();
+      if (!safeContent) {
+        return null;
+      }
+
+      return {
+        role,
+        content: safeContent.slice(0, 4000),
+      } satisfies ChatMessage;
+    })
+    .filter((value): value is ChatMessage => Boolean(value));
+
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+async function callGroq(messages: ChatMessage[], apiKey: string) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(API_URL, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,
@@ -34,27 +137,103 @@ export const handler: Handler = async (event) => {
       },
       body: JSON.stringify({
         model: MODEL,
-        temperature: 0.7,
-        max_tokens: 400,
+        temperature: 0.6,
+        max_tokens: 600,
         messages,
       }),
+      signal: controller.signal,
     });
 
     if (!response.ok) {
       const text = await response.text();
-      return { statusCode: 502, body: text || "Groq error" };
+      const message = text || response.statusText || "Groq error";
+      return {
+        ok: false,
+        statusCode: response.status === 401 ? 401 : 502,
+        message,
+      } as const;
     }
 
-    const json = await response.json();
-    const content = json?.choices?.[0]?.message?.content ?? "…";
-
-    return {
-      statusCode: 200,
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content }),
+    const json = (await response.json()) as {
+      choices?: { message?: { content?: string } }[];
     };
+
+    const content = json?.choices?.[0]?.message?.content?.trim() ?? "";
+    return { ok: true, content } as const;
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Server error";
-    return { statusCode: 500, body: message };
+    const isAbort = error instanceof Error && error.name === "AbortError";
+    const message = error instanceof Error ? error.message : "Request failed";
+    return {
+      ok: false,
+      statusCode: isAbort ? 504 : 500,
+      message,
+    } as const;
+  } finally {
+    clearTimeout(timer);
   }
+}
+
+async function checkOnline(apiKey: string | undefined) {
+  if (!apiKey) {
+    return { statusCode: 503, body: { status: "offline" as const } };
+  }
+
+  return { statusCode: 200, body: { status: "online" as const } };
+}
+
+export const handler: Handler = async (event) => {
+  const origin = event.headers.origin ?? event.headers.Origin;
+  const cors = resolveCors(origin);
+
+  if (event.httpMethod === "OPTIONS") {
+    const statusCode = cors.allowed ? 204 : 403;
+    return {
+      statusCode,
+      headers: cors.headers,
+      body: "",
+    };
+  }
+
+  if (!cors.allowed) {
+    return jsonResponse(403, { error: "Origin not allowed" }, cors.headers);
+  }
+
+  const apiKey = process.env.GROQ_API_KEY;
+
+  if (event.httpMethod === "GET") {
+    const status = await checkOnline(apiKey);
+    return jsonResponse(status.statusCode, status.body, cors.headers);
+  }
+
+  if (event.httpMethod !== "POST") {
+    return jsonResponse(405, { error: "Method not allowed" }, cors.headers);
+  }
+
+  if (!apiKey) {
+    return jsonResponse(503, { error: "Missing GROQ_API_KEY" }, cors.headers);
+  }
+
+  const { messages } = readBody(event.body) as { messages?: unknown };
+  const sanitized = sanitizeMessages(messages);
+
+  if (!sanitized) {
+    return jsonResponse(400, { error: "messages must be a non-empty array" }, cors.headers);
+  }
+
+  const lastMessage = sanitized[sanitized.length - 1];
+  if (lastMessage.role !== "user") {
+    return jsonResponse(400, { error: "Last message must be from the user" }, cors.headers);
+  }
+
+  if (lastMessage.content.length > 2000) {
+    return jsonResponse(413, { error: "Message too long" }, cors.headers);
+  }
+
+  const result = await callGroq(sanitized, apiKey);
+
+  if (!result.ok) {
+    return jsonResponse(result.statusCode, { error: result.message }, cors.headers);
+  }
+
+  return jsonResponse(200, { content: result.content }, cors.headers);
 };

--- a/src/components/TurianChat.tsx
+++ b/src/components/TurianChat.tsx
@@ -1,139 +1,373 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
 import "./turian-chat.css";
 
-type Msg = { role: "user" | "assistant"; content: string };
+type Role = "user" | "assistant";
 
-const SYSTEM_PROMPT =
-  "You are Turian the Durian, a cheerful Naturverse guide. " +
-  "Answer briefly (1-4 sentences), be playful but helpful, avoid claims that require real-world actions.";
-
-const LS_KEY = "naturverse_turian_chat_v1";
-const DEFAULT_GREETING: Msg = {
-  role: "assistant",
-  content: "Howdy! I'm Turian the Durian. Ask for tips, quests, or fun facts. 🥥🌿",
+type ConversationMessage = {
+  id: string;
+  role: Role;
+  content: string;
+  offline?: boolean;
 };
 
-function offlineReply(input: string): string {
-  const tips = [
-    "Plant a tiny seed of kindness today.",
-    "Take three slow breaths—growth starts inside.",
-    "Spot one green thing nearby and smile at it.",
-    "Tiny steps beat perfect plans. What's one step?",
-  ];
-  const pick = tips[(input.length + tips.length) % tips.length];
-  return `Offline Turian here 🌱\n${pick}`;
+type ChatStatus = "checking" | "online" | "offline";
+
+const STORAGE_KEY = "naturverse:turian";
+const MAX_HISTORY = 20;
+const MAX_INPUT_CHARS = 800;
+const FUNCTION_ENDPOINT = "/.netlify/functions/turian-chat";
+const SYSTEM_PROMPT = `You are Turian the Durian—cheerful, concise, G-rated guide to the Naturverse.
+If asked outside Naturverse scope, give a short friendly answer.
+Keep replies under 80–120 words.`;
+
+const DEFAULT_GREETING: ConversationMessage = {
+  id: "turian-greeting",
+  role: "assistant",
+  content:
+    "Heya! I'm Turian the Durian, your cheerful Naturverse guide. Ask for quests, tips, or fun facts and I'll keep it light!",
+};
+
+const OFFLINE_REPLIES = [
+  "My cloud link is snoozing, but Turian's roots stay steady. Try one tiny Naturverse act—stretch like a fern and picture the jungle cheering you on.",
+  "Offline mode engaged, yet I'm still bursting with jungle cheer. Sketch or jot a quick idea so we can grow it together when the breeze returns.",
+  "Even without the Groq gusts, I can offer a seed of wonder. Take three slow breaths and imagine bioluminescent vines lighting your next step.",
+  "The data vines are tangled right now, but kindness still travels fast. Share a smile or refill a bottle to keep Naturverse magic flowing.",
+];
+
+function hashString(value: string) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value.charCodeAt(index);
+    hash = (hash << 5) - hash + char;
+    hash |= 0;
+  }
+  return hash;
+}
+
+function summarizePrompt(prompt: string) {
+  const trimmed = prompt.trim();
+  if (!trimmed) return "";
+  return trimmed.length > 60 ? `${trimmed.slice(0, 57)}…` : trimmed;
+}
+
+function createOfflineMessage(prompt: string) {
+  const seed = prompt ? hashString(prompt) : Date.now();
+  const index = Math.abs(seed) % OFFLINE_REPLIES.length;
+  const base = OFFLINE_REPLIES[index];
+  const snippet = summarizePrompt(prompt);
+
+  if (!snippet) {
+    return `${base} I'll be back online soon with more sparkle.`;
+  }
+
+  return `${base} I saved your question "${snippet}" for when the signal returns.`;
+}
+
+function makeId() {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function loadInitialMessages(): ConversationMessage[] {
+  if (typeof window === "undefined") {
+    return [DEFAULT_GREETING];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [DEFAULT_GREETING];
+
+    const parsed = JSON.parse(raw) as ConversationMessage[];
+    if (!Array.isArray(parsed)) return [DEFAULT_GREETING];
+
+    const sanitized = parsed.reduce<ConversationMessage[]>((acc, entry) => {
+      if (!entry || typeof entry !== "object") {
+        return acc;
+      }
+
+      const message = entry as Partial<ConversationMessage> & Record<string, unknown>;
+      const content = typeof message.content === "string" ? message.content.trim() : "";
+      if (!content) {
+        return acc;
+      }
+
+      const role: Role = message.role === "user" ? "user" : "assistant";
+      acc.push({
+        id: typeof message.id === "string" ? message.id : makeId(),
+        role,
+        content,
+        offline: message.offline === true ? true : undefined,
+      });
+
+      return acc;
+    }, []);
+
+    return sanitized.length ? sanitized.slice(-MAX_HISTORY) : [DEFAULT_GREETING];
+  } catch {
+    return [DEFAULT_GREETING];
+  }
 }
 
 export default function TurianChat() {
-  const [messages, setMessages] = useState<Msg[]>(() => {
-    if (typeof window === "undefined") return [DEFAULT_GREETING];
-    try {
-      const saved = window.localStorage.getItem(LS_KEY);
-      return saved ? (JSON.parse(saved) as Msg[]) : [DEFAULT_GREETING];
-    } catch {
-      return [DEFAULT_GREETING];
-    }
-  });
+  const [messages, setMessages] = useState<ConversationMessage[]>(() => loadInitialMessages());
   const [input, setInput] = useState("");
+  const [status, setStatus] = useState<ChatStatus>(() =>
+    typeof window === "undefined" ? "offline" : "checking",
+  );
   const [loading, setLoading] = useState(false);
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const endRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(LS_KEY, JSON.stringify(messages));
+    if (typeof window === "undefined") return;
+    try {
+      const snapshot = messages.slice(-MAX_HISTORY);
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+    } catch {
+      // Ignore storage failures silently.
     }
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
   }, [messages]);
 
-  const apiMessages = useMemo(
-    () => [
-      { role: "system" as const, content: SYSTEM_PROMPT },
-      ...messages.map((message) => ({ role: message.role, content: message.content })),
-    ],
-    [messages],
-  );
+  useEffect(() => {
+    if (typeof window === "undefined") return;
 
-  async function send() {
+    const animation = requestAnimationFrame(() => {
+      endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+    });
+
+    return () => cancelAnimationFrame(animation);
+  }, [messages, loading]);
+
+  const ensureOnline = useCallback(async (): Promise<"online" | "offline"> => {
+    if (typeof window === "undefined" || typeof fetch === "undefined") {
+      return "offline";
+    }
+
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 7_000);
+      const response = await fetch(FUNCTION_ENDPOINT, {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+
+      if (response.ok) {
+        const data = (await response.json().catch(() => null)) as
+          | { status?: string }
+          | null;
+
+        if (data?.status === "online") {
+          setStatus("online");
+          return "online";
+        }
+      }
+    } catch {
+      // ignore network errors – we'll fall back to offline
+    }
+
+    setStatus("offline");
+    return "offline";
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    void ensureOnline();
+  }, [ensureOnline]);
+
+  const appendOffline = useCallback((prompt: string) => {
+    const offlineMessage: ConversationMessage = {
+      id: makeId(),
+      role: "assistant",
+      content: createOfflineMessage(prompt),
+      offline: true,
+    };
+
+    setMessages((prev) => {
+      const next = [...prev, offlineMessage];
+      return next.slice(-MAX_HISTORY);
+    });
+  }, []);
+
+  async function sendMessage() {
     const trimmed = input.trim();
     if (!trimmed || loading) return;
 
-    const mine: Msg = { role: "user", content: trimmed };
-    setMessages((prev) => [...prev, mine]);
+    if (trimmed.length > MAX_INPUT_CHARS) {
+      setInput(trimmed.slice(0, MAX_INPUT_CHARS));
+      return;
+    }
+
+    const userMessage: ConversationMessage = {
+      id: makeId(),
+      role: "user",
+      content: trimmed,
+    };
+
+    const nextHistory = [...messages, userMessage].slice(-MAX_HISTORY);
+    setMessages(nextHistory);
     setInput("");
     setLoading(true);
 
+    const currentStatus = await ensureOnline();
+    if (currentStatus !== "online") {
+      appendOffline(trimmed);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 20_000);
+
     try {
-      const response = await fetch("/.netlify/functions/turian-chat", {
+      const response = await fetch(FUNCTION_ENDPOINT, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ messages: [...apiMessages, { role: "user", content: trimmed }] }),
+        body: JSON.stringify({
+          messages: [
+            { role: "system", content: SYSTEM_PROMPT },
+            ...nextHistory.map(({ role, content }) => ({ role, content })),
+          ],
+        }),
+        signal: controller.signal,
       });
 
-      let text: string;
-      if (response.ok) {
-        const json = await response.json();
-        text = String(json?.content ?? "").trim();
-      } else {
-        text = offlineReply(trimmed);
+      if (!response.ok) {
+        setStatus("offline");
+        appendOffline(trimmed);
+        return;
       }
 
-      setMessages((prev) => [
-        ...prev,
-        { role: "assistant", content: text || offlineReply(trimmed) },
-      ]);
-    } catch {
-      setMessages((prev) => [
-        ...prev,
-        { role: "assistant", content: offlineReply(trimmed) },
-      ]);
+      const data = (await response.json().catch(() => null)) as { content?: string } | null;
+      const text = data?.content ? String(data.content).trim() : "";
+
+      if (!text) {
+        setStatus("offline");
+        appendOffline(trimmed);
+        return;
+      }
+
+      const assistantMessage: ConversationMessage = {
+        id: makeId(),
+        role: "assistant",
+        content: text,
+      };
+
+      setStatus("online");
+      setMessages((prev) => {
+        const next = [...prev, assistantMessage];
+        return next.slice(-MAX_HISTORY);
+      });
+    } catch (error) {
+      if (!(error instanceof DOMException && error.name === "AbortError")) {
+        console.error("Turian chat request failed", error);
+      }
+      setStatus("offline");
+      appendOffline(trimmed);
     } finally {
+      clearTimeout(timeout);
       setLoading(false);
     }
   }
 
   function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
-    if (event.key === "Enter") {
+    if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
-      send();
+      void sendMessage();
     }
   }
 
+  const statusLabel =
+    status === "online" ? "Online" : status === "offline" ? "Offline mode" : "Checking…";
+
+  const statusDescription =
+    status === "online"
+      ? "Connected via Groq (meta-llama/llama-3.1-8b-instant)."
+      : status === "offline"
+        ? "Offline mode active—Turian replies locally until the link returns."
+        : "Checking Groq connection…";
+
   return (
-    <div className="turian-card turian-chat-card">
-      <h3 className="turian-chat-title">Chat with Turian</h3>
-      <div className="turian-chat-scroll" ref={scrollRef} aria-live="polite">
-        {messages.map((message, index) => (
-          <div key={`${message.role}-${index}`} className={`turian-chat-bubble ${message.role}`}>
-            <p>{message.content}</p>
+    <section className="turian-chat-card" aria-label="Chat with Turian">
+      <header className="turian-chat-header">
+        <h3 className="turian-chat-title">Chat with Turian</h3>
+        <span className={`turian-chat-status ${status}`} role="status" aria-live="polite">
+          <span className="turian-chat-status-dot" aria-hidden />
+          {statusLabel}
+        </span>
+      </header>
+
+      <div
+        ref={scrollRef}
+        className="turian-chat-scroll"
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions"
+        aria-label="Turian conversation thread"
+      >
+        {messages.map((message) => (
+          <div key={message.id} className={`turian-chat-row ${message.role}`}>
+            <div
+              className={`turian-chat-bubble ${message.role}${message.offline ? " offline" : ""}`}
+            >
+              {message.offline && (
+                <span className="turian-chat-chip offline">
+                  <span className="turian-chat-chip-dot" aria-hidden />
+                  Offline mode
+                </span>
+              )}
+              <p>{message.content}</p>
+            </div>
           </div>
         ))}
+
         {loading && (
-          <div className="turian-chat-typing" aria-hidden="true">
-            <span />
-            <span />
-            <span />
+          <div className="turian-chat-row assistant typing" aria-hidden="true">
+            <div className="turian-chat-bubble assistant">
+              <span className="turian-chat-chip typing" aria-hidden>
+                <span className="turian-chat-chip-dot" aria-hidden />
+                Turian is typing
+              </span>
+              <div className="turian-chat-dots">
+                <span />
+                <span />
+                <span />
+              </div>
+            </div>
           </div>
         )}
+
+        <div ref={endRef} aria-hidden="true" />
       </div>
 
       <div className="turian-chat-composer">
         <input
+          type="text"
           aria-label="Message Turian"
           placeholder="Ask Turian something…"
           value={input}
           onChange={(event) => setInput(event.target.value)}
           onKeyDown={onKeyDown}
+          disabled={loading}
+          maxLength={MAX_INPUT_CHARS}
+          autoComplete="off"
+          enterKeyHint="send"
+          spellCheck
         />
-        <button className="turian-chat-send" onClick={send} disabled={loading || !input.trim()}>
+        <button
+          type="button"
+          className="turian-chat-send"
+          onClick={() => void sendMessage()}
+          disabled={loading || !input.trim()}
+        >
           {loading ? "Sending…" : "Send"}
         </button>
       </div>
 
-      <p className="turian-chat-footnote">
-        Uses a free demo model via a secure Netlify Function. If the model isn’t reachable,
-        Turian role-plays locally so the page never feels empty.
+      <p className="turian-chat-footnote" aria-live="polite">
+        <strong>{statusLabel}.</strong> {statusDescription}
       </p>
-    </div>
+    </section>
   );
 }

--- a/src/components/turian-chat.css
+++ b/src/components/turian-chat.css
@@ -1,73 +1,207 @@
 .turian-chat-card {
-  background: var(--card, #fff);
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  border-radius: 16px;
-  padding: 16px;
-  max-width: 960px;
+  width: min(100%, 620px);
   margin: 0 auto;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.04);
+  background: #ffffff;
+  border-radius: 22px;
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  padding: clamp(18px, 2.8vw, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+  font-size: 16px;
 }
 
-.turian-chat-card .turian-chat-title {
-  text-align: center;
-  margin: 0 0 8px;
+.turian-chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
-.turian-chat-card .turian-chat-scroll {
-  height: 40vh;
-  min-height: 280px;
-  overflow: auto;
-  background: #f7faff;
-  border-radius: 12px;
-  padding: 12px;
+.turian-chat-title {
+  margin: 0;
+  font-size: clamp(1.15rem, 2.4vw, 1.35rem);
+  color: #1d4ed8;
 }
 
-.turian-chat-card .turian-chat-bubble {
-  max-width: 84%;
-  margin: 8px 0;
-  padding: 10px 12px;
-  border-radius: 14px;
-  line-height: 1.45;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  word-break: break-word;
-}
-
-.turian-chat-card .turian-chat-bubble.user {
-  background: #2f6bff;
-  color: #fff;
-  margin-left: auto;
-  border-bottom-right-radius: 6px;
-}
-
-.turian-chat-card .turian-chat-bubble.assistant {
-  background: #fff;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  color: #222;
-  margin-right: auto;
-  border-bottom-left-radius: 6px;
-}
-
-.turian-chat-card .turian-chat-typing {
+.turian-chat-status {
   display: inline-flex;
-  gap: 4px;
-  margin: 6px 10px;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #1d4ed8;
 }
 
-.turian-chat-card .turian-chat-typing span {
+.turian-chat-status.offline {
+  color: #b45309;
+}
+
+.turian-chat-status.checking {
+  color: #475569;
+}
+
+.turian-chat-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.turian-chat-status.offline .turian-chat-status-dot {
+  box-shadow: 0 0 0 4px rgba(180, 83, 9, 0.2);
+}
+
+.turian-chat-status.checking .turian-chat-status-dot {
+  box-shadow: 0 0 0 4px rgba(71, 85, 105, 0.2);
+}
+
+.turian-chat-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #f8fbff 0%, #eef3ff 100%);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.06);
+  max-height: min(60vh, 520px);
+  overflow-y: auto;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+}
+
+.turian-chat-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.turian-chat-scroll::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.45);
+  border-radius: 999px;
+}
+
+.turian-chat-row {
+  display: flex;
+  width: 100%;
+}
+
+.turian-chat-row.user {
+  justify-content: flex-end;
+}
+
+.turian-chat-row.assistant {
+  justify-content: flex-start;
+}
+
+.turian-chat-bubble {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 20px;
+  background: #ffffff;
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+  width: fit-content;
+  max-width: min(100%, 520px);
+  line-height: 1.55;
+  color: #1f2937;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.turian-chat-bubble.assistant {
+  border-color: rgba(15, 23, 42, 0.1);
+}
+
+.turian-chat-bubble.assistant.offline {
+  background: #fffbeb;
+  border-color: rgba(234, 179, 8, 0.65);
+  box-shadow: 0 12px 28px rgba(250, 204, 21, 0.25);
+}
+
+.turian-chat-bubble.user {
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  border-color: transparent;
+  color: #ffffff;
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.35);
+}
+
+.turian-chat-bubble p {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: clamp(180px, 36vh, 320px);
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.turian-chat-bubble p::-webkit-scrollbar {
+  width: 6px;
+}
+
+.turian-chat-bubble p::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.4);
+  border-radius: 999px;
+}
+
+.turian-chat-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+.turian-chat-chip.offline {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid rgba(250, 204, 21, 0.6);
+}
+
+.turian-chat-chip.typing {
+  background: rgba(37, 99, 235, 0.1);
+  color: #1d4ed8;
+}
+
+.turian-chat-chip-dot {
   width: 6px;
   height: 6px;
-  border-radius: 50%;
-  background: #8aa3ff;
-  opacity: 0.7;
-  animation: turian-chat-bounce 1s infinite ease-in-out;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.8;
 }
 
-.turian-chat-card .turian-chat-typing span:nth-child(2) {
+.turian-chat-dots {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.turian-chat-dots span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #a5b4fc;
+  opacity: 0.75;
+  animation: turian-chat-bounce 1.1s infinite ease-in-out;
+}
+
+.turian-chat-dots span:nth-child(2) {
   animation-delay: 0.15s;
 }
 
-.turian-chat-card .turian-chat-typing span:nth-child(3) {
+.turian-chat-dots span:nth-child(3) {
   animation-delay: 0.3s;
 }
 
@@ -76,49 +210,125 @@
   80%,
   100% {
     transform: scale(0.7);
+    opacity: 0.6;
   }
   40% {
     transform: scale(1);
+    opacity: 1;
   }
 }
 
-.turian-chat-card .turian-chat-composer {
+.turian-chat-composer {
   display: flex;
-  gap: 8px;
-  margin-top: 10px;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 6px 6px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  background: #f4f7ff;
+  flex-wrap: nowrap;
 }
 
-.turian-chat-card .turian-chat-composer input {
+.turian-chat-composer input {
   flex: 1;
-  border-radius: 999px;
-  border: 1px solid #ccd7ff;
-  padding: 12px 14px;
-}
-
-.turian-chat-card .turian-chat-send {
+  min-width: 0;
   border: 0;
+  background: transparent;
+  padding: 10px 0;
+  font-size: 16px;
+  color: #1f2937;
+}
+
+.turian-chat-composer input:focus {
+  outline: none;
+}
+
+.turian-chat-send {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   border-radius: 999px;
-  padding: 12px 18px;
+  border: none;
+  padding: 10px 20px;
+  font-size: 15px;
   font-weight: 700;
-  background: #2f6bff;
-  color: #fff;
-  box-shadow: 0 6px 0 #b6c5ff;
+  color: #ffffff;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.35);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 }
 
-.turian-chat-card .turian-chat-send:disabled {
+.turian-chat-send:disabled {
   opacity: 0.6;
+  cursor: not-allowed;
   box-shadow: none;
+  transform: none;
 }
 
-.turian-chat-card .turian-chat-footnote {
+.turian-chat-send:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.4);
+}
+
+.turian-chat-send:not(:disabled):active {
+  transform: translateY(0);
+}
+
+.turian-chat-footnote {
+  margin: 0;
   text-align: center;
   font-size: 0.85rem;
-  color: #6b7280;
-  margin-top: 8px;
+  color: #64748b;
+  line-height: 1.45;
 }
 
-@media (min-width: 768px) {
-  .turian-chat-card .turian-chat-scroll {
-    height: 52vh;
+.turian-chat-footnote strong {
+  color: #1d4ed8;
+}
+
+@media (max-width: 768px) {
+  .turian-chat-card {
+    width: 100%;
+    border-radius: 20px;
+    padding: 16px 18px;
+    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.1);
+  }
+
+  .turian-chat-scroll {
+    max-height: 58vh;
+    padding: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .turian-chat-card {
+    padding: 16px 14px;
+  }
+
+  .turian-chat-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .turian-chat-composer {
+    padding: 6px 6px 6px 14px;
+  }
+
+  .turian-chat-send {
+    padding: 10px 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .turian-chat-dots span {
+    animation: none;
+  }
+
+  .turian-chat-send {
+    transition: none;
   }
 }


### PR DESCRIPTION
## Summary
- add a CORS-aware Netlify handler for Turian chat that exposes a GET status probe, sanitizes payloads, and falls back cleanly when Groq is unavailable
- refactor the TurianChat React component to persist the last 20 turns, detect online/offline states, surface a typing indicator, and swap to persona replies when offline
- refresh the chat stylesheet so the card clamps at 620px, mobile input controls stay usable, and offline replies display a dedicated chip

## Testing
- `npm run typecheck` *(fails: repository still references Next.js/Supabase modules and missing types outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cac3dcbee083298c9358683e811045