### PR TITLE
refactor: rename avatar tables and helpers to navatar

### DIFF
--- a/client/src/pages/NavatarCreator.tsx
+++ b/client/src/pages/NavatarCreator.tsx
@@ -9,10 +9,10 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 const categories = [
-  { id: 'fruit', name: '🍎 Fruit', description: 'Sweet and colorful fruit avatars' },
-  { id: 'animal', name: '🦁 Animal', description: 'Wild and wonderful creatures' },
-  { id: 'spirit', name: '✨ Spirit', description: 'Mystical and magical beings' },
-  { id: 'insect', name: '🦋 Insect', description: 'Tiny but mighty creatures' },
+  { id: 'fruit', name: '🍎 Fruit', description: 'Sweet and colorful fruit navatars' },
+  { id: 'animal', name: '🦁 Animal', description: 'Wild and wonderful navatar creatures' },
+  { id: 'spirit', name: '✨ Spirit', description: 'Mystical and magical navatars' },
+  { id: 'insect', name: '🦋 Insect', description: 'Tiny but mighty navatars' },
 ];
 
 export default function NavatarCreator() {
@@ -30,16 +30,16 @@ export default function NavatarCreator() {
     setSuccess('');
 
     try {
-      // Create navatar in Supabase avatars table
+      // Create navatar in Supabase navatars table
       const categoryData = categories.find((c) => c.id === selectedCategory);
       const { data, error: insertError } = await supabase
-        .from('avatars')
+        .from('navatars')
         .insert({
-          user_id: user.id,
-          name: `${categoryData?.name} Avatar`,
-          category: selectedCategory,
+          owner_id: user.id,
+          name: `${categoryData?.name} Navatar`,
+          base_type: selectedCategory,
           image_url: null, // Will be set when user uploads custom image
-          appearance_data: {
+          metadata: {
             category: selectedCategory,
             emoji: categoryData?.name.split(' ')[0],
             createdAt: new Date().toISOString(),
@@ -71,7 +71,7 @@ export default function NavatarCreator() {
             🎨 Navatar Creator
           </h1>
           <p className="text-white/90 text-lg">
-            Create your magical nature avatar to represent you in The Naturverse!
+            Create your magical nature navatar to represent you in The Naturverse!
           </p>
 
           {error && (

--- a/docs/db-helpers.md
+++ b/docs/db-helpers.md
@@ -1,7 +1,7 @@
 # DB query helpers
 
 - Profiles: `getProfile`, `updateProfile`
-- Avatars: `createAvatar`, `getAvatarsByUser`
+- Navatars: `createNavatar`, `getNavatarsByUser`
 - Stamps: `awardStamp`, `getStamps`
 - XP: `addXp`, `getXpTotal`, `getXpHistory`
 - Badges: `awardBadge`, `getBadges`

--- a/src/lib/api/navatar.ts
+++ b/src/lib/api/navatar.ts
@@ -1,39 +1,39 @@
 import { supabase } from '../db'
 import type { Database } from '../../types/db'
 
-type Avatar = Database['public']['Tables']['avatars']['Row']
-type AvatarInsert = Database['public']['Tables']['avatars']['Insert']
-type AvatarUpdate = Database['public']['Tables']['avatars']['Update']
+type Navatar = Database['public']['Tables']['navatars']['Row']
+type NavatarInsert = Database['public']['Tables']['navatars']['Insert']
+type NavatarUpdate = Database['public']['Tables']['navatars']['Update']
 
-export async function listMyAvatars() {
+export async function listMyNavatars() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return []
   const { data, error } = await supabase
-    .from('avatars')
+    .from('navatars')
     .select('*')
-    .eq('user_id', user.id)
+    .eq('owner_id', user.id)
     .order('created_at', { ascending: false })
   if (error) throw error
-  return data as Avatar[]
+  return data as Navatar[]
 }
 
-export async function createAvatar(input: AvatarInsert) {
+export async function createNavatar(input: NavatarInsert) {
   const { data, error } = await supabase
-    .from('avatars')
+    .from('navatars')
     .insert(input)
     .select()
     .single()
   if (error) throw error
-  return data as Avatar
+  return data as Navatar
 }
 
-export async function updateAvatar(id: string, patch: AvatarUpdate) {
+export async function updateNavatar(id: string, patch: NavatarUpdate) {
   const { data, error } = await supabase
-    .from('avatars')
+    .from('navatars')
     .update(patch)
     .eq('id', id)
     .select()
     .single()
   if (error) throw error
-  return data as Avatar
+  return data as Navatar
 }

--- a/src/lib/avatars.ts
+++ b/src/lib/avatars.ts
@@ -1,33 +1,33 @@
 import { supabase } from "./supabase-client";
 
-export type AvatarRow = {
+export type NavatarRow = {
   id: string;
-  user_id: string;
+  owner_id: string;
   name: string | null;
   image_url: string | null;
-  appearance_data?: any | null;
+  metadata?: any | null;
   is_primary?: boolean | null;
 };
 
-export async function getMyAvatar(userId: string) {
+export async function getMyNavatar(userId: string) {
   return supabase
-    .from("avatars")
+    .from("navatars")
     .select("*")
-    .eq("user_id", userId)
-    .maybeSingle<AvatarRow>();
+    .eq("owner_id", userId)
+    .maybeSingle<NavatarRow>();
 }
 
-// Pick/Set current avatar image + optional name (single row per user)
-export async function upsertMyAvatar(userId: string, fields: Partial<AvatarRow>) {
+// Pick/Set current navatar image + optional name (single row per user)
+export async function upsertMyNavatar(userId: string, fields: Partial<NavatarRow>) {
   const payload = {
-    user_id: userId,
+    owner_id: userId,
     is_primary: true,
     ...fields,
   };
   return supabase
-    .from("avatars")
-    .upsert(payload, { onConflict: "user_id" })
+    .from("navatars")
+    .upsert(payload, { onConflict: "owner_id" })
     .select()
-    .maybeSingle<AvatarRow>();
+    .maybeSingle<NavatarRow>();
 }
 

--- a/src/lib/navatar/useSupabase.ts
+++ b/src/lib/navatar/useSupabase.ts
@@ -5,22 +5,22 @@ const supabase = createClient(
   import.meta.env.VITE_SUPABASE_ANON_KEY!
 );
 
-// Table names & storage buckets are **avatars**
-export async function saveAvatarRow(payload: any) {
-  // e.g., { user_id, name, image_url, meta }
-  return await supabase.from("avatars").insert(payload).select().single();
+// Table name is **navatars** (storage bucket remains **avatars**)
+export async function saveNavatarRow(payload: any) {
+  // e.g., { owner_id, name, image_url, meta }
+  return await supabase.from("navatars").insert(payload).select().single();
 }
 
-export async function listAvatarsByUser(userId: string) {
+export async function listNavatarsByUser(userId: string) {
   return await supabase
-    .from("avatars")
+    .from("navatars")
     .select("*")
-    .eq("user_id", userId)
+    .eq("owner_id", userId)
     .order("created_at", { ascending: false });
 }
 
 // Storage bucket also **avatars**
-export async function uploadAvatarImage(userId: string, file: File) {
+export async function uploadNavatarImage(userId: string, file: File) {
   const path = `${userId}/${Date.now()}-${file.name}`;
   const { data, error } = await supabase
     .storage

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -24,22 +24,22 @@ export async function updateProfile(userId: string, updates: Record<string, unkn
 }
 
 // --------------------
-// Avatars
+// Navatars
 // --------------------
-export async function createAvatar(navatar: Record<string, unknown>) {
+export async function createNavatar(navatar: Record<string, unknown>) {
   const { data, error } = await supabase
-    .from('avatars')
+    .from('navatars')
     .insert(navatar)
     .select();
   if (error) throw error;
   return data;
 }
 
-export async function getAvatarsByUser(userId: string) {
+export async function getNavatarsByUser(userId: string) {
   const { data, error } = await supabase
-    .from('avatars')
+    .from('navatars')
     .select('*')
-    .eq('user_id', userId);
+    .eq('owner_id', userId);
   if (error) throw error;
   return data;
 }

--- a/src/lib/supabaseHelpers.ts
+++ b/src/lib/supabaseHelpers.ts
@@ -5,7 +5,7 @@ export const supabase = createClient(
   import.meta.env.VITE_SUPABASE_ANON_KEY!
 );
 
-type SaveNavatarParams = {
+type UpsertNavatarParams = {
   id?: string;
   name: string;
   species: string;
@@ -22,7 +22,7 @@ const cleanField = (value?: string) => {
 
 const cleanList = (list?: string[]) => (list ?? []).map((item) => item.trim()).filter((item) => item.length > 0);
 
-export async function saveNavatar(params: SaveNavatarParams) {
+export async function upsertNavatarWithCard(params: UpsertNavatarParams) {
   const { data: userData, error: userError } = await supabase.auth.getUser();
   if (userError) throw userError;
   const userId = userData?.user?.id;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -115,9 +115,9 @@ export type WishlistItem = CatalogItem & {
   wishedAt: Date;
 };
 
-export type CharacterCard = {
+export type NavatarCardRow = {
   id: string;
-  user_id: string;
+  owner_id: string;
   navatar_id: string | null;
   name: string | null;
   species: string | null;

--- a/src/pages/navatar/index.tsx
+++ b/src/pages/navatar/index.tsx
@@ -2,15 +2,15 @@ import { useEffect, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarTabs from "../../components/NavatarTabs";
 import NavatarCard from "../../components/NavatarCard";
-import { getMyAvatar, getMyCharacterCard } from "../../lib/navatar";
-import type { CharacterCard } from "../../lib/navatar";
+import { getMyNavatar, getMyNavatarCard } from "../../lib/navatar";
+import type { NavatarRecord, NavatarCard as NavatarCardRecord } from "../../lib/navatar";
 import { useAuthUser } from "../../lib/useAuthUser";
 import { Link } from "react-router-dom";
 import "../../styles/navatar.css";
 
 export default function MyNavatarPage() {
-  const [avatar, setAvatar] = useState<any | null>(null);
-  const [card, setCard] = useState<CharacterCard | null>(null);
+  const [navatar, setNavatar] = useState<NavatarRecord | null>(null);
+  const [card, setCard] = useState<NavatarCardRecord | null>(null);
   const { user } = useAuthUser();
 
   useEffect(() => {
@@ -18,9 +18,9 @@ export default function MyNavatarPage() {
     let alive = true;
     (async () => {
       try {
-        const my = await getMyAvatar();
-        if (alive) setAvatar(my);
-        const c = await getMyCharacterCard();
+        const my = await getMyNavatar();
+        if (alive) setNavatar(my);
+        const c = await getMyNavatarCard();
         if (alive) setCard(c);
       } catch {
         // ignore
@@ -41,7 +41,7 @@ export default function MyNavatarPage() {
       <div className="nv-hub-grid mt-6">
         <section>
           <div className="nv-panel">
-            <NavatarCard src={avatar?.image_url || undefined} title={avatar?.name || "Turian"} />
+            <NavatarCard src={navatar?.image_url || undefined} title={navatar?.name || "Turian"} />
           </div>
         </section>
 

--- a/src/pages/navatar/mint.tsx
+++ b/src/pages/navatar/mint.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
 import NavatarTabs from "../../components/NavatarTabs";
-import { getMyCharacterCard, navatarImageUrl } from "../../lib/navatar";
+import { getMyNavatarCard, navatarImageUrl } from "../../lib/navatar";
 import { getActiveNavatarId } from "../../lib/localNavatar";
 import { supabase } from "../../lib/supabase-client";
 import "../../styles/navatar.css";
@@ -19,12 +19,12 @@ export default function MintNavatarPage() {
 
     (async () => {
       const { data } = await supabase
-        .from("avatars")
+        .from("navatars")
         .select("id,name,image_path")
         .eq("id", activeId)
         .maybeSingle();
       setNavatar(data);
-      const c = await getMyCharacterCard();
+      const c = await getMyNavatarCard();
       setCard(c);
     })();
   }, []);

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -22,22 +22,59 @@ export type Database = {
         };
         Update: Partial<Database['public']['Tables']['profiles']['Insert']>;
       };
-      avatars: {
+      navatars: {
         Row: {
           id: string;
-          user_id: string;
+          owner_id: string;
           name: string | null;
-          base_type: string;
+          base_type: string | null;
+          species: string | null;
+          kingdom: string | null;
           backstory: string | null;
           image_url: string | null;
+          image_path: string | null;
+          thumbnail_url: string | null;
+          is_public: boolean | null;
+          is_primary: boolean | null;
+          metadata: Record<string, unknown> | null;
+          card: Record<string, unknown> | null;
           created_at: string;
           updated_at: string;
         };
-        Insert: Omit<
-          Database['public']['Tables']['avatars']['Row'],
-          'id' | 'created_at' | 'updated_at'
-        >;
-        Update: Partial<Database['public']['Tables']['avatars']['Insert']>;
+        Insert: {
+          id?: string;
+          owner_id: string;
+          name?: string | null;
+          base_type?: string | null;
+          species?: string | null;
+          kingdom?: string | null;
+          backstory?: string | null;
+          image_url?: string | null;
+          image_path?: string | null;
+          thumbnail_url?: string | null;
+          is_public?: boolean | null;
+          is_primary?: boolean | null;
+          metadata?: Record<string, unknown> | null;
+          card?: Record<string, unknown> | null;
+        };
+        Update: Partial<Database['public']['Tables']['navatars']['Insert']>;
+      };
+      navatar_cards: {
+        Row: {
+          id: string;
+          navatar_id: string;
+          powers: string[] | null;
+          traits: string[] | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          navatar_id: string;
+          powers?: string[] | null;
+          traits?: string[] | null;
+        };
+        Update: Partial<Database['public']['Tables']['navatar_cards']['Insert']>;
       };
       passport_stamps: {
         Row: { id: number; user_id: string; kingdom: string; stamped_at: string };


### PR DESCRIPTION
## Summary
- update all navatar data access helpers to query the `navatars` and `navatar_cards` tables instead of the legacy `avatars` table
- rename related TypeScript types, queries, and page logic so navatar is the canonical name across the app and client navatar creator
- refresh docs and supporting utilities to reflect the new navatar naming

## Testing
- `npm run typecheck` *(fails: existing project TypeScript errors and missing Next.js modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb03759bc83298ef45cd038bbe804