### PR TITLE
Fix Netlify build: add zod to dependencies (was missing)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "three": "^0.160.0",
     "workbox-window": "^7.1.0",
     "nprogress": "^0.2.0",
-    "react-helmet-async": "^2.0.4"
+    "react-helmet-async": "^2.0.4",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^20.14.11",


### PR DESCRIPTION
## Summary
- add zod to runtime dependencies so the Netlify AI function can bundle it

## Testing
- npm install zod --save *(fails: npm 403 Forbidden fetching @vitejs/plugin-react-swc in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbef84331883299d296174a857d258