### PR TITLE
Wire Naturversity quiz flow and stub Turian art button

### DIFF
--- a/src/components/naturversity/Quiz.tsx
+++ b/src/components/naturversity/Quiz.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useMemo, useState } from "react";
+import type { NaturversityQuizItem } from "@/lib/ai/promptSchemas";
+
+type Props = {
+  items: NaturversityQuizItem[];
+  onPassed?: () => void;
+};
+
+const normalize = (value: string) => value.trim().toLowerCase();
+
+export default function NaturversityQuiz({ items, onPassed }: Props) {
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+  const [checked, setChecked] = useState(false);
+  const [hasPassed, setHasPassed] = useState(false);
+
+  useEffect(() => {
+    setAnswers({});
+    setChecked(false);
+    setHasPassed(false);
+  }, [items]);
+
+  const allCorrect = useMemo(
+    () =>
+      items.length > 0 &&
+      items.every((item, index) => normalize(answers[index] ?? "") === normalize(item.a)),
+    [items, answers]
+  );
+
+  const handleCheck = () => {
+    setChecked(true);
+    if (allCorrect && !hasPassed) {
+      setHasPassed(true);
+      onPassed?.();
+    }
+  };
+
+  return (
+    <div className="lesson-quiz__list">
+      {items.map((item, index) => (
+        <div key={`${item.q}-${index}`} className="lesson-quiz__item">
+          <div className="lesson-quiz__prompt">
+            <span className="lesson-quiz__number">{index + 1}.</span> {item.q}
+          </div>
+          {Array.isArray(item.choices) && item.choices.length ? (
+            <div className="lesson-quiz__choices">
+              {item.choices.map((choice) => (
+                <label key={`${item.q}-${choice}`} className="lesson-quiz__choice">
+                  <input
+                    type="radio"
+                    name={`quiz-${index}`}
+                    value={choice}
+                    checked={answers[index] === choice}
+                    onChange={() =>
+                      setAnswers((prev) => ({
+                        ...prev,
+                        [index]: choice,
+                      }))
+                    }
+                  />
+                  <span>{choice}</span>
+                </label>
+              ))}
+            </div>
+          ) : (
+            <input
+              className="lesson-quiz__input"
+              value={answers[index] ?? ""}
+              onChange={(event) =>
+                setAnswers((prev) => ({
+                  ...prev,
+                  [index]: event.target.value,
+                }))
+              }
+              placeholder="Your answer…"
+            />
+          )}
+        </div>
+      ))}
+
+      <button
+        type="button"
+        className="lesson-quiz__check"
+        onClick={handleCheck}
+        disabled={!items.length}
+      >
+        Check answers
+      </button>
+
+      {checked && (
+        <p className={`lesson-quiz__result ${allCorrect ? "is-correct" : "is-incorrect"}`}>
+          {allCorrect
+            ? "Great job! You passed."
+            : "Not quite — tweak your answers and try again."}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/ai/promptSchemas.ts
+++ b/src/lib/ai/promptSchemas.ts
@@ -1,0 +1,79 @@
+export type NaturversityQuizItem = {
+  q: string;
+  a: string;
+  choices?: string[];
+};
+
+export type NaturversityQuiz = {
+  topic: string;
+  age: number;
+  items: NaturversityQuizItem[];
+};
+
+export type NaturversityQuizRequest = {
+  topic: string;
+  age: number;
+  outline: string[];
+};
+
+export const NATURVERSITY_QUIZ_JSON_SCHEMA = {
+  type: "object",
+  required: ["topic", "age", "items"],
+  properties: {
+    topic: { type: "string" },
+    age: { type: "number", minimum: 4, maximum: 16 },
+    items: {
+      type: "array",
+      minItems: 3,
+      maxItems: 3,
+      items: {
+        type: "object",
+        required: ["q", "a"],
+        properties: {
+          q: { type: "string" },
+          a: { type: "string" },
+          choices: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 2,
+            maxItems: 6,
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+export const NATURVERSITY_QUIZ_SYSTEM_PROMPT = `You are a playful, accurate kids' quiz writer.
+Return STRICT JSON matching this schema:
+{"topic": "string", "age": 8, "items": [{"q":"string","a":"string","choices":["A","B","C","D"]}]}
+- 3 items exactly
+- choices must include the correct answer "a"
+- keep simple, age-appropriate
+- no extra commentary`;
+
+export const NATURVERSITY_QUIZ_SAFETY_RULES = `Keep questions positive, encouraging, and curious.
+Avoid anything scary, violent, political, or adult. Use kid-friendly language.`;
+
+export function clampNaturversityQuizAge(age: number): number {
+  if (!Number.isFinite(age)) return 8;
+  const rounded = Math.round(age);
+  if (rounded < 4) return 4;
+  if (rounded > 16) return 16;
+  return rounded;
+}
+
+export function buildNaturversityQuizUserPrompt(topic: string, age: number, outline: string[]): string {
+  const safeTopic = topic.trim().slice(0, 120) || "Nature";
+  const safeAge = clampNaturversityQuizAge(age);
+  const safeOutline = outline
+    .map((item) => item?.trim().slice(0, 160))
+    .filter(Boolean)
+    .slice(0, 8);
+  const outlineBlock = safeOutline.length
+    ? safeOutline.map((item) => `- ${item}`).join("\n")
+    : "- (no outline provided)";
+  return `Topic: ${safeTopic}\nAge: ${safeAge}\nOutline bullets:\n${outlineBlock}`;
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -14,6 +14,7 @@ export default function GenerateNavatarPage() {
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
   const [draftUrl, setDraftUrl] = useState<string | undefined>();
+  const [genBusy, setGenBusy] = useState(false);
   const nav = useNavigate();
   const toast = useToast();
 
@@ -26,6 +27,15 @@ export default function GenerateNavatarPage() {
     setDraftUrl(url);
     return () => URL.revokeObjectURL(url);
   }, [file]);
+
+  function handleGenerateArt() {
+    if (genBusy) return;
+    setGenBusy(true);
+    setTimeout(() => {
+      setGenBusy(false);
+      toast({ text: "AI art & edits coming soon." });
+    }, 400);
+  }
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
@@ -62,6 +72,18 @@ export default function GenerateNavatarPage() {
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
         />
+        <button
+          type="button"
+          className="pill"
+          onClick={handleGenerateArt}
+          disabled={genBusy}
+          style={{ width: "100%" }}
+        >
+          {genBusy ? "Thinking…" : "Generate Art with Turian"}
+        </button>
+        <p style={{ margin: 0, fontSize: "0.85rem", color: "#4b5563", textAlign: "center" }}>
+          AI art previews coming soon — this button is ready for Turian.
+        </p>
         <input
           style={{ display: "block", width: "100%" }}
           placeholder="Name (optional)"
@@ -74,7 +96,7 @@ export default function GenerateNavatarPage() {
         </button>
       </form>
       <p className="center" style={{ opacity: 0.8 }}>
-        AI art & edit coming soon.
+        We’ll save art here as soon as the Turian image maker comes online.
       </p>
     </main>
   );

--- a/src/styles/lesson-builder.css
+++ b/src/styles/lesson-builder.css
@@ -174,6 +174,97 @@
   color: #4b5563;
 }
 
+.lesson-quiz__list {
+  display: grid;
+  gap: 14px;
+}
+
+.lesson-quiz__item {
+  padding: 12px;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #dbeafe;
+  box-shadow: 0 6px 14px rgba(30, 64, 175, 0.06);
+}
+
+.lesson-quiz__prompt {
+  font-weight: 600;
+  color: var(--nv-blue-800, #1e40af);
+}
+
+.lesson-quiz__number {
+  margin-right: 6px;
+}
+
+.lesson-quiz__choices {
+  display: grid;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.lesson-quiz__choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.lesson-quiz__choice input {
+  accent-color: var(--nv-blue-700, #2563eb);
+}
+
+.lesson-quiz__input {
+  margin-top: 8px;
+  width: 100%;
+  border: 1px solid #c7d2fe;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 0.95rem;
+}
+
+.lesson-quiz__check {
+  justify-self: start;
+  padding: 8px 18px;
+  border-radius: 999px;
+  background: #1e4ed8;
+  color: #fff;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease;
+}
+
+.lesson-quiz__check:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(30, 78, 216, 0.18);
+}
+
+.lesson-quiz__check:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.lesson-quiz__result {
+  margin: 0;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+.lesson-quiz__result.is-correct {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.lesson-quiz__result.is-incorrect {
+  background: rgba(248, 113, 113, 0.12);
+  color: #b91c1c;
+  border: 1px solid rgba(248, 113, 113, 0.24);
+}
+
 .lesson-reward {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add Groq-backed Naturversity quiz generation to the shared Netlify AI function with schema-aware sanitization helpers
- define Naturversity quiz prompt schemas/utilities and render a reusable quiz component with new lesson builder styles
- persist lesson quizzes locally, surface the quiz and reward flow in the builder, and stub a Generate Art action on the Navatar page

## Testing
- `npm run typecheck` *(fails: missing Next.js/Supabase types and API overloads from existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68cb725cd044832985feda3019e34df4