### PR TITLE
Refine AI handler and navatar card experience

### DIFF
--- a/netlify/functions/ai.ts
+++ b/netlify/functions/ai.ts
@@ -1,208 +1,95 @@
-import type { Handler } from "@netlify/functions";
+import type { Handler } from '@netlify/functions'
+import { z } from 'zod'
 
-type SchemaKey =
-  | "name"
-  | "species"
-  | "kingdom"
-  | "backstory"
-  | "title"
-  | "intro"
-  | "outline"
-  | "activities"
-  | "quiz";
-type LessonSchema = SchemaKey[];
+const MODEL = process.env.GROQ_MODEL || 'llama-3.1-8b-instant' // safe default
 
-const MODEL = process.env.GROQ_MODEL || "llama-3.1-8b-instant";
-const API_KEY = process.env.GROQ_API_KEY;
-const TTL_MS = 1000 * 60 * 30; // 30 minutes
-
-type CacheEntry = { t: number; v: unknown };
-
-declare global {
-  // eslint-disable-next-line no-var
-  var __aiCache: Map<string, CacheEntry> | undefined;
+const HEADERS = {
+  'content-type': 'application/json',
+  'access-control-allow-origin': '*',
 }
 
-const ok = (data: unknown) => ({
-  statusCode: 200,
-  headers: {
-    "content-type": "application/json",
-    "access-control-allow-origin": "*",
-  },
-  body: JSON.stringify({ ok: true, data }),
-});
+const Quiz = z.object({
+  questions: z.array(z.object({
+    q: z.string(),
+    options: z.tuple([z.string(), z.string(), z.string(), z.string()]),
+    answer: z.enum(['A','B','C','D'])
+  })).length(3)
+})
 
-const bad = (message: string, statusCode = 400) => ({
-  statusCode,
-  headers: {
-    "content-type": "application/json",
-    "access-control-allow-origin": "*",
-  },
-  body: JSON.stringify({ ok: false, error: message }),
-});
+const Card = z.object({
+  name: z.string(),
+  species: z.string(),
+  kingdom: z.string(),
+  backstory: z.string(),
+  powers: z.array(z.string()).default([]),
+  traits: z.array(z.string()).default([]),
+})
 
-type RequestBody = {
-  kind?: string;
-  input?: Record<string, unknown> | null;
-};
+type Action = 'lesson' | 'quiz' | 'card'
+type Body = { action: Action; prompt: string }
 
-type PromptConfig = {
-  schema: LessonSchema;
-  system: string;
-  user: string;
-};
-
-function buildPrompt(kind: string, input: Record<string, unknown> | null | undefined): PromptConfig {
-  switch (kind) {
-    case "navatar.card": {
-      const description = String(input?.description ?? "").slice(0, 2000);
-      return {
-        schema: ["name", "species", "kingdom", "backstory"],
-        system:
-          "You are Turian, a friendly kids guide. Return concise JSON only with keys: name, species, kingdom, backstory. Keep it positive and G-rated.",
-        user: `Describe a fun character from this description:\n${description}`,
-      };
-    }
-    case "naturversity.lesson": {
-      const topic = String(input?.topic ?? "").slice(0, 200);
-      const age = Number(input?.age ?? 0) || 0;
-      return {
-        schema: ["title", "intro", "outline", "activities", "quiz"],
-        system:
-          "You write short, kid-friendly nature lessons. Return JSON with title, intro (1 paragraph), outline (3 bullets), activities (2 short items), quiz (3 Q&A). No extra text.",
-        user: `Topic: ${topic}\nAge: ${age}`,
-      };
-    }
-    default:
-      throw new Error("Unknown kind");
-  }
+const systemByAction: Record<Action,string> = {
+  lesson:
+    'You are Turian. Create a short kid-friendly lesson (title, intro, outline[3 bullets], activities[2]). Return ONLY JSON: {title, intro, outline:[...], activities:[...]}',
+  quiz:
+    'You are Turian. Create 3 multiple-choice (A–D) questions for kids about the given topic and age. Return ONLY JSON: {questions:[{q, options:[A,B,C,D], answer}]}',
+  card:
+    'You are Turian. Turn the description into a friendly character card. Return ONLY JSON: {name, species, kingdom, backstory, powers[], traits[]}. Powers/traits should be single words.',
 }
 
-function getCache(): Map<string, CacheEntry> {
-  if (!globalThis.__aiCache) {
-    globalThis.__aiCache = new Map<string, CacheEntry>();
-  }
-  return globalThis.__aiCache;
-}
-
-type Sanitized = Record<string, string | string[] | { q: string; a: string }[]>;
-
-function sanitizeBySchema(schema: LessonSchema, value: Record<string, unknown>): Sanitized {
-  const clean: Sanitized = {};
-  for (const key of schema) {
-    const raw = value[key];
-    if (Array.isArray(raw)) {
-      if (key === "quiz") {
-        clean[key] = raw
-          .slice(0, 3)
-          .map((item) => {
-            if (typeof item === "object" && item !== null) {
-              const q = String((item as Record<string, unknown>).q ?? "").slice(0, 320);
-              const a = String((item as Record<string, unknown>).a ?? "").slice(0, 320);
-              return { q, a };
-            }
-            return { q: String(item ?? "").slice(0, 320), a: "" };
-          })
-          .filter((item) => item.q.length > 0);
-      } else {
-        const limit = key === "outline" ? 3 : key === "activities" ? 2 : raw.length;
-        clean[key] = raw
-          .slice(0, limit)
-          .map((entry) => String(entry ?? "").slice(0, 320))
-          .filter((entry) => entry.length > 0);
-      }
-    } else {
-      clean[key] = String(raw ?? "").slice(0, 800);
-    }
-  }
-  return clean;
+function pickJson(text: string) {
+  const m = text.match(/\{[\s\S]*\}$/)
+  return m ? m[0] : text // best effort
 }
 
 export const handler: Handler = async (event) => {
-  if (event.httpMethod === "OPTIONS") {
-    return {
-      statusCode: 204,
-      headers: {
-        "access-control-allow-origin": "*",
-        "access-control-allow-methods": "POST,OPTIONS",
-        "access-control-allow-headers": "content-type",
-      },
-      body: "",
-    };
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers: HEADERS, body: JSON.stringify({ error:'Method not allowed' }) }
   }
 
-  if (event.httpMethod !== "POST") return bad("POST only", 405);
-  if (!API_KEY) return bad("Server missing GROQ_API_KEY", 500);
+  let body: Body
+  try { body = JSON.parse(event.body || '{}') } 
+  catch { return { statusCode: 400, headers: HEADERS, body: JSON.stringify({ error:'Bad JSON' }) } }
 
-  let body: RequestBody;
-  try {
-    body = JSON.parse(event.body || "{}") as RequestBody;
-  } catch (error) {
-    return bad("Invalid JSON body");
+  const { action, prompt } = body
+  if (!action || !prompt) {
+    return { statusCode: 422, headers: HEADERS, body: JSON.stringify({ error:'Missing action or prompt' }) }
   }
 
-  const { kind, input } = body;
-  if (!kind) return bad("Missing kind");
-
-  let cfg: PromptConfig;
-  try {
-    cfg = buildPrompt(kind, input ?? {});
-  } catch (error) {
-    return bad(error instanceof Error ? error.message : "Unsupported kind");
-  }
-
-  const cacheKey = `${kind}:${JSON.stringify(input ?? {})}`;
-  const cache = getCache();
-  const now = Date.now();
-  const cached = cache.get(cacheKey);
-  if (cached && now - cached.t < TTL_MS) {
-    return ok(cached.v);
-  }
-
-  const response = await fetch("https://api.groq.com/openai/v1/chat/completions", {
-    method: "POST",
+  // call Groq
+  const resp = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
     headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${API_KEY}`,
+      'content-type': 'application/json',
+      'authorization': `Bearer ${process.env.GROQ_API_KEY!}`
     },
     body: JSON.stringify({
       model: MODEL,
-      temperature: 0.6,
       messages: [
-        { role: "system", content: cfg.system },
-        { role: "user", content: cfg.user },
+        { role: 'system', content: systemByAction[action] },
+        { role: 'user', content: prompt.trim() }
       ],
-      response_format: { type: "json_object" },
-      max_tokens: 800,
-    }),
-  });
+      temperature: 0.4,
+      max_tokens: 1024
+    })
+  })
 
-  if (!response.ok) {
-    return bad(`Groq error ${response.status}`, response.status);
+  const text = await resp.text()
+  if (!resp.ok) {
+    // forward Groq’s actual error message so the client can show it
+    return { statusCode: resp.status, headers: HEADERS, body: text }
   }
 
-  let payload: any;
+  // extract + validate
+  const data = JSON.parse(pickJson(JSON.parse(text).choices[0].message.content))
   try {
-    payload = await response.json();
-  } catch (error) {
-    return bad("Invalid response from Groq", 502);
+    if (action === 'quiz') Quiz.parse(data)
+    if (action === 'card') Card.parse(data)
+  } catch (e) {
+    return { statusCode: 422, headers: HEADERS, body: JSON.stringify({ error:'Bad AI JSON', detail: (e as Error).message, raw:data }) }
   }
 
-  const content = payload?.choices?.[0]?.message?.content;
-  if (typeof content !== "string") {
-    return bad("Groq returned no content", 502);
-  }
+  return { statusCode: 200, headers: HEADERS, body: JSON.stringify({ ok:true, data }) }
+}
 
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = JSON.parse(content) as Record<string, unknown>;
-  } catch (error) {
-    return bad("Groq returned invalid JSON", 502);
-  }
-
-  const clean = sanitizeBySchema(cfg.schema, parsed);
-  cache.set(cacheKey, { t: now, v: clean });
-  return ok(clean);
-};
-
-export default handler;
+export default handler

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,26 +1,54 @@
-export async function callAI<T>(kind: string, input: unknown): Promise<T> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 30000);
-  try {
-    const response = await fetch("/.netlify/functions/ai", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ kind, input }),
-      signal: controller.signal,
-    });
+export type AiAction = 'lesson' | 'quiz' | 'card'
 
-    const json = await response.json().catch(() => ({ ok: false, error: "Invalid server response" }));
-    if (!response.ok || !json.ok) {
-      const message = json?.error || `AI failed (${response.status})`;
-      throw new Error(message);
+type AiSuccess<T> = { ok: true; data: T }
+type AiError = { ok?: false; error?: string | { message?: string } }
+
+type AiEnvelope<T> = AiSuccess<T> | AiError | null
+
+function safeJson<T>(input: string): T | null {
+  try {
+    return JSON.parse(input) as T
+  } catch {
+    return null
+  }
+}
+
+function extractError(payload: AiEnvelope<unknown>, fallback: string) {
+  if (!payload) return fallback
+  const raw = (payload as AiError).error
+  if (!raw) return fallback
+  if (typeof raw === 'string') return raw
+  if (typeof raw.message === 'string' && raw.message.trim().length > 0) return raw.message
+  return fallback
+}
+
+export async function callAI<T>(action: AiAction, prompt: string): Promise<T> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 30000)
+
+  try {
+    const response = await fetch('/.netlify/functions/ai', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ action, prompt }),
+      signal: controller.signal,
+    })
+
+    const text = await response.text()
+    const json = safeJson<AiEnvelope<T>>(text)
+
+    if (!response.ok || !json || json.ok !== true) {
+      const message = extractError(json, text || `AI failed (${response.status})`)
+      throw new Error(message)
     }
-    return json.data as T;
+
+    return json.data
   } catch (error) {
-    if (error instanceof DOMException && error.name === "AbortError") {
-      throw new Error("AI request timed out");
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error('AI request timed out')
     }
-    throw error instanceof Error ? error : new Error("AI request failed");
+    throw error instanceof Error ? error : new Error('AI request failed')
   } finally {
-    clearTimeout(timeout);
+    clearTimeout(timeout)
   }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -563,10 +563,14 @@ footer a:hover {
   color: var(--naturverse-blue) !important;
 }
 [data-page="naturbank"] button,
-[data-page="naturbank"] .btn {
+[data-page="naturbank"] .btn {  
   background: var(--naturverse-blue) !important;
   color: #fff !important;
   border: none !important;
+}
+
+.page-bottom-actions {
+  padding-bottom: 84px;
 }
 
 /* Optional: inputs look consistent next to blue labels */


### PR DESCRIPTION
## Summary
- replace the Netlify AI handler with a streamlined Groq client that validates quiz and card payloads and surfaces API errors
- update the client AI helper to use the new action/prompt contract with better error messages and fetch quiz content after building a lesson
- normalize navatar card state, ensure powers/traits defaults, allow local saves when logged out, and keep the save button accessible with extra bottom padding

## Testing
- `npm run typecheck` *(fails: repository contains Next.js references and missing Supabase typings unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cbeb943bf88329bc10124013377340