### PR TITLE
Fix navatar save UX and user ownership

### DIFF
--- a/src/lib/supabaseHelpers.ts
+++ b/src/lib/supabaseHelpers.ts
@@ -26,7 +26,7 @@ export async function saveNavatar(params: SaveNavatarParams) {
   }
 
   const base = {
-    owner_id: userId,
+    user_id: userId,
     name: cleanField(params.name),
     species: cleanField(params.species),
     kingdom: cleanField(params.kingdom),

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -302,7 +302,7 @@ export default function NavatarCardPage() {
           <Link to="/navatar" className="pill">
             Back to My Navatar
           </Link>
-          <button className="pill pill--active" disabled={!canSave || saving}>
+          <button className="pill pill--active" type="submit" disabled={saving}>
             {saving ? "Saving…" : "Save"}
           </button>
         </div>

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -59,7 +59,7 @@ export default function UploadNavatarPage() {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <button className="pill pill--active" type="submit">
+        <button className="pill pill--active" type="submit" disabled={!file}>
           Save
         </button>
       </form>


### PR DESCRIPTION
## Summary
- keep the Navatar card save button as a submit control so onSave guards manage eligibility
- disable the Navatar upload save button until a file is chosen for clearer feedback
- write `user_id` when saving Navatars so row-level security rules allow the request

## Testing
- npm run typecheck *(fails: requires Next.js-related modules/types that are not available in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68cebe6bdb6883298a8b1a1258fd8b52