### PR TITLE
Add Groq-backed AI flows for Navatar and Naturversity

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,8 @@
 [functions]
   node_bundler = "esbuild"
   directory = "netlify/functions"
+  included_files = []
+  external_node_modules = []
 
 # SPA routing
 [[redirects]]
@@ -19,6 +21,11 @@
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
+
+[[headers]]
+  for = "/.netlify/functions/ai"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
 
 [[headers]]
   for = "/*"

--- a/netlify/functions/ai.ts
+++ b/netlify/functions/ai.ts
@@ -1,0 +1,208 @@
+import type { Handler } from "@netlify/functions";
+
+type SchemaKey =
+  | "name"
+  | "species"
+  | "kingdom"
+  | "backstory"
+  | "title"
+  | "intro"
+  | "outline"
+  | "activities"
+  | "quiz";
+type LessonSchema = SchemaKey[];
+
+const MODEL = process.env.GROQ_MODEL || "llama-3.1-8b-instant";
+const API_KEY = process.env.GROQ_API_KEY;
+const TTL_MS = 1000 * 60 * 30; // 30 minutes
+
+type CacheEntry = { t: number; v: unknown };
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __aiCache: Map<string, CacheEntry> | undefined;
+}
+
+const ok = (data: unknown) => ({
+  statusCode: 200,
+  headers: {
+    "content-type": "application/json",
+    "access-control-allow-origin": "*",
+  },
+  body: JSON.stringify({ ok: true, data }),
+});
+
+const bad = (message: string, statusCode = 400) => ({
+  statusCode,
+  headers: {
+    "content-type": "application/json",
+    "access-control-allow-origin": "*",
+  },
+  body: JSON.stringify({ ok: false, error: message }),
+});
+
+type RequestBody = {
+  kind?: string;
+  input?: Record<string, unknown> | null;
+};
+
+type PromptConfig = {
+  schema: LessonSchema;
+  system: string;
+  user: string;
+};
+
+function buildPrompt(kind: string, input: Record<string, unknown> | null | undefined): PromptConfig {
+  switch (kind) {
+    case "navatar.card": {
+      const description = String(input?.description ?? "").slice(0, 2000);
+      return {
+        schema: ["name", "species", "kingdom", "backstory"],
+        system:
+          "You are Turian, a friendly kids guide. Return concise JSON only with keys: name, species, kingdom, backstory. Keep it positive and G-rated.",
+        user: `Describe a fun character from this description:\n${description}`,
+      };
+    }
+    case "naturversity.lesson": {
+      const topic = String(input?.topic ?? "").slice(0, 200);
+      const age = Number(input?.age ?? 0) || 0;
+      return {
+        schema: ["title", "intro", "outline", "activities", "quiz"],
+        system:
+          "You write short, kid-friendly nature lessons. Return JSON with title, intro (1 paragraph), outline (3 bullets), activities (2 short items), quiz (3 Q&A). No extra text.",
+        user: `Topic: ${topic}\nAge: ${age}`,
+      };
+    }
+    default:
+      throw new Error("Unknown kind");
+  }
+}
+
+function getCache(): Map<string, CacheEntry> {
+  if (!globalThis.__aiCache) {
+    globalThis.__aiCache = new Map<string, CacheEntry>();
+  }
+  return globalThis.__aiCache;
+}
+
+type Sanitized = Record<string, string | string[] | { q: string; a: string }[]>;
+
+function sanitizeBySchema(schema: LessonSchema, value: Record<string, unknown>): Sanitized {
+  const clean: Sanitized = {};
+  for (const key of schema) {
+    const raw = value[key];
+    if (Array.isArray(raw)) {
+      if (key === "quiz") {
+        clean[key] = raw
+          .slice(0, 3)
+          .map((item) => {
+            if (typeof item === "object" && item !== null) {
+              const q = String((item as Record<string, unknown>).q ?? "").slice(0, 320);
+              const a = String((item as Record<string, unknown>).a ?? "").slice(0, 320);
+              return { q, a };
+            }
+            return { q: String(item ?? "").slice(0, 320), a: "" };
+          })
+          .filter((item) => item.q.length > 0);
+      } else {
+        const limit = key === "outline" ? 3 : key === "activities" ? 2 : raw.length;
+        clean[key] = raw
+          .slice(0, limit)
+          .map((entry) => String(entry ?? "").slice(0, 320))
+          .filter((entry) => entry.length > 0);
+      }
+    } else {
+      clean[key] = String(raw ?? "").slice(0, 800);
+    }
+  }
+  return clean;
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return {
+      statusCode: 204,
+      headers: {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "POST,OPTIONS",
+        "access-control-allow-headers": "content-type",
+      },
+      body: "",
+    };
+  }
+
+  if (event.httpMethod !== "POST") return bad("POST only", 405);
+  if (!API_KEY) return bad("Server missing GROQ_API_KEY", 500);
+
+  let body: RequestBody;
+  try {
+    body = JSON.parse(event.body || "{}") as RequestBody;
+  } catch (error) {
+    return bad("Invalid JSON body");
+  }
+
+  const { kind, input } = body;
+  if (!kind) return bad("Missing kind");
+
+  let cfg: PromptConfig;
+  try {
+    cfg = buildPrompt(kind, input ?? {});
+  } catch (error) {
+    return bad(error instanceof Error ? error.message : "Unsupported kind");
+  }
+
+  const cacheKey = `${kind}:${JSON.stringify(input ?? {})}`;
+  const cache = getCache();
+  const now = Date.now();
+  const cached = cache.get(cacheKey);
+  if (cached && now - cached.t < TTL_MS) {
+    return ok(cached.v);
+  }
+
+  const response = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      temperature: 0.6,
+      messages: [
+        { role: "system", content: cfg.system },
+        { role: "user", content: cfg.user },
+      ],
+      response_format: { type: "json_object" },
+      max_tokens: 800,
+    }),
+  });
+
+  if (!response.ok) {
+    return bad(`Groq error ${response.status}`, response.status);
+  }
+
+  let payload: any;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    return bad("Invalid response from Groq", 502);
+  }
+
+  const content = payload?.choices?.[0]?.message?.content;
+  if (typeof content !== "string") {
+    return bad("Groq returned no content", 502);
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(content) as Record<string, unknown>;
+  } catch (error) {
+    return bad("Groq returned invalid JSON", 502);
+  }
+
+  const clean = sanitizeBySchema(cfg.schema, parsed);
+  cache.set(cacheKey, { t: now, v: clean });
+  return ok(clean);
+};
+
+export default handler;

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,26 @@
+export async function callAI<T>(kind: string, input: unknown): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30000);
+  try {
+    const response = await fetch("/.netlify/functions/ai", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ kind, input }),
+      signal: controller.signal,
+    });
+
+    const json = await response.json().catch(() => ({ ok: false, error: "Invalid server response" }));
+    if (!response.ok || !json.ok) {
+      const message = json?.error || `AI failed (${response.status})`;
+      throw new Error(message);
+    }
+    return json.data as T;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error("AI request timed out");
+    }
+    throw error instanceof Error ? error : new Error("AI request failed");
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,55 @@
+import { demoGrant } from "@/lib/naturbank";
+import { demoAddStamp } from "@/lib/passport";
+
+type NaturEventMap = {
+  grant_natur: { amount: number; note?: string | null };
+  passport_stamp: { world: string; note?: string | null };
+};
+
+export type NaturEventName = keyof NaturEventMap;
+
+type NaturEventPayload = NaturEventMap[NaturEventName];
+type GrantPayload = NaturEventMap["grant_natur"];
+type StampPayload = NaturEventMap["passport_stamp"];
+type NaturEventResult =
+  | ReturnType<typeof demoGrant>
+  | ReturnType<typeof demoAddStamp>
+  | null;
+
+function isGrantPayload(name: NaturEventName, payload: NaturEventPayload): payload is GrantPayload {
+  return name === "grant_natur";
+}
+
+function isStampPayload(name: NaturEventName, payload: NaturEventPayload): payload is StampPayload {
+  return name === "passport_stamp";
+}
+
+export function naturEvent(name: "grant_natur", payload: GrantPayload): NaturEventResult;
+export function naturEvent(name: "passport_stamp", payload: StampPayload): NaturEventResult;
+export function naturEvent(name: NaturEventName, payload: NaturEventPayload): NaturEventResult {
+  if (isGrantPayload(name, payload)) {
+    const amount = Number(payload.amount);
+    if (!Number.isFinite(amount) || amount <= 0) return null;
+    const note = (payload.note ?? "").toString().slice(0, 160);
+    const wallet = demoGrant(amount, note);
+    if (typeof window !== "undefined") {
+      try {
+        window.dispatchEvent(
+          new CustomEvent("natur:bank-granted", {
+            detail: { amount, note },
+          }),
+        );
+      } catch {}
+    }
+    return wallet;
+  }
+
+  if (isStampPayload(name, payload)) {
+    const world = (payload.world ?? "").toString().trim().slice(0, 80);
+    if (!world) return null;
+    const note = payload.note ? payload.note.toString().slice(0, 160) : undefined;
+    return demoAddStamp(world, note);
+  }
+
+  return null;
+}

--- a/src/lib/localdb.ts
+++ b/src/lib/localdb.ts
@@ -1,0 +1,157 @@
+export type NavatarCardDraft = {
+  description: string;
+  name: string;
+  species: string;
+  kingdom: string;
+  backstory: string;
+  powers: string;
+  traits: string;
+};
+
+export type LessonQuizItem = { q: string; a: string };
+export type LessonPlan = {
+  title: string;
+  intro: string;
+  outline: string[];
+  activities: string[];
+  quiz: LessonQuizItem[];
+};
+
+type StoredPlan = {
+  topic: string;
+  age: number;
+  plan: LessonPlan;
+  savedAt: number;
+};
+
+const NAVATAR_DRAFT_KEY = "naturverse.navatar.card.v1";
+const LESSON_PLANS_KEY = "naturverse.ai.lessonPlans.v1";
+
+const NAVATAR_DEFAULT: NavatarCardDraft = {
+  description: "",
+  name: "",
+  species: "",
+  kingdom: "",
+  backstory: "",
+  powers: "",
+  traits: "",
+};
+
+function readJson<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw);
+    return parsed ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson<T>(key: string, value: T) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {}
+}
+
+export function readNavatarDraft(): NavatarCardDraft {
+  const draft = readJson<Partial<NavatarCardDraft>>(NAVATAR_DRAFT_KEY, {});
+  return { ...NAVATAR_DEFAULT, ...draft };
+}
+
+export function saveNavatarDraft(partial: Partial<NavatarCardDraft>): NavatarCardDraft {
+  const merged = { ...readNavatarDraft(), ...partial };
+  writeJson(NAVATAR_DRAFT_KEY, merged);
+  return merged;
+}
+
+export function clearNavatarDraft() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(NAVATAR_DRAFT_KEY);
+  } catch {}
+}
+
+function sanitizeLessonPlan(plan: LessonPlan): LessonPlan {
+  const sanitizeString = (value: unknown, limit = 320) => String(value ?? "").trim().slice(0, limit);
+  const sanitizeList = (value: unknown[], limit: number) =>
+    value
+      .slice(0, limit)
+      .map((item) => sanitizeString(item))
+      .filter((item) => item.length > 0);
+
+  const quiz = Array.isArray(plan.quiz)
+    ? plan.quiz
+        .slice(0, 3)
+        .map((item) => ({
+          q: sanitizeString(item?.q, 320),
+          a: sanitizeString(item?.a, 320),
+        }))
+        .filter((entry) => entry.q.length > 0)
+    : [];
+
+  return {
+    title: sanitizeString(plan.title, 160),
+    intro: sanitizeString(plan.intro, 480),
+    outline: Array.isArray(plan.outline) ? sanitizeList(plan.outline, 3) : [],
+    activities: Array.isArray(plan.activities) ? sanitizeList(plan.activities, 2) : [],
+    quiz,
+  };
+}
+
+function clampAge(age: number) {
+  if (!Number.isFinite(age)) return 0;
+  const safe = Math.round(age);
+  if (safe < 3) return 3;
+  if (safe > 18) return 18;
+  return safe;
+}
+
+function readLessonPlans(): StoredPlan[] {
+  const list = readJson<StoredPlan[]>(LESSON_PLANS_KEY, []);
+  if (!Array.isArray(list)) return [];
+  return list
+    .map((entry) => {
+      const topic = String(entry?.topic ?? "").trim();
+      const age = clampAge(Number(entry?.age ?? 0));
+      const plan = sanitizeLessonPlan(entry?.plan ?? ({} as LessonPlan));
+      const savedAt = Number(entry?.savedAt ?? Date.now());
+      return { topic, age, plan, savedAt };
+    })
+    .filter((entry) => entry.topic.length > 0 && entry.age > 0);
+}
+
+function writeLessonPlans(list: StoredPlan[]) {
+  writeJson(LESSON_PLANS_KEY, list);
+}
+
+export function saveLessonPlan(topic: string, age: number, plan: LessonPlan): StoredPlan | null {
+  const cleanTopic = topic.trim().slice(0, 160);
+  const cleanAge = clampAge(age);
+  if (!cleanTopic || cleanAge <= 0) return null;
+  const sanitized = sanitizeLessonPlan(plan);
+  const entry: StoredPlan = {
+    topic: cleanTopic,
+    age: cleanAge,
+    plan: sanitized,
+    savedAt: Date.now(),
+  };
+  const list = readLessonPlans().filter((item) => !(item.topic === cleanTopic && item.age === cleanAge));
+  list.unshift(entry);
+  writeLessonPlans(list.slice(0, 20));
+  return entry;
+}
+
+export function loadLessonPlan(topic: string, age: number): LessonPlan | null {
+  const cleanTopic = topic.trim().slice(0, 160);
+  const cleanAge = clampAge(age);
+  if (!cleanTopic || cleanAge <= 0) return null;
+  const match = readLessonPlans().find((item) => item.topic === cleanTopic && item.age === cleanAge);
+  return match ? match.plan : null;
+}
+
+export function listLessonPlans(): StoredPlan[] {
+  return readLessonPlans();
+}

--- a/src/pages/Naturversity.tsx
+++ b/src/pages/Naturversity.tsx
@@ -62,6 +62,17 @@ export default function NaturversityPage() {
             <p className="tile__subtitle">Nature, art, music, wellness, crypto basics…</p>
           </div>
         </Link>
+
+        {/* Lesson Builder */}
+        <Link to="/naturversity/builder" className="tile">
+          <div className="tile__icon" aria-hidden>
+            <span role="img" aria-label="lightbulb">💡</span>
+          </div>
+          <div className="tile__body">
+            <h2 className="tile__title">Lesson Builder</h2>
+            <p className="tile__subtitle">Draft a mini-lesson with Turian’s help.</p>
+          </div>
+        </Link>
       </div>
 
       <p className="coming-soon">Coming soon: AI tutors and step-by-step lessons.</p>

--- a/src/pages/naturversity/Builder.tsx
+++ b/src/pages/naturversity/Builder.tsx
@@ -1,0 +1,240 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import Breadcrumbs from "../../components/Breadcrumbs";
+import { useToast } from "../../components/Toast";
+import { callAI } from "@/lib/ai";
+import { naturEvent } from "@/lib/events";
+import { LessonPlan, saveLessonPlan, loadLessonPlan, listLessonPlans } from "@/lib/localdb";
+import { setTitle } from "../_meta";
+import "../../styles/lesson-builder.css";
+
+type LessonResponse = {
+  title?: string;
+  intro?: string;
+  outline?: string[];
+  activities?: string[];
+  quiz?: { q: string; a: string }[];
+};
+
+const DEFAULT_PLAN: LessonPlan = {
+  title: "",
+  intro: "",
+  outline: [],
+  activities: [],
+  quiz: [],
+};
+
+export default function LessonBuilderPage() {
+  setTitle("Lesson Builder");
+  const toast = useToast();
+  const aiEnabled = import.meta.env.PROD || import.meta.env.VITE_ENABLE_AI === "true";
+  const [topic, setTopic] = useState("");
+  const [age, setAge] = useState("8");
+  const [plan, setPlan] = useState<LessonPlan | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cooldownUntil, setCooldownUntil] = useState(0);
+
+  const numericAge = useMemo(() => {
+    const value = Number(age);
+    if (Number.isFinite(value)) return Math.min(18, Math.max(3, Math.round(value)));
+    return 0;
+  }, [age]);
+
+  useEffect(() => {
+    const [recent] = listLessonPlans();
+    if (recent) {
+      setTopic(recent.topic);
+      setAge(String(recent.age));
+      setPlan(recent.plan);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!topic.trim() || numericAge === 0) return;
+    const stored = loadLessonPlan(topic, numericAge);
+    if (stored) setPlan(stored);
+  }, [topic, numericAge]);
+
+  const ensureCooldown = () => {
+    const now = Date.now();
+    if (now < cooldownUntil) {
+      toast({ text: "Let Turian wrap up the last lesson first.", kind: "warn" });
+      return false;
+    }
+    setCooldownUntil(now + 3000);
+    return true;
+  };
+
+  const sanitizePlan = (input: LessonResponse): LessonPlan => ({
+    title: String(input.title ?? "").trim(),
+    intro: String(input.intro ?? "").trim(),
+    outline: Array.isArray(input.outline)
+      ? input.outline
+          .slice(0, 3)
+          .map(item => String(item ?? "").trim())
+          .filter(Boolean)
+      : [],
+    activities: Array.isArray(input.activities)
+      ? input.activities
+          .slice(0, 2)
+          .map(item => String(item ?? "").trim())
+          .filter(Boolean)
+      : [],
+    quiz: Array.isArray(input.quiz)
+      ? input.quiz
+          .slice(0, 3)
+          .map((item) => ({
+            q: String(item?.q ?? "").trim(),
+            a: String(item?.a ?? "").trim(),
+          }))
+          .filter((item) => item.q.length > 0)
+      : [],
+  });
+
+  async function buildLesson(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!aiEnabled) return;
+
+    const trimmedTopic = topic.trim();
+    if (!trimmedTopic) {
+      setError("Enter a topic first.");
+      return;
+    }
+    if (numericAge <= 0) {
+      setError("Enter an age between 3 and 18.");
+      return;
+    }
+    if (!ensureCooldown()) return;
+
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await callAI<LessonResponse>("naturversity.lesson", {
+        topic: trimmedTopic,
+        age: numericAge,
+      });
+      const built = sanitizePlan(response);
+      const stored = saveLessonPlan(trimmedTopic, numericAge, { ...DEFAULT_PLAN, ...built });
+      const finalized = stored?.plan ?? built;
+      setPlan(finalized);
+      toast({ text: "Lesson ready!" });
+      naturEvent("grant_natur", { amount: 5, note: `Lesson: ${finalized.title || trimmedTopic}` });
+      naturEvent("passport_stamp", { world: "Learning", note: finalized.title || trimmedTopic });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Could not build that lesson.";
+      setError(message);
+      toast({ text: message, kind: "err" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="page-wrap">
+      <Breadcrumbs />
+      <main className="lesson-builder" id="main">
+        <h1>Lesson Builder</h1>
+        <p className="lead">Co-create a Naturversity mini-lesson with Turian.</p>
+
+        {!aiEnabled ? (
+          <p className="muted">AI helpers are disabled for this build.</p>
+        ) : (
+          <form className="lesson-form" onSubmit={buildLesson}>
+            <label>
+              Topic
+              <input
+                value={topic}
+                onChange={(event) => setTopic(event.target.value)}
+                placeholder="Rainforest animals, pollination, constellations…"
+              />
+            </label>
+            <label className="lesson-age">
+              Age
+              <input
+                type="number"
+                min={3}
+                max={18}
+                value={age}
+                onChange={(event) => setAge(event.target.value)}
+              />
+            </label>
+            <button type="submit" className="lesson-btn" disabled={busy}>
+              {busy ? (
+                <>
+                  <span className="spinner spinner-inline" aria-hidden="true" /> Building…
+                </>
+              ) : (
+                "Build lesson"
+              )}
+            </button>
+            <p className="hint">We store plans locally so you can revisit them later.</p>
+          </form>
+        )}
+
+        {error && <p className="error-text">{error}</p>}
+
+        <section className="lesson-output" aria-live="polite">
+          {plan ? (
+            <>
+              <header className="lesson-output__header">
+                <h2>{plan.title || "Lesson preview"}</h2>
+                <div className="lesson-output__meta">Designed for age {numericAge || age || "8"}</div>
+              </header>
+              <p className="lesson-output__intro">{plan.intro || "Your intro will appear here."}</p>
+
+              <div className="lesson-output__grid">
+                <div className="lesson-output__card">
+                  <h3>Outline</h3>
+                  {plan.outline.length ? (
+                    <ul>
+                      {plan.outline.map((item, index) => (
+                        <li key={`${item}-${index}`}>{item}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="placeholder">3 bullet points appear here.</p>
+                  )}
+                </div>
+                <div className="lesson-output__card">
+                  <h3>Activities</h3>
+                  {plan.activities.length ? (
+                    <ol>
+                      {plan.activities.map((item, index) => (
+                        <li key={`${item}-${index}`}>{item}</li>
+                      ))}
+                    </ol>
+                  ) : (
+                    <p className="placeholder">Hands-on prompts land here.</p>
+                  )}
+                </div>
+              </div>
+
+              <section className="lesson-quiz">
+                <h3>Quiz</h3>
+                {plan.quiz.length ? (
+                  <ul>
+                    {plan.quiz.map((item, index) => (
+                      <li key={`${item.q}-${index}`}>
+                        <strong>{item.q}</strong>
+                        <span>{item.a}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="placeholder">Three check-in questions will show here.</p>
+                )}
+              </section>
+
+              <aside className="lesson-reward" aria-live="polite">
+                <div className="lesson-reward__pill">+5 NATUR</div>
+                <div className="lesson-reward__note">Learning passport stamp awarded</div>
+              </aside>
+            </>
+          ) : (
+            <p className="placeholder">Build a lesson to see the outline, activities, and quiz.</p>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -29,6 +29,7 @@ import Courses from './pages/naturversity/Courses';
 import CourseDetail from './pages/naturversity/CourseDetail';
 import LanguagesHub from './pages/naturversity/languages';
 import LanguageDetail from './pages/naturversity/languages/[slug]';
+import LessonBuilder from './pages/naturversity/Builder';
 import NaturversityLayout from './layouts/Naturversity';
 import NaturBankPage from './pages/naturbank';
 import BankWallet from './pages/naturbank/Wallet';
@@ -105,6 +106,7 @@ export const router = createBrowserRouter([
           { path: 'partners', element: <Partners /> },
           { path: 'courses', element: <Courses /> },
           { path: 'course/:slug', element: <CourseDetail /> },
+          { path: 'builder', element: <LessonBuilder /> },
           { path: 'languages', element: <LanguagesHub /> },
           { path: 'languages/:slug', element: <LanguageDetail /> },
         ],

--- a/src/styles/lesson-builder.css
+++ b/src/styles/lesson-builder.css
@@ -1,0 +1,224 @@
+.lesson-builder {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem 4rem;
+  color: var(--nv-blue-700);
+}
+
+.lesson-builder h1 {
+  margin-bottom: 0.25rem;
+}
+
+.lesson-builder .lead {
+  margin-top: 0;
+  color: #4b5563;
+}
+
+.lesson-form {
+  margin-top: 1.5rem;
+  border: 1px solid #dbeafe;
+  background: #f8fbff;
+  border-radius: 16px;
+  padding: 18px;
+  display: grid;
+  gap: 14px;
+}
+
+.lesson-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  color: var(--nv-blue-800, #1e40af);
+}
+
+.lesson-form input {
+  border: 1px solid #c7d2fe;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 1rem;
+}
+
+.lesson-age {
+  max-width: 200px;
+}
+
+.lesson-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: 999px;
+  background: #1e4ed8;
+  color: #fff;
+  font-weight: 700;
+  border: 1px solid #1e4ed8;
+  cursor: pointer;
+  transition: transform .16s ease, box-shadow .16s ease;
+}
+
+.lesson-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(30, 78, 216, 0.18);
+}
+
+.lesson-btn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.lesson-builder .spinner-inline {
+  width: 18px;
+  height: 18px;
+  border-width: 2px;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.error-text {
+  margin-top: 1rem;
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.lesson-output {
+  margin-top: 2rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  background: #fff;
+  padding: 22px;
+  box-shadow: 0 18px 38px rgba(18, 72, 166, 0.08);
+  display: grid;
+  gap: 18px;
+}
+
+.lesson-output__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lesson-output__meta {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.lesson-output__intro {
+  margin: 0;
+  line-height: 1.5;
+  color: #1f2937;
+}
+
+.lesson-output__grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.lesson-output__card {
+  border: 1px solid #e0e7ff;
+  border-radius: 14px;
+  padding: 16px;
+  background: #f5f7ff;
+}
+
+.lesson-output__card h3 {
+  margin: 0 0 10px;
+  color: var(--nv-blue-800, #1e40af);
+}
+
+.lesson-output__card ul,
+.lesson-output__card ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #1f2937;
+}
+
+.lesson-output__card li {
+  margin-bottom: 6px;
+}
+
+.lesson-quiz {
+  border: 1px solid #e0e7ff;
+  border-radius: 14px;
+  padding: 16px;
+  background: #f9fbff;
+}
+
+.lesson-quiz h3 {
+  margin: 0 0 12px;
+  color: var(--nv-blue-800, #1e40af);
+}
+
+.lesson-quiz ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 10px;
+}
+
+.lesson-quiz li {
+  list-style-type: decimal;
+  color: #1f2937;
+}
+
+.lesson-quiz li span {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.92rem;
+  color: #4b5563;
+}
+
+.lesson-reward {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-radius: 14px;
+  padding: 12px 16px;
+  background: linear-gradient(90deg, rgba(59,130,246,0.12), rgba(16,185,129,0.12));
+  border: 1px solid rgba(30,64,175,0.18);
+}
+
+.lesson-reward__pill {
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.lesson-reward__note {
+  color: #1f2937;
+  font-size: 0.95rem;
+}
+
+.placeholder {
+  margin: 0;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.muted {
+  color: #6b7280;
+}
+
+@media (max-width: 720px) {
+  .lesson-builder {
+    padding: 1.25rem 1rem 3.5rem;
+  }
+
+  .lesson-form {
+    padding: 16px;
+  }
+
+  .lesson-output {
+    padding: 18px;
+  }
+
+  .lesson-reward {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -102,6 +102,63 @@
 .form-card textarea {
   width: 100%;
 }
+.form-card .ai-card {
+  margin-bottom: 1.25rem;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid #dbeafe;
+  background: #f8fbff;
+  display: grid;
+  gap: 12px;
+}
+.ai-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+.ai-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid #1e4ed8;
+  background: #1e4ed8;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform .16s ease, box-shadow .16s ease;
+}
+.ai-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(30, 78, 216, 0.18);
+}
+.ai-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+.ai-btn--ghost {
+  background: #eef2ff;
+  color: #1e40af;
+  border-color: #c7d2fe;
+}
+.spinner-inline {
+  width: 18px;
+  height: 18px;
+  border-width: 2px;
+}
+.ai-note {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #4b5563;
+}
+.backstory-input {
+  min-height: 140px;
+  line-height: 1.4;
+}
 .row.gap {
   display: flex;
   gap: 0.75rem;
@@ -146,6 +203,26 @@
   .nv-hub-grid {
     grid-template-columns: 1fr 420px;
     align-items: start;
+  }
+}
+
+@media (max-width: 640px) {
+  .form-card .ai-card {
+    padding: 14px;
+  }
+  .ai-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .ai-btn {
+    width: 100%;
+  }
+  .form-card textarea.backstory-input {
+    display: -webkit-box;
+    -webkit-line-clamp: 8;
+    -webkit-box-orient: vertical;
+    overflow: auto;
+    max-height: calc(1.4em * 8);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a shared Netlify function that proxies Groq with prompt routing, caching, and CORS headers
- add client helpers, storage utilities, and reward dispatchers and wire them into the Navatar card UI under a feature flag
- create the Naturversity lesson builder page with persisted plans, reward events, and responsive styling

## Testing
- npm run typecheck *(fails: longstanding missing Next.js/Supabase module types and implicit any warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68cb66491b548329b0b6f1fc164c0d08