### PR TITLE
Make Turian theme-aware (persona + context)

### DIFF
--- a/netlify/functions/turian-chat.ts
+++ b/netlify/functions/turian-chat.ts
@@ -1,43 +1,154 @@
 import type { Handler } from '@netlify/functions';
 
-const MODEL = 'llama-3.1-8b-instant'; // fast, consistent
-const SYS = `You are Turian the Durian — cheerful, brief, family-friendly. 
+type ChatMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+const SYS = `You are Turian the Durian — cheerful, brief, family-friendly.
 Never mention you are an AI. Answer in 1–3 sentences.`;
+
+const GROQ_MODEL = process.env.GROQ_MODEL || 'mixtral-8x7b-32768';
+const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+const TEMPERATURE = 0.6;
+const MAX_MESSAGES = 24;
 
 export const handler: Handler = async (evt) => {
   if (evt.httpMethod === 'OPTIONS') {
     return cors(200, '');
   }
+
+  if (evt.httpMethod !== 'POST') {
+    return cors(405, JSON.stringify({ error: 'method_not_allowed' }));
+  }
+
+  if (!process.env.GROQ_API_KEY && !process.env.OPENAI_API_KEY) {
+    return cors(503, JSON.stringify({ error: 'offline' }));
+  }
+
+  let payload: { messages?: unknown; prompt?: unknown };
   try {
-    const { prompt } = JSON.parse(evt.body || '{}');
+    payload = evt.body ? JSON.parse(evt.body) : {};
+  } catch {
+    return cors(400, JSON.stringify({ error: 'invalid_payload' }));
+  }
 
-    const r = await fetch('https://api.groq.com/openai/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${process.env.GROQ_API_KEY}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        temperature: 0.6,
-        messages: [
-          { role: 'system', content: SYS },
-          { role: 'user', content: prompt?.toString().slice(0, 2000) || '' }
-        ]
-      })
-    });
+  try {
+    let messages = normalizeMessages(payload.messages);
 
-    if (!r.ok) throw new Error('groq unavailable');
+    if (!messages) {
+      const prompt = typeof payload.prompt === 'string' ? payload.prompt.trim() : '';
+      if (!prompt) {
+        return cors(400, JSON.stringify({ error: 'invalid_payload' }));
+      }
+      messages = normalizeMessages([
+        { role: 'system', content: SYS },
+        { role: 'user', content: prompt },
+      ]);
+    }
 
-    const data = await r.json();
-    const reply = data.choices?.[0]?.message?.content?.trim() || "Hmm, I'm stumped! Try another angle?";
+    if (!messages) {
+      return cors(400, JSON.stringify({ error: 'invalid_payload' }));
+    }
 
+    const reply = await sendToProvider(messages);
     return cors(200, JSON.stringify({ reply }));
-  } catch (e) {
-    // Let the client drop to offline persona
+  } catch {
     return cors(503, JSON.stringify({ error: 'offline' }));
   }
 };
+
+async function sendToProvider(messages: ChatMessage[]): Promise<string> {
+  if (process.env.GROQ_API_KEY) {
+    return callGroq(messages);
+  }
+  if (process.env.OPENAI_API_KEY) {
+    return callOpenAI(messages);
+  }
+  throw new Error('no_provider');
+}
+
+async function callGroq(messages: ChatMessage[]): Promise<string> {
+  const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: GROQ_MODEL,
+      temperature: TEMPERATURE,
+      messages,
+    }),
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error('groq_unavailable');
+  }
+
+  const text = data?.choices?.[0]?.message?.content?.trim();
+  if (!text) {
+    throw new Error('groq_empty');
+  }
+
+  return text;
+}
+
+async function callOpenAI(messages: ChatMessage[]): Promise<string> {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: OPENAI_MODEL,
+      temperature: TEMPERATURE,
+      messages,
+    }),
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error('openai_unavailable');
+  }
+
+  const text = data?.choices?.[0]?.message?.content?.trim();
+  if (!text) {
+    throw new Error('openai_empty');
+  }
+
+  return text;
+}
+
+function normalizeMessages(input: unknown): ChatMessage[] | null {
+  if (!Array.isArray(input)) return null;
+
+  const sanitized: ChatMessage[] = [];
+
+  for (const raw of input) {
+    if (!raw || typeof raw !== 'object') continue;
+    const role = (raw as any).role;
+    if (role !== 'system' && role !== 'user' && role !== 'assistant') continue;
+    const content = typeof (raw as any).content === 'string' ? (raw as any).content.trim() : '';
+    if (!content) continue;
+    sanitized.push({
+      role,
+      content: content.slice(0, 2000),
+    });
+  }
+
+  if (!sanitized.length) return null;
+
+  const limited = sanitized.length > MAX_MESSAGES ? sanitized.slice(-MAX_MESSAGES) : sanitized;
+
+  if (limited[0]?.role !== 'system') {
+    return [{ role: 'system', content: SYS }, ...limited];
+  }
+
+  return limited;
+}
 
 function cors(status: number, body: string) {
   return {
@@ -45,8 +156,9 @@ function cors(status: number, body: string) {
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-      'Access-Control-Allow-Methods': 'POST, OPTIONS'
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Content-Type': 'application/json',
     },
-    body
+    body,
   };
 }

--- a/src/components/TurianAssistant.tsx
+++ b/src/components/TurianAssistant.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { assistantMap } from "@/data/assistantMap";
 import { logEvent } from "@/lib/analytics";
 import { findRoute } from "@/lib/navIntents";
+import { askTurian, type ChatMessage } from "@/lib/ai/client";
+import { buildMessages, type NavatarCtx } from "@/lib/ai/prompt";
+import { getActiveNavatarForUser } from "@/lib/navatar/useNavatar";
+import { useAuthUser } from "@/lib/useAuthUser";
 import AssistantFab from "./AssistantFab";
 
 /** Brand tokens (adjust if your blue is different) */
@@ -16,6 +21,17 @@ type TurianAssistantProps = {
 };
 
 type ChatMsg = { role: "user" | "assistant"; content: string };
+
+const ASSISTANT_HISTORY_LIMIT = 12;
+
+const toAssistantHistory = (items: ChatMsg[]): ChatMessage[] =>
+  items
+    .map((msg): ChatMessage => ({
+      role: msg.role === "user" ? "user" : "assistant",
+      content: msg.content,
+    }))
+    .filter((msg) => msg.content.trim().length > 0)
+    .slice(-ASSISTANT_HISTORY_LIMIT);
 
 function getZone(pathname: string) {
   // tiny helper so we can answer differently later (Home, Worlds, Zones, etc.)
@@ -45,13 +61,18 @@ function isSignedIn() {
 export default function TurianAssistant({
   isAuthed,
 }: TurianAssistantProps) {
+  const { user } = useAuthUser();
+  const routerLocation = useLocation();
+  const pathname = routerLocation.pathname;
   const [open, setOpen] = useState(false);
   const [input, setInput] = useState("");
   const [thinking, setThinking] = useState(false);
   const [messages, setMessages] = useState<ChatMsg[]>([]);
+  const [navatar, setNavatar] = useState<NavatarCtx>({});
   const listRef = useRef<HTMLDivElement | null>(null);
 
-  const zone = useMemo(() => getZone(window.location.pathname), []);
+  const zone = useMemo(() => getZone(pathname), [pathname]);
+  const theme = useMemo(() => ({ route: pathname || "/", zone }), [pathname, zone]);
 
   useEffect(() => {
     // starter tip so the box isn't empty
@@ -63,6 +84,32 @@ export default function TurianAssistant({
       ]);
     }
   }, []); // eslint-disable-line
+
+  useEffect(() => {
+    let active = true;
+
+    if (!user?.id) {
+      setNavatar({});
+      return () => {
+        active = false;
+      };
+    }
+
+    (async () => {
+      try {
+        const data = await getActiveNavatarForUser(user.id);
+        if (!active) return;
+        setNavatar(data);
+      } catch {
+        if (!active) return;
+        setNavatar({});
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [user?.id]);
 
   useEffect(() => {
     if (listRef.current) {
@@ -86,11 +133,11 @@ export default function TurianAssistant({
 
   function openBot() {
     setOpen(true);
-    void logEvent({ event: "bot_open", from_page: location.pathname });
+    void logEvent({ event: "bot_open", from_page: pathname });
   }
   function closeBot() {
     setOpen(false);
-    void logEvent({ event: "bot_close", from_page: location.pathname });
+    void logEvent({ event: "bot_close", from_page: pathname });
   }
 
   async function onSend() {
@@ -99,7 +146,7 @@ export default function TurianAssistant({
 
     await logEvent({
       event: "bot_message",
-      from_page: location.pathname,
+      from_page: pathname,
       text,
     });
 
@@ -107,7 +154,7 @@ export default function TurianAssistant({
     if (target) {
       await logEvent({
         event: "bot_navigate",
-        from_page: location.pathname,
+        from_page: pathname,
         to_page: target,
         text,
       });
@@ -115,7 +162,7 @@ export default function TurianAssistant({
         ...m,
         { role: "assistant", content: `Taking you to ${target}…` },
       ]);
-      location.assign(target);
+      window.location.assign(target);
       return;
     }
 
@@ -133,29 +180,21 @@ export default function TurianAssistant({
       return;
     }
 
+    const history = toAssistantHistory(messages);
     setMessages((m) => [...m, { role: "user", content: text }]);
     setInput("");
 
     try {
       setThinking(true);
-      const res = await fetch("/.netlify/functions/chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          zone,
-          messages: [
-            { role: "system", content: `You are Turian in ${zone}.` },
-            ...messages,
-            { role: "user", content: text },
-          ],
-        }),
-      });
-
-      if (!res.ok) throw new Error(await res.text());
-      const json = (await res.json()) as { reply?: string };
+      const baseMessages = buildMessages(text, navatar, theme);
+      const [systemMessage, userMessage] = baseMessages;
+      const payload: ChatMessage[] = [systemMessage, ...history, userMessage].filter(
+        (msg): msg is ChatMessage => Boolean(msg?.content),
+      );
+      const reply = await askTurian(payload);
       setMessages((m) => [
         ...m,
-        { role: "assistant", content: json.reply || "Okay!" },
+        { role: "assistant", content: reply },
       ]);
     } catch (e) {
       setMessages((m) => [

--- a/src/components/TurianChat.tsx
+++ b/src/components/TurianChat.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { demoGrant } from '@/lib/naturbank';
 import { demoAddStamp } from '@/lib/passport';
+import { askTurian, type ChatMessage } from '@/lib/ai/client';
+import { buildMessages, type NavatarCtx } from '@/lib/ai/prompt';
+import { getActiveNavatarForUser } from '@/lib/navatar/useNavatar';
+import { useAuthUser } from '@/lib/useAuthUser';
 import './turian.css';
 
 type Role = 'user' | 'bot' | 'notice';
@@ -40,6 +45,7 @@ const STORAGE_KEY = 'naturverse.turian.thread.v1';
 const QUEST_TAG = /<<quest\|([^|]+)\|([^|]+)\|([^|]+)\|([^|>]+)(?:\|([^|>]+))?>>/i;
 const QUEST_REWARD = 5;
 const MAX_ENTRIES = 80;
+const MAX_HISTORY_MESSAGES = 12;
 
 const INITIAL_ENTRIES: ChatEntry[] = [
   {
@@ -200,7 +206,18 @@ const limitEntries = (entries: ChatEntry[]) => {
   return entries.slice(entries.length - MAX_ENTRIES);
 };
 
+const toHistoryMessages = (entries: ChatEntry[]): ChatMessage[] =>
+  entries
+    .filter((item): item is ChatMessageEntry => item.kind === 'message' && item.role !== 'notice')
+    .map((item): ChatMessage => ({
+      role: item.role === 'user' ? 'user' : 'assistant',
+      content: item.text,
+    }))
+    .slice(-MAX_HISTORY_MESSAGES);
+
 export function TurianChat() {
+  const { user } = useAuthUser();
+  const { pathname } = useLocation();
   const [entries, setEntries] = useState<ChatEntry[]>(() => INITIAL_ENTRIES);
   const [input, setInput] = useState('');
   const [online, setOnline] = useState<boolean>(true);
@@ -208,6 +225,8 @@ export function TurianChat() {
   const [processingQuestId, setProcessingQuestId] = useState<string | null>(null);
   const [toast, setToast] = useState('');
   const [hydrated, setHydrated] = useState(false);
+  const [navatar, setNavatar] = useState<NavatarCtx>({});
+  const theme = useMemo(() => ({ route: pathname || '/', zone: 'Turian Chat' }), [pathname]);
   const view = useRef<HTMLDivElement>(null);
   const offlineNotice = useRef(false);
 
@@ -219,6 +238,32 @@ export function TurianChat() {
     }
     setHydrated(true);
   }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    if (!user?.id) {
+      setNavatar({});
+      return () => {
+        active = false;
+      };
+    }
+
+    (async () => {
+      try {
+        const data = await getActiveNavatarForUser(user.id);
+        if (!active) return;
+        setNavatar(data);
+      } catch {
+        if (!active) return;
+        setNavatar({});
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [user?.id]);
 
   useEffect(() => {
     if (!hydrated) return;
@@ -314,21 +359,23 @@ export function TurianChat() {
   const ask = async () => {
     const trimmed = input.trim();
     if (!trimmed) return;
+    const prompt = buildPrompt(trimmed);
+    const history = toHistoryMessages(entries);
+
     addMessage('user', trimmed);
     setInput('');
     setBusy(true);
 
     try {
-      const r = await fetch('/.netlify/functions/turian-chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: buildPrompt(trimmed) }),
-      });
-      if (!r.ok) throw new Error('offline');
-      const { reply } = await r.json();
+      const baseMessages = buildMessages(prompt, navatar, theme);
+      const [systemMessage, userMessage] = baseMessages;
+      const payload: ChatMessage[] = [systemMessage, ...history, userMessage].filter(
+        (msg): msg is ChatMessage => Boolean(msg?.content),
+      );
+      const reply = await askTurian(payload);
       setOnline(true);
       offlineNotice.current = false;
-      handleReply(String(reply ?? ''), trimmed);
+      handleReply(reply, trimmed);
     } catch {
       handleOffline(trimmed);
     } finally {

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -1,0 +1,28 @@
+export type ChatMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+export async function askTurian(messages: ChatMessage[]): Promise<string> {
+  const res = await fetch('/.netlify/functions/turian-chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messages }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `AI error ${res.status}`);
+  }
+
+  const data = (await res.json()) as { reply?: unknown; text?: unknown };
+  const reply =
+    (typeof data.reply === 'string' && data.reply.trim()) ||
+    (typeof data.text === 'string' && data.text.trim());
+
+  if (!reply) {
+    throw new Error('Empty AI response');
+  }
+
+  return reply;
+}

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -1,0 +1,69 @@
+export type NavatarCtx = {
+  name?: string;
+  species?: string;
+  kingdom?: string;
+  backstory?: string;
+  imageUrl?: string;
+};
+
+export type ThemeCtx = {
+  route: string;
+  world?: string;
+  zone?: string;
+};
+
+type ChatMessage = { role: 'system' | 'user'; content: string };
+
+function routeHint(route: string) {
+  const value = route || '/';
+  if (value.startsWith('/navatar/mint')) {
+    return 'User is on the NFT/Mint page. Be upbeat about future minting and suggest making merch in the Marketplace for now.';
+  }
+  if (value.startsWith('/navatar/card')) {
+    return 'User is editing their Character Card. Offer short, vivid suggestions for name/species/kingdom/backstory.';
+  }
+  if (value.startsWith('/naturversity')) {
+    return 'Adopt a supportive teacher tone. Give 2–3 step guidance and 1 fun example.';
+  }
+  if (value.startsWith('/marketplace')) {
+    return 'Focus on creative merch ideas featuring their Navatar; keep it playful and kind.';
+  }
+  if (value.startsWith('/navatar')) {
+    return 'User is exploring Navatars. Encourage creativity and spotlight their character details.';
+  }
+  return 'Default to playful, kind, eco-positive tone.';
+}
+
+export function buildMessages(
+  userText: string,
+  navatar: NavatarCtx = {},
+  theme: ThemeCtx,
+): ChatMessage[] {
+  const system = [
+    'You are Turian, the Naturverse guide.',
+    'Tone: playful, kind, creative, eco-positive. Avoid violence/scare.',
+    'Keep replies concise (2–5 sentences) unless asked for details.',
+    'You can suggest quests, nature facts, creativity prompts, and simple steps.',
+    'If user requests real medical/financial/legal advice, politely decline and suggest fun alternative learning.',
+    `Context hint: ${routeHint(theme.route)}`,
+    theme.world ? `World: ${theme.world}.` : '',
+    theme.zone ? `Zone: ${theme.zone}.` : '',
+    navatar?.name || navatar?.species || navatar?.kingdom || navatar?.backstory || navatar?.imageUrl
+      ? 'User has a Navatar:'
+      : '',
+    navatar?.name ? `• Name: ${navatar.name}` : '',
+    navatar?.species ? `• Species: ${navatar.species}` : '',
+    navatar?.kingdom ? `• Kingdom: ${navatar.kingdom}` : '',
+    navatar?.backstory ? `• Backstory: ${navatar.backstory}` : '',
+    navatar?.imageUrl ? `• Image URL: ${navatar.imageUrl}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return [
+    { role: 'system', content: system },
+    { role: 'user', content: userText },
+  ];
+}
+
+export type PromptMessages = ReturnType<typeof buildMessages>;

--- a/src/lib/navatar/useNavatar.ts
+++ b/src/lib/navatar/useNavatar.ts
@@ -1,0 +1,44 @@
+import { supabase } from '@/lib/supabaseClient';
+
+type NavatarRow = {
+  name: string | null;
+  species: string | null;
+  kingdom: string | null;
+  backstory: string | null;
+  image_url: string | null;
+};
+
+export type NavatarProfile = {
+  name?: string;
+  species?: string;
+  kingdom?: string;
+  backstory?: string;
+  imageUrl?: string;
+};
+
+export async function getActiveNavatarForUser(userId: string): Promise<NavatarProfile> {
+  if (!userId) return {};
+
+  const { data, error } = await supabase
+    .from('navatars')
+    .select('name,species,kingdom,backstory,image_url')
+    .eq('owner_id', userId)
+    .order('updated_at', { ascending: false, nullsFirst: false })
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle<NavatarRow>();
+
+  if (error && (error as any).code !== 'PGRST116') {
+    throw error;
+  }
+
+  if (!data) return {};
+
+  return {
+    name: data.name ?? undefined,
+    species: data.species ?? undefined,
+    kingdom: data.kingdom ?? undefined,
+    backstory: data.backstory ?? undefined,
+    imageUrl: data.image_url ?? undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- add a prompt builder and client helper that wraps Turian requests with Naturverse tone, navatar details, and route hints
- load the active user navatar and pass theme-aware prompts from both the Turian chat page and assistant widget
- update the Netlify turian-chat proxy to sanitize message history and forward to Groq or OpenAI based on environment keys

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf78fa220883299bf9b08eb505eb6e