### PR TITLE
Add Stability AI navatar generation flow

### DIFF
--- a/netlify/functions/generate-navatar.ts
+++ b/netlify/functions/generate-navatar.ts
@@ -1,0 +1,62 @@
+import type { Handler } from "@netlify/functions";
+
+const API_URL = "https://api.stability.ai/v2beta/stable-image/generate/core";
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, body: "Method not allowed" };
+  }
+
+  const apiKey = process.env.STABILITY_API_KEY;
+  if (!apiKey) {
+    return { statusCode: 500, body: "Missing STABILITY_API_KEY" };
+  }
+
+  let prompt: string | undefined;
+  try {
+    const payload = JSON.parse(event.body ?? "{}");
+    prompt = typeof payload.prompt === "string" ? payload.prompt.trim() : undefined;
+  } catch (error) {
+    return { statusCode: 400, body: "Invalid JSON payload" };
+  }
+
+  if (!prompt) {
+    return { statusCode: 400, body: "Prompt is required" };
+  }
+
+  try {
+    const response = await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "image/png",
+      },
+      body: JSON.stringify({
+        prompt,
+        output_format: "png",
+        width: 512,
+        height: 512,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return { statusCode: response.status, body: errorText || "Failed to generate image" };
+    }
+
+    const buffer = await response.arrayBuffer();
+    const base64 = Buffer.from(buffer).toString("base64");
+
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        image: `data:image/png;base64,${base64}`,
+      }),
+    };
+  } catch (error: any) {
+    const message = error?.message ?? "Internal error";
+    return { statusCode: 500, body: message };
+  }
+};

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -14,6 +14,7 @@ export default function GenerateNavatarPage() {
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
   const [draftUrl, setDraftUrl] = useState<string | undefined>();
+  const [isGenerating, setIsGenerating] = useState(false);
   const nav = useNavigate();
   const toast = useToast();
 
@@ -29,7 +30,10 @@ export default function GenerateNavatarPage() {
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
-    if (!file) return;
+    if (!file) {
+      toast({ text: "Add or generate an image first", kind: "err" });
+      return;
+    }
     try {
       const row = await uploadNavatar(file, name || undefined);
       setActiveNavatarId(row.id);
@@ -39,6 +43,59 @@ export default function GenerateNavatarPage() {
       toast({ text: "Save failed", kind: "err" });
     }
   }
+
+  async function handleGenerate() {
+    if (!prompt.trim()) {
+      toast({ text: "Describe your Navatar first", kind: "err" });
+      return;
+    }
+
+    setIsGenerating(true);
+    try {
+      const res = await fetch("/.netlify/functions/generate-navatar", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt }),
+      });
+
+      if (!res.ok) {
+        const message = await res.text();
+        throw new Error(message || "Failed to generate image");
+      }
+
+      const data: { image?: string } = await res.json();
+      if (!data?.image) {
+        throw new Error("No image returned");
+      }
+
+      // Convert base64 data URI to a File so existing upload flow works.
+      const base64 = data.image.split(",")[1];
+      if (!base64) {
+        throw new Error("Invalid image payload");
+      }
+
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+
+      const blob = new Blob([bytes], { type: "image/png" });
+      const generatedFile = new File([blob], `navatar-${Date.now()}.png`, { type: "image/png" });
+
+      setDraftUrl(data.image);
+      setFile(generatedFile);
+      toast({ text: "Navatar generated ✓", kind: "ok" });
+    } catch (error) {
+      console.error(error);
+      const message = error instanceof Error ? error.message : "Error generating image";
+      toast({ text: message, kind: "err" });
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  const canSave = Boolean(file) && !isGenerating;
 
   return (
     <main className="page-pad mx-auto max-w-4xl p-4">
@@ -62,19 +119,33 @@ export default function GenerateNavatarPage() {
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
         />
+        <button
+          type="button"
+          className="pill"
+          onClick={handleGenerate}
+          disabled={isGenerating}
+          style={{ width: "100%" }}
+        >
+          {isGenerating ? "Generating…" : "Generate with Stability AI"}
+        </button>
         <input
           style={{ display: "block", width: "100%" }}
           placeholder="Name (optional)"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
-        <button className="pill pill--active" type="submit" style={{ marginTop: 8 }}>
-          Save
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+          disabled={isGenerating}
+        />
+        <button className="pill pill--active" type="submit" style={{ marginTop: 8 }} disabled={!canSave}>
+          {isGenerating ? "Generating…" : "Save"}
         </button>
       </form>
       <p className="center" style={{ opacity: 0.8 }}>
-        AI art & edit coming soon.
+        Powered by Stability AI – free tier includes 25 generations/day.
       </p>
     </main>
   );


### PR DESCRIPTION
## Summary
- add a Netlify function that posts prompts to Stability AI using the `STABILITY_API_KEY`
- update the Navatar Generate page to trigger the new function, preview results, and guard the save flow

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf8726dcb48329997bd8d3c8961391