### PR TITLE
Fix save actions and RLS for Navatar + remove stray Next.js types

### DIFF
--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -1,8 +1,15 @@
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY ?? process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error("Missing Supabase configuration");
+}
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey, { auth: { persistSession: false } });
 
 export async function getNavatarUrl(userId: string): Promise<string | null> {
-  const supabase = createClientComponentClient();
-  // assumes table `profiles` with column `navatar_url`
   const { data, error } = await supabase
     .from("profiles")
     .select("navatar_url")

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^20.14.11",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react-swc": "^3.7.1",
+    "@vitejs/plugin-react": "^4.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
     "vite": "^5.4.2",

--- a/src/lib/api/navatar.ts
+++ b/src/lib/api/navatar.ts
@@ -11,16 +11,22 @@ export async function listMyAvatars() {
   const { data, error } = await supabase
     .from('navatars')
     .select('*')
-    .eq('owner_id', user.id)
+    .eq('user_id', user.id)
     .order('created_at', { ascending: false })
   if (error) throw error
   return data as Navatar[]
 }
 
 export async function createAvatar(input: NavatarInsert) {
+  const payload: NavatarInsert = { ...input };
+  if (!payload.user_id) {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('Not signed in');
+    payload.user_id = user.id;
+  }
   const { data, error } = await supabase
     .from('navatars')
-    .insert(input)
+    .insert(payload)
     .select()
     .single()
   if (error) throw error

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,1 +1,1 @@
-export { supabase } from './supabaseClient';
+export { getBrowserClient, supabase } from './supabaseClient';

--- a/src/lib/fixtures.ts
+++ b/src/lib/fixtures.ts
@@ -26,13 +26,13 @@ export const ALL_KINGDOMS = [
 export const sampleStamps: PassportStampRow[] = [
   {
     id: 's1',
-    owner_id: 'u1',
+    user_id: 'u1',
     kingdom: 'thailandia',
     stamped_at: new Date().toISOString(),
   },
   {
     id: 's2',
-    owner_id: 'u1',
+    user_id: 'u1',
     kingdom: 'amerilandia',
     stamped_at: new Date().toISOString(),
   },
@@ -41,14 +41,14 @@ export const sampleStamps: PassportStampRow[] = [
 export const sampleXp: XpLedgerRow[] = [
   {
     id: 'x1',
-    owner_id: 'u1',
+    user_id: 'u1',
     delta: 10,
     reason: 'welcome',
     created_at: new Date().toISOString(),
   },
   {
     id: 'x2',
-    owner_id: 'u1',
+    user_id: 'u1',
     delta: 5,
     reason: 'quest',
     created_at: new Date(Date.now() - 3 * 864e5).toISOString(),
@@ -79,7 +79,7 @@ export const sampleProducts: ProductRow[] = [
 export const sampleWishlist: WishlistRow[] = [
   {
     id: 'w1',
-    owner_id: 'u1',
+    user_id: 'u1',
     product_id: 'p2',
     created_at: new Date().toISOString(),
   },
@@ -87,7 +87,7 @@ export const sampleWishlist: WishlistRow[] = [
 
 export const sampleNavatar: NavatarRow = {
   id: 'n1',
-  owner_id: 'u1',
+  user_id: 'u1',
   name: 'Macaw',
   base_type: 'animal',
   species: 'Macaw',

--- a/src/lib/mappers.ts
+++ b/src/lib/mappers.ts
@@ -35,7 +35,7 @@ export function mapProfileRow(row: ProfileRow): Profile {
 export function mapNavatarRow(row: NavatarRow): Navatar {
   return {
     id: row.id,
-    ownerId: row.owner_id,
+    userId: row.user_id,
     name: row.name ?? 'Navatar',
     base: row.base_type,
     species: row.species ?? undefined,

--- a/src/lib/navatar/useSupabase.ts
+++ b/src/lib/navatar/useSupabase.ts
@@ -2,7 +2,7 @@ import { supabase } from '@/lib/supabaseClient';
 
 // Table names are navatars; storage bucket remains **avatars**
 export async function saveAvatarRow(payload: any) {
-  // e.g., { owner_id, name, image_url, meta }
+  // e.g., { user_id, name, image_url, meta }
   return await supabase.from('navatars').insert(payload).select().single();
 }
 
@@ -10,7 +10,7 @@ export async function listAvatarsByUser(userId: string) {
   return await supabase
     .from('navatars')
     .select('*')
-    .eq('owner_id', userId)
+    .eq('user_id', userId)
     .order('created_at', { ascending: false });
 }
 

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -39,7 +39,7 @@ export async function getAvatarsByUser(userId: string) {
   const { data, error } = await supabase
     .from('navatars')
     .select('*')
-    .eq('owner_id', userId);
+    .eq('user_id', userId);
   if (error) throw error;
   return data;
 }

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabaseClient';
+import { getBrowserClient, supabase } from './supabaseClient';
 
-export { supabase };
-export const createClient = () => supabase;
+export { getBrowserClient, supabase };
+export const createClient = () => getBrowserClient();

--- a/src/lib/supabase/browser.ts
+++ b/src/lib/supabase/browser.ts
@@ -1,0 +1,25 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+let browserClient: SupabaseClient | null = null;
+
+export function getBrowserClient(): SupabaseClient {
+  if (browserClient) return browserClient;
+
+  const url = import.meta.env.VITE_SUPABASE_URL;
+  const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    throw new Error('Missing Supabase configuration.');
+  }
+
+  browserClient = createClient(url, anonKey, {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+    },
+  });
+
+  return browserClient;
+}
+

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,23 +1,7 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+import { getBrowserClient } from './supabase/browser';
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase environment variables.');
-}
+export { getBrowserClient } from './supabase/browser';
 
-type NaturverseGlobal = typeof globalThis & {
-  __naturverseSupabase?: SupabaseClient;
-};
-
-const globalRef = globalThis as NaturverseGlobal;
-
-export const supabase: SupabaseClient =
-  globalRef.__naturverseSupabase ??
-  (globalRef.__naturverseSupabase = createClient(supabaseUrl, supabaseAnonKey, {
-    auth: {
-      persistSession: true,
-      detectSessionInUrl: true,
-    },
-  }));
+export const supabase: SupabaseClient = getBrowserClient();

--- a/src/lib/supabaseHelpers.ts
+++ b/src/lib/supabaseHelpers.ts
@@ -26,7 +26,7 @@ export async function saveNavatar(params: SaveNavatarParams) {
   }
 
   const base = {
-    owner_id: userId,
+    user_id: userId,
     name: cleanField(params.name),
     species: cleanField(params.species),
     kingdom: cleanField(params.kingdom),
@@ -52,6 +52,7 @@ export async function saveNavatar(params: SaveNavatarParams) {
     .from("navatar_cards")
     .upsert(
       {
+        user_id: userId,
         navatar_id: navatarRow.id,
         powers: cleanList(params.powers),
         traits: cleanList(params.traits),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,7 +10,7 @@ export type ProfileRow = {
 
 export type NavatarRow = {
   id: string;
-  owner_id: string;
+  user_id: string;
   name: string | null;
   base_type: 'animal' | 'fruit' | 'insect' | 'spirit';
   species: string | null;
@@ -23,7 +23,7 @@ export type NavatarRow = {
 
 export type PassportStampRow = {
   id: string;
-  owner_id: string;
+  user_id: string;
   kingdom: string;
   stamped_at: string;
 };
@@ -38,7 +38,7 @@ export type BadgeRow = {
 
 export type XpLedgerRow = {
   id: string;
-  owner_id: string;
+  user_id: string;
   delta: number;
   reason: string;
   created_at: string;
@@ -56,7 +56,7 @@ export type ProductRow = {
 
 export type WishlistRow = {
   id: string;
-  owner_id: string;
+  user_id: string;
   product_id: string;
   created_at: string;
 };
@@ -73,7 +73,7 @@ export type Profile = {
 
 export type Navatar = {
   id: string;
-  ownerId: string;
+  userId: string;
   name: string;
   base: NavatarRow['base_type'];
   species?: string;

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -145,21 +145,21 @@ export default function NavatarCardPage() {
     }
   }
 
-  const canSave = useMemo(
-    () => [name, species, kingdom, backstory, powers, traits].some(v => v.trim().length > 0),
-    [name, species, kingdom, backstory, powers, traits]
-  );
-
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
-    if (!canSave) return;
+    if (saving) return;
+    if (!user) {
+      toast({ text: "Please sign in to save.", kind: "err" });
+      return;
+    }
+    if (!avatar?.id) {
+      toast({ text: "Pick a Navatar first.", kind: "err" });
+      return;
+    }
+
     setSaving(true);
     setErr(null);
     try {
-      if (!user || !avatar?.id) {
-        toast({ text: "Pick a Navatar first.", kind: "err" });
-        return;
-      }
 
       const powersArr = (powers || "")
         .split(",")
@@ -302,7 +302,7 @@ export default function NavatarCardPage() {
           <Link to="/navatar" className="pill">
             Back to My Navatar
           </Link>
-          <button className="pill pill--active" disabled={!canSave || saving}>
+          <button className="pill pill--active" type="submit" disabled={saving}>
             {saving ? "Saving…" : "Save"}
           </button>
         </div>

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -13,6 +13,7 @@ export default function UploadNavatarPage() {
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
   const [previewUrl, setPreviewUrl] = useState<string | undefined>();
+  const [saving, setSaving] = useState(false);
   const nav = useNavigate();
   const toast = useToast();
 
@@ -28,7 +29,12 @@ export default function UploadNavatarPage() {
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
-    if (!file) return;
+    if (saving) return;
+    if (!file) {
+      toast({ text: "Choose an image first.", kind: "warn" });
+      return;
+    }
+    setSaving(true);
     try {
       const row = await uploadNavatar(file, name || undefined);
       setActiveNavatarId(row.id);
@@ -36,6 +42,8 @@ export default function UploadNavatarPage() {
       nav("/navatar");
     } catch {
       toast({ text: "Upload failed", kind: "err" });
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -59,8 +67,8 @@ export default function UploadNavatarPage() {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <button className="pill pill--active" type="submit">
-          Save
+        <button className="pill pill--active" type="submit" disabled={saving}>
+          {saving ? "Saving…" : "Save"}
         </button>
       </form>
     </main>

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -25,7 +25,7 @@ export type Database = {
       navatars: {
         Row: {
           id: string;
-          owner_id: string;
+          user_id: string;
           name: string | null;
           image_url: string | null;
           image_path: string | null;
@@ -34,7 +34,7 @@ export type Database = {
         };
         Insert: {
           id?: string;
-          owner_id: string;
+          user_id: string;
           name?: string | null;
           image_url?: string | null;
           image_path?: string | null;
@@ -46,7 +46,7 @@ export type Database = {
       navatar_cards: {
         Row: {
           id: string;
-          owner_id: string;
+          user_id: string;
           navatar_id: string | null;
           name: string | null;
           species: string | null;
@@ -59,7 +59,7 @@ export type Database = {
         };
         Insert: {
           id?: string;
-          owner_id: string;
+          user_id: string;
           navatar_id?: string | null;
           name?: string | null;
           species?: string | null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,11 +10,11 @@
     "allowJs": false,
     "noEmit": true,
     "strict": true,
-    "types": ["node"],
+    "types": ["vite/client", "node"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
     }
   },
-  "include": ["app", "components", "lib", "scripts", "src"]
+  "include": ["src", "scripts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, splitVendorChunkPlugin } from 'vite';
-import react from '@vitejs/plugin-react-swc';
+import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 import path from 'path';
 


### PR DESCRIPTION
## Summary
- replace the Next.js helper in `lib/profile.ts` with a plain Supabase client and switch Vite to use the standard React plugin/types
- add a shared browser Supabase singleton and propagate `user_id` across navatar helpers, queries, and types so RLS policies can validate writes
- update the navatar card/upload flows to only disable the save button while persisting and surface missing-session errors before writing

## Testing
- `npm run build`
- `npm run typecheck` *(fails: existing repo type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cea68cace48329af3d14f522070006