### PR TITLE
Fix service worker handling for previews

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,6 +4,9 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Cache-Control: public, max-age=31536000, immutable
 
+/index.html
+  Cache-Control: no-store, must-revalidate
+
 /*.html
   Content-Type: text/html; charset=UTF-8
   Cache-Control: no-cache

--- a/src/init/pwa.ts
+++ b/src/init/pwa.ts
@@ -1,0 +1,22 @@
+export function initPWA() {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+    return;
+  }
+
+  const host = window.location.host;
+  const isPreview = host.includes('--') || host.endsWith('netlify.app');
+
+  if (isPreview) {
+    navigator.serviceWorker
+      .getRegistrations()
+      .then((registrations) => registrations.forEach((registration) => registration.unregister()))
+      .catch(() => {});
+    return;
+  }
+
+  if (import.meta.env.PROD) {
+    window.addEventListener('load', () => {
+      import('../register-sw').catch(() => {});
+    });
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,9 @@ import { supabase } from '@/lib/supabaseClient';
 import './runtime-logger';
 import { prefetchGlob, prefetchOnHover } from './lib/prefetch';
 import './boot/warmup';
+import { initPWA } from './init/pwa';
+
+initPWA();
 
 async function bootstrap() {
   const { data } = await supabase.auth.getSession();
@@ -65,6 +68,3 @@ document.addEventListener('DOMContentLoaded', () => {
 
 import './styles/overrides.css';
 
-if (import.meta.env.PROD) {
-  import('./register-sw');
-}

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -302,7 +302,11 @@ export default function NavatarCardPage() {
           <Link to="/navatar" className="pill">
             Back to My Navatar
           </Link>
-          <button className="pill pill--active" disabled={!canSave || saving}>
+          <button
+            className="pill pill--active"
+            type="submit"
+            disabled={saving || !canSave}
+          >
             {saving ? "Saving…" : "Save"}
           </button>
         </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     splitVendorChunkPlugin(),
     VitePWA({
       registerType: 'autoUpdate',
-      injectRegister: 'auto',
+      injectRegister: null,
       workbox: {
         globPatterns: ['**/*.{js,css,html,svg,png,ico,webp,woff2}'],
         maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
@@ -35,6 +35,17 @@ export default defineConfig({
       },
       // Runtime caching for stuff that isn’t in the precache
       runtimeCaching: [
+        {
+          urlPattern: ({ request }) =>
+            request.destination === 'script' || request.destination === 'style',
+          handler: 'NetworkFirst',
+          options: {
+            cacheName: 'nv-assets',
+            cacheableResponse: {
+              statuses: [200],
+            },
+          },
+        },
         {
           urlPattern: ({ request }) => request.destination === 'image',
           handler: 'CacheFirst',


### PR DESCRIPTION
## Summary
- add an initPWA helper that removes service workers on preview hosts and hooks registration to the main bootstrap
- update the PWA build config to stop auto-injecting registration code and to guard script/style requests with a NetworkFirst cache
- make the Navatar save button submit reliably and prevent index.html from being cached in Netlify previews

## Testing
- npm run typecheck *(fails: repository is missing Next.js and other type declarations used outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cec26dc2e48329be98d11e3e1ef75c