### PR TITLE
Add quest rewards flow to Turian chat

### DIFF
--- a/src/components/TurianChat.tsx
+++ b/src/components/TurianChat.tsx
@@ -1,16 +1,235 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { demoGrant } from '@/lib/naturbank';
+import { demoAddStamp } from '@/lib/passport';
 import './turian.css';
 
-type Msg = { role: 'user'|'bot'|'notice'; text: string };
+type Role = 'user' | 'bot' | 'notice';
+type QuestStatus = 'offered' | 'accepted';
+
+type QuestOffer = {
+  id: string;
+  title: string;
+  rewardNatur: number;
+  world: string;
+  stampLabel: string;
+};
+
+type ChatMessageEntry = {
+  id: string;
+  kind: 'message';
+  role: Role;
+  text: string;
+  createdAt: number;
+};
+
+type ChatQuestEntry = {
+  id: string;
+  kind: 'quest';
+  quest: QuestOffer;
+  status: QuestStatus;
+  createdAt: number;
+  acceptedAt?: number;
+  receipt?: string;
+};
+
+type ChatEntry = ChatMessageEntry | ChatQuestEntry;
+
+type OfflineQuest = QuestOffer & { instructions: string };
+
+const STORAGE_KEY = 'naturverse.turian.thread.v1';
+const QUEST_TAG = /<<quest\|([^|]+)\|([^|]+)\|([^|]+)\|([^|>]+)(?:\|([^|>]+))?>>/i;
+const QUEST_REWARD = 5;
+const MAX_ENTRIES = 80;
+
+const INITIAL_ENTRIES: ChatEntry[] = [
+  {
+    id: 'welcome',
+    kind: 'message',
+    role: 'bot',
+    text: "Heya! I'm Turian the Durian, your cheerful Naturverse guide. Ask for quests, tips, or fun facts and I'll keep it light!",
+    createdAt: Date.now(),
+  },
+];
+
+const OFFLINE_QUESTS: OfflineQuest[] = [
+  {
+    id: 'plant-a-seed',
+    title: 'Plant a seed IRL 🌱',
+    rewardNatur: QUEST_REWARD,
+    world: 'Flora',
+    stampLabel: 'Flora',
+    instructions: 'Find a seed or bean and tuck it into soil today. Give it a tiny sip of water to help it sprout.',
+  },
+  {
+    id: 'sky-sketch',
+    title: 'Sketch today\'s sky ☁️',
+    rewardNatur: QUEST_REWARD,
+    world: 'Skylands',
+    stampLabel: 'Skylands',
+    instructions: 'Step outside for a minute and doodle what the sky looks like right now—colors, clouds, or stars!',
+  },
+  {
+    id: 'nature-sounds',
+    title: 'Collect a nature sound 🎶',
+    rewardNatur: QUEST_REWARD,
+    world: 'Fauna',
+    stampLabel: 'Fauna',
+    instructions: 'Listen closely outdoors and imitate or record one sound from a bird, bug, or breeze.',
+  },
+  {
+    id: 'water-guardian',
+    title: 'Water a friendly plant 💧',
+    rewardNatur: QUEST_REWARD,
+    world: 'Aqua',
+    stampLabel: 'Aqua',
+    instructions: 'Choose a plant (indoor or outdoor) and give it a caring splash of water to brighten its day.',
+  },
+];
+
+const KEYWORD_HINTS: { regex: RegExp; questId: string }[] = [
+  { regex: /(seed|plant|garden)/i, questId: 'plant-a-seed' },
+  { regex: /(sky|cloud|star)/i, questId: 'sky-sketch' },
+  { regex: /(sound|bird|listen)/i, questId: 'nature-sounds' },
+  { regex: /(water|thirsty|plant)/i, questId: 'water-guardian' },
+];
+
+const wantsQuest = (text: string) => /(quest|mission|challenge|task)/i.test(text);
+
+const createId = (prefix: string) => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+};
+
+const sanitizeMessageEntry = (item: any): ChatMessageEntry | null => {
+  if (!item || typeof item !== 'object') return null;
+  if (item.kind !== 'message') return null;
+  const role: Role = item.role === 'user' || item.role === 'bot' || item.role === 'notice' ? item.role : 'bot';
+  const text = typeof item.text === 'string' ? item.text : '';
+  if (!text) return null;
+  const createdAt = typeof item.createdAt === 'number' ? item.createdAt : Date.now();
+  const id = typeof item.id === 'string' ? item.id : createId('msg');
+  return { id, kind: 'message', role, text, createdAt };
+};
+
+const sanitizeQuestEntry = (item: any): ChatQuestEntry | null => {
+  if (!item || typeof item !== 'object') return null;
+  if (item.kind !== 'quest' || !item.quest || typeof item.quest !== 'object') return null;
+  const questRaw = item.quest;
+  const quest: QuestOffer = {
+    id: typeof questRaw.id === 'string' ? questRaw.id : createId('quest'),
+    title: typeof questRaw.title === 'string' ? questRaw.title : 'Mini quest',
+    rewardNatur: Number.isFinite(questRaw.rewardNatur) && questRaw.rewardNatur > 0 ? questRaw.rewardNatur : QUEST_REWARD,
+    world: typeof questRaw.world === 'string' && questRaw.world.trim() ? questRaw.world : 'Flora',
+    stampLabel: typeof questRaw.stampLabel === 'string' && questRaw.stampLabel.trim()
+      ? questRaw.stampLabel
+      : (typeof questRaw.world === 'string' ? questRaw.world : 'Flora'),
+  };
+  const id = typeof item.id === 'string' ? item.id : createId('quest');
+  const createdAt = typeof item.createdAt === 'number' ? item.createdAt : Date.now();
+  const status: QuestStatus = item.status === 'accepted' ? 'accepted' : 'offered';
+  const acceptedAt = typeof item.acceptedAt === 'number' ? item.acceptedAt : undefined;
+  const receipt = typeof item.receipt === 'string' ? item.receipt : undefined;
+  return { id, kind: 'quest', quest, status, createdAt, acceptedAt, receipt };
+};
+
+const loadStoredEntries = (): ChatEntry[] | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    const entries: ChatEntry[] = [];
+    for (const item of parsed) {
+      const msg = sanitizeMessageEntry(item);
+      if (msg) { entries.push(msg); continue; }
+      const quest = sanitizeQuestEntry(item);
+      if (quest) { entries.push(quest); }
+    }
+    return entries.length ? entries : null;
+  } catch {
+    return null;
+  }
+};
+
+const persistEntries = (entries: ChatEntry[]) => {
+  if (typeof window === 'undefined') return;
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(entries)); } catch {}
+};
+
+const parseQuestTag = (text: string) => {
+  const match = text.match(QUEST_TAG);
+  if (!match) {
+    return { cleaned: text.trim(), quest: null as QuestOffer | null };
+  }
+  const [, id, title, natur, world, label] = match;
+  const reward = Number(natur);
+  const quest: QuestOffer = {
+    id: (id || '').trim() || createId('quest'),
+    title: (title || '').trim() || 'Mini quest',
+    rewardNatur: Number.isFinite(reward) && reward > 0 ? reward : QUEST_REWARD,
+    world: (world || '').trim() || 'Flora',
+    stampLabel: (label || world || '').trim() || 'Flora',
+  };
+  const cleaned = text.replace(match[0], '').replace(/\s{2,}/g, ' ').trim();
+  return { cleaned, quest };
+};
+
+const pickOfflineQuest = (prompt: string): OfflineQuest => {
+  const match = KEYWORD_HINTS.find(({ regex }) => regex.test(prompt));
+  if (match) {
+    const found = OFFLINE_QUESTS.find(q => q.id === match.questId);
+    if (found) return found;
+  }
+  return OFFLINE_QUESTS[Math.floor(Math.random() * OFFLINE_QUESTS.length)];
+};
+
+const composeLocalQuestReply = (prompt: string, offline: boolean) => {
+  const quest = pickOfflineQuest(prompt);
+  const intro = offline
+    ? "The connection's snoozing, but I still have a nature mission for you!"
+    : "I've got a mini quest you can try right away!";
+  const text = `${intro} ${quest.instructions} <<quest|${quest.id}|${quest.title}|${quest.rewardNatur}|${quest.world}|${quest.stampLabel}>>`;
+  return { text, quest };
+};
+
+const limitEntries = (entries: ChatEntry[]) => {
+  if (entries.length <= MAX_ENTRIES) return entries;
+  return entries.slice(entries.length - MAX_ENTRIES);
+};
 
 export function TurianChat() {
-  const [msgs, setMsgs] = useState<Msg[]>([
-    { role: 'bot', text: "Heya! I'm Turian the Durian, your cheerful Naturverse guide. Ask for quests, tips, or fun facts and I'll keep it light!" }
-  ]);
+  const [entries, setEntries] = useState<ChatEntry[]>(() => INITIAL_ENTRIES);
   const [input, setInput] = useState('');
-  const [online, setOnline] = useState<boolean>(true); // toggled by pinging the function
+  const [online, setOnline] = useState<boolean>(true);
   const [busy, setBusy] = useState(false);
+  const [processingQuestId, setProcessingQuestId] = useState<string | null>(null);
+  const [toast, setToast] = useState('');
+  const [hydrated, setHydrated] = useState(false);
   const view = useRef<HTMLDivElement>(null);
+  const offlineNotice = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = loadStoredEntries();
+    if (stored && stored.length) {
+      setEntries(stored);
+    }
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    persistEntries(entries);
+  }, [entries, hydrated]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const id = window.setTimeout(() => setToast(''), 2400);
+    return () => window.clearTimeout(id);
+  }, [toast]);
 
   // simple heartbeat to decide ONLINE/OFFLINE badge
   useEffect(() => {
@@ -18,19 +237,84 @@ export function TurianChat() {
       try {
         const r = await fetch('/.netlify/functions/turian-chat-ping');
         setOnline(r.ok);
-      } catch { setOnline(false); }
+      } catch {
+        setOnline(false);
+      }
     };
     ping();
   }, []);
 
   useEffect(() => {
     view.current?.scrollTo({ top: view.current.scrollHeight, behavior: 'smooth' });
-  }, [msgs, busy]);
+  }, [entries, busy, processingQuestId]);
+
+  const appendEntries = (next: ChatEntry[]) => {
+    if (!next.length) return;
+    setEntries(prev => limitEntries([...prev, ...next]));
+  };
+
+  const addMessage = (role: Role, text: string) => {
+    if (!text.trim()) return;
+    const entry: ChatMessageEntry = {
+      id: createId('msg'),
+      kind: 'message',
+      role,
+      text: text.trim(),
+      createdAt: Date.now(),
+    };
+    appendEntries([entry]);
+  };
+
+  const addQuestEntry = (quest: QuestOffer) => {
+    const entry: ChatQuestEntry = {
+      id: createId('quest'),
+      kind: 'quest',
+      quest,
+      status: 'offered',
+      createdAt: Date.now(),
+    };
+    appendEntries([entry]);
+  };
+
+  const handleReply = (reply: string, prompt: string) => {
+    const { cleaned, quest } = parseQuestTag(reply);
+    if (cleaned) addMessage('bot', cleaned);
+    if (quest) {
+      addQuestEntry({ ...quest, title: quest.title || 'Mini quest' });
+      return;
+    }
+    if (wantsQuest(prompt)) {
+      const local = composeLocalQuestReply(prompt, false);
+      const parsed = parseQuestTag(local.text);
+      if (parsed.cleaned) addMessage('bot', parsed.cleaned);
+      if (parsed.quest) addQuestEntry(parsed.quest);
+    }
+  };
+
+  const handleOffline = (prompt: string) => {
+    setOnline(false);
+    if (!offlineNotice.current) {
+      addMessage('notice', "Offline mode engaged, yet I'm still bursting with jungle cheer. I'll keep sharing tips and quests locally until the breeze returns.");
+      offlineNotice.current = true;
+    }
+    const local = composeLocalQuestReply(prompt, true);
+    const parsed = parseQuestTag(local.text);
+    if (parsed.cleaned) addMessage('bot', parsed.cleaned);
+    if (parsed.quest) addQuestEntry(parsed.quest);
+  };
+
+  const buildPrompt = (prompt: string) => {
+    const base = prompt.trim();
+    const guidance = wantsQuest(prompt)
+      ? 'If the explorer asks for a quest, give them one playful real-world action. After your short reply, add the tag <<quest|id|Title emoji|5|World|World>> exactly once so we can render the quest UI.'
+      : 'If you share a quest, append the tag <<quest|id|Title emoji|5|World|World>> at the end so the UI can render it.';
+    return `${base}\n\n${guidance}`;
+  };
 
   const ask = async () => {
-    if (!input.trim()) return;
-    const q = input.trim();
-    setMsgs(m => [...m, { role: 'user', text: q }]);
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    addMessage('user', trimmed);
     setInput('');
     setBusy(true);
 
@@ -38,21 +322,52 @@ export function TurianChat() {
       const r = await fetch('/.netlify/functions/turian-chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: q })
+        body: JSON.stringify({ prompt: buildPrompt(trimmed) }),
       });
       if (!r.ok) throw new Error('offline');
       const { reply } = await r.json();
-      setMsgs(m => [...m, { role: 'bot', text: reply }]);
       setOnline(true);
+      offlineNotice.current = false;
+      handleReply(String(reply ?? ''), trimmed);
     } catch {
-      setOnline(false);
-      setMsgs(m => [...m, { role: 'notice', text:
-        "Offline mode engaged, yet I'm still bursting with jungle cheer. Ask about worlds, quests, or how to earn NATUR—I'll answer locally until the breeze returns."
-      }]);
+      handleOffline(trimmed);
     } finally {
       setBusy(false);
     }
   };
+
+  const acceptQuest = async (entry: ChatQuestEntry) => {
+    if (entry.status === 'accepted') return;
+    setProcessingQuestId(entry.id);
+    const receipt = `+${entry.quest.rewardNatur} NATUR granted • Stamp added (${entry.quest.stampLabel})`;
+    try {
+      demoGrant(entry.quest.rewardNatur, `Quest: ${entry.quest.title}`);
+      demoAddStamp(entry.quest.world, entry.quest.title);
+      setEntries(prev => prev.map(item => {
+        if (item.kind === 'quest' && item.id === entry.id) {
+          return { ...item, status: 'accepted', acceptedAt: Date.now(), receipt };
+        }
+        return item;
+      }));
+      setToast(receipt);
+    } catch {
+      setToast('Whoops! I could not grant that reward. Try again in a moment.');
+    } finally {
+      setProcessingQuestId(null);
+    }
+  };
+
+  const markLater = (entry: ChatQuestEntry) => {
+    setToast('Quest saved for later! Accept when you are ready.');
+    setEntries(prev => prev.map(item => {
+      if (item.kind === 'quest' && item.id === entry.id) {
+        return { ...item, status: 'offered' };
+      }
+      return item;
+    }));
+  };
+
+  const canSend = useMemo(() => input.trim().length > 0 && !busy, [input, busy]);
 
   return (
     <div className="turian-chat_card" aria-live="polite">
@@ -61,12 +376,53 @@ export function TurianChat() {
         <span>{online ? 'Online' : 'Offline mode'}</span>
       </div>
 
-      <div ref={view} style={{maxHeight: 420, overflowY: 'auto', padding: 4}}>
-        {msgs.map((m, i) => (
-          <div key={i} className={`turian-msg turian-msg--${m.role}`}>
-            {m.text}
-          </div>
-        ))}
+      <div ref={view} className="turian-thread" style={{ maxHeight: 420, overflowY: 'auto', padding: 4 }}>
+        {entries.map(entry => {
+          if (entry.kind === 'message') {
+            return (
+              <div key={entry.id} className={`turian-msg turian-msg--${entry.role}`}>
+                {entry.text}
+              </div>
+            );
+          }
+          const accepted = entry.status === 'accepted';
+          const accepting = processingQuestId === entry.id;
+          return (
+            <div key={entry.id} className={`turian-quest ${accepted ? 'turian-quest--accepted' : ''}`}>
+              <div className="turian-quest__title">{entry.quest.title}</div>
+              <div className="turian-quest__reward">Reward: +{entry.quest.rewardNatur} NATUR &amp; 1 Passport stamp ({entry.quest.stampLabel})</div>
+              {accepted ? (
+                <div className="turian-quest__footer">
+                  <span className="turian-quest__status">Accepted ✓</span>
+                  {entry.receipt && <div className="turian-quest__receipt">{entry.receipt}</div>}
+                  <div className="turian-quest__links">
+                    <a href="/naturbank" className="turian-quest__link">View in NaturBank</a>
+                    <a href="/passport" className="turian-quest__link">View Passport</a>
+                  </div>
+                </div>
+              ) : (
+                <div className="turian-quest__actions">
+                  <button
+                    type="button"
+                    className="turian-quest__btn turian-quest__btn--accept"
+                    onClick={() => acceptQuest(entry)}
+                    disabled={accepting}
+                  >
+                    {accepting ? 'Accepting…' : 'Accept'}
+                  </button>
+                  <button
+                    type="button"
+                    className="turian-quest__btn turian-quest__btn--later"
+                    onClick={() => markLater(entry)}
+                    disabled={accepting}
+                  >
+                    Later
+                  </button>
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
 
       <div className="turian-composer">
@@ -75,14 +431,23 @@ export function TurianChat() {
           placeholder="Ask Turian something..."
           value={input}
           onChange={e => setInput(e.target.value)}
-          onKeyDown={e => (e.key === 'Enter' ? ask() : null)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && canSend) {
+              e.preventDefault();
+              ask();
+            }
+          }}
           inputMode="text"
           aria-label="Message Turian"
         />
-        <button className="turian-send" disabled={busy || !input.trim()} onClick={ask}>
+        <button className="turian-send" disabled={!canSend} onClick={ask}>
           {busy ? '…' : 'Send'}
         </button>
       </div>
+
+      {toast && (
+        <div className="turian-toast" role="status" aria-live="assertive">{toast}</div>
+      )}
     </div>
   );
 }

--- a/src/lib/passport.ts
+++ b/src/lib/passport.ts
@@ -1,0 +1,61 @@
+import type { PassportStamp } from '../types/passport';
+
+const STAMP_KEY = 'naturverse.passport.stamps.v1';
+const MAX_STAMPS = 60;
+
+const read = (): PassportStamp[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STAMP_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(Boolean) as PassportStamp[];
+  } catch {
+    return [];
+  }
+};
+
+const write = (list: PassportStamp[]) => {
+  if (typeof window === 'undefined') return;
+  try { localStorage.setItem(STAMP_KEY, JSON.stringify(list)); } catch {}
+};
+
+const newId = () => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `stamp-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+};
+
+export type DemoStamp = PassportStamp;
+
+/** Add a local/demo passport stamp and broadcast a change event. */
+export function demoAddStamp(world: string, note?: string): DemoStamp | null {
+  const trimmedWorld = world?.trim();
+  if (!trimmedWorld) return null;
+
+  const label = note?.trim();
+  const stamp: PassportStamp = {
+    id: newId(),
+    user_id: 'local',
+    world: trimmedWorld,
+    title: label || 'Quest Reward',
+    note: label ? 'Quest completed with Turian' : 'Quest reward from Turian',
+    created_at: new Date().toISOString(),
+  };
+
+  try {
+    const existing = read();
+    const next = [stamp, ...existing];
+    write(next.slice(0, MAX_STAMPS));
+  } catch {}
+
+  try {
+    window.dispatchEvent(new CustomEvent('natur:stamp-granted', { detail: { world: trimmedWorld, stamp } }));
+  } catch {}
+
+  return stamp;
+}
+
+export * from './passport/store';

--- a/src/pages/turian.css
+++ b/src/pages/turian.css
@@ -55,6 +55,8 @@
   padding: 12px 14px;
   margin: 10px 0;
   line-height: 1.35;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 .turian-msg--user   { background: #2f68ff; color: #fff; }
 .turian-msg--bot    { background: #f5f8ff; color: #1f2d4d; }
@@ -84,6 +86,168 @@
   cursor: pointer;
 }
 .turian-send:disabled { opacity: 0.5; cursor: default; }
+
+.turian-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.turian-thread > .turian-msg,
+.turian-thread > .turian-quest {
+  margin: 0;
+}
+
+.turian-quest {
+  border: 1px solid #dbe6ff;
+  background: linear-gradient(135deg, #f4f8ff 0%, #ffffff 100%);
+  border-radius: 18px;
+  padding: 16px;
+  box-shadow: 0 14px 30px rgba(53, 101, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.turian-quest--accepted {
+  background: linear-gradient(135deg, #f0fff4 0%, #ffffff 100%);
+  border-color: #8ce8b4;
+}
+
+.turian-quest__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1f2d4d;
+}
+
+.turian-quest__reward {
+  font-size: 0.92rem;
+  color: #314262;
+}
+
+.turian-quest__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.turian-quest__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.turian-quest__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 700;
+  color: #166534;
+  background: rgba(59, 130, 246, 0.08);
+  padding: 6px 12px;
+  border-radius: 999px;
+  width: fit-content;
+}
+
+.turian-quest__receipt {
+  background: #fef3c7;
+  border-radius: 12px;
+  padding: 8px 12px;
+  font-size: 0.92rem;
+  color: #854d0e;
+  width: fit-content;
+}
+
+.turian-quest__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.turian-quest__link {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #2f68ff;
+  text-decoration: none;
+}
+
+.turian-quest__link:hover,
+.turian-quest__link:focus {
+  text-decoration: underline;
+}
+
+.turian-quest__btn {
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.turian-quest__btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+  transform: none;
+  box-shadow: none;
+}
+
+.turian-quest__btn--accept {
+  background: linear-gradient(135deg, #3f7cff 0%, #2452ff 100%);
+  color: #fff;
+  box-shadow: 0 10px 18px rgba(36, 82, 255, 0.25);
+}
+
+.turian-quest__btn--accept:not(:disabled):hover,
+.turian-quest__btn--accept:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(36, 82, 255, 0.32);
+}
+
+.turian-quest__btn--later {
+  background: #fff;
+  color: #2f68ff;
+  border-color: #2f68ff;
+}
+
+.turian-quest__btn--later:not(:disabled):hover,
+.turian-quest__btn--later:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(47, 104, 255, 0.12);
+}
+
+.turian-toast {
+  margin-top: 16px;
+  align-self: center;
+  background: rgba(47, 104, 255, 0.95);
+  color: #fff;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.92rem;
+  box-shadow: 0 18px 32px rgba(35, 78, 210, 0.28);
+}
+
+@media (max-width: 540px) {
+  .turian-quest__actions {
+    flex-direction: column;
+  }
+
+  .turian-quest__btn {
+    width: 100%;
+    text-align: center;
+  }
+
+  .turian-quest__links {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .turian-quest__link {
+    width: fit-content;
+  }
+}
 
 /* Badge row */
 .turian-status {

--- a/src/styles/turian.css
+++ b/src/styles/turian.css
@@ -39,11 +39,154 @@
   background: #fff;
   overflow: hidden;
 }
+.turian-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.turian-thread > .turian-msg,
+.turian-thread > .turian-quest {
+  margin: 0;
+}
 .turian-msgs {
   max-height: 48vh;
   overflow: auto;
   padding: 12px;
   background: var(--nv-surface);
+}
+.turian-msg {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.turian-quest {
+  border: 1px solid #dbe6ff;
+  background: linear-gradient(135deg, #f4f8ff 0%, #ffffff 100%);
+  border-radius: 18px;
+  padding: 16px;
+  box-shadow: 0 14px 30px rgba(53, 101, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.turian-quest--accepted {
+  background: linear-gradient(135deg, #f0fff4 0%, #ffffff 100%);
+  border-color: #8ce8b4;
+}
+.turian-quest__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1f2d4d;
+}
+.turian-quest__reward {
+  font-size: 0.92rem;
+  color: #314262;
+}
+.turian-quest__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.turian-quest__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.turian-quest__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 700;
+  color: #166534;
+  background: rgba(59, 130, 246, 0.08);
+  padding: 6px 12px;
+  border-radius: 999px;
+  width: fit-content;
+}
+.turian-quest__receipt {
+  background: #fef3c7;
+  border-radius: 12px;
+  padding: 8px 12px;
+  font-size: 0.92rem;
+  color: #854d0e;
+  width: fit-content;
+}
+.turian-quest__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+.turian-quest__link {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #2f68ff;
+  text-decoration: none;
+}
+.turian-quest__link:hover,
+.turian-quest__link:focus {
+  text-decoration: underline;
+}
+.turian-quest__btn {
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+.turian-quest__btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+  transform: none;
+  box-shadow: none;
+}
+.turian-quest__btn--accept {
+  background: linear-gradient(135deg, #3f7cff 0%, #2452ff 100%);
+  color: #fff;
+  box-shadow: 0 10px 18px rgba(36, 82, 255, 0.25);
+}
+.turian-quest__btn--accept:not(:disabled):hover,
+.turian-quest__btn--accept:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(36, 82, 255, 0.32);
+}
+.turian-quest__btn--later {
+  background: #fff;
+  color: #2f68ff;
+  border-color: #2f68ff;
+}
+.turian-quest__btn--later:not(:disabled):hover,
+.turian-quest__btn--later:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(47, 104, 255, 0.12);
+}
+.turian-toast {
+  margin-top: 16px;
+  align-self: center;
+  background: rgba(47, 104, 255, 0.95);
+  color: #fff;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.92rem;
+  box-shadow: 0 18px 32px rgba(35, 78, 210, 0.28);
+}
+
+@media (max-width: 540px) {
+  .turian-quest__actions {
+    flex-direction: column;
+  }
+  .turian-quest__btn {
+    width: 100%;
+    text-align: center;
+  }
+  .turian-quest__links {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .turian-quest__link {
+    width: fit-content;
+  }
 }
 .msg {
   display: flex;


### PR DESCRIPTION
## Summary
- detect quest tags in Turian replies, persist chat history locally, and surface inline quest cards with offline fallbacks and acceptance flows
- add demo helpers to award NATUR and passport stamps when quests are accepted
- style the Turian chat UI for quest cards, toast messaging, and mobile-friendly actions

## Testing
- `npm run typecheck` *(fails: project depends on Next.js and Supabase typings that are not available in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68cad62a785c8329ae1336932bd528be