### PR TITLE
Add persistent Turian quest tracker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
 import TurianAssistant from './components/TurianAssistant';
 import { useAuth } from './lib/auth-context';
+import { mountConfettiOnce } from './lib/confetti';
 import './styles/magic.css';
 // TEMP: disable interactions while we isolate the crash
 // import { initInteractions } from './init/interactions';
@@ -17,6 +18,10 @@ export default function App() {
   const isAuthed = ready && !!user;
   useEffect(() => {
     // SAFE MODE: interactions temporarily disabled
+    const detach = mountConfettiOnce();
+    return () => {
+      detach?.();
+    };
   }, []);
   return (
     <CartProvider>

--- a/src/components/MyQuestsCard.tsx
+++ b/src/components/MyQuestsCard.tsx
@@ -1,0 +1,81 @@
+import { useQuestState } from "@/features/quests/useQuestState";
+import "./my-quests.css";
+
+export default function MyQuestsCard() {
+  const {
+    active,
+    streak,
+    completedToday,
+    feedback,
+    syncMessage,
+    error,
+    marking,
+    markComplete,
+  } = useQuestState();
+
+  return (
+    <section className="my-quests" aria-labelledby="my-quests-title">
+      <h3 id="my-quests-title" className="my-quests__title">
+        My Quests
+      </h3>
+
+      {!active && (
+        <div className="my-quests__empty" role="status">
+          No active quest yet. Tap <strong>Give me a quest</strong> above to get started.
+        </div>
+      )}
+
+      {active && (
+        <div className={`my-quests__card ${completedToday ? "my-quests__card--done" : ""}`}>
+          <div className="my-quests__header">
+            <div className="my-quests__info">
+              <div className="my-quests__label">Active quest</div>
+              <div className="my-quests__name">{active.title}</div>
+              <div className="my-quests__meta">
+                Reward: +{active.rewardNatur} NATUR • Stamp: {active.stamp}
+              </div>
+            </div>
+            <div className="my-quests__streak" aria-label={`Daily streak ${streak} day${streak === 1 ? "" : "s"}`}>
+              <span aria-hidden="true">🔥</span>
+              <span>{streak}</span>
+              <span className="my-quests__streak-label">day{streak === 1 ? "" : "s"}</span>
+            </div>
+          </div>
+
+          <div className="my-quests__actions">
+            {completedToday ? (
+              <button className="my-quests__button my-quests__button--done" type="button" disabled>
+                Completed today ✓
+              </button>
+            ) : (
+              <button
+                className="my-quests__button my-quests__button--primary"
+                type="button"
+                onClick={markComplete}
+                disabled={marking}
+              >
+                {marking ? "Marking…" : "Mark complete"}
+              </button>
+            )}
+          </div>
+
+          {feedback && (
+            <div className="my-quests__status" role="status" aria-live="polite">
+              <div className="my-quests__status-main">✅ {feedback}</div>
+              {syncMessage && <div className="my-quests__status-sub">{syncMessage}</div>}
+            </div>
+          )}
+
+          {error && (
+            <div className="my-quests__status my-quests__status--error" role="alert">
+              <div className="my-quests__status-main">⚠️ {error}</div>
+              <div className="my-quests__status-sub">
+                Your progress is safe — try again when you have a steadier connection.
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/my-quests.css
+++ b/src/components/my-quests.css
@@ -1,0 +1,151 @@
+.my-quests {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.my-quests__title {
+  font-weight: 800;
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.my-quests__empty {
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid var(--card-border, #e5eaf5);
+  background: #fff;
+  color: #475569;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.my-quests__card {
+  border-radius: 12px;
+  border: 1px solid var(--card-border, #e5eaf5);
+  background: linear-gradient(180deg, #f7fbff 0%, #eef5ff 100%);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.my-quests__card--done {
+  background: linear-gradient(180deg, #f8fff7 0%, #edf8ed 100%);
+}
+
+.my-quests__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.my-quests__label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+  margin-bottom: 4px;
+}
+
+.my-quests__name {
+  font-weight: 700;
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.my-quests__meta {
+  margin-top: 4px;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.my-quests__streak {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-weight: 700;
+  color: #ef4444;
+  font-size: 0.95rem;
+}
+
+.my-quests__streak-label {
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+.my-quests__actions {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.my-quests__button {
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: transform 120ms ease, box-shadow 120ms ease, opacity 120ms ease;
+}
+
+.my-quests__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.my-quests__button--primary {
+  background: #2e62ff;
+  color: #fff;
+  box-shadow: 0 10px 18px rgba(46, 98, 255, 0.18);
+}
+
+.my-quests__button--primary:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(46, 98, 255, 0.24);
+}
+
+.my-quests__button--done {
+  background: #e2e8f0;
+  color: #475569;
+}
+
+.my-quests__status {
+  border-radius: 10px;
+  padding: 12px 14px;
+  background: rgba(34, 197, 94, 0.12);
+  color: #14532d;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.my-quests__status--error {
+  background: rgba(248, 113, 113, 0.18);
+  color: #991b1b;
+}
+
+.my-quests__status-main {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.my-quests__status-sub {
+  font-size: 0.85rem;
+  color: inherit;
+  opacity: 0.85;
+}
+
+@media (max-width: 640px) {
+  .my-quests__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .my-quests__streak {
+    justify-content: flex-start;
+  }
+}

--- a/src/features/quests/useQuestState.ts
+++ b/src/features/quests/useQuestState.ts
@@ -1,0 +1,266 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { addBadge, addStamp, grantNatur } from "@/utils/progress";
+
+export type Quest = {
+  id: string;
+  title: string;
+  world: string;
+  rewardNatur: number;
+  stamp: string;
+};
+
+const LS_ACTIVE = "natur:activeQuest";
+const LS_LAST_DONE_DAY = "natur:lastQuestDay";
+const LS_STREAK = "natur:streak";
+
+type QuestDetail = {
+  id?: unknown;
+  title?: unknown;
+  world?: unknown;
+  rewardNatur?: unknown;
+  stamp?: unknown;
+};
+
+type MarkStatus = "idle" | "marking";
+
+type QuestEvent = CustomEvent<QuestDetail>;
+
+const todayKey = () => new Date().toISOString().slice(0, 10);
+
+const readJSON = <T,>(key: string): T | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+};
+
+const writeJSON = (key: string, value: unknown) => {
+  if (typeof window === "undefined") return;
+  try {
+    if (value === null || value === undefined) {
+      window.localStorage.removeItem(key);
+    } else {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    }
+  } catch {
+    // ignore storage quota issues silently
+  }
+};
+
+const readActiveQuest = (): Quest | null => {
+  const data = readJSON<QuestDetail>(LS_ACTIVE);
+  if (!data) return null;
+  const parsed = normalizeQuest(data);
+  return parsed;
+};
+
+const readLastCompletion = () => {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(LS_LAST_DONE_DAY);
+  } catch {
+    return null;
+  }
+};
+
+const writeLastCompletion = (value: string) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(LS_LAST_DONE_DAY, value);
+  } catch {}
+};
+
+const readStreak = () => {
+  if (typeof window === "undefined") return 0;
+  const stored = window.localStorage.getItem(LS_STREAK);
+  if (!stored) return 0;
+  const num = Number(stored);
+  return Number.isFinite(num) && num > 0 ? Math.floor(num) : 0;
+};
+
+const writeStreak = (value: number) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(LS_STREAK, String(Math.max(0, Math.floor(value))));
+  } catch {}
+};
+
+function normalizeQuest(raw: QuestDetail | null | undefined): Quest | null {
+  if (!raw || typeof raw !== "object") return null;
+  const id = typeof raw.id === "string" ? raw.id : "";
+  const title = typeof raw.title === "string" ? raw.title : "";
+  const world = typeof raw.world === "string" ? raw.world : "";
+  const stamp = typeof raw.stamp === "string" ? raw.stamp : world;
+  const natur = Number((raw as QuestDetail).rewardNatur);
+  if (!id || !title) return null;
+  return {
+    id,
+    title,
+    world: world || stamp || "Neighborhood",
+    stamp: stamp || world || "Neighborhood",
+    rewardNatur: Number.isFinite(natur) && natur > 0 ? Math.round(natur) : 0,
+  };
+}
+
+function yesterdayKey(key: string) {
+  const base = new Date(`${key}T00:00:00`);
+  if (Number.isNaN(base.getTime())) return "";
+  base.setDate(base.getDate() - 1);
+  return base.toISOString().slice(0, 10);
+}
+
+export function useQuestState() {
+  const [active, setActiveState] = useState<Quest | null>(() => readActiveQuest());
+  const [streak, setStreak] = useState<number>(() => readStreak());
+  const [completedToday, setCompletedToday] = useState<boolean>(() => readLastCompletion() === todayKey());
+  const [feedback, setFeedback] = useState("");
+  const [syncMessage, setSyncMessage] = useState("");
+  const [error, setError] = useState("");
+  const [status, setStatus] = useState<MarkStatus>("idle");
+
+  const setActive = useCallback((quest: Quest | null) => {
+    setActiveState(quest);
+    if (quest) {
+      writeJSON(LS_ACTIVE, quest);
+      setCompletedToday(readLastCompletion() === todayKey());
+    } else {
+      writeJSON(LS_ACTIVE, null);
+      setCompletedToday(false);
+    }
+    setFeedback("");
+    setSyncMessage("");
+    setError("");
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = (event: Event) => {
+      const quest = normalizeQuest((event as QuestEvent).detail);
+      if (!quest) return;
+      setActive(quest);
+    };
+    window.addEventListener("natur:quest:accepted", handler);
+    return () => window.removeEventListener("natur:quest:accepted", handler);
+  }, [setActive]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const last = readLastCompletion();
+    if (last && last !== todayKey()) {
+      const stored = readStreak();
+      if (stored !== streak) setStreak(stored);
+    }
+  }, [streak]);
+
+  const markComplete = useCallback(async () => {
+    if (!active || status === "marking" || completedToday) return;
+    setStatus("marking");
+    setError("");
+    setFeedback("");
+    setSyncMessage("");
+
+    try {
+      const [naturResult, stampResult, badgeResult] = await Promise.all([
+        grantNatur(active.rewardNatur, `Quest: ${active.title}`),
+        addStamp(active.world, active.title),
+        addBadge(active.world),
+      ]);
+
+      const detailParts: string[] = [];
+      if (active.rewardNatur > 0) {
+        detailParts.push(`+${active.rewardNatur} NATUR`);
+      }
+      if (active.stamp) {
+        detailParts.push(`Stamp: ${active.stamp}`);
+      }
+      if (badgeResult.award) {
+        detailParts.push(`${badgeResult.award.emoji} ${badgeResult.award.label}`);
+      }
+      if (detailParts.length) {
+        setFeedback(detailParts.join(" • "));
+      }
+
+      const statuses = [naturResult.status, stampResult.status, badgeResult.status];
+      const allRemote = statuses.every((state) => state === "remote" || state === "noop");
+      setSyncMessage(
+        allRemote
+          ? "Synced to NaturBank and Passport."
+          : "Saved locally — sign in to sync later."
+      );
+
+      const last = readLastCompletion();
+      const today = todayKey();
+      const storedStreak = readStreak();
+      let nextStreak = storedStreak > 0 ? storedStreak : streak;
+      if (last === today) {
+        nextStreak = storedStreak || streak || 1;
+      } else if (last && last === yesterdayKey(today)) {
+        nextStreak = (storedStreak || streak) + 1;
+      } else {
+        nextStreak = 1;
+      }
+      setStreak(nextStreak);
+      writeStreak(nextStreak);
+      setCompletedToday(true);
+      writeLastCompletion(today);
+
+      try {
+        writeJSON(LS_ACTIVE, active);
+      } catch {}
+
+      try {
+        window.dispatchEvent(
+          new CustomEvent("natur:reward", {
+            detail: { natur: active.rewardNatur, note: `Quest: ${active.title}` },
+          })
+        );
+      } catch {}
+
+      try {
+        window.dispatchEvent(
+          new CustomEvent("natur:stamp", {
+            detail: { world: active.world, note: "Quest completed with Turian" },
+          })
+        );
+      } catch {}
+
+      try {
+        window.dispatchEvent(new CustomEvent("natur:confetti"));
+      } catch {}
+    } catch (err) {
+      console.error("quest:markComplete failed", err);
+      setError("Whoops! Turian couldn't record that quest just now. Try again in a moment.");
+    } finally {
+      setStatus("idle");
+    }
+  }, [active, completedToday, status, streak]);
+
+  return useMemo(
+    () => ({
+      active,
+      streak,
+      completedToday,
+      feedback,
+      syncMessage,
+      error,
+      marking: status === "marking",
+      setActive,
+      markComplete,
+    }),
+    [
+      active,
+      streak,
+      completedToday,
+      feedback,
+      syncMessage,
+      error,
+      status,
+      setActive,
+      markComplete,
+    ]
+  );
+}

--- a/src/lib/confetti.ts
+++ b/src/lib/confetti.ts
@@ -28,3 +28,39 @@ export function confettiBurst(x = 0.5, y = 0.4) {
   }
   setTimeout(()=>root.remove(), 1000);
 }
+
+type ConfettiEventDetail = {
+  x?: number;
+  y?: number;
+};
+
+let detach: (() => void) | null = null;
+
+export function mountConfettiOnce(): (() => void) | undefined {
+  if (typeof window === 'undefined') return undefined;
+  if (detach) return detach;
+
+  const clamp = (value: number, fallback: number) => {
+    if (!Number.isFinite(value)) return fallback;
+    return Math.min(1, Math.max(0, value));
+  };
+
+  const handler = (event: Event) => {
+    const detail = (event as CustomEvent<ConfettiEventDetail>).detail;
+    if (detail && (typeof detail.x === 'number' || typeof detail.y === 'number')) {
+      const nextX = clamp(detail.x ?? 0.5, 0.5);
+      const nextY = clamp(detail.y ?? 0.4, 0.4);
+      confettiBurst(nextX, nextY);
+      return;
+    }
+    confettiBurst();
+  };
+
+  window.addEventListener('natur:confetti', handler as EventListener);
+  detach = () => {
+    window.removeEventListener('natur:confetti', handler as EventListener);
+    detach = null;
+  };
+
+  return detach;
+}


### PR DESCRIPTION
## Summary
- add a reusable quest state hook that persists the active quest, streak, and completion status while dispatching reward events
- introduce a dedicated My Quests card with styling and mount it on the Turian page so quests persist and can be completed later
- adjust Turian quest accept flows, chat messaging, and confetti handling to rely on the shared quest state and event listener

## Testing
- npm run typecheck *(fails: repo already missing Next.js modules/types and has existing Supabase typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68caed0ef9108329a0b8b853e7391320