### PR TITLE
Fix Navatar Upload & Card saving (Vite + Supabase, no Next.js changes)

### DIFF
--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -1,6 +1,6 @@
 import { supabase } from './supabaseClient';
 import { getActiveNavatarId } from './localNavatar';
-import { saveNavatar as upsertNavatar } from './supabaseHelpers';
+import { saveAvatar as upsertNavatar } from './supabaseHelpers';
 
 export const NAVATAR_BUCKET = 'avatars';
 export const NAVATAR_PREFIX = 'navatars';
@@ -201,12 +201,23 @@ export async function saveCharacterCard(input: {
     traits: input.traits ?? [],
   });
 
+  const savedRecord = { ...saved } as Record<string, any>;
+  const ownerId =
+    (savedRecord.owner_id as string | undefined) ??
+    (savedRecord.user_id as string | undefined);
+
+  if (!ownerId) {
+    throw new Error('Saved navatar is missing an owner');
+  }
+
+  savedRecord.owner_id = ownerId;
+
   const powers = Array.isArray(saved.powers) ? saved.powers : [];
   const traits = Array.isArray(saved.traits) ? saved.traits : [];
 
   return {
     id: saved.id as string,
-    owner_id: saved.owner_id as string,
+    owner_id: ownerId,
     name: saved.name ?? null,
     species: saved.species ?? null,
     kingdom: saved.kingdom ?? null,

--- a/src/lib/navatar/uploadNavatar.ts
+++ b/src/lib/navatar/uploadNavatar.ts
@@ -1,0 +1,74 @@
+import { getBrowserClient } from "../supabaseClient";
+
+const NAVATAR_BUCKET = "avatars";
+const NAVATAR_PREFIX = "navatars";
+
+export async function uploadNavatar(
+  file: File,
+  name?: string
+): Promise<Record<string, any>> {
+  const supabase = getBrowserClient();
+
+  const {
+    data: userData,
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) throw userError;
+
+  const user = userData?.user;
+
+  if (!user) {
+    throw new Error("Not signed in");
+  }
+
+  const ext = (file.name.split(".").pop() || "png").toLowerCase();
+  const objectName = `${NAVATAR_PREFIX}/${user.id}/${Date.now()}.${ext}`;
+
+  const { error: uploadError } = await supabase.storage
+    .from(NAVATAR_BUCKET)
+    .upload(objectName, file, { upsert: true });
+
+  if (uploadError) throw uploadError;
+
+  const { data: pub } = supabase.storage
+    .from(NAVATAR_BUCKET)
+    .getPublicUrl(objectName);
+
+  const imageUrl = pub.publicUrl;
+
+  const cleanedName = (name ?? file.name).trim();
+
+  const {
+    data: row,
+    error: upsertError,
+  } = await supabase
+    .from("navatars")
+    .upsert(
+      {
+        user_id: user.id,
+        name: cleanedName || null,
+        image_path: objectName,
+        image_url: imageUrl,
+      },
+      { onConflict: "id" }
+    )
+    .select()
+    .single();
+
+  if (upsertError) throw upsertError;
+
+  if (!row) {
+    throw new Error("Upload failed");
+  }
+
+  const normalized = { ...row } as Record<string, any>;
+  if (!("user_id" in normalized)) {
+    normalized.user_id = user.id;
+  }
+  if (!("owner_id" in normalized)) {
+    normalized.owner_id = normalized.user_id;
+  }
+
+  return normalized;
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,23 +1,27 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+let browserClient: SupabaseClient | null = null;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase environment variables.');
-}
+export function getBrowserClient(): SupabaseClient {
+  if (browserClient) return browserClient;
 
-type NaturverseGlobal = typeof globalThis & {
-  __naturverseSupabase?: SupabaseClient;
-};
+  const url = import.meta.env.VITE_SUPABASE_URL;
+  const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-const globalRef = globalThis as NaturverseGlobal;
+  if (!url || !key) {
+    throw new Error("Missing Supabase environment variables.");
+  }
 
-export const supabase: SupabaseClient =
-  globalRef.__naturverseSupabase ??
-  (globalRef.__naturverseSupabase = createClient(supabaseUrl, supabaseAnonKey, {
+  browserClient = createClient(url, key, {
     auth: {
+      storage: typeof window !== "undefined" ? window.localStorage : undefined,
       persistSession: true,
       detectSessionInUrl: true,
+      autoRefreshToken: true,
     },
-  }));
+  });
+
+  return browserClient;
+}
+
+export const supabase = getBrowserClient();

--- a/src/lib/supabaseHelpers.ts
+++ b/src/lib/supabaseHelpers.ts
@@ -1,11 +1,11 @@
-import { supabase } from '@/lib/supabaseClient';
+import { getBrowserClient } from "@/lib/supabaseClient";
 
-type SaveNavatarParams = {
+type SaveAvatarParams = {
   id?: string;
-  name: string;
-  species: string;
-  kingdom: string;
-  backstory: string;
+  name?: string;
+  species?: string;
+  kingdom?: string;
+  backstory?: string;
   powers?: string[];
   traits?: string[];
 };
@@ -15,26 +15,33 @@ const cleanField = (value?: string) => {
   return text.length > 0 ? text : null;
 };
 
-const cleanList = (list?: string[]) => (list ?? []).map((item) => item.trim()).filter((item) => item.length > 0);
+const cleanList = (list?: string[]) =>
+  (list ?? []).map((item) => item.trim()).filter((item) => item.length > 0);
 
-export async function saveNavatar(params: SaveNavatarParams) {
+export async function saveAvatar(
+  params: SaveAvatarParams
+): Promise<Record<string, any>> {
+  const supabase = getBrowserClient();
+
   const { data: userData, error: userError } = await supabase.auth.getUser();
   if (userError) throw userError;
-  const userId = userData?.user?.id;
-  if (!userId) {
+
+  const user = userData?.user;
+  if (!user) {
     throw new Error("Not signed in");
   }
 
-  const base = {
-    owner_id: userId,
+  const base: Record<string, any> = {
+    id: params.id,
+    user_id: user.id,
     name: cleanField(params.name),
     species: cleanField(params.species),
     kingdom: cleanField(params.kingdom),
     backstory: cleanField(params.backstory),
-  } as Record<string, any>;
+  };
 
-  if (params.id) {
-    base.id = params.id;
+  if (!base.id) {
+    delete base.id;
   }
 
   const { data: navatarRow, error: navatarError } = await supabase
@@ -48,22 +55,30 @@ export async function saveNavatar(params: SaveNavatarParams) {
     throw new Error("Failed to save navatar");
   }
 
+  const cardPayload: Record<string, any> = {
+    navatar_id: navatarRow.id,
+    powers: cleanList(params.powers),
+    traits: cleanList(params.traits),
+  };
+
   const { data: cardRow, error: cardError } = await supabase
     .from("navatar_cards")
-    .upsert(
-      {
-        navatar_id: navatarRow.id,
-        powers: cleanList(params.powers),
-        traits: cleanList(params.traits),
-      },
-      { onConflict: "navatar_id" }
-    )
+    .upsert(cardPayload, { onConflict: "navatar_id" })
     .select()
     .single();
 
   if (cardError) throw cardError;
+
+  const normalizedNavatar = { ...navatarRow } as Record<string, any>;
+  if (!("user_id" in normalizedNavatar)) {
+    normalizedNavatar.user_id = user.id;
+  }
+  if (!("owner_id" in normalizedNavatar)) {
+    normalizedNavatar.owner_id = normalizedNavatar.user_id;
+  }
+
   return {
-    ...navatarRow,
+    ...normalizedNavatar,
     powers: (cardRow?.powers as string[] | null) ?? [],
     traits: (cardRow?.traits as string[] | null) ?? [],
   };

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -9,7 +9,7 @@ import { useToast } from "../../components/Toast";
 import { callAI } from "@/lib/ai";
 import { naturEvent } from "@/lib/events";
 import { readNavatarDraft, saveNavatarDraft } from "@/lib/localdb";
-import { saveNavatar } from "@/lib/supabaseHelpers";
+import { saveAvatar } from "@/lib/supabaseHelpers";
 import "../../styles/navatar.css";
 
 type NavatarAiResult = {
@@ -146,17 +146,38 @@ export default function NavatarCardPage() {
   }
 
   const canSave = useMemo(
-    () => [name, species, kingdom, backstory, powers, traits].some(v => v.trim().length > 0),
-    [name, species, kingdom, backstory, powers, traits]
+    () =>
+      !!user &&
+      !!(avatar?.id || navatarId) &&
+      [name, species, kingdom, backstory, powers, traits].some(
+        v => v.trim().length > 0
+      ),
+    [
+      user,
+      avatar?.id,
+      navatarId,
+      name,
+      species,
+      kingdom,
+      backstory,
+      powers,
+      traits,
+    ]
   );
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
-    if (!canSave) return;
+    if (!canSave || saving) return;
     setSaving(true);
     setErr(null);
     try {
-      if (!user || !avatar?.id) {
+      if (!user) {
+        toast({ text: "Sign in to save your Navatar.", kind: "err" });
+        return;
+      }
+
+      const currentNavatarId = navatarId ?? avatar?.id;
+      if (!currentNavatarId) {
         toast({ text: "Pick a Navatar first.", kind: "err" });
         return;
       }
@@ -171,8 +192,8 @@ export default function NavatarCardPage() {
         .map(s => s.trim())
         .filter(Boolean);
 
-      const saved = await saveNavatar({
-        id: navatarId ?? undefined,
+      const saved = await saveAvatar({
+        id: currentNavatarId,
         name,
         species,
         kingdom,
@@ -302,7 +323,7 @@ export default function NavatarCardPage() {
           <Link to="/navatar" className="pill">
             Back to My Navatar
           </Link>
-          <button className="pill pill--active" disabled={!canSave || saving}>
+          <button className="pill pill--active" type="submit" disabled={!canSave || saving}>
             {saving ? "Saving…" : "Save"}
           </button>
         </div>

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
 import NavatarTabs from "../../components/NavatarTabs";
-import { uploadNavatar } from "../../lib/navatar";
+import { uploadNavatar } from "../../lib/navatar/uploadNavatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import "../../styles/navatar.css";
@@ -13,6 +13,7 @@ export default function UploadNavatarPage() {
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
   const [previewUrl, setPreviewUrl] = useState<string | undefined>();
+  const [saving, setSaving] = useState(false);
   const nav = useNavigate();
   const toast = useToast();
 
@@ -28,14 +29,17 @@ export default function UploadNavatarPage() {
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
-    if (!file) return;
+    if (!file || saving) return;
+    setSaving(true);
     try {
       const row = await uploadNavatar(file, name || undefined);
       setActiveNavatarId(row.id);
       toast({ text: "Uploaded ✓", kind: "ok" });
       nav("/navatar");
-    } catch {
-      toast({ text: "Upload failed", kind: "err" });
+    } catch (err: any) {
+      toast({ text: err?.message ?? "Upload failed", kind: "err" });
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -59,8 +63,8 @@ export default function UploadNavatarPage() {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <button className="pill pill--active" type="submit">
-          Save
+        <button className="pill pill--active" type="submit" disabled={!file || saving}>
+          {saving ? "Saving…" : "Save"}
         </button>
       </form>
     </main>


### PR DESCRIPTION
## Summary
- replace the singleton Supabase export with a cached `getBrowserClient` helper so browser sessions reuse the same client
- add a dedicated navatar upload helper that stores files in Supabase Storage, publishes a URL, and upserts the navatar row with `user_id`
- update the card saver to enforce `user_id` writes, normalise returned rows, and wire the upload/card pages to the new helpers with proper saving states

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf593ecf948329bd41e6b421e959e7