### PR TITLE
Scope FAB hit-area + make Save submits

### DIFF
--- a/src/components/AssistantFab.tsx
+++ b/src/components/AssistantFab.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+type AssistantFabProps = {
+  onClick?: () => void;
+  ariaLabel?: string;
+};
+
+/**
+ * Small, self-contained FAB whose wrapper cannot steal clicks.
+ * The wrapper has pointer-events: none; only the button is interactive.
+ */
+export default function AssistantFab({ onClick, ariaLabel = "Ask Turian" }: AssistantFabProps) {
+  return (
+    <div className="fab-root" aria-hidden={false}>
+      <button
+        type="button"
+        className="fab-button"
+        aria-label={ariaLabel}
+        onClick={onClick}
+      >
+        <img
+          src="/favicon-64x64.png"
+          alt=""
+          width={32}
+          height={32}
+          style={{ display: "block" }}
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/components/TurianAssistant.tsx
+++ b/src/components/TurianAssistant.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { assistantMap } from "@/data/assistantMap";
 import { logEvent } from "@/lib/analytics";
 import { findRoute } from "@/lib/navIntents";
+import AssistantFab from "./AssistantFab";
 
 /** Brand tokens (adjust if your blue is different) */
 const BRAND_BLUE = "#2563EB"; // Naturverse blue
@@ -175,37 +176,12 @@ export default function TurianAssistant({
 
   return (
     <>
-      {/* Floating button (bottom-right) */}
-      <button
-        aria-label="Ask Turian"
-        onClick={open ? closeBot : openBot}
-        style={{
-          position: "fixed",
-          right: 16,
-          bottom: 16,
-          width: 56,
-          height: 56,
-          borderRadius: "50%",
-          background: "#ffffff",
-          border: `2px solid ${BRAND_BLUE}`,
-          boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
-          display: open ? "none" : "inline-flex",
-          alignItems: "center",
-          justifyContent: "center",
-          padding: 0,
-          cursor: "pointer",
-          zIndex: 90_000,
-        }}
-      >
-        {/* Turian head from /public */}
-        <img
-          src="/favicon-64x64.png"
-          alt="Turian"
-          width={32}
-          height={32}
-          style={{ display: "block" }}
+      {!open && (
+        <AssistantFab
+          ariaLabel="Ask Turian"
+          onClick={openBot}
         />
-      </button>
+      )}
 
       {/* Drawer */}
       {open && (

--- a/src/pages/navatar/card.tsx
+++ b/src/pages/navatar/card.tsx
@@ -302,7 +302,7 @@ export default function NavatarCardPage() {
           <Link to="/navatar" className="pill">
             Back to My Navatar
           </Link>
-          <button className="pill pill--active" disabled={!canSave || saving}>
+          <button type="submit" className="pill pill--active" disabled={!canSave || saving}>
             {saving ? "Saving…" : "Save"}
           </button>
         </div>

--- a/src/pages/navatar/upload.tsx
+++ b/src/pages/navatar/upload.tsx
@@ -59,7 +59,7 @@ export default function UploadNavatarPage() {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <button className="pill pill--active" type="submit">
+        <button type="submit" className="pill pill--active">
           Save
         </button>
       </form>

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -30,7 +30,6 @@
   color: #fff;
   border-color: #1e4ed8;
   font-weight: 700;
-  pointer-events: none;
 }
 
 /* --- Card: single source of truth for size & fit --- */

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -105,3 +105,36 @@ header .nv-icon {
 .btn-danger{ background:#fff0f0; border-color:#e11d48; color:#e11d48; }
 .nv-cart-badge{ position:relative; display:inline-flex; align-items:center; gap:.25rem; }
 .nv-cart-dot{ position:absolute; top:-6px; right:-10px; font:600 12px/1 system-ui; padding:.15rem .35rem; border-radius:999px; background:#1f64ff; color:#fff; }
+
+/* ===== Assistant FAB fixes ===== */
+/* The wrapper must NOT cover the page; keep it to the button’s box only */
+.fab-root {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 56px;
+  height: 56px;
+  z-index: 9999;           /* visible above content */
+  pointer-events: none;    /* wrapper never steals clicks */
+}
+
+.fab-root > .fab-button {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: 2px solid rgba(37, 99, 235, .35);
+  box-shadow: rgba(0, 0, 0, .15) 6px 6px 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  padding: 0;
+  cursor: pointer;
+  pointer-events: auto; /* only the visible circle is clickable */
+}
+
+/* make sure pills can receive pointer events */
+.pill,
+.pill--active {
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Summary
- add an AssistantFab component so the floating button only exposes a 56×56px click target and its wrapper never steals pointer events
- style the FAB container in CSS and guarantee pills keep pointer-events so form controls remain clickable
- switch Navatar Save buttons to explicit submit buttons

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf74b4e1148329a75196f972dec125