### PR TITLE
Fix Vite React plugin warning and connect Turian assistant to Groq

### DIFF
--- a/netlify/functions/ask-turian.ts
+++ b/netlify/functions/ask-turian.ts
@@ -1,0 +1,64 @@
+import type { Handler } from '@netlify/functions';
+
+const SYSTEM_PROMPT = `
+You are "Turian", the friendly guide of the Naturverse™—a playful world of
+kingdoms, characters, quests, wellness, creativity, and kindness.
+Tone: encouraging, curious, concise. Avoid medical/financial advice.
+When users mention "Navatar", help with characters, images, cards, and
+Naturverse features. Keep answers practical and upbeat.
+`;
+
+const API_BASE = 'https://api.groq.com/openai/v1';
+const MODEL = process.env.GROQ_MODEL_ID ?? 'llama-3.1-8b-instant';
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+  try {
+    const apiKey = process.env.GROQ_API_KEY;
+    if (!apiKey) return { statusCode: 500, body: 'Missing GROQ_API_KEY' };
+
+    const { messages = [] } = JSON.parse(event.body ?? '{}');
+
+    const payload = {
+      model: MODEL,
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        ...messages,
+      ],
+      temperature: 0.6,
+      max_tokens: 1024,
+    } satisfies {
+      model: string;
+      messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>;
+      temperature: number;
+      max_tokens: number;
+    };
+
+    const res = await fetch(`${API_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      return { statusCode: res.status, body: text };
+    }
+
+    const data = await res.json();
+    const content = data?.choices?.[0]?.message?.content ?? '';
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { statusCode: 500, body: message };
+  }
+};

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/node": "^20.14.11",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
     "@vitejs/plugin-react-swc": "^3.7.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",

--- a/src/components/TurianAssistant.tsx
+++ b/src/components/TurianAssistant.tsx
@@ -133,34 +133,38 @@ export default function TurianAssistant({
       return;
     }
 
-    setMessages((m) => [...m, { role: "user", content: text }]);
+    const userMessage: ChatMsg = { role: "user", content: text };
+    const updatedMessages = [...messages, userMessage];
+    setMessages(updatedMessages);
     setInput("");
+    setThinking(true);
 
     try {
-      setThinking(true);
-      const res = await fetch("/.netlify/functions/chat", {
+      const apiMessages: { role: "user" | "assistant" | "system"; content: string }[] = [
+        { role: "system", content: `The visitor is currently in the ${zone} zone.` },
+        ...updatedMessages,
+      ];
+
+      const res = await fetch("/.netlify/functions/ask-turian", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          zone,
-          messages: [
-            { role: "system", content: `You are Turian in ${zone}.` },
-            ...messages,
-            { role: "user", content: text },
-          ],
-        }),
+        body: JSON.stringify({ messages: apiMessages }),
       });
 
       if (!res.ok) throw new Error(await res.text());
-      const json = (await res.json()) as { reply?: string };
+      const { content } = (await res.json()) as { content?: string };
       setMessages((m) => [
         ...m,
-        { role: "assistant", content: json.reply || "Okay!" },
+        { role: "assistant", content: content?.trim() || "…" },
       ]);
     } catch (e) {
+      console.error(e);
       setMessages((m) => [
         ...m,
-        { role: "assistant", content: "Something went wrong. Try again." },
+        {
+          role: "assistant",
+          content: "Hmm, I had trouble reaching Turian. Try again?",
+        },
       ]);
     } finally {
       setThinking(false);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,106 +1,119 @@
 import { defineConfig, splitVendorChunkPlugin } from 'vite';
-import react from '@vitejs/plugin-react-swc';
 import { VitePWA } from 'vite-plugin-pwa';
 import path from 'path';
 
-export default defineConfig({
-  plugins: [
-    react(),
-    // keeps a stable vendor chunk so the browser can cache it longer
-    splitVendorChunkPlugin(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      injectRegister: 'auto',
-      workbox: {
-        globPatterns: ['**/*.{js,css,html,svg,png,ico,webp,woff2}'],
-        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
-      },
-      manifest: {
-        name: 'Naturverse',
-        short_name: 'Naturverse',
-        theme_color: '#2563eb',
-        background_color: '#ffffff',
-        start_url: '/',
-        display: 'standalone',
-        icons: [
-          { src: '/favicon-192x192.png', sizes: '192x192', type: 'image/png' },
-          { src: '/favicon-256x256.png', sizes: '256x256', type: 'image/png' },
+async function reactPlugin() {
+  try {
+    const { default: reactSwc } = await import('@vitejs/plugin-react-swc');
+    return reactSwc();
+  } catch {
+    const { default: reactBabel } = await import('@vitejs/plugin-react');
+    return reactBabel();
+  }
+}
+
+export default defineConfig(async () => {
+  const react = await reactPlugin();
+
+  return {
+    plugins: [
+      react,
+      // keeps a stable vendor chunk so the browser can cache it longer
+      splitVendorChunkPlugin(),
+      VitePWA({
+        registerType: 'autoUpdate',
+        injectRegister: 'auto',
+        workbox: {
+          globPatterns: ['**/*.{js,css,html,svg,png,ico,webp,woff2}'],
+          maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+        },
+        manifest: {
+          name: 'Naturverse',
+          short_name: 'Naturverse',
+          theme_color: '#2563eb',
+          background_color: '#ffffff',
+          start_url: '/',
+          display: 'standalone',
+          icons: [
+            { src: '/favicon-192x192.png', sizes: '192x192', type: 'image/png' },
+            { src: '/favicon-256x256.png', sizes: '256x256', type: 'image/png' },
+            {
+              src: '/favicon-512x512.png',
+              sizes: '512x512',
+              type: 'image/png',
+              purpose: 'any maskable',
+            },
+          ],
+        },
+        // Runtime caching for stuff that isn’t in the precache
+        runtimeCaching: [
           {
-            src: '/favicon-512x512.png',
-            sizes: '512x512',
-            type: 'image/png',
-            purpose: 'any maskable',
+            urlPattern: ({ request }) => request.destination === 'image',
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'nv-images',
+              expiration: {
+                maxEntries: 60,
+                maxAgeSeconds: 60 * 60 * 24 * 30,
+              },
+            },
+          },
+          {
+            urlPattern: /https:\/\/[^/]*supabase\.co\/.*/i,
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'nv-supabase',
+              expiration: {
+                maxEntries: 100,
+                maxAgeSeconds: 60 * 60 * 24,
+              },
+            },
           },
         ],
-      },
-      // Runtime caching for stuff that isn’t in the precache
-      runtimeCaching: [
-        {
-          urlPattern: ({ request }) => request.destination === 'image',
-          handler: 'CacheFirst',
-          options: {
-            cacheName: 'nv-images',
-            expiration: {
-              maxEntries: 60,
-              maxAgeSeconds: 60 * 60 * 24 * 30,
-            },
-          },
-        },
-        {
-          urlPattern: /https:\/\/[^/]*supabase\.co\/.*/i,
-          handler: 'StaleWhileRevalidate',
-          options: {
-            cacheName: 'nv-supabase',
-            expiration: {
-              maxEntries: 100,
-              maxAgeSeconds: 60 * 60 * 24,
-            },
-          },
-        },
-      ],
-    }),
-  ],
-  // Ensure built asset URLs are absolute so Netlify previews don't rewrite them
-  base: '/',
-  envPrefix: 'VITE_',
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
-  optimizeDeps: {
-    // Force pre-bundling during dev & build warmup
-    include: [
-      'react',
-      'react-dom',
-      'react-router-dom',
-      '@supabase/supabase-js',
-      'three',
-      // add others you always ship:
-      // "zustand", "clsx", "dayjs", ...
-      'react-helmet-async',
+      }),
     ],
-  },
-  build: {
-    outDir: 'dist',
-    rollupOptions: {
-      external: [],
-      output: {
-        // Small, predictable chunks for better caching
-        manualChunks(id) {
-          if (id.includes('node_modules')) {
-            if (id.includes('react-router')) return 'vendor-router';
-            if (id.includes('@supabase')) return 'vendor-supabase';
-            if (id.includes('react') || id.includes('react-dom')) return 'vendor-react';
-            return 'vendor';
-          }
-        },
+    // Ensure built asset URLs are absolute so Netlify previews don't rewrite them
+    base: '/',
+    envPrefix: 'VITE_',
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
       },
     },
-    sourcemap: true, // ensure production sourcemaps
-    commonjsOptions: {
-      // allow CJS in node_modules to be bundled
-      include: [/node_modules/],
+    optimizeDeps: {
+      // Force pre-bundling during dev & build warmup
+      include: [
+        'react',
+        'react-dom',
+        'react-router-dom',
+        '@supabase/supabase-js',
+        'three',
+        // add others you always ship:
+        // "zustand", "clsx", "dayjs", ...
+        'react-helmet-async',
+      ],
     },
-  },
+    build: {
+      outDir: 'dist',
+      rollupOptions: {
+        external: [],
+        output: {
+          // Small, predictable chunks for better caching
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              if (id.includes('react-router')) return 'vendor-router';
+              if (id.includes('@supabase')) return 'vendor-supabase';
+              if (id.includes('react') || id.includes('react-dom')) return 'vendor-react';
+              return 'vendor';
+            }
+          },
+        },
+      },
+      sourcemap: true, // ensure production sourcemaps
+      commonjsOptions: {
+        // allow CJS in node_modules to be bundled
+        include: [/node_modules/],
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- add a helper to prefer the Vite React SWC plugin when it is installed and fall back to the Babel plugin otherwise
- add an `ask-turian` Netlify function that forwards chats to Groq with the Naturverse system prompt
- update the floating Turian assistant to call the new function with zone context and friendlier error handling

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf80e78c488329bba05fc8d2bfa04d