### PR TITLE
Add Turian quest board with synced rewards

### DIFF
--- a/src/pages/Turian.tsx
+++ b/src/pages/Turian.tsx
@@ -1,7 +1,76 @@
+import { useMemo, useState } from "react";
 import TurianChat from "../components/TurianChat";
+import { addBadge, addStamp, grantNatur } from "../utils/progress";
+import { setTitle } from "./_meta";
 import "./turian.css";
 
+type QuestCategory = "Nature" | "Learning" | "Creative" | "Adventure" | "Fun";
+
+type Quest = {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  category: QuestCategory;
+  reward: { natur: number; stamp: string };
+};
+
+const QUESTS: Quest[] = [
+  {
+    id: "leafy-art",
+    title: "Leafy Art",
+    description: "Collect 5 different leaves and create a collage. Snap a photo or describe your masterpiece!",
+    icon: "🎨",
+    category: "Creative",
+    reward: { natur: 5, stamp: "Neighborhood" },
+  },
+  {
+    id: "star-gazing",
+    title: "Star Gazing",
+    description: "Look at the night sky and spot 5 constellations or bright stars. Sketch or name your favorites!",
+    icon: "✨",
+    category: "Nature",
+    reward: { natur: 5, stamp: "Skywatch" },
+  },
+  {
+    id: "fruit-friend",
+    title: "Fruit Friend",
+    description: "Draw your favorite fruit, give it a silly name, and invent a short story about its adventures.",
+    icon: "🍎",
+    category: "Fun",
+    reward: { natur: 5, stamp: "Creative" },
+  },
+  {
+    id: "riddle-me",
+    title: "Riddle Me",
+    description: "Solve Turian's riddle: What has roots as nobody sees, is taller than trees, up, up it goes?",
+    icon: "🧠",
+    category: "Learning",
+    reward: { natur: 5, stamp: "Learning" },
+  },
+  {
+    id: "nature-hike",
+    title: "Nature Hike",
+    description: "Take a 10-minute walk outside and spot three different plants or trees. Describe what makes them unique.",
+    icon: "🥾",
+    category: "Adventure",
+    reward: { natur: 5, stamp: "Adventure" },
+  },
+];
+
+function pickRandomQuest(previous?: Quest | null): Quest {
+  if (QUESTS.length === 1) return QUESTS[0];
+  let next = QUESTS[Math.floor(Math.random() * QUESTS.length)];
+  if (!previous) return next;
+  for (let attempt = 0; attempt < 4 && next.id === previous.id; attempt += 1) {
+    next = QUESTS[Math.floor(Math.random() * QUESTS.length)];
+  }
+  return next.id === previous.id ? QUESTS.find((quest) => quest.id !== previous.id) ?? next : next;
+}
+
 export default function TurianPage() {
+  setTitle("Turian");
+
   return (
     <main className="nv-page">
       <nav className="nv-breadcrumbs">
@@ -15,6 +84,8 @@ export default function TurianPage() {
         </p>
       </section>
 
+      <TurianQuestBoard />
+
       <section className="turian-chat_section">
         <h2 className="turian-chat_heading">Chat with Turian</h2>
         {/* badge lives inside the card header; status text is set by the component */}
@@ -24,3 +95,160 @@ export default function TurianPage() {
   );
 }
 
+function TurianQuestBoard() {
+  const [quest, setQuest] = useState<Quest | null>(null);
+  const [status, setStatus] = useState<"idle" | "accepting" | "accepted" | "error">("idle");
+  const [feedback, setFeedback] = useState("");
+  const [syncMessage, setSyncMessage] = useState("");
+  const [error, setError] = useState("");
+
+  const categoryClass = useMemo(() => {
+    if (!quest) return "";
+    return quest.category.toLowerCase();
+  }, [quest]);
+
+  const rollQuest = () => {
+    const next = pickRandomQuest(quest);
+    setQuest(next);
+    setStatus("idle");
+    setFeedback("");
+    setSyncMessage("");
+    setError("");
+  };
+
+  const acceptQuest = async () => {
+    if (!quest || status === "accepting" || status === "accepted") return;
+    setStatus("accepting");
+    setError("");
+
+    try {
+      const naturResult = await grantNatur(quest.reward.natur, `Quest: ${quest.title}`);
+      const stampResult = await addStamp(quest.reward.stamp, quest.title);
+      const badgeResult = await addBadge(quest.reward.stamp);
+
+      const details = [
+        `+${quest.reward.natur} NATUR`,
+        `Stamp: ${quest.reward.stamp}`,
+      ];
+      if (badgeResult.award) {
+        details.push(`${badgeResult.award.emoji} ${badgeResult.award.label}`);
+      }
+      setFeedback(details.join(" • "));
+
+      const allRemote = [naturResult.status, stampResult.status, badgeResult.status].every(
+        (state) => state === "remote" || state === "noop",
+      );
+      setSyncMessage(
+        allRemote
+          ? "Synced to NaturBank and Passport."
+          : "Saved locally — sign in to sync later.",
+      );
+
+      setStatus("accepted");
+    } catch (err) {
+      console.error(err);
+      setFeedback("");
+      setSyncMessage("");
+      setError("Whoops! Turian couldn't record that quest just now. Try again in a moment.");
+      setStatus("error");
+    }
+  };
+
+  return (
+    <section className="turian-quests" aria-labelledby="turian-quests-title">
+      <h2 id="turian-quests-title" className="turian-quests__title">
+        Quest Board
+      </h2>
+      <p className="turian-quests__lead">
+        Turian rotates five playful missions each day. Spin up a quest, head outside, and earn NATUR with
+        passport stamps and badges.
+      </p>
+
+      <div className="turian-quests__actions">
+        <button
+          type="button"
+          className="turian-quests__button"
+          onClick={rollQuest}
+          disabled={status === "accepting"}
+        >
+          {quest ? "Surprise me again" : "Give me a quest"}
+        </button>
+      </div>
+
+      {quest ? (
+        <article
+          key={quest.id}
+          className={`turian-quest-card turian-quest-card--${categoryClass} ${
+            status === "accepted" ? "turian-quest-card--complete" : ""
+          }`}
+        >
+          <div className="turian-quest-card__icon" aria-hidden="true">
+            {quest.icon}
+          </div>
+          <div className="turian-quest-card__body">
+            <div className="turian-quest-card__category">{quest.category}</div>
+            <h3 className="turian-quest-card__title">{quest.title}</h3>
+            <p className="turian-quest-card__text">{quest.description}</p>
+
+            <div className="turian-quest-card__meta">
+              <span className="turian-quest-card__chip" aria-label={`Reward ${quest.reward.natur} NATUR`}>
+                <span className="turian-quest-card__chip-icon" aria-hidden="true">
+                  🪙
+                </span>
+                +{quest.reward.natur} NATUR
+              </span>
+              <span className="turian-quest-card__chip" aria-label={`Passport stamp ${quest.reward.stamp}`}>
+                <span className="turian-quest-card__chip-icon" aria-hidden="true">
+                  📘
+                </span>
+                {quest.reward.stamp} stamp
+              </span>
+            </div>
+
+            <div className="turian-quest-card__actions">
+              <button
+                type="button"
+                className="turian-quest-card__button turian-quest-card__button--primary"
+                onClick={acceptQuest}
+                disabled={status === "accepting" || status === "accepted"}
+              >
+                {status === "accepting" ? "Accepting…" : status === "accepted" ? "Accepted" : "Accept quest"}
+              </button>
+              <button
+                type="button"
+                className="turian-quest-card__button turian-quest-card__button--ghost"
+                onClick={rollQuest}
+                disabled={status === "accepting"}
+              >
+                Another quest
+              </button>
+            </div>
+
+            {feedback && status === "accepted" && (
+              <div className="turian-quest-card__status" role="status" aria-live="polite">
+                <div className="turian-quest-card__status-main">✅ {feedback}</div>
+                <div className="turian-quest-card__status-sub">{syncMessage}</div>
+              </div>
+            )}
+
+            {status === "error" && error && (
+              <div className="turian-quest-card__status turian-quest-card__status--error" role="status" aria-live="assertive">
+                <div className="turian-quest-card__status-main">⚠️ {error}</div>
+                <div className="turian-quest-card__status-sub">
+                  Your progress is safe — try again when you have a steadier connection.
+                </div>
+              </div>
+            )}
+          </div>
+        </article>
+      ) : (
+        <div className="turian-quests__placeholder" role="status" aria-live="polite">
+          <p>
+            Tap <strong>Give me a quest</strong> to unlock a mini-mission. Turian will keep it gentle and fun for
+            explorers of all ages.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/pages/turian.css
+++ b/src/pages/turian.css
@@ -30,6 +30,332 @@
   color: #334155;
 }
 
+/* Quest board */
+.turian-quests {
+  margin: 28px auto 36px;
+  max-width: 780px;
+  padding: 0 8px;
+  text-align: center;
+}
+
+.turian-quests__title {
+  margin: 0 0 6px;
+  font-size: clamp(22px, 3.6vw, 32px);
+  font-weight: 700;
+  color: #102a68;
+}
+
+.turian-quests__lead {
+  margin: 0 auto 18px;
+  color: #334155;
+  font-size: clamp(14px, 2.4vw, 17px);
+  max-width: 560px;
+}
+
+.turian-quests__actions {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 18px;
+}
+
+.turian-quests__button {
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  padding: 12px 28px;
+  cursor: pointer;
+  box-shadow: 0 18px 34px rgba(37, 99, 235, 0.24);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.turian-quests__button:not(:disabled):hover,
+.turian-quests__button:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 40px rgba(37, 99, 235, 0.3);
+}
+
+.turian-quests__button:disabled {
+  opacity: 0.55;
+  cursor: default;
+  transform: none;
+  box-shadow: none;
+}
+
+.turian-quests__placeholder {
+  border: 1px dashed rgba(79, 120, 255, 0.5);
+  background: rgba(79, 120, 255, 0.08);
+  border-radius: 18px;
+  padding: 22px 18px;
+  max-width: 640px;
+  margin: 0 auto;
+  color: #1f2d4d;
+  font-size: 0.96rem;
+  box-shadow: 0 16px 30px rgba(79, 120, 255, 0.12);
+}
+
+@keyframes turian-quest-rise {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.turian-quest-card {
+  --card-start: rgba(59, 130, 246, 0.16);
+  --card-end: rgba(255, 255, 255, 0.96);
+  --card-border: rgba(59, 130, 246, 0.35);
+  --icon-bg: rgba(59, 130, 246, 0.16);
+  --icon-shadow: rgba(15, 23, 42, 0.12);
+  background: linear-gradient(135deg, var(--card-start) 0%, var(--card-end) 100%);
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  padding: 22px 24px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 18px;
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.14);
+  animation: turian-quest-rise 0.42s ease;
+  text-align: left;
+  color: #0f172a;
+}
+
+.turian-quest-card--complete {
+  border-color: rgba(16, 185, 129, 0.45);
+  box-shadow: 0 26px 46px rgba(16, 185, 129, 0.18);
+}
+
+.turian-quest-card--nature {
+  --card-start: rgba(34, 197, 94, 0.22);
+  --card-border: rgba(16, 185, 129, 0.5);
+  --icon-bg: rgba(16, 185, 129, 0.18);
+}
+
+.turian-quest-card--learning {
+  --card-start: rgba(59, 130, 246, 0.22);
+  --card-border: rgba(37, 99, 235, 0.45);
+  --icon-bg: rgba(59, 130, 246, 0.18);
+}
+
+.turian-quest-card--creative {
+  --card-start: rgba(244, 114, 182, 0.24);
+  --card-border: rgba(236, 72, 153, 0.45);
+  --icon-bg: rgba(244, 114, 182, 0.24);
+}
+
+.turian-quest-card--adventure {
+  --card-start: rgba(250, 204, 21, 0.28);
+  --card-border: rgba(234, 179, 8, 0.55);
+  --icon-bg: rgba(250, 204, 21, 0.22);
+}
+
+.turian-quest-card--fun {
+  --card-start: rgba(99, 102, 241, 0.24);
+  --card-border: rgba(79, 70, 229, 0.5);
+  --icon-bg: rgba(99, 102, 241, 0.2);
+}
+
+.turian-quest-card__icon {
+  width: clamp(72px, 18vw, 104px);
+  height: clamp(72px, 18vw, 104px);
+  border-radius: 26px;
+  display: grid;
+  place-items: center;
+  background: var(--icon-bg);
+  font-size: clamp(36px, 9vw, 60px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45), 0 12px 24px var(--icon-shadow);
+}
+
+.turian-quest-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.turian-quest-card__category {
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.62);
+}
+
+.turian-quest-card__title {
+  margin: 0;
+  font-size: clamp(20px, 3.2vw, 26px);
+  line-height: 1.15;
+  color: #0b1d4a;
+}
+
+.turian-quest-card__text {
+  margin: 0;
+  font-size: 0.98rem;
+  color: #1f2d4d;
+}
+
+.turian-quest-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.turian-quest-card__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.turian-quest-card__chip-icon {
+  font-size: 1.05rem;
+}
+
+.turian-quest-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.turian-quest-card__button {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 22px;
+  font-size: 0.96rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.turian-quest-card__button--primary {
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #fff;
+  box-shadow: 0 18px 32px rgba(37, 99, 235, 0.24);
+}
+
+.turian-quest-card__button--primary:not(:disabled):hover,
+.turian-quest-card__button--primary:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 38px rgba(37, 99, 235, 0.32);
+}
+
+.turian-quest-card__button--ghost {
+  background: rgba(255, 255, 255, 0.9);
+  color: #1f2937;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+}
+
+.turian-quest-card__button--ghost:not(:disabled):hover,
+.turian-quest-card__button--ghost:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.12);
+}
+
+.turian-quest-card__button:disabled {
+  opacity: 0.55;
+  cursor: default;
+  transform: none;
+  box-shadow: none;
+}
+
+.turian-quest-card__status {
+  margin-top: 14px;
+  padding: 12px 16px;
+  border-radius: 18px;
+  background: rgba(16, 185, 129, 0.16);
+  border: 1px solid rgba(16, 185, 129, 0.45);
+}
+
+.turian-quest-card__status-main {
+  font-weight: 700;
+  color: #065f46;
+}
+
+.turian-quest-card__status-sub {
+  margin-top: 4px;
+  font-size: 0.9rem;
+  color: #0f172a;
+  opacity: 0.78;
+}
+
+.turian-quest-card__status--error {
+  background: rgba(248, 113, 113, 0.16);
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
+.turian-quest-card__status--error .turian-quest-card__status-main {
+  color: #b91c1c;
+}
+
+.turian-quest-card__status--error .turian-quest-card__status-sub {
+  color: #7f1d1d;
+  opacity: 0.85;
+}
+
+@media (max-width: 720px) {
+  .turian-quest-card {
+    grid-template-columns: 1fr;
+    padding: 20px;
+  }
+
+  .turian-quest-card__icon {
+    margin: 0 auto;
+  }
+
+  .turian-quest-card__body {
+    text-align: left;
+  }
+
+  .turian-quest-card__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .turian-quest-card__button {
+    width: 100%;
+  }
+
+  .turian-quests__lead {
+    font-size: 0.95rem;
+  }
+
+  .turian-quests__button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .turian-quest-card__title {
+    font-size: 22px;
+  }
+
+  .turian-quest-card__text {
+    font-size: 0.94rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .turian-quest-card {
+    animation: none;
+  }
+
+  .turian-quests__button,
+  .turian-quest-card__button {
+    transition: none;
+  }
+}
+
 /* Chat section */
 .turian-chat_section { margin-top: 8px; }
 .turian-chat_heading {

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -1,0 +1,275 @@
+import { supabase } from "@/lib/supabase-client";
+import { demoGrant } from "@/lib/naturbank";
+import { demoAddStamp } from "@/lib/passport";
+import {
+  addBadge as addLocalBadge,
+  getBadges as getLocalBadges,
+} from "@/lib/passport/store";
+import type { PassportStamp } from "@/types/passport";
+
+export type ProgressSource = "remote" | "local" | "noop";
+
+export type GrantNaturResult = {
+  status: ProgressSource;
+};
+
+export type StampResult = {
+  status: ProgressSource;
+  stamp?: PassportStamp | null;
+};
+
+export type BadgeLevel = "bronze" | "silver" | "gold";
+
+export type BadgeAward = {
+  level: BadgeLevel;
+  label: string;
+  emoji: string;
+  threshold: number;
+};
+
+export type BadgeResult = {
+  status: ProgressSource;
+  award?: BadgeAward;
+};
+
+const BADGE_LABELS: Record<BadgeLevel, string> = {
+  bronze: "Bronze",
+  silver: "Silver",
+  gold: "Gold",
+};
+
+const BADGE_LEVEL_CONFIG: Record<BadgeLevel, { threshold: number; emoji: string }> = {
+  bronze: { threshold: 3, emoji: "🥉" },
+  silver: { threshold: 6, emoji: "🥈" },
+  gold: { threshold: 10, emoji: "🥇" },
+};
+
+const BADGE_LEVELS: BadgeLevel[] = ["bronze", "silver", "gold"];
+
+const REGION_THRESHOLD_OVERRIDES: Record<string, Partial<Record<BadgeLevel, number>>> = {
+  Neighborhood: { bronze: 3, silver: 6, gold: 10 },
+  Skywatch: { bronze: 3, silver: 6, gold: 10 },
+  Creative: { bronze: 3, silver: 6, gold: 10 },
+  Learning: { bronze: 3, silver: 6, gold: 10 },
+  Adventure: { bronze: 3, silver: 6, gold: 10 },
+  Fun: { bronze: 3, silver: 6, gold: 10 },
+};
+
+const LOCAL_STAMP_KEY = "naturverse.passport.stamps.v1";
+
+async function getCurrentUserId() {
+  try {
+    const { data } = await supabase.auth.getSession();
+    return data.session?.user?.id ?? null;
+  } catch (error) {
+    console.warn("progress:getSession failed", error);
+    return null;
+  }
+}
+
+function sanitizeNote(note: string) {
+  const trimmed = note.trim();
+  return trimmed.length ? trimmed : "Turian quest reward";
+}
+
+function dispatchStampEvent(world: string, stamp: PassportStamp | null | undefined) {
+  if (typeof window === "undefined" || !stamp) return;
+  try {
+    window.dispatchEvent(new CustomEvent("natur:stamp-granted", { detail: { world, stamp } }));
+  } catch {}
+}
+
+function readLocalStamps(): PassportStamp[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(LOCAL_STAMP_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(Boolean) as PassportStamp[];
+  } catch (error) {
+    console.warn("progress:readLocalStamps failed", error);
+    return [];
+  }
+}
+
+function slugifyRegion(value: string) {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "quest";
+}
+
+function buildBadgeLabel(region: string, level: BadgeLevel) {
+  return `${region} ${BADGE_LABELS[level]} Badge`;
+}
+
+function resolveThreshold(region: string, level: BadgeLevel) {
+  return REGION_THRESHOLD_OVERRIDES[region]?.[level] ?? BADGE_LEVEL_CONFIG[level].threshold;
+}
+
+type BadgeComputation = {
+  level: BadgeLevel;
+  threshold: number;
+  emoji: string;
+};
+
+function determineBadge(region: string, count: number): BadgeComputation | null {
+  if (count <= 0) return null;
+  let unlocked: BadgeComputation | null = null;
+  for (const level of BADGE_LEVELS) {
+    const threshold = resolveThreshold(region, level);
+    if (count >= threshold) {
+      unlocked = { level, threshold, emoji: BADGE_LEVEL_CONFIG[level].emoji };
+    }
+  }
+  return unlocked;
+}
+
+function createBadgeCode(region: string, level: BadgeLevel) {
+  const slug = slugifyRegion(region);
+  return `turian-${slug}-${level}`;
+}
+
+function toBadgeAward(region: string, computation: BadgeComputation): BadgeAward {
+  return {
+    level: computation.level,
+    label: buildBadgeLabel(region, computation.level),
+    emoji: computation.emoji,
+    threshold: computation.threshold,
+  };
+}
+
+function addBadgeLocal(region: string): BadgeResult {
+  try {
+    const stamps = readLocalStamps();
+    const count = stamps.reduce((total, stamp) => (stamp.world === region ? total + 1 : total), 0);
+    const unlocked = determineBadge(region, count);
+    if (!unlocked) return { status: "noop" };
+
+    const code = createBadgeCode(region, unlocked.level);
+    const existing = getLocalBadges().some((badge) => badge.id === code);
+    if (existing) return { status: "noop" };
+
+    const award = toBadgeAward(region, unlocked);
+    addLocalBadge({
+      id: code,
+      title: award.label,
+      emoji: award.emoji,
+      desc: `Earned by completing ${award.threshold}+ ${region.toLowerCase()} quests.`,
+    });
+    return { status: "local", award };
+  } catch (error) {
+    console.error("progress:addBadge local fallback failed", error);
+    throw error;
+  }
+}
+
+async function addBadgeRemote(region: string, userId: string): Promise<BadgeResult> {
+  const { count, error: countError } = await supabase
+    .from("passport_stamps")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", userId)
+    .eq("world", region);
+  if (countError) throw countError;
+
+  const unlocked = determineBadge(region, count ?? 0);
+  if (!unlocked) return { status: "noop" };
+
+  const code = createBadgeCode(region, unlocked.level);
+  const { data: existing, error: existingError } = await supabase
+    .from("passport_badges")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("code", code)
+    .maybeSingle();
+  if (existingError) throw existingError;
+  if (existing) return { status: "noop" };
+
+  const award = toBadgeAward(region, unlocked);
+  const { error: insertError } = await supabase
+    .from("passport_badges")
+    .insert({ user_id: userId, code, label: award.label });
+  if (insertError) throw insertError;
+
+  return { status: "remote", award };
+}
+
+export async function grantNatur(amount: number, note: string): Promise<GrantNaturResult> {
+  const safeAmount = Number.isFinite(amount) ? Math.max(0, Math.round(amount)) : 0;
+  if (safeAmount <= 0) return { status: "noop" };
+  const entryNote = sanitizeNote(note);
+
+  try {
+    const userId = await getCurrentUserId();
+    if (userId) {
+      const { error } = await supabase.rpc("earn_spend_natur", {
+        p_kind: "earn",
+        p_amount: safeAmount,
+        p_meta: { source: "turian-quest", note: entryNote },
+      });
+      if (error) throw error;
+      return { status: "remote" };
+    }
+  } catch (error) {
+    console.warn("progress:grantNatur remote failed", error);
+  }
+
+  try {
+    demoGrant(safeAmount, entryNote);
+    return { status: "local" };
+  } catch (error) {
+    console.error("progress:grantNatur local fallback failed", error);
+    throw error;
+  }
+}
+
+export async function addStamp(region: string, questTitle: string): Promise<StampResult> {
+  const world = region.trim();
+  if (!world) return { status: "noop" };
+  const title = questTitle.trim() || "Turian Quest";
+  const note = `Quest: ${title}`;
+
+  try {
+    const userId = await getCurrentUserId();
+    if (userId) {
+      const { data, error } = await supabase
+        .from("passport_stamps")
+        .insert({ user_id: userId, world, title, note })
+        .select("id,user_id,world,title,note,created_at")
+        .single();
+      if (error) throw error;
+      const stamp = data as PassportStamp;
+      dispatchStampEvent(world, stamp);
+      return { status: "remote", stamp };
+    }
+  } catch (error) {
+    console.warn("progress:addStamp remote failed", error);
+  }
+
+  try {
+    const stamp = demoAddStamp(world, title);
+    if (!stamp) return { status: "noop" };
+    return { status: "local", stamp };
+  } catch (error) {
+    console.error("progress:addStamp local fallback failed", error);
+    throw error;
+  }
+}
+
+export async function addBadge(region: string): Promise<BadgeResult> {
+  const trimmed = region.trim();
+  if (!trimmed) return { status: "noop" };
+
+  try {
+    const userId = await getCurrentUserId();
+    if (userId) {
+      return await addBadgeRemote(trimmed, userId);
+    }
+  } catch (error) {
+    console.warn("progress:addBadge remote failed", error);
+  }
+
+  return addBadgeLocal(trimmed);
+}


### PR DESCRIPTION
## Summary
- add a quest board to Turian’s page with five themed missions and acceptance flow
- create progress utilities to sync NATUR rewards, passport stamps, and badges with Supabase and local fallbacks
- refresh Turian styling with responsive quest card layouts and animations

## Testing
- npm run typecheck *(fails: repository lacks Next.js dependencies and Supabase types used by other packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cadd79fbec83299b2926a7036a21a4