### PR TITLE
Fix Netlify preview asset rewrites

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
     <div id="root"></div>
+    <!-- Absolute path prevents preview builds from rewriting module requests -->
     <script type="module" src="/src/main.tsx"></script>
 
     <!-- perf: lazy-enable all imgs that don't opt-out -->

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
-/* /index.html 200
+/assets/*   /assets/:splat   200
+/*          /index.html      200

--- a/src/register-sw.ts
+++ b/src/register-sw.ts
@@ -1,5 +1,10 @@
+// Only register the PWA service worker on the main production domain.
+// Netlify deploy previews should bypass SW to avoid cached HTML intercepting asset requests.
+const isMainDomain =
+  typeof window !== 'undefined' && window.location.hostname === 'thenaturverse.com';
+
 // Only runs in production builds
-if (import.meta.env.PROD && 'serviceWorker' in navigator) {
+if (import.meta.env.PROD && 'serviceWorker' in navigator && isMainDomain) {
   // vite-plugin-pwa injects /sw.js for us
   import('workbox-window').then(({ Workbox }) => {
     const wb = new Workbox('/sw.js');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,6 +60,8 @@ export default defineConfig({
       ],
     }),
   ],
+  // Ensure built asset URLs are absolute so Netlify previews don't rewrite them
+  base: '/',
   envPrefix: 'VITE_',
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- ensure the Vite build always emits absolute asset URLs so Netlify previews resolve bundles correctly
- gate the service worker registration to the production domain to keep previews from serving cached HTML
- add explicit Netlify redirects so /assets/* files bypass the SPA fallback while keeping client-side routing working

## Testing
- npm run typecheck
- npm run build *(fails: cannot download @vitejs/plugin-react-swc from registry due to 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7d09d4c48329beb69253a7dbb57c