### PR TITLE
Fix navatar upload flow and disable preview PWA

### DIFF
--- a/src/lib/navatar.ts
+++ b/src/lib/navatar.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabaseClient';
 import { getActiveNavatarId } from './localNavatar';
 import { saveNavatar as upsertNavatar } from './supabaseHelpers';
+import { saveAvatarRow, uploadAvatarImage, type AvatarRowPayload } from './navatar/useSupabase';
 
 export const NAVATAR_BUCKET = 'avatars';
 export const NAVATAR_PREFIX = 'navatars';
@@ -79,7 +80,7 @@ export async function pickNavatar(imagePath: string, name?: string): Promise<Nav
   const owner_id = await getSessionUserId();
   const { data: pub } = supabase.storage.from(NAVATAR_BUCKET).getPublicUrl(imagePath);
 
-  const payload: Record<string, any> = {
+  const payload: AvatarRowPayload = {
     owner_id,
     name: name ?? 'My Navatar',
     image_url: pub.publicUrl ?? null,
@@ -90,29 +91,28 @@ export async function pickNavatar(imagePath: string, name?: string): Promise<Nav
   const existingId = await resolveExistingNavatarId(owner_id);
   if (existingId) payload.id = existingId;
 
-  const { data, error } = await supabase
-    .from('navatars')
-    .upsert(payload, { onConflict: 'id' })
-    .select('*')
-    .single();
-
-  if (error) throw error;
-  return data as NavatarRow;
+  const saved = await saveAvatarRow(payload);
+  return saved as NavatarRow;
 }
 
 /** Upload a custom image then store it in public.navatars */
-export async function uploadNavatar(file: File, name?: string): Promise<NavatarRow> {
+export async function uploadAvatar(file: File, name?: string): Promise<NavatarRow> {
   const owner_id = await getSessionUserId();
-  const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
-  const key = `${NAVATAR_PREFIX}/${owner_id}/${crypto.randomUUID()}.${ext}`;
+  const image = await uploadAvatarImage(owner_id, file);
 
-  const { error: upErr } = await supabase
-    .storage.from(NAVATAR_BUCKET)
-    .upload(key, file, { upsert: true });
+  const payload: AvatarRowPayload = {
+    owner_id,
+    name: name ?? 'My Navatar',
+    image_url: image.publicUrl ?? null,
+    image_path: image.path ?? null,
+    updated_at: new Date().toISOString(),
+  };
 
-  if (upErr) throw upErr;
+  const existingId = await resolveExistingNavatarId(owner_id);
+  if (existingId) payload.id = existingId;
 
-  return pickNavatar(key, name);
+  const saved = await saveAvatarRow(payload);
+  return saved as NavatarRow;
 }
 
 /** Load the current user's navatar row */

--- a/src/lib/navatar/useSupabase.ts
+++ b/src/lib/navatar/useSupabase.ts
@@ -1,9 +1,25 @@
 import { supabase } from '@/lib/supabaseClient';
 
-// Table names are navatars; storage bucket remains **avatars**
-export async function saveAvatarRow(payload: any) {
-  // e.g., { owner_id, name, image_url, meta }
-  return await supabase.from('navatars').insert(payload).select().single();
+export type AvatarRowPayload = {
+  id?: string;
+  owner_id: string;
+  name?: string | null;
+  image_url?: string | null;
+  image_path?: string | null;
+  updated_at?: string | null;
+  [key: string]: unknown;
+};
+
+// Table writes
+export async function saveAvatarRow(payload: AvatarRowPayload) {
+  const { data, error } = await supabase
+    .from('navatars')
+    .upsert(payload, { onConflict: 'id' })
+    .select('*')
+    .single();
+
+  if (error) throw error;
+  return data;
 }
 
 export async function listAvatarsByUser(userId: string) {
@@ -14,16 +30,20 @@ export async function listAvatarsByUser(userId: string) {
     .order('created_at', { ascending: false });
 }
 
-// Storage bucket also **avatars**
+// Storage bucket **avatars**
 export async function uploadAvatarImage(userId: string, file: File) {
-  const path = `${userId}/${Date.now()}-${file.name}`;
-  const { data, error } = await supabase
-    .storage
-    .from('avatars')
-    .upload(path, file, { upsert: false });
+  const ext = (file.name.split('.').pop() || 'png').toLowerCase();
+  const path = `${userId}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+
+  const { error } = await supabase.storage.from('avatars').upload(path, file, {
+    cacheControl: '31536000',
+    upsert: false,
+    contentType: file.type || 'image/png',
+  });
+
   if (error) throw error;
-  const { data: pub } = await supabase.storage
-    .from('avatars')
-    .getPublicUrl(path);
-  return pub.publicUrl; // public URL for card
+
+  const { data: pub } = await supabase.storage.from('avatars').getPublicUrl(path);
+  return { publicUrl: pub.publicUrl, path };
 }
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -64,7 +64,3 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 import './styles/overrides.css';
-
-if (import.meta.env.PROD) {
-  import('./register-sw');
-}

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -152,6 +152,7 @@ export default function NavatarCardPage() {
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
+    if (saving) return;
     if (!canSave) return;
     setSaving(true);
     setErr(null);
@@ -185,10 +186,13 @@ export default function NavatarCardPage() {
         setNavatarId(saved.id as string);
       }
 
+      toast({ text: "Saved ✓", kind: "ok" });
       nav("/navatar");
     } catch (e: any) {
       console.error(e);
-      setErr(e.message ?? "Save failed");
+      const message = e?.message ?? "Save failed";
+      setErr(message);
+      toast({ text: message, kind: "err" });
     } finally {
       setSaving(false);
     }
@@ -302,7 +306,7 @@ export default function NavatarCardPage() {
           <Link to="/navatar" className="pill">
             Back to My Navatar
           </Link>
-          <button className="pill pill--active" disabled={!canSave || saving}>
+          <button className="pill pill--active" type="submit" disabled={!canSave || saving}>
             {saving ? "Saving…" : "Save"}
           </button>
         </div>

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
 import NavatarTabs from "../../components/NavatarTabs";
-import { uploadNavatar } from "../../lib/navatar";
+import { uploadAvatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import "../../styles/navatar.css";
@@ -31,7 +31,7 @@ export default function GenerateNavatarPage() {
     e.preventDefault();
     if (!file) return;
     try {
-      const row = await uploadNavatar(file, name || undefined);
+      const row = await uploadAvatar(file, name || undefined);
       setActiveNavatarId(row.id);
       toast({ text: "Saved ✓", kind: "ok" });
       nav("/navatar");

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
 import NavatarTabs from "../../components/NavatarTabs";
-import { uploadNavatar } from "../../lib/navatar";
+import { uploadAvatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import "../../styles/navatar.css";
@@ -13,6 +13,7 @@ export default function UploadNavatarPage() {
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
   const [previewUrl, setPreviewUrl] = useState<string | undefined>();
+  const [saving, setSaving] = useState(false);
   const nav = useNavigate();
   const toast = useToast();
 
@@ -28,14 +29,22 @@ export default function UploadNavatarPage() {
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
-    if (!file) return;
+    if (saving) return;
+    if (!file) {
+      toast({ text: "Pick an image first.", kind: "warn" });
+      return;
+    }
     try {
-      const row = await uploadNavatar(file, name || undefined);
+      setSaving(true);
+      const row = await uploadAvatar(file, name || undefined);
       setActiveNavatarId(row.id);
       toast({ text: "Uploaded ✓", kind: "ok" });
       nav("/navatar");
-    } catch {
-      toast({ text: "Upload failed", kind: "err" });
+    } catch (err: any) {
+      console.error(err);
+      toast({ text: err?.message || "Upload failed", kind: "err" });
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -59,8 +68,8 @@ export default function UploadNavatarPage() {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <button className="pill pill--active" type="submit">
-          Save
+        <button className="pill pill--active" type="submit" disabled={saving}>
+          {saving ? "Saving…" : "Save"}
         </button>
       </form>
     </main>

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -226,3 +226,16 @@
   }
 }
 
+/* Keep the helper FAB from overlapping the form hit area */
+.ai-fab {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 56px;
+  height: 56px;
+  z-index: 20;
+}
+.ai-fab-overlay {
+  pointer-events: none;
+}
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,62 +3,68 @@ import react from '@vitejs/plugin-react-swc';
 import { VitePWA } from 'vite-plugin-pwa';
 import path from 'path';
 
+const enablePwa = process.env.VITE_ENABLE_PWA === 'true';
+
 export default defineConfig({
   plugins: [
     react(),
     // keeps a stable vendor chunk so the browser can cache it longer
     splitVendorChunkPlugin(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      injectRegister: 'auto',
-      workbox: {
-        globPatterns: ['**/*.{js,css,html,svg,png,ico,webp,woff2}'],
-        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
-      },
-      manifest: {
-        name: 'Naturverse',
-        short_name: 'Naturverse',
-        theme_color: '#2563eb',
-        background_color: '#ffffff',
-        start_url: '/',
-        display: 'standalone',
-        icons: [
-          { src: '/favicon-192x192.png', sizes: '192x192', type: 'image/png' },
-          { src: '/favicon-256x256.png', sizes: '256x256', type: 'image/png' },
-          {
-            src: '/favicon-512x512.png',
-            sizes: '512x512',
-            type: 'image/png',
-            purpose: 'any maskable',
-          },
-        ],
-      },
-      // Runtime caching for stuff that isn’t in the precache
-      runtimeCaching: [
-        {
-          urlPattern: ({ request }) => request.destination === 'image',
-          handler: 'CacheFirst',
-          options: {
-            cacheName: 'nv-images',
-            expiration: {
-              maxEntries: 60,
-              maxAgeSeconds: 60 * 60 * 24 * 30,
+    ...(enablePwa
+      ? [
+          VitePWA({
+            registerType: 'autoUpdate',
+            injectRegister: 'auto',
+            workbox: {
+              globPatterns: ['**/*.{js,css,html,svg,png,ico,webp,woff2}'],
+              maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
             },
-          },
-        },
-        {
-          urlPattern: /https:\/\/[^/]*supabase\.co\/.*/i,
-          handler: 'StaleWhileRevalidate',
-          options: {
-            cacheName: 'nv-supabase',
-            expiration: {
-              maxEntries: 100,
-              maxAgeSeconds: 60 * 60 * 24,
+            manifest: {
+              name: 'Naturverse',
+              short_name: 'Naturverse',
+              theme_color: '#2563eb',
+              background_color: '#ffffff',
+              start_url: '/',
+              display: 'standalone',
+              icons: [
+                { src: '/favicon-192x192.png', sizes: '192x192', type: 'image/png' },
+                { src: '/favicon-256x256.png', sizes: '256x256', type: 'image/png' },
+                {
+                  src: '/favicon-512x512.png',
+                  sizes: '512x512',
+                  type: 'image/png',
+                  purpose: 'any maskable',
+                },
+              ],
             },
-          },
-        },
-      ],
-    }),
+            // Runtime caching for stuff that isn’t in the precache
+            runtimeCaching: [
+              {
+                urlPattern: ({ request }) => request.destination === 'image',
+                handler: 'CacheFirst',
+                options: {
+                  cacheName: 'nv-images',
+                  expiration: {
+                    maxEntries: 60,
+                    maxAgeSeconds: 60 * 60 * 24 * 30,
+                  },
+                },
+              },
+              {
+                urlPattern: /https:\/\/[^/]*supabase\.co\/.*/i,
+                handler: 'StaleWhileRevalidate',
+                options: {
+                  cacheName: 'nv-supabase',
+                  expiration: {
+                    maxEntries: 100,
+                    maxAgeSeconds: 60 * 60 * 24,
+                  },
+                },
+              },
+            ],
+          }),
+        ]
+      : []),
   ],
   envPrefix: 'VITE_',
   resolve: {


### PR DESCRIPTION
## Summary
- gate the PWA plugin on `VITE_ENABLE_PWA` and remove preview service worker registration so the PWA no longer interferes locally
- tighten the Navatar FAB overlay styling
- update the Navatar upload/card flows and Supabase helpers to upload into the `avatars` bucket and show loading/toast feedback

## Testing
- npm run typecheck
- npm run build *(fails: missing @vitejs/plugin-react-swc in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6e0c62d48329873abe59d6468a7b