### PR TITLE
Refine navatar AI flow and quiz handling

### DIFF
--- a/src/components/naturversity/Quiz.tsx
+++ b/src/components/naturversity/Quiz.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { callAI } from "@/lib/ai";
+
+type QuizOption = string;
+type QuizQ = { q: string; options: QuizOption[]; answer: string };
+type QuizData = { questions: QuizQ[] };
+
+type Props = {
+  topic: string;
+  age: number;
+};
+
+function normalizeQuiz(input: any): QuizData | null {
+  if (!input || !Array.isArray(input.questions)) return null;
+
+  const questions: QuizQ[] = input.questions
+    .slice(0, 3)
+    .map((entry: any) => {
+      const q = String(entry?.q ?? "").trim();
+      const answer = String(entry?.answer ?? "").trim().toUpperCase();
+      const rawOptions = Array.isArray(entry?.options) ? entry.options : [];
+      const options = rawOptions
+        .slice(0, 4)
+        .map((opt: unknown) => String(opt ?? "").trim())
+        .filter((opt: string) => opt.length > 0);
+
+      return { q, options, answer };
+    })
+    .filter((item: QuizQ) => item.q.length > 0 && item.options.length > 0);
+
+  if (questions.length === 0) return null;
+
+  return { questions };
+}
+
+export default function Quiz({ topic, age }: Props) {
+  const [quiz, setQuiz] = useState<QuizData | null>(null);
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+  const [result, setResult] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    const trimmed = topic.trim();
+    if (!trimmed) {
+      setError("Enter a topic first.");
+      return;
+    }
+
+    if (!Number.isFinite(age) || age <= 0) {
+      setError("Add an age to personalize the quiz.");
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+    setResult("");
+
+    try {
+      const promptAge = Number.isFinite(age) && age > 0 ? Math.round(age) : undefined;
+      const data = await callAI<QuizData>("quiz", {
+        prompt: `${trimmed} for age ${promptAge ?? "kids"}`,
+        age: promptAge,
+      });
+      const normalized = normalizeQuiz(data);
+      if (!normalized) {
+        setQuiz(null);
+        setError("Quiz unavailable right now. Try again.");
+        return;
+      }
+      setQuiz(normalized);
+      setAnswers({});
+    } catch (e: any) {
+      setQuiz(null);
+      setError(e?.message || "Quiz failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const submit = () => {
+    if (!quiz) return;
+    let correct = 0;
+    quiz.questions.forEach((item, index) => {
+      const guess = (answers[index] || "").toUpperCase();
+      if (guess && item.answer && guess === item.answer.toUpperCase()) {
+        correct += 1;
+      }
+    });
+    setResult(`You got ${correct} / ${quiz.questions.length} correct!`);
+  };
+
+  const handleSelect = (index: number, value: string) => {
+    setAnswers((prev) => ({ ...prev, [index]: value }));
+  };
+
+  return (
+    <div style={{ display: "grid", gap: 12 }}>
+      <button
+        type="button"
+        className="lesson-btn"
+        onClick={load}
+        disabled={loading}
+      >
+        {loading ? "Loading…" : quiz ? "Load another quiz" : "Load quiz"}
+      </button>
+
+      {quiz ? (
+        <div style={{ display: "grid", gap: 16 }}>
+          {quiz.questions.map((item, index) => (
+            <div key={`${item.q}-${index}`} className="quiz-q" style={{ border: "1px solid #e0e7ff", borderRadius: 12, padding: 12 }}>
+              <div style={{ fontWeight: 600, marginBottom: 8 }}>
+                {index + 1}. {item.q}
+              </div>
+              <div style={{ display: "grid", gap: 6 }}>
+                {item.options.map((opt, optIndex) => {
+                  const value = String.fromCharCode(65 + optIndex);
+                  return (
+                    <label key={`${item.q}-${value}`} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <input
+                        type="radio"
+                        name={`quiz-${index}`}
+                        value={value}
+                        checked={(answers[index] || "") === value}
+                        onChange={(event) => handleSelect(index, event.target.value)}
+                      />
+                      <span>
+                        {value}. {opt}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+          <button type="button" className="lesson-btn" onClick={submit}>
+            Check answers
+          </button>
+        </div>
+      ) : (
+        <p className="placeholder" style={{ margin: 0 }}>
+          Three check-in questions will show here after loading a quiz.
+        </p>
+      )}
+
+      {result && <p style={{ margin: 0, fontWeight: 600 }}>{result}</p>}
+      {error && <p className="error-text">{error}</p>}
+    </div>
+  );
+}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,19 +1,42 @@
-export async function callAI<T>(kind: string, input: unknown): Promise<T> {
+export type AIAction = "lesson" | "quiz" | "card" | "backstory";
+
+type AIParams = {
+  prompt: string;
+  age?: number;
+};
+
+export async function callAI<T>(action: AIAction, params: AIParams): Promise<T> {
+  const prompt = String(params.prompt ?? "").trim();
+  if (!prompt) {
+    throw new Error("Prompt is required");
+  }
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 30000);
+
   try {
     const response = await fetch("/.netlify/functions/ai", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ kind, input }),
+      body: JSON.stringify({ action, prompt, age: params.age }),
       signal: controller.signal,
     });
 
-    const json = await response.json().catch(() => ({ ok: false, error: "Invalid server response" }));
-    if (!response.ok || !json.ok) {
-      const message = json?.error || `AI failed (${response.status})`;
-      throw new Error(message);
+    const text = await response.text();
+    let json: any = null;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      // ignore, handled below
     }
+
+    if (!response.ok || !json?.ok) {
+      const message =
+        (json && typeof json.error === "string" && json.error) ||
+        (text && !response.ok ? text : "AI request failed");
+      throw new Error(message || `AI failed (${response.status})`);
+    }
+
     return json.data as T;
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {

--- a/src/lib/avatars.ts
+++ b/src/lib/avatars.ts
@@ -31,33 +31,3 @@ export async function upsertMyAvatar(userId: string, fields: Partial<AvatarRow>)
     .maybeSingle<AvatarRow>();
 }
 
-// Character Card (stored in character_cards, linked by avatar_id)
-export async function saveCharacterCard(params: {
-  userId: string;
-  avatarId: string;
-  name?: string;
-  species?: string;
-  kingdom?: string;
-  backstory?: string;
-  powers?: string[];
-  traits?: string[];
-}) {
-  const { userId, avatarId, ...card } = params;
-  return supabase
-    .from("character_cards")
-    .upsert(
-      [{ user_id: userId, avatar_id: avatarId, ...card }],
-      { onConflict: "avatar_id" }
-    )
-    .select()
-    .maybeSingle();
-}
-
-export async function getCharacterCard(avatarId: string) {
-  return supabase
-    .from("character_cards")
-    .select("*")
-    .eq("avatar_id", avatarId)
-    .maybeSingle();
-}
-

--- a/src/lib/supabaseHelpers.ts
+++ b/src/lib/supabaseHelpers.ts
@@ -1,0 +1,75 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_ANON_KEY!
+);
+
+type SaveNavatarParams = {
+  id?: string;
+  name: string;
+  species: string;
+  kingdom: string;
+  backstory: string;
+  powers?: string[];
+  traits?: string[];
+};
+
+const cleanField = (value?: string) => {
+  const text = String(value ?? "").trim();
+  return text.length > 0 ? text : null;
+};
+
+const cleanList = (list?: string[]) => (list ?? []).map((item) => item.trim()).filter((item) => item.length > 0);
+
+export async function saveNavatar(params: SaveNavatarParams) {
+  const { data: userData, error: userError } = await supabase.auth.getUser();
+  if (userError) throw userError;
+  const userId = userData?.user?.id;
+  if (!userId) {
+    throw new Error("Not signed in");
+  }
+
+  const base = {
+    owner_id: userId,
+    name: cleanField(params.name),
+    species: cleanField(params.species),
+    kingdom: cleanField(params.kingdom),
+    backstory: cleanField(params.backstory),
+  } as Record<string, any>;
+
+  if (params.id) {
+    base.id = params.id;
+  }
+
+  const { data: navatarRow, error: navatarError } = await supabase
+    .from("navatars")
+    .upsert(base, { onConflict: "id" })
+    .select()
+    .single();
+
+  if (navatarError) throw navatarError;
+  if (!navatarRow?.id) {
+    throw new Error("Failed to save navatar");
+  }
+
+  const { data: cardRow, error: cardError } = await supabase
+    .from("navatar_cards")
+    .upsert(
+      {
+        navatar_id: navatarRow.id,
+        powers: cleanList(params.powers),
+        traits: cleanList(params.traits),
+      },
+      { onConflict: "navatar_id" }
+    )
+    .select()
+    .single();
+
+  if (cardError) throw cardError;
+  return {
+    ...navatarRow,
+    powers: (cardRow?.powers as string[] | null) ?? [],
+    traits: (cardRow?.traits as string[] | null) ?? [],
+  };
+}

--- a/src/pages/naturversity/Builder.tsx
+++ b/src/pages/naturversity/Builder.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import { useToast } from "../../components/Toast";
+import Quiz from "../../components/naturversity/Quiz";
 import { callAI } from "@/lib/ai";
 import { naturEvent } from "@/lib/events";
 import { LessonPlan, saveLessonPlan, loadLessonPlan, listLessonPlans } from "@/lib/localdb";
@@ -12,7 +13,6 @@ type LessonResponse = {
   intro?: string;
   outline?: string[];
   activities?: string[];
-  quiz?: { q: string; a: string }[];
 };
 
 const DEFAULT_PLAN: LessonPlan = {
@@ -80,15 +80,7 @@ export default function LessonBuilderPage() {
           .map(item => String(item ?? "").trim())
           .filter(Boolean)
       : [],
-    quiz: Array.isArray(input.quiz)
-      ? input.quiz
-          .slice(0, 3)
-          .map((item) => ({
-            q: String(item?.q ?? "").trim(),
-            a: String(item?.a ?? "").trim(),
-          }))
-          .filter((item) => item.q.length > 0)
-      : [],
+    quiz: [],
   });
 
   async function buildLesson(event: FormEvent<HTMLFormElement>) {
@@ -109,8 +101,8 @@ export default function LessonBuilderPage() {
     setBusy(true);
     setError(null);
     try {
-      const response = await callAI<LessonResponse>("naturversity.lesson", {
-        topic: trimmedTopic,
+      const response = await callAI<LessonResponse>("lesson", {
+        prompt: trimmedTopic,
         age: numericAge,
       });
       const built = sanitizePlan(response);
@@ -211,17 +203,10 @@ export default function LessonBuilderPage() {
 
               <section className="lesson-quiz">
                 <h3>Quiz</h3>
-                {plan.quiz.length ? (
-                  <ul>
-                    {plan.quiz.map((item, index) => (
-                      <li key={`${item.q}-${index}`}>
-                        <strong>{item.q}</strong>
-                        <span>{item.a}</span>
-                      </li>
-                    ))}
-                  </ul>
+                {aiEnabled ? (
+                  <Quiz topic={topic} age={numericAge} />
                 ) : (
-                  <p className="placeholder">Three check-in questions will show here.</p>
+                  <p className="placeholder">Enable AI helpers to load quiz questions.</p>
                 )}
               </section>
 

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
 import NavatarTabs from "../../components/NavatarTabs";
-import { getCardForAvatar, navatarImageUrl } from "../../lib/navatar";
+import { getMyCharacterCard, navatarImageUrl } from "../../lib/navatar";
 import { getActiveNavatarId } from "../../lib/localNavatar";
 import { supabase } from "../../lib/supabase-client";
 import "../../styles/navatar.css";
@@ -24,7 +24,7 @@ export default function MintNavatarPage() {
         .eq("id", activeId)
         .maybeSingle();
       setNavatar(data);
-      const c = await getCardForAvatar(activeId);
+      const c = await getMyCharacterCard();
       setCard(c);
     })();
   }, []);


### PR DESCRIPTION
## Summary
- replace the Netlify AI function with a JSON-only handler keyed by action and updated Groq model defaults
- switch client helpers to the new action-based API, add an interactive Naturversity quiz component, and refresh the lesson builder display
- add a Supabase navatar saver, update navatar persistence to the navatars/navatar_cards tables, and wire the card UI to the new helper

## Testing
- npm run typecheck *(fails: repo includes Next.js + Supabase packages not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9c8ad8788329b073da2c2e058175