### PR TITLE
Fix navatar save actions and Supabase client singleton

### DIFF
--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -1,9 +1,11 @@
-import { supabase } from './supabaseClient';
+import { getBrowserClient } from './supabase/browser';
 import { getActiveNavatarId } from './localNavatar';
 import { saveNavatar as upsertNavatar } from './supabaseHelpers';
 
 export const NAVATAR_BUCKET = 'avatars';
 export const NAVATAR_PREFIX = 'navatars';
+
+const supabase = getBrowserClient();
 
 export type NavatarRow = {
   id: string;

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,4 +1,5 @@
-import { supabase } from './supabaseClient';
+import { getBrowserClient } from './supabaseClient';
 
-export { supabase };
-export const createClient = () => supabase;
+export const supabase = getBrowserClient();
+export { getBrowserClient };
+export const createClient = () => getBrowserClient();

--- a/src/lib/supabase/browser.ts
+++ b/src/lib/supabase/browser.ts
@@ -1,0 +1,23 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = import.meta.env.VITE_SUPABASE_URL;
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!url || !anonKey) {
+  throw new Error('Missing Supabase environment variables.');
+}
+
+let client: ReturnType<typeof createClient> | undefined;
+
+export function getBrowserClient() {
+  if (!client) {
+    client = createClient(url, anonKey, {
+      auth: {
+        persistSession: true,
+        detectSessionInUrl: true,
+      },
+    });
+  }
+
+  return client;
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,23 +1,6 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getBrowserClient } from './supabase/browser';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+export const supabase: SupabaseClient = getBrowserClient();
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase environment variables.');
-}
-
-type NaturverseGlobal = typeof globalThis & {
-  __naturverseSupabase?: SupabaseClient;
-};
-
-const globalRef = globalThis as NaturverseGlobal;
-
-export const supabase: SupabaseClient =
-  globalRef.__naturverseSupabase ??
-  (globalRef.__naturverseSupabase = createClient(supabaseUrl, supabaseAnonKey, {
-    auth: {
-      persistSession: true,
-      detectSessionInUrl: true,
-    },
-  }));
+export { getBrowserClient };

--- a/src/lib/supabaseHelpers.ts
+++ b/src/lib/supabaseHelpers.ts
@@ -1,4 +1,6 @@
-import { supabase } from '@/lib/supabaseClient';
+import { getBrowserClient } from '@/lib/supabase/browser';
+
+const supabase = getBrowserClient();
 
 type SaveNavatarParams = {
   id?: string;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,10 +13,11 @@ import './styles/nv-sweep.css';
 import ToastProvider from './components/Toast';
 import SkipLink from './components/SkipLink';
 import OfflineBanner from './components/OfflineBanner';
-import { supabase } from '@/lib/supabaseClient';
+import { getBrowserClient } from '@/lib/supabase/browser';
 import './runtime-logger';
-import { prefetchGlob, prefetchOnHover } from './lib/prefetch';
 import './boot/warmup';
+
+const supabase = getBrowserClient();
 
 async function bootstrap() {
   const { data } = await supabase.auth.getSession();
@@ -25,36 +26,20 @@ async function bootstrap() {
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       {/* Ensure auth context wraps the entire app so Home gets updates immediately */}
-        <AuthProvider initialSession={initialSession}>
-          <SkipLink />
-          <ToastProvider>
-            <OfflineBanner />
-            <BaseAuthProvider>
-              <App />
-            </BaseAuthProvider>
-          </ToastProvider>
-        </AuthProvider>
-      </React.StrictMode>,
+      <AuthProvider initialSession={initialSession}>
+        <SkipLink />
+        <ToastProvider>
+          <OfflineBanner />
+          <BaseAuthProvider>
+            <App />
+          </BaseAuthProvider>
+        </ToastProvider>
+      </AuthProvider>
+    </React.StrictMode>,
   );
 }
 
 bootstrap();
-
-// Prefetch common route chunks at idle
-if ('requestIdleCallback' in window) {
-  (window as any).requestIdleCallback(() => {
-    const routes = import.meta.glob('./routes/**/index.tsx');
-    prefetchGlob(routes);
-  });
-} else {
-  setTimeout(() => {
-    const routes = import.meta.glob('./routes/**/index.tsx');
-    prefetchGlob(routes);
-  }, 100);
-}
-
-// Also prefetch when users hover links
-prefetchOnHover();
 
 // Force lazy loading for any <img> missing it (no deps, safe)
 document.addEventListener('DOMContentLoaded', () => {

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
@@ -150,9 +150,9 @@ export default function NavatarCardPage() {
     [name, species, kingdom, backstory, powers, traits]
   );
 
-  async function onSave(e: React.FormEvent) {
+  async function onSave(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (!canSave) return;
+    if (!canSave || saving) return;
     setSaving(true);
     setErr(null);
     try {
@@ -185,6 +185,7 @@ export default function NavatarCardPage() {
         setNavatarId(saved.id as string);
       }
 
+      toast({ text: "Saved ✓", kind: "ok" });
       nav("/navatar");
     } catch (e: any) {
       console.error(e);
@@ -302,7 +303,7 @@ export default function NavatarCardPage() {
           <Link to="/navatar" className="pill">
             Back to My Navatar
           </Link>
-          <button className="pill pill--active" disabled={!canSave || saving}>
+          <button className="pill pill--active" type="submit" disabled={!canSave || saving}>
             {saving ? "Saving…" : "Save"}
           </button>
         </div>

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
@@ -13,6 +13,7 @@ export default function UploadNavatarPage() {
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
   const [previewUrl, setPreviewUrl] = useState<string | undefined>();
+  const [saving, setSaving] = useState(false);
   const nav = useNavigate();
   const toast = useToast();
 
@@ -26,16 +27,20 @@ export default function UploadNavatarPage() {
     return () => URL.revokeObjectURL(url);
   }, [file]);
 
-  async function onSave(e: React.FormEvent) {
+  async function onSave(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (!file) return;
+    if (!file || saving) return;
+    setSaving(true);
     try {
       const row = await uploadNavatar(file, name || undefined);
       setActiveNavatarId(row.id);
       toast({ text: "Uploaded ✓", kind: "ok" });
       nav("/navatar");
-    } catch {
+    } catch (error) {
+      console.error(error);
       toast({ text: "Upload failed", kind: "err" });
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -59,8 +64,8 @@ export default function UploadNavatarPage() {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <button className="pill pill--active" type="submit">
-          Save
+        <button className="pill pill--active" type="submit" disabled={!file || saving}>
+          {saving ? "Saving…" : "Save"}
         </button>
       </form>
     </main>


### PR DESCRIPTION
## Summary
- add a browser Supabase client helper and reuse it from existing utilities
- harden the Navatar card and upload forms so they gate double submits and surface success toasts
- remove the eager module prefetch hook while debugging preview bundle caching issues

## Testing
- npm run typecheck *(fails: existing missing Next.js/Supabase types and legacy implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ceaf9da68483299e6cd0f8adaeb710