### PR TITLE
Improve Netlify AI function JSON handling

### DIFF
--- a/netlify/functions/ai.ts
+++ b/netlify/functions/ai.ts
@@ -1,6 +1,7 @@
 import type { Handler } from "@netlify/functions";
+import { ZodError, z } from "zod";
 
-type SchemaKey =
+type LegacySchemaKey =
   | "name"
   | "species"
   | "kingdom"
@@ -10,11 +11,16 @@ type SchemaKey =
   | "outline"
   | "activities"
   | "quiz";
-type LessonSchema = SchemaKey[];
 
-const MODEL = process.env.GROQ_MODEL || "llama-3.1-8b-instant";
-const API_KEY = process.env.GROQ_API_KEY;
-const TTL_MS = 1000 * 60 * 30; // 30 minutes
+type LegacyLessonSchema = LegacySchemaKey[];
+
+type LegacyPromptConfig = {
+  schema: LegacyLessonSchema;
+  system: string;
+  user: string;
+};
+
+type Sanitized = Record<string, string | string[] | { q: string; a: string }[]>;
 
 type CacheEntry = { t: number; v: unknown };
 
@@ -23,36 +29,336 @@ declare global {
   var __aiCache: Map<string, CacheEntry> | undefined;
 }
 
-const ok = (data: unknown) => ({
-  statusCode: 200,
-  headers: {
-    "content-type": "application/json",
-    "access-control-allow-origin": "*",
-  },
-  body: JSON.stringify({ ok: true, data }),
-});
+const GROQ_KEY = process.env.GROQ_API_KEY;
+const MODEL = process.env.GROQ_MODEL ?? "llama-3.1-8b-instant";
+const TTL_MS = 1000 * 60 * 30; // 30 minutes
 
-const bad = (message: string, statusCode = 400) => ({
-  statusCode,
-  headers: {
-    "content-type": "application/json",
-    "access-control-allow-origin": "*",
-  },
-  body: JSON.stringify({ ok: false, error: message }),
-});
-
-type RequestBody = {
-  kind?: string;
-  input?: Record<string, unknown> | null;
+const JSON_HEADERS: Record<string, string> = {
+  "content-type": "application/json",
+  "access-control-allow-origin": "*",
 };
 
-type PromptConfig = {
-  schema: LessonSchema;
-  system: string;
-  user: string;
+const OPTIONS_HEADERS: Record<string, string> = {
+  ...JSON_HEADERS,
+  "access-control-allow-methods": "POST,OPTIONS",
+  "access-control-allow-headers": "content-type",
 };
 
-function buildPrompt(kind: string, input: Record<string, unknown> | null | undefined): PromptConfig {
+const QuizSchema = z.object({
+  questions: z.array(
+    z.object({
+      q: z.string(),
+      options: z.array(z.string()).length(4),
+      answer: z.enum(["A", "B", "C", "D"]),
+    }),
+  ),
+});
+
+const LessonPlanSchema = z.object({
+  title: z.string(),
+  age: z.number(),
+  intro: z.string(),
+  outline: z.array(z.string()),
+  activities: z.array(z.string()),
+});
+
+const CardSchema = z.object({
+  name: z.string(),
+  species: z.string(),
+  kingdom: z.string(),
+  backstory: z.string(),
+  powers: z.array(z.string()).optional(),
+  traits: z.array(z.string()).optional(),
+});
+
+const systemByAction = {
+  quiz: "You are Turian. Create a 3-question multiple-choice quiz (A–D) for kids.\nReturn ONLY JSON: {questions:[{q,options:[A,B,C,D],answer}]}",
+  lesson: "You are Turian. Create a lesson plan.\nReturn ONLY JSON: {title,age,intro,outline[],activities[]}",
+  card: "You are Turian. Turn this into a character card.\nReturn ONLY JSON: {name,species,kingdom,backstory,powers[],traits[]}",
+} as const;
+
+type Action = keyof typeof systemByAction;
+
+type ActionBody = {
+  action?: unknown;
+  prompt?: unknown;
+  age?: unknown;
+};
+
+type LegacyBody = {
+  kind?: unknown;
+  input?: unknown;
+};
+
+const schemaByAction: Record<Action, z.ZodTypeAny> = {
+  quiz: QuizSchema,
+  lesson: LessonPlanSchema,
+  card: CardSchema,
+};
+
+const chatUrl = "https://api.groq.com/openai/v1/chat/completions";
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return new Response("", { status: 204, headers: OPTIONS_HEADERS });
+  }
+
+  if (event.httpMethod !== "POST") {
+    return errorResponse("Method not allowed", 405);
+  }
+
+  if (!GROQ_KEY) {
+    return errorResponse("Server missing GROQ_API_KEY", 500);
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(event.body || "{}");
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  if (!body || typeof body !== "object") {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const payload = body as Record<string, unknown>;
+
+  if ("action" in payload) {
+    return handleActionRequest(payload as ActionBody);
+  }
+
+  return handleLegacyRequest(payload as LegacyBody);
+};
+
+export default handler;
+
+function successResponse(data: unknown, status = 200): Response {
+  return jsonResponse({ ok: true, data }, status);
+}
+
+function errorResponse(error: string, status = 400, extra?: Record<string, unknown>): Response {
+  return jsonResponse({ ok: false, error, ...(extra ?? {}) }, status);
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: JSON_HEADERS,
+  });
+}
+
+function getCache(): Map<string, CacheEntry> {
+  if (!globalThis.__aiCache) {
+    globalThis.__aiCache = new Map<string, CacheEntry>();
+  }
+  return globalThis.__aiCache;
+}
+
+async function handleActionRequest(body: ActionBody): Promise<Response> {
+  const action = typeof body.action === "string" ? (body.action as Action) : undefined;
+  const promptRaw = typeof body.prompt === "string" ? body.prompt.trim() : "";
+  const ageValue = typeof body.age === "number" && Number.isFinite(body.age) ? body.age : undefined;
+
+  if (!action || !isAction(action) || !promptRaw) {
+    return errorResponse("Missing action or prompt", 400);
+  }
+
+  const system = systemByAction[action];
+  const schema = schemaByAction[action];
+  const prompt = promptRaw.slice(0, 4000);
+  const userMessage = ageValue !== undefined ? `${prompt} (age ${ageValue})` : prompt;
+
+  try {
+    const { response, text } = await callGroq(
+      [
+        { role: "system", content: system },
+        { role: "user", content: userMessage },
+      ],
+      { temperature: 0.4, maxTokens: 800, responseFormat: { type: "json_object" } },
+    );
+
+    if (!response.ok) {
+      return errorResponse("Groq request failed", response.status, {
+        status: response.status,
+        detail: text,
+      });
+    }
+
+    const parsedContent = parseGroqResponse(text);
+    if (!parsedContent.ok) {
+      return errorResponse(parsedContent.error, parsedContent.status, {
+        detail: parsedContent.detail,
+      });
+    }
+
+    const raw = extractJsonFromContent(parsedContent.content);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return errorResponse("Model did not return valid JSON", 502, {
+        content: parsedContent.content,
+      });
+    }
+
+    try {
+      const cleaned = schema.parse(parsed);
+      return successResponse(cleaned);
+    } catch (err) {
+      if (err instanceof ZodError) {
+        return errorResponse("Model response validation failed", 502, {
+          detail: err.issues,
+        });
+      }
+      throw err;
+    }
+  } catch (err) {
+    return errorResponse("Server error", 500, {
+      detail: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+async function handleLegacyRequest(body: LegacyBody): Promise<Response> {
+  const kind = typeof body.kind === "string" ? body.kind : "";
+  const input = isRecord(body.input) ? (body.input as Record<string, unknown>) : null;
+
+  if (!kind) {
+    return errorResponse("Missing kind", 400);
+  }
+
+  let cfg: LegacyPromptConfig;
+  try {
+    cfg = buildLegacyPrompt(kind, input ?? {});
+  } catch (error) {
+    return errorResponse(error instanceof Error ? error.message : "Unsupported kind", 400);
+  }
+
+  const cache = getCache();
+  const cacheKey = `${kind}:${JSON.stringify(input ?? {})}`;
+  const now = Date.now();
+  const cached = cache.get(cacheKey);
+  if (cached && now - cached.t < TTL_MS) {
+    return successResponse(cached.v);
+  }
+
+  try {
+    const { response, text } = await callGroq(
+      [
+        { role: "system", content: cfg.system },
+        { role: "user", content: cfg.user },
+      ],
+      { temperature: 0.6, maxTokens: 800, responseFormat: { type: "json_object" } },
+    );
+
+    if (!response.ok) {
+      return errorResponse("Groq request failed", response.status, {
+        status: response.status,
+        detail: text,
+      });
+    }
+
+    const parsedContent = parseGroqResponse(text);
+    if (!parsedContent.ok) {
+      return errorResponse(parsedContent.error, parsedContent.status, {
+        detail: parsedContent.detail,
+      });
+    }
+
+    const raw = extractJsonFromContent(parsedContent.content);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return errorResponse("Groq returned invalid JSON", 502, {
+        content: parsedContent.content,
+      });
+    }
+
+    if (!parsed || typeof parsed !== "object") {
+      return errorResponse("Groq returned invalid JSON", 502, {
+        content: parsedContent.content,
+      });
+    }
+
+    const clean = sanitizeBySchema(cfg.schema, parsed as Record<string, unknown>);
+    cache.set(cacheKey, { t: now, v: clean });
+    return successResponse(clean);
+  } catch (err) {
+    return errorResponse("Server error", 500, {
+      detail: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function isAction(value: string): value is Action {
+  return value in systemByAction;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function callGroq(
+  messages: { role: "system" | "user" | "assistant"; content: string }[],
+  options: { temperature: number; maxTokens: number; responseFormat?: Record<string, unknown> },
+): Promise<{ response: Response; text: string }> {
+  const response = await fetch(chatUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${GROQ_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      temperature: options.temperature,
+      max_tokens: options.maxTokens,
+      messages,
+      ...(options.responseFormat ? { response_format: options.responseFormat } : {}),
+    }),
+  });
+
+  const text = await response.text();
+  return { response, text };
+}
+
+type GroqParseResult =
+  | { ok: true; content: string }
+  | { ok: false; status: number; error: string; detail: string };
+
+function parseGroqResponse(text: string): GroqParseResult {
+  let payload: any;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    return {
+      ok: false,
+      status: 502,
+      error: "Groq returned non-JSON response",
+      detail: text,
+    };
+  }
+
+  const content = payload?.choices?.[0]?.message?.content;
+  if (typeof content !== "string" || !content.trim()) {
+    return {
+      ok: false,
+      status: 502,
+      error: "Groq returned no content",
+      detail: text,
+    };
+  }
+
+  return { ok: true, content };
+}
+
+function extractJsonFromContent(content: string): string {
+  const match = content.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  return (match ? match[1] : content).trim();
+}
+
+function buildLegacyPrompt(kind: string, input: Record<string, unknown> | null | undefined): LegacyPromptConfig {
   switch (kind) {
     case "navatar.card": {
       const description = String(input?.description ?? "").slice(0, 2000);
@@ -78,16 +384,7 @@ function buildPrompt(kind: string, input: Record<string, unknown> | null | undef
   }
 }
 
-function getCache(): Map<string, CacheEntry> {
-  if (!globalThis.__aiCache) {
-    globalThis.__aiCache = new Map<string, CacheEntry>();
-  }
-  return globalThis.__aiCache;
-}
-
-type Sanitized = Record<string, string | string[] | { q: string; a: string }[]>;
-
-function sanitizeBySchema(schema: LessonSchema, value: Record<string, unknown>): Sanitized {
+function sanitizeBySchema(schema: LegacyLessonSchema, value: Record<string, unknown>): Sanitized {
   const clean: Sanitized = {};
   for (const key of schema) {
     const raw = value[key];
@@ -117,92 +414,3 @@ function sanitizeBySchema(schema: LessonSchema, value: Record<string, unknown>):
   }
   return clean;
 }
-
-export const handler: Handler = async (event) => {
-  if (event.httpMethod === "OPTIONS") {
-    return {
-      statusCode: 204,
-      headers: {
-        "access-control-allow-origin": "*",
-        "access-control-allow-methods": "POST,OPTIONS",
-        "access-control-allow-headers": "content-type",
-      },
-      body: "",
-    };
-  }
-
-  if (event.httpMethod !== "POST") return bad("POST only", 405);
-  if (!API_KEY) return bad("Server missing GROQ_API_KEY", 500);
-
-  let body: RequestBody;
-  try {
-    body = JSON.parse(event.body || "{}") as RequestBody;
-  } catch (error) {
-    return bad("Invalid JSON body");
-  }
-
-  const { kind, input } = body;
-  if (!kind) return bad("Missing kind");
-
-  let cfg: PromptConfig;
-  try {
-    cfg = buildPrompt(kind, input ?? {});
-  } catch (error) {
-    return bad(error instanceof Error ? error.message : "Unsupported kind");
-  }
-
-  const cacheKey = `${kind}:${JSON.stringify(input ?? {})}`;
-  const cache = getCache();
-  const now = Date.now();
-  const cached = cache.get(cacheKey);
-  if (cached && now - cached.t < TTL_MS) {
-    return ok(cached.v);
-  }
-
-  const response = await fetch("https://api.groq.com/openai/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${API_KEY}`,
-    },
-    body: JSON.stringify({
-      model: MODEL,
-      temperature: 0.6,
-      messages: [
-        { role: "system", content: cfg.system },
-        { role: "user", content: cfg.user },
-      ],
-      response_format: { type: "json_object" },
-      max_tokens: 800,
-    }),
-  });
-
-  if (!response.ok) {
-    return bad(`Groq error ${response.status}`, response.status);
-  }
-
-  let payload: any;
-  try {
-    payload = await response.json();
-  } catch (error) {
-    return bad("Invalid response from Groq", 502);
-  }
-
-  const content = payload?.choices?.[0]?.message?.content;
-  if (typeof content !== "string") {
-    return bad("Groq returned no content", 502);
-  }
-
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = JSON.parse(content) as Record<string, unknown>;
-  } catch (error) {
-    return bad("Groq returned invalid JSON", 502);
-  }
-
-  const clean = sanitizeBySchema(cfg.schema, parsed);
-  cache.set(cacheKey, { t: now, v: clean });
-  return ok(clean);
-};
-
-export default handler;


### PR DESCRIPTION
## Summary
- rewrite the Netlify AI function to always send JSON responses with consistent headers
- parse Groq responses as text, unwrap fenced JSON, and validate with zod for the new action-based flow
- preserve the legacy kind/input prompts with caching and sanitation while routing both request styles through the new error handling

## Testing
- npm run typecheck *(fails: existing project configuration is missing Next.js modules and Supabase typings, causing unrelated errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cbae36d6d48329b2ac3d759890db41