### PR TITLE
Add navatars storage bucket and update uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-router-dom": "^6.28.0",
     "@supabase/supabase-js": "^2.45.4",
     "@supabase/auth-helpers-react": "^0.5.0",
+    "nanoid": "^3.3.11",
     "three": "^0.160.0",
     "workbox-window": "^7.1.0",
     "nprogress": "^0.2.0",

--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -1,8 +1,9 @@
 import { supabase } from './supabaseClient';
 import { getActiveNavatarId } from './localNavatar';
 import { saveNavatar as upsertNavatar } from './supabaseHelpers';
+import { NAVATAR_BUCKET, uploadNavatar as uploadNavatarToBucket } from './storage';
 
-export const NAVATAR_BUCKET = 'avatars';
+export { NAVATAR_BUCKET } from './storage';
 export const NAVATAR_PREFIX = 'navatars';
 
 export type NavatarRow = {
@@ -40,7 +41,7 @@ export function navatarImageUrl(path: string | null) {
   return data?.publicUrl ?? null;
 }
 
-/** List available navatars to pick (reads files under avatars/navatars) */
+/** List available navatars to pick (reads files under the navatars bucket) */
 export async function listNavatars(): Promise<{ name: string; url: string; path: string }[]> {
   const { data, error } = await supabase
     .storage.from(NAVATAR_BUCKET)
@@ -103,16 +104,13 @@ export async function pickNavatar(imagePath: string, name?: string): Promise<Nav
 /** Upload a custom image then store it in public.navatars */
 export async function uploadNavatar(file: File, name?: string): Promise<NavatarRow> {
   const owner_id = await getSessionUserId();
-  const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
-  const key = `${NAVATAR_PREFIX}/${owner_id}/${crypto.randomUUID()}.${ext}`;
+  const uploaded = await uploadNavatarToBucket(file, owner_id, name);
 
-  const { error: upErr } = await supabase
-    .storage.from(NAVATAR_BUCKET)
-    .upload(key, file, { upsert: true });
+  if (!uploaded.image_path) {
+    throw new Error('Upload succeeded without a file path');
+  }
 
-  if (upErr) throw upErr;
-
-  return pickNavatar(key, name);
+  return pickNavatar(uploaded.image_path, name);
 }
 
 /** Load the current user's navatar row */

--- a/src/lib/navatar/useSupabase.ts
+++ b/src/lib/navatar/useSupabase.ts
@@ -1,6 +1,7 @@
 import { supabase } from '@/lib/supabaseClient';
+import { NAVATAR_BUCKET } from '@/lib/storage';
 
-// Table names are navatars; storage bucket remains **avatars**
+// Table names are navatars; storage bucket is navatars
 export async function saveAvatarRow(payload: any) {
   // e.g., { owner_id, name, image_url, meta }
   return await supabase.from('navatars').insert(payload).select().single();
@@ -14,16 +15,16 @@ export async function listAvatarsByUser(userId: string) {
     .order('created_at', { ascending: false });
 }
 
-// Storage bucket also **avatars**
+// Storage bucket helper
 export async function uploadAvatarImage(userId: string, file: File) {
   const path = `${userId}/${Date.now()}-${file.name}`;
   const { data, error } = await supabase
     .storage
-    .from('avatars')
+    .from(NAVATAR_BUCKET)
     .upload(path, file, { upsert: false });
   if (error) throw error;
   const { data: pub } = await supabase.storage
-    .from('avatars')
+    .from(NAVATAR_BUCKET)
     .getPublicUrl(path);
   return pub.publicUrl; // public URL for card
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,7 +1,32 @@
 import { supabase } from '@/lib/supabaseClient';
+import { nanoid } from 'nanoid';
 
 function sanitizeFilename(name: string) {
   return name.toLowerCase().replace(/[^a-z0-9\.\-_]/g, '_');
+}
+
+export const NAVATAR_BUCKET = 'navatars';
+
+export async function uploadNavatar(file: File, userId: string, name?: string) {
+  const ext = (file.name.split('.').pop() || 'png').toLowerCase();
+  const id = nanoid(12);
+  const path = `${userId}/${id}.${ext}`;
+
+  const { error: upErr } = await supabase.storage.from(NAVATAR_BUCKET).upload(path, file, {
+    upsert: true,
+    contentType: file.type,
+  });
+
+  if (upErr) throw upErr;
+
+  const { data: pub } = supabase.storage.from(NAVATAR_BUCKET).getPublicUrl(path);
+
+  return {
+    id,
+    image_path: path,
+    image_url: pub.publicUrl,
+    name: (name || null) as string | null,
+  };
 }
 
 export async function uploadAvatar(userId: string, file: File) {

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -4,8 +4,10 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
 import NavatarTabs from "../../components/NavatarTabs";
-import { uploadNavatar } from "../../lib/navatar";
+import { pickNavatar } from "../../lib/navatar";
+import { uploadNavatar } from "../../lib/storage";
 import { setActiveNavatarId } from "../../lib/localNavatar";
+import { useAuthUser } from "../../lib/useAuthUser";
 import { useToast } from "../../components/Toast";
 import "../../styles/navatar.css";
 
@@ -16,6 +18,7 @@ export default function GenerateNavatarPage() {
   const [draftUrl, setDraftUrl] = useState<string | undefined>();
   const nav = useNavigate();
   const toast = useToast();
+  const { user } = useAuthUser();
 
   useEffect(() => {
     if (!file) {
@@ -30,8 +33,13 @@ export default function GenerateNavatarPage() {
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
     if (!file) return;
+    if (!user?.id) {
+      toast({ text: "Please sign in.", kind: "err" });
+      return;
+    }
     try {
-      const row = await uploadNavatar(file, name || undefined);
+      const uploaded = await uploadNavatar(file, user.id, name || undefined);
+      const row = await pickNavatar(uploaded.image_path, name || undefined);
       setActiveNavatarId(row.id);
       toast({ text: "Saved ✓", kind: "ok" });
       nav("/navatar");

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -4,8 +4,10 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
 import NavatarTabs from "../../components/NavatarTabs";
-import { uploadNavatar } from "../../lib/navatar";
+import { pickNavatar } from "../../lib/navatar";
+import { uploadNavatar } from "../../lib/storage";
 import { setActiveNavatarId } from "../../lib/localNavatar";
+import { useAuthUser } from "../../lib/useAuthUser";
 import { useToast } from "../../components/Toast";
 import "../../styles/navatar.css";
 
@@ -15,6 +17,7 @@ export default function UploadNavatarPage() {
   const [previewUrl, setPreviewUrl] = useState<string | undefined>();
   const nav = useNavigate();
   const toast = useToast();
+  const { user } = useAuthUser();
 
   useEffect(() => {
     if (!file) {
@@ -29,8 +32,13 @@ export default function UploadNavatarPage() {
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
     if (!file) return;
+    if (!user?.id) {
+      toast({ text: "Please sign in.", kind: "err" });
+      return;
+    }
     try {
-      const row = await uploadNavatar(file, name || undefined);
+      const uploaded = await uploadNavatar(file, user.id, name || undefined);
+      const row = await pickNavatar(uploaded.image_path, name || undefined);
       setActiveNavatarId(row.id);
       toast({ text: "Uploaded ✓", kind: "ok" });
       nav("/navatar");

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../lib/supabaseClient';
+import { NAVATAR_BUCKET } from '../lib/storage';
 
 const IMAGE_EXT = ['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg'];
 
@@ -6,7 +7,7 @@ export async function listNavatarImages() {
   const path = 'navatars';
   const { data, error } = await supabase
     .storage
-    .from('avatars')
+    .from(NAVATAR_BUCKET)
     .list(path, { limit: 200, sortBy: { column: 'name', order: 'asc' } });
 
   if (error) throw error;
@@ -19,7 +20,7 @@ export async function listNavatarImages() {
     })
     .map(item => {
       const fullPath = `${path}/${item.name}`;
-      const { data: pub } = supabase.storage.from('avatars').getPublicUrl(fullPath);
+      const { data: pub } = supabase.storage.from(NAVATAR_BUCKET).getPublicUrl(fullPath);
       return { name: item.name, url: pub.publicUrl, path: fullPath };
     });
 }

--- a/supabase/migrations/2026-01-15_create_navatars_bucket.sql
+++ b/supabase/migrations/2026-01-15_create_navatars_bucket.sql
@@ -1,0 +1,35 @@
+-- Create navatars bucket and storage policies
+
+-- 1) Bucket (idempotent)
+insert into storage.buckets (id, name, public)
+select 'navatars','navatars', true
+where not exists (select 1 from storage.buckets where id = 'navatars');
+
+-- 3) Read: allow anyone to read files in the 'navatars' bucket (needed for public images)
+create policy "navatars_read_public"
+on storage.objects
+for select
+to public
+using (bucket_id = 'navatars');
+
+-- 4) Insert: allow signed-in users to upload to 'navatars'
+create policy "navatars_insert_auth"
+on storage.objects
+for insert
+to authenticated
+with check (bucket_id = 'navatars');
+
+-- 5) Update: allow owners to overwrite their own files
+create policy "navatars_update_owner"
+on storage.objects
+for update
+to authenticated
+using (bucket_id = 'navatars' and owner = auth.uid())
+with check (bucket_id = 'navatars' and owner = auth.uid());
+
+-- 6) Delete: allow owners to delete their own files
+create policy "navatars_delete_owner"
+on storage.objects
+for delete
+to authenticated
+using (bucket_id = 'navatars' and owner = auth.uid());


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates the `navatars` storage bucket and grants read/write policies
- introduce a client storage helper backed by the new bucket and update navatar utilities to consume it
- wire the upload and generate pages to the helper using the signed-in user before saving the navatar row

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf5db3f6208329a297c4d3301d2809