### PR TITLE
Fix navatar card saves to include user_id and reuse browser Supabase client

### DIFF
--- a/src/lib/api/navatar.ts
+++ b/src/lib/api/navatar.ts
@@ -5,22 +5,35 @@ type Navatar = Database['public']['Tables']['navatars']['Row']
 type NavatarInsert = Database['public']['Tables']['navatars']['Insert']
 type NavatarUpdate = Database['public']['Tables']['navatars']['Update']
 
+function normalizeOwnershipFields<T extends { owner_id?: string | null; user_id?: string | null }>(
+  input: T
+) {
+  const userId = input.user_id ?? input.owner_id
+  if (!userId) throw new Error('user_id is required')
+  return {
+    ...input,
+    user_id: userId,
+    owner_id: input.owner_id ?? userId,
+  }
+}
+
 export async function listMyAvatars() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return []
   const { data, error } = await supabase
     .from('navatars')
     .select('*')
-    .eq('owner_id', user.id)
+    .eq('user_id', user.id)
     .order('created_at', { ascending: false })
   if (error) throw error
   return data as Navatar[]
 }
 
 export async function createAvatar(input: NavatarInsert) {
+  const payload = normalizeOwnershipFields(input)
   const { data, error } = await supabase
     .from('navatars')
-    .insert(input)
+    .insert(payload)
     .select()
     .single()
   if (error) throw error
@@ -28,9 +41,13 @@ export async function createAvatar(input: NavatarInsert) {
 }
 
 export async function updateAvatar(id: string, patch: NavatarUpdate) {
+  const payload =
+    patch.user_id !== undefined || patch.owner_id !== undefined
+      ? normalizeOwnershipFields(patch)
+      : patch
   const { data, error } = await supabase
     .from('navatars')
-    .update(patch)
+    .update(payload)
     .eq('id', id)
     .select()
     .single()

--- a/src/lib/fixtures.ts
+++ b/src/lib/fixtures.ts
@@ -88,6 +88,7 @@ export const sampleWishlist: WishlistRow[] = [
 export const sampleNavatar: NavatarRow = {
   id: 'n1',
   owner_id: 'u1',
+  user_id: 'u1',
   name: 'Macaw',
   base_type: 'animal',
   species: 'Macaw',

--- a/src/lib/mappers.ts
+++ b/src/lib/mappers.ts
@@ -35,7 +35,7 @@ export function mapProfileRow(row: ProfileRow): Profile {
 export function mapNavatarRow(row: NavatarRow): Navatar {
   return {
     id: row.id,
-    ownerId: row.owner_id,
+    ownerId: row.owner_id ?? row.user_id,
     name: row.name ?? 'Navatar',
     base: row.base_type,
     species: row.species ?? undefined,

--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -8,6 +8,7 @@ export const NAVATAR_PREFIX = 'navatars';
 export type NavatarRow = {
   id: string;
   owner_id: string;
+  user_id: string;
   name: string | null;
   image_url: string | null;
   image_path: string | null;
@@ -18,6 +19,7 @@ export type NavatarRow = {
 export type CharacterCard = {
   id: string;
   owner_id: string;
+  user_id: string;
   name: string | null;
   species: string | null;
   kingdom: string | null;
@@ -27,6 +29,23 @@ export type CharacterCard = {
   created_at: string | null;
   updated_at: string | null;
 };
+
+function normalizeOwnership<T extends { owner_id?: string | null; user_id?: string | null }>(row: T) {
+  const userId = row.user_id ?? row.owner_id;
+  if (!userId) {
+    throw new Error('Navatar row is missing user ownership metadata.');
+  }
+
+  return {
+    ...row,
+    user_id: userId,
+    owner_id: row.owner_id ?? userId,
+  };
+}
+
+function normalizeNavatarRow(row: any): NavatarRow {
+  return normalizeOwnership(row) as NavatarRow;
+}
 
 export async function getSessionUserId() {
   const { data: { user } } = await supabase.auth.getUser();
@@ -57,14 +76,14 @@ export async function listNavatars(): Promise<{ name: string; url: string; path:
     });
 }
 
-async function resolveExistingNavatarId(ownerId: string): Promise<string | null> {
+async function resolveExistingNavatarId(userId: string): Promise<string | null> {
   const activeId = getActiveNavatarId();
   if (activeId) return activeId;
 
   const { data, error } = await supabase
     .from('navatars')
     .select('id')
-    .eq('owner_id', ownerId)
+    .eq('user_id', userId)
     .order('updated_at', { ascending: false, nullsFirst: false })
     .order('created_at', { ascending: false })
     .limit(1)
@@ -76,18 +95,19 @@ async function resolveExistingNavatarId(ownerId: string): Promise<string | null>
 
 /** Pick an existing image and upsert it into public.navatars */
 export async function pickNavatar(imagePath: string, name?: string): Promise<NavatarRow> {
-  const owner_id = await getSessionUserId();
+  const userId = await getSessionUserId();
   const { data: pub } = supabase.storage.from(NAVATAR_BUCKET).getPublicUrl(imagePath);
 
   const payload: Record<string, any> = {
-    owner_id,
+    owner_id: userId,
+    user_id: userId,
     name: name ?? 'My Navatar',
     image_url: pub.publicUrl ?? null,
     image_path: imagePath,
     updated_at: new Date().toISOString(),
   };
 
-  const existingId = await resolveExistingNavatarId(owner_id);
+  const existingId = await resolveExistingNavatarId(userId);
   if (existingId) payload.id = existingId;
 
   const { data, error } = await supabase
@@ -97,14 +117,14 @@ export async function pickNavatar(imagePath: string, name?: string): Promise<Nav
     .single();
 
   if (error) throw error;
-  return data as NavatarRow;
+  return normalizeNavatarRow(data);
 }
 
 /** Upload a custom image then store it in public.navatars */
 export async function uploadNavatar(file: File, name?: string): Promise<NavatarRow> {
-  const owner_id = await getSessionUserId();
+  const userId = await getSessionUserId();
   const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
-  const key = `${NAVATAR_PREFIX}/${owner_id}/${crypto.randomUUID()}.${ext}`;
+  const key = `${NAVATAR_PREFIX}/${userId}/${crypto.randomUUID()}.${ext}`;
 
   const { error: upErr } = await supabase
     .storage.from(NAVATAR_BUCKET)
@@ -117,43 +137,43 @@ export async function uploadNavatar(file: File, name?: string): Promise<NavatarR
 
 /** Load the current user's navatar row */
 export async function getMyAvatar(): Promise<NavatarRow | null> {
-  const owner_id = await getSessionUserId();
+  const userId = await getSessionUserId();
   const activeId = getActiveNavatarId();
 
   if (activeId) {
     const { data, error } = await supabase
       .from('navatars')
       .select('*')
-      .eq('owner_id', owner_id)
+      .eq('user_id', userId)
       .eq('id', activeId)
       .maybeSingle();
 
     if (error && (error as any).code !== 'PGRST116') throw error;
-    if (data) return data as NavatarRow;
+    if (data) return normalizeNavatarRow(data);
   }
 
   const { data, error } = await supabase
     .from('navatars')
     .select('*')
-    .eq('owner_id', owner_id)
+    .eq('user_id', userId)
     .order('updated_at', { ascending: false, nullsFirst: false })
     .order('created_at', { ascending: false })
     .limit(1)
     .maybeSingle();
 
   if (error && (error as any).code !== 'PGRST116') throw error;
-  return (data as NavatarRow | null) ?? null;
+  return data ? normalizeNavatarRow(data) : null;
 }
 
 /** Load the current user's character card */
 export async function getMyCharacterCard(): Promise<CharacterCard | null> {
-  const ownerId = await getSessionUserId();
+  const userId = await getSessionUserId();
   const { data, error } = await supabase
     .from('navatars')
     .select(
-      'id, owner_id, name, species, kingdom, backstory, created_at, updated_at, navatar_cards(powers, traits, updated_at)'
+      'id, user_id, owner_id, name, species, kingdom, backstory, created_at, updated_at, navatar_cards(powers, traits, updated_at)'
     )
-    .eq('owner_id', ownerId)
+    .eq('user_id', userId)
     .order('updated_at', { ascending: false, nullsFirst: true })
     .order('created_at', { ascending: false })
     .limit(1)
@@ -162,22 +182,24 @@ export async function getMyCharacterCard(): Promise<CharacterCard | null> {
   if (error && (error as any).code !== 'PGRST116') throw error;
   if (!data) return null;
 
-  const metaRaw = (data as any).navatar_cards;
+  const normalized = normalizeOwnership(data);
+  const metaRaw = (normalized as any).navatar_cards;
   const meta = Array.isArray(metaRaw) ? metaRaw[0] : metaRaw;
   const powers = (meta?.powers as string[] | null) ?? [];
   const traits = (meta?.traits as string[] | null) ?? [];
 
   return {
-    id: data.id as string,
-    owner_id: data.owner_id as string,
-    name: (data as any).name ?? null,
-    species: (data as any).species ?? null,
-    kingdom: (data as any).kingdom ?? null,
-    backstory: (data as any).backstory ?? null,
+    id: normalized.id as string,
+    owner_id: normalized.owner_id as string,
+    user_id: normalized.user_id as string,
+    name: (normalized as any).name ?? null,
+    species: (normalized as any).species ?? null,
+    kingdom: (normalized as any).kingdom ?? null,
+    backstory: (normalized as any).backstory ?? null,
     powers,
     traits,
-    created_at: (data as any).created_at ?? null,
-    updated_at: (data as any).updated_at ?? meta?.updated_at ?? null,
+    created_at: (normalized as any).created_at ?? null,
+    updated_at: (normalized as any).updated_at ?? meta?.updated_at ?? null,
   };
 }
 
@@ -203,17 +225,19 @@ export async function saveCharacterCard(input: {
 
   const powers = Array.isArray(saved.powers) ? saved.powers : [];
   const traits = Array.isArray(saved.traits) ? saved.traits : [];
+  const normalized = normalizeOwnership(saved);
 
   return {
-    id: saved.id as string,
-    owner_id: saved.owner_id as string,
-    name: saved.name ?? null,
-    species: saved.species ?? null,
-    kingdom: saved.kingdom ?? null,
-    backstory: saved.backstory ?? null,
+    id: normalized.id as string,
+    owner_id: normalized.owner_id as string,
+    user_id: normalized.user_id as string,
+    name: (normalized as any).name ?? null,
+    species: (normalized as any).species ?? null,
+    kingdom: (normalized as any).kingdom ?? null,
+    backstory: (normalized as any).backstory ?? null,
     powers,
     traits,
-    created_at: saved.created_at ?? null,
-    updated_at: saved.updated_at ?? null,
+    created_at: (normalized as any).created_at ?? null,
+    updated_at: (normalized as any).updated_at ?? null,
   } satisfies CharacterCard;
 }

--- a/src/lib/navatar/useSupabase.ts
+++ b/src/lib/navatar/useSupabase.ts
@@ -2,15 +2,22 @@ import { supabase } from '@/lib/supabaseClient';
 
 // Table names are navatars; storage bucket remains **avatars**
 export async function saveAvatarRow(payload: any) {
-  // e.g., { owner_id, name, image_url, meta }
-  return await supabase.from('navatars').insert(payload).select().single();
+  // e.g., { owner_id, user_id, name, image_url, meta }
+  const normalized = { ...payload };
+  if (!normalized.user_id && normalized.owner_id) {
+    normalized.user_id = normalized.owner_id;
+  }
+  if (!normalized.owner_id && normalized.user_id) {
+    normalized.owner_id = normalized.user_id;
+  }
+  return await supabase.from('navatars').insert(normalized).select().single();
 }
 
 export async function listAvatarsByUser(userId: string) {
   return await supabase
     .from('navatars')
     .select('*')
-    .eq('owner_id', userId)
+    .eq('user_id', userId)
     .order('created_at', { ascending: false });
 }
 

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -27,9 +27,16 @@ export async function updateProfile(userId: string, updates: Record<string, unkn
 // Avatars
 // --------------------
 export async function createAvatar(navatar: Record<string, unknown>) {
+  const payload = { ...navatar } as Record<string, any>;
+  if (!payload.user_id && payload.owner_id) {
+    payload.user_id = payload.owner_id;
+  }
+  if (!payload.owner_id && payload.user_id) {
+    payload.owner_id = payload.user_id;
+  }
   const { data, error } = await supabase
     .from('navatars')
-    .insert(navatar)
+    .insert(payload)
     .select();
   if (error) throw error;
   return data;
@@ -39,7 +46,7 @@ export async function getAvatarsByUser(userId: string) {
   const { data, error } = await supabase
     .from('navatars')
     .select('*')
-    .eq('owner_id', userId);
+    .eq('user_id', userId);
   if (error) throw error;
   return data;
 }

--- a/src/lib/supabase/browser.ts
+++ b/src/lib/supabase/browser.ts
@@ -1,0 +1,26 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __naturverseBrowserSupabase: SupabaseClient | undefined;
+}
+
+export function getBrowserClient(): SupabaseClient {
+  if (!globalThis.__naturverseBrowserSupabase) {
+    const url = import.meta.env.VITE_SUPABASE_URL;
+    const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+    if (!url || !key) {
+      throw new Error('Missing Supabase environment variables.');
+    }
+
+    globalThis.__naturverseBrowserSupabase = createClient(url, key, {
+      auth: {
+        persistSession: true,
+        detectSessionInUrl: true,
+      },
+    });
+  }
+
+  return globalThis.__naturverseBrowserSupabase;
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,23 +1,7 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+import { getBrowserClient } from './supabase/browser';
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase environment variables.');
-}
+export const supabase: SupabaseClient = getBrowserClient();
 
-type NaturverseGlobal = typeof globalThis & {
-  __naturverseSupabase?: SupabaseClient;
-};
-
-const globalRef = globalThis as NaturverseGlobal;
-
-export const supabase: SupabaseClient =
-  globalRef.__naturverseSupabase ??
-  (globalRef.__naturverseSupabase = createClient(supabaseUrl, supabaseAnonKey, {
-    auth: {
-      persistSession: true,
-      detectSessionInUrl: true,
-    },
-  }));
+export { getBrowserClient };

--- a/src/lib/supabaseHelpers.ts
+++ b/src/lib/supabaseHelpers.ts
@@ -27,6 +27,7 @@ export async function saveNavatar(params: SaveNavatarParams) {
 
   const base = {
     owner_id: userId,
+    user_id: userId,
     name: cleanField(params.name),
     species: cleanField(params.species),
     kingdom: cleanField(params.kingdom),
@@ -52,6 +53,8 @@ export async function saveNavatar(params: SaveNavatarParams) {
     .from("navatar_cards")
     .upsert(
       {
+        owner_id: userId,
+        user_id: userId,
         navatar_id: navatarRow.id,
         powers: cleanList(params.powers),
         traits: cleanList(params.traits),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,7 @@ export type ProfileRow = {
 export type NavatarRow = {
   id: string;
   owner_id: string;
+  user_id: string;
   name: string | null;
   base_type: 'animal' | 'fruit' | 'insect' | 'spirit';
   species: string | null;

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -26,6 +26,7 @@ export type Database = {
         Row: {
           id: string;
           owner_id: string;
+          user_id: string;
           name: string | null;
           image_url: string | null;
           image_path: string | null;
@@ -35,6 +36,7 @@ export type Database = {
         Insert: {
           id?: string;
           owner_id: string;
+          user_id: string;
           name?: string | null;
           image_url?: string | null;
           image_path?: string | null;
@@ -47,6 +49,7 @@ export type Database = {
         Row: {
           id: string;
           owner_id: string;
+          user_id: string;
           navatar_id: string | null;
           name: string | null;
           species: string | null;
@@ -60,6 +63,7 @@ export type Database = {
         Insert: {
           id?: string;
           owner_id: string;
+          user_id: string;
           navatar_id?: string | null;
           name?: string | null;
           species?: string | null;


### PR DESCRIPTION
## Summary
- add a browser Supabase client helper and reuse it from the existing supabaseClient export
- send user_id alongside owner_id when creating or updating navatars and navatar_cards
- refresh navatar helpers, queries, and generated types to rely on user_id ownership metadata

## Testing
- `npm run typecheck` *(fails: repo is missing Next.js/React Native type deps and nprogress types in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9c9e6f38832992b1890f37a64467