### PR TITLE
fix: reuse shared Supabase client across app

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,9 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
-
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+import { supabase } from './supabase-client';
+export { supabase } from './supabase-client';
 
 export async function getSession() {
   const { data } = await supabase.auth.getSession();

--- a/lib/rewards.ts
+++ b/lib/rewards.ts
@@ -1,9 +1,7 @@
 import { confettiBurst } from './confetti';
-import { createClient } from '@supabase/supabase-js';
+import { supabase as sharedSupabase } from './supabase-client';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-const sb = (url && key) ? createClient(url, key) : null;
+const sb = sharedSupabase;
 
 type StampGrant = { world: string; inc?: number };
 

--- a/lib/supabase-client.ts
+++ b/lib/supabase-client.ts
@@ -1,8 +1,25 @@
-import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { createClient as createSupabaseClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const requireEnv = (value: string | undefined, message: string) => {
+  if (!value) throw new Error(message);
+  return value;
+};
+
+const supabaseUrl = requireEnv(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  'Missing Supabase environment variables. Set NEXT_PUBLIC_SUPABASE_URL.'
+);
+const supabaseAnonKey = requireEnv(
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  'Missing Supabase environment variables. Set NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+);
+
+const globalForSupabase = globalThis as unknown as {
+  __naturverseNextSupabase?: SupabaseClient;
+};
 
 export function createClient() {
-  return createSupabaseClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  return createSupabaseClient(supabaseUrl, supabaseAnonKey);
 }
+
+export const supabase = globalForSupabase.__naturverseNextSupabase ??= createClient();

--- a/src/lib/navatar/useSupabase.ts
+++ b/src/lib/navatar/useSupabase.ts
@@ -1,9 +1,4 @@
-import { createClient } from "@supabase/supabase-js";
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL!,
-  import.meta.env.VITE_SUPABASE_ANON_KEY!
-);
+import { supabase } from "@/lib/supabase-client";
 
 // Table names & storage buckets are **avatars**
 export async function saveAvatarRow(payload: any) {

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,10 +1,47 @@
-import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { createClient as createSupabaseClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+type EnvKey =
+  | 'VITE_SUPABASE_URL'
+  | 'VITE_SUPABASE_ANON_KEY'
+  | 'NEXT_PUBLIC_SUPABASE_URL'
+  | 'NEXT_PUBLIC_SUPABASE_ANON_KEY';
+
+const fromImportMeta = (key: EnvKey) => {
+  try {
+    return (import.meta.env as Record<string, string | undefined>)[key];
+  } catch {
+    return undefined;
+  }
+};
+
+const fromProcessEnv = (key: EnvKey) => {
+  return typeof process !== 'undefined' ? process.env?.[key] : undefined;
+};
+
+const resolveEnv = (primary: EnvKey, fallback: EnvKey) => {
+  return fromImportMeta(primary) ?? fromImportMeta(fallback) ?? fromProcessEnv(primary) ?? fromProcessEnv(fallback);
+};
+
+const requireEnv = (value: string | undefined, message: string) => {
+  if (!value) throw new Error(message);
+  return value;
+};
+
+const supabaseUrl = requireEnv(
+  resolveEnv('VITE_SUPABASE_URL', 'NEXT_PUBLIC_SUPABASE_URL'),
+  'Missing Supabase environment variables. Set VITE_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL.'
+);
+const supabaseAnonKey = requireEnv(
+  resolveEnv('VITE_SUPABASE_ANON_KEY', 'NEXT_PUBLIC_SUPABASE_ANON_KEY'),
+  'Missing Supabase environment variables. Set VITE_SUPABASE_ANON_KEY or NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+);
+
+const globalForSupabase = globalThis as unknown as {
+  __naturverseSupabase?: SupabaseClient;
+};
 
 export function createClient() {
   return createSupabaseClient(supabaseUrl, supabaseAnonKey);
 }
 
-export const supabase = createClient();
+export const supabase = globalForSupabase.__naturverseSupabase ??= createClient();

--- a/src/lib/supabaseHelpers.ts
+++ b/src/lib/supabaseHelpers.ts
@@ -1,9 +1,4 @@
-import { createClient } from "@supabase/supabase-js";
-
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL!,
-  import.meta.env.VITE_SUPABASE_ANON_KEY!
-);
+import { supabase } from "./supabase-client";
 
 type SaveNavatarParams = {
   id?: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,10 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL?: string;
+  readonly VITE_SUPABASE_ANON_KEY?: string;
+  readonly NEXT_PUBLIC_SUPABASE_URL?: string;
+  readonly NEXT_PUBLIC_SUPABASE_ANON_KEY?: string;
   readonly NEXT_PUBLIC_SITE_URL?: string;
   readonly NEXT_PUBLIC_PLAUSIBLE_DOMAIN?: string;
 }


### PR DESCRIPTION
## Summary
- ensure the browser Supabase client resolves env vars from both Vite and NEXT_PUBLIC prefixes and reuse a singleton across reloads
- update navatar helpers, rewards logic, and Next auth utilities to consume the shared client and refine feature flag detection
- document the Supabase env keys exposed to Vite for better type checking

## Testing
- `npm run typecheck` *(fails: repository is missing Next.js and related type dependencies upstream)*

------
https://chatgpt.com/codex/tasks/task_e_68cd46bebc848329926dc1686e839099