### PR TITLE
Unify navatar uploads with avatars bucket storage helper

### DIFF
--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -1,8 +1,9 @@
 import { supabase } from './supabaseClient';
 import { getActiveNavatarId } from './localNavatar';
 import { saveNavatar as upsertNavatar } from './supabaseHelpers';
+import { getNavatarPublicUrl, uploadNavatarImage, NAVATAR_BUCKET } from './navatar/storage';
+export { NAVATAR_BUCKET } from './navatar/storage';
 
-export const NAVATAR_BUCKET = 'avatars';
 export const NAVATAR_PREFIX = 'navatars';
 
 export type NavatarRow = {
@@ -35,9 +36,7 @@ export async function getSessionUserId() {
 }
 
 export function navatarImageUrl(path: string | null) {
-  if (!path) return null;
-  const { data } = supabase.storage.from(NAVATAR_BUCKET).getPublicUrl(path);
-  return data?.publicUrl ?? null;
+  return getNavatarPublicUrl(path);
 }
 
 /** List available navatars to pick (reads files under avatars/navatars) */
@@ -52,9 +51,11 @@ export async function listNavatars(): Promise<{ name: string; url: string; path:
     .filter(item => item.name && !item.name.endsWith('/'))
     .map(item => {
       const path = `${NAVATAR_PREFIX}/${item.name}`;
-      const { data: pub } = supabase.storage.from(NAVATAR_BUCKET).getPublicUrl(path);
-      return { name: item.name!, url: pub.publicUrl, path };
-    });
+      const publicUrl = getNavatarPublicUrl(path);
+      if (!publicUrl) return null;
+      return { name: item.name!, url: publicUrl, path };
+    })
+    .filter((item): item is { name: string; url: string; path: string } => Boolean(item));
 }
 
 async function resolveExistingNavatarId(ownerId: string): Promise<string | null> {
@@ -77,42 +78,31 @@ async function resolveExistingNavatarId(ownerId: string): Promise<string | null>
 /** Pick an existing image and upsert it into public.navatars */
 export async function pickNavatar(imagePath: string, name?: string): Promise<NavatarRow> {
   const owner_id = await getSessionUserId();
-  const { data: pub } = supabase.storage.from(NAVATAR_BUCKET).getPublicUrl(imagePath);
-
-  const payload: Record<string, any> = {
-    owner_id,
-    name: name ?? 'My Navatar',
-    image_url: pub.publicUrl ?? null,
-    image_path: imagePath,
-    updated_at: new Date().toISOString(),
-  };
-
   const existingId = await resolveExistingNavatarId(owner_id);
-  if (existingId) payload.id = existingId;
+  const publicUrl = getNavatarPublicUrl(imagePath);
 
-  const { data, error } = await supabase
-    .from('navatars')
-    .upsert(payload, { onConflict: 'id' })
-    .select('*')
-    .single();
+  const saved = await upsertNavatar({
+    id: existingId ?? undefined,
+    name: name ?? 'My Navatar',
+    image_url: publicUrl ?? null,
+    image_path: imagePath,
+  });
 
-  if (error) throw error;
-  return data as NavatarRow;
+  return saved as NavatarRow;
 }
 
 /** Upload a custom image then store it in public.navatars */
 export async function uploadNavatar(file: File, name?: string): Promise<NavatarRow> {
-  const owner_id = await getSessionUserId();
-  const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
-  const key = `${NAVATAR_PREFIX}/${owner_id}/${crypto.randomUUID()}.${ext}`;
+  const upload = await uploadNavatarImage(file, name);
+  const existingId = await resolveExistingNavatarId(upload.userId);
+  const saved = await upsertNavatar({
+    id: existingId ?? undefined,
+    name: name ?? 'My Navatar',
+    image_url: upload.publicUrl ?? null,
+    image_path: upload.path,
+  });
 
-  const { error: upErr } = await supabase
-    .storage.from(NAVATAR_BUCKET)
-    .upload(key, file, { upsert: true });
-
-  if (upErr) throw upErr;
-
-  return pickNavatar(key, name);
+  return saved as NavatarRow;
 }
 
 /** Load the current user's navatar row */

--- a/src/lib/navatar/storage.ts
+++ b/src/lib/navatar/storage.ts
@@ -1,0 +1,43 @@
+import { supabase } from '@/lib/supabaseClient';
+import { getUserId } from '@/lib/session';
+
+export const NAVATAR_BUCKET = 'avatars';
+
+function inferExt(file: File) {
+  const fromType = file.type?.split('/')?.[1];
+  if (fromType) return fromType;
+
+  const name = file.name || 'upload';
+  const dot = name.lastIndexOf('.');
+  return dot >= 0 ? name.slice(dot + 1) : 'png';
+}
+
+function slug(input: string | undefined) {
+  return (input || 'navatar')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+export function getNavatarPublicUrl(path: string | null) {
+  if (!path) return null;
+  const { data } = supabase.storage.from(NAVATAR_BUCKET).getPublicUrl(path);
+  return data?.publicUrl ?? null;
+}
+
+export async function uploadNavatarImage(file: File, displayName?: string) {
+  const userId = await getUserId();
+  if (!userId) throw new Error('Not signed in');
+
+  const ext = inferExt(file);
+  const key = `navatars/${userId}/${Date.now()}-${slug(displayName)}.${ext}`;
+
+  const { error } = await supabase.storage.from(NAVATAR_BUCKET).upload(key, file, {
+    cacheControl: '3600',
+    upsert: false,
+  });
+  if (error) throw error;
+
+  const publicUrl = getNavatarPublicUrl(key);
+  return { path: key, publicUrl, userId };
+}

--- a/src/lib/supabaseHelpers.ts
+++ b/src/lib/supabaseHelpers.ts
@@ -2,15 +2,17 @@ import { supabase } from '@/lib/supabaseClient';
 
 type SaveNavatarParams = {
   id?: string;
-  name: string;
-  species: string;
-  kingdom: string;
-  backstory: string;
+  name?: string | null;
+  species?: string | null;
+  kingdom?: string | null;
+  backstory?: string | null;
   powers?: string[];
   traits?: string[];
+  image_url?: string | null;
+  image_path?: string | null;
 };
 
-const cleanField = (value?: string) => {
+const cleanField = (value?: string | null) => {
   const text = String(value ?? "").trim();
   return text.length > 0 ? text : null;
 };
@@ -25,16 +27,36 @@ export async function saveNavatar(params: SaveNavatarParams) {
     throw new Error("Not signed in");
   }
 
-  const base = {
+  const base: Record<string, any> = {
     owner_id: userId,
-    name: cleanField(params.name),
-    species: cleanField(params.species),
-    kingdom: cleanField(params.kingdom),
-    backstory: cleanField(params.backstory),
-  } as Record<string, any>;
+  };
 
   if (params.id) {
     base.id = params.id;
+  }
+
+  if (params.name !== undefined) {
+    base.name = cleanField(params.name);
+  }
+
+  if (params.species !== undefined) {
+    base.species = cleanField(params.species);
+  }
+
+  if (params.kingdom !== undefined) {
+    base.kingdom = cleanField(params.kingdom);
+  }
+
+  if (params.backstory !== undefined) {
+    base.backstory = cleanField(params.backstory);
+  }
+
+  if (params.image_url !== undefined) {
+    base.image_url = cleanField(params.image_url);
+  }
+
+  if (params.image_path !== undefined) {
+    base.image_path = cleanField(params.image_path);
   }
 
   const { data: navatarRow, error: navatarError } = await supabase
@@ -48,20 +70,35 @@ export async function saveNavatar(params: SaveNavatarParams) {
     throw new Error("Failed to save navatar");
   }
 
-  const { data: cardRow, error: cardError } = await supabase
-    .from("navatar_cards")
-    .upsert(
-      {
-        navatar_id: navatarRow.id,
-        powers: cleanList(params.powers),
-        traits: cleanList(params.traits),
-      },
-      { onConflict: "navatar_id" }
-    )
-    .select()
-    .single();
+  let cardRow: any = null;
+  const shouldUpdateCard = params.powers !== undefined || params.traits !== undefined;
 
-  if (cardError) throw cardError;
+  if (shouldUpdateCard) {
+    const { data, error } = await supabase
+      .from("navatar_cards")
+      .upsert(
+        {
+          navatar_id: navatarRow.id,
+          powers: cleanList(params.powers),
+          traits: cleanList(params.traits),
+        },
+        { onConflict: "navatar_id" }
+      )
+      .select()
+      .single();
+
+    if (error) throw error;
+    cardRow = data;
+  } else {
+    const { data, error } = await supabase
+      .from("navatar_cards")
+      .select()
+      .eq("navatar_id", navatarRow.id)
+      .maybeSingle();
+
+    if (error && (error as any).code !== "PGRST116") throw error;
+    cardRow = data;
+  }
   return {
     ...navatarRow,
     powers: (cardRow?.powers as string[] | null) ?? [],

--- a/supabase/storage-policies.sql
+++ b/supabase/storage-policies.sql
@@ -1,36 +1,42 @@
--- Storage buckets: avatars, navatars (create from Studio if not present)
--- RLS policies so users can read public files and write their own
-
--- Public read for these buckets
+-- Ensure the avatars bucket exists (public read is handled via policy)
 INSERT INTO storage.buckets (id, name, public)
-VALUES ('avatars','avatars', true)
+VALUES ('avatars', 'avatars', true)
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO storage.buckets (id, name, public)
-VALUES ('navatars','navatars', true)
-ON CONFLICT (id) DO NOTHING;
+-- Enable RLS if not already enabled
+alter table storage.objects enable row level security;
 
--- Policies (idempotent)
--- Delete existing with same names if present
-DO $$
-BEGIN
-  DELETE FROM storage.policies WHERE name IN
-    ('avatars-public-read','avatars-owner-write','navatars-public-read','navatars-owner-write');
-EXCEPTION WHEN OTHERS THEN NULL;
-END$$;
+-- Drop old policies so re-running this script is safe
+drop policy if exists "public read avatars" on storage.objects;
+drop policy if exists "avatars_user_insert" on storage.objects;
+drop policy if exists "avatars_owner_update" on storage.objects;
+drop policy if exists "avatars_owner_delete" on storage.objects;
 
--- Public read
-INSERT INTO storage.policies (name, bucket_id, definition, action)
-VALUES
-('avatars-public-read','avatars', '(bucket_id = ''avatars'')', 'SELECT'),
-('navatars-public-read','navatars', '(bucket_id = ''navatars'')', 'SELECT');
+-- 1) Public read of files in "avatars"
+create policy "public read avatars"
+on storage.objects
+for select
+to public
+using (bucket_id = 'avatars');
 
--- Owner write (folder per user: userId/*)
-INSERT INTO storage.policies (name, bucket_id, definition, action)
-VALUES
-('avatars-owner-write','avatars',
- 'auth.role() = ''authenticated'' AND (storage.foldername(name))[1] = auth.uid()::text',
- 'INSERT'),
-('navatars-owner-write','navatars',
- 'auth.role() = ''authenticated'' AND (storage.foldername(name))[1] = auth.uid()::text',
- 'INSERT');
+-- 2) Insert: only logged-in users can upload to "avatars"
+create policy "avatars_user_insert"
+on storage.objects
+for insert
+to authenticated
+with check (bucket_id = 'avatars');
+
+-- 3) Update: only owner can modify their files in "avatars"
+create policy "avatars_owner_update"
+on storage.objects
+for update
+to authenticated
+using (bucket_id = 'avatars' and owner = auth.uid())
+with check (bucket_id = 'avatars' and owner = auth.uid());
+
+-- 4) Delete: only owner can delete their files in "avatars"
+create policy "avatars_owner_delete"
+on storage.objects
+for delete
+to authenticated
+using (bucket_id = 'avatars' and owner = auth.uid());


### PR DESCRIPTION
## Summary
- add a navatar storage helper to upload files to the avatars bucket and expose their public URL
- allow saveNavatar to accept optional image metadata without overwriting card data
- update navatar helpers and storage policies so avatars-only RLS can be applied cleanly

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf69ec1e148329b510d1df31cb75c6