### PR TITLE
Fix navatar save interactions

### DIFF
--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -150,8 +150,8 @@ export default function NavatarCardPage() {
     [name, species, kingdom, backstory, powers, traits]
   );
 
-  async function onSave(e: React.FormEvent) {
-    e.preventDefault();
+  async function onSave(e?: React.FormEvent | React.MouseEvent) {
+    e?.preventDefault?.();
     if (!canSave) return;
     setSaving(true);
     setErr(null);
@@ -302,7 +302,13 @@ export default function NavatarCardPage() {
           <Link to="/navatar" className="pill">
             Back to My Navatar
           </Link>
-          <button className="pill pill--active" disabled={!canSave || saving}>
+          <button
+            className="pill pill--active"
+            type="submit"
+            onClick={onSave}
+            aria-label="Save card"
+            disabled={!canSave || saving}
+          >
             {saving ? "Saving…" : "Save"}
           </button>
         </div>

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -26,13 +26,13 @@ export default function UploadNavatarPage() {
     return () => URL.revokeObjectURL(url);
   }, [file]);
 
-  async function onSave(e: React.FormEvent) {
-    e.preventDefault();
+  async function onSave(e?: React.FormEvent | React.MouseEvent) {
+    e?.preventDefault?.();
     if (!file) return;
     try {
       const row = await uploadNavatar(file, name || undefined);
       setActiveNavatarId(row.id);
-      toast({ text: "Uploaded ✓", kind: "ok" });
+      toast({ text: "Uploaded ✔", kind: "ok" });
       nav("/navatar");
     } catch {
       toast({ text: "Upload failed", kind: "err" });
@@ -59,7 +59,12 @@ export default function UploadNavatarPage() {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <button className="pill pill--active" type="submit">
+        <button
+          className="pill pill--active"
+          type="submit"
+          onClick={onSave}
+          aria-label="Save navatar"
+        >
           Save
         </button>
       </form>

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -226,3 +226,34 @@
   }
 }
 
+/* Keep FAB from overlapping important controls */
+.fab,
+.mascot-fab,
+.naturverse-fab {
+  position: fixed;
+  right: 16px;
+  bottom: 96px;
+  z-index: 5;
+  width: 56px;
+  height: 56px;
+}
+
+/* Make sure the click target is only the visible circle */
+.fab *,
+.mascot-fab *,
+.naturverse-fab * {
+  pointer-events: auto;
+}
+.fab::before,
+.mascot-fab::before,
+.naturverse-fab::before {
+  content: none !important;
+}
+
+/* Ensure primary pills are always above ornaments */
+.pill,
+.pill--active {
+  position: relative;
+  z-index: 30;
+}
+


### PR DESCRIPTION
## Summary
- lower the mascot FAB layering and bump pill buttons above ornaments so form controls stay tappable
- add an explicit click fallback when saving navatars and cards to guarantee the submit handler runs
- tweak the upload success toast copy to match the new UI glyph

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf7264335083299a60753c073ca888