### PR TITLE
Use multipart Stability API for Navatar generator

### DIFF
--- a/netlify/functions/generate-navatar.ts
+++ b/netlify/functions/generate-navatar.ts
@@ -1,0 +1,54 @@
+import type { Handler } from "@netlify/functions";
+
+const API_URL = "https://api.stability.ai/v2beta/stable-image/generate/core";
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, body: "Method not allowed" };
+  }
+
+  try {
+    const { prompt } = JSON.parse(event.body ?? "{}");
+    if (!prompt || typeof prompt !== "string") {
+      return { statusCode: 400, body: "Prompt is required" };
+    }
+
+    // Build multipart/form-data body
+    const form = new FormData();
+    form.append("prompt", prompt);
+    form.append("output_format", "png");
+    form.append("aspect_ratio", "1:1"); // square avatar
+    // Optional: pick a model (commented means default/core)
+    // form.append("model", "sd3");
+
+    // IMPORTANT: do NOT set Content-Type header (fetch sets boundary)
+    const resp = await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.STABILITY_API_KEY!}`,
+        Accept: "image/png",
+      },
+      body: form,
+    });
+
+    // If Stability returns JSON, it’s an error payload
+    const ct = resp.headers.get("content-type") || "";
+    if (!resp.ok) {
+      const text = await resp.text();
+      return { statusCode: resp.status, body: text };
+    }
+    if (ct.includes("application/json")) {
+      const err = await resp.text();
+      return { statusCode: 500, body: err };
+    }
+
+    const buf = Buffer.from(await resp.arrayBuffer());
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ image: `data:image/png;base64,${buf.toString("base64")}` }),
+    };
+  } catch (e: any) {
+    return { statusCode: 500, body: e?.message ?? "Internal error" };
+  }
+};

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,8 +29,13 @@ export default function Footer() {
           color: "var(--nv-blue-600)",
         }}
       >
-        {/* LEFT: copyright (always blue) */}
-        <small style={{ color: "var(--nv-blue-600)" }}>{SITE.copyright}</small>
+        {/* LEFT: copyright + attribution */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <small style={{ color: "var(--nv-blue-600)" }}>{SITE.copyright}</small>
+          <small style={{ color: "var(--nv-blue-600)", opacity: 0.9 }}>
+            Powered by Stability AI — free tier includes 25 generations/day.
+          </small>
+        </div>
 
         {/* CENTER: policy links */}
         <nav

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -13,17 +13,19 @@ export default function GenerateNavatarPage() {
   const [prompt, setPrompt] = useState("");
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
-  const [draftUrl, setDraftUrl] = useState<string | undefined>();
+  const [preview, setPreview] = useState<string | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | undefined>();
   const nav = useNavigate();
   const toast = useToast();
 
   useEffect(() => {
     if (!file) {
-      setDraftUrl(undefined);
+      setPreview(undefined);
       return;
     }
     const url = URL.createObjectURL(file);
-    setDraftUrl(url);
+    setPreview(url);
     return () => URL.revokeObjectURL(url);
   }, [file]);
 
@@ -40,6 +42,45 @@ export default function GenerateNavatarPage() {
     }
   }
 
+  const handleGenerate = async () => {
+    const bodyPrompt = prompt.trim();
+    if (!bodyPrompt) {
+      setErr("Please describe your Navatar first.");
+      return;
+    }
+
+    setLoading(true);
+    setErr(undefined);
+    try {
+      const res = await fetch("/.netlify/functions/generate-navatar", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: bodyPrompt }),
+      });
+      const text = await res.text();
+      if (!res.ok) throw new Error(text || res.statusText);
+      const data = JSON.parse(text);
+      if (!data.image) throw new Error("No image returned");
+      setPreview(data.image);
+
+      const comma = data.image.indexOf(",");
+      if (comma === -1) throw new Error("Unexpected image payload");
+      const base64 = data.image.slice(comma + 1);
+      const byteString = atob(base64);
+      const byteArray = new Uint8Array(byteString.length);
+      for (let i = 0; i < byteString.length; i += 1) {
+        byteArray[i] = byteString.charCodeAt(i);
+      }
+      const generatedFile = new File([byteArray], "navatar.png", { type: "image/png" });
+      setFile(generatedFile);
+    } catch (e: any) {
+      console.error(e);
+      setErr(e?.message ?? "Generation failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <main className="page-pad mx-auto max-w-4xl p-4">
       <div className="bcRow">
@@ -54,13 +95,16 @@ export default function GenerateNavatarPage() {
         onSubmit={onSave}
         style={{ maxWidth: 520, margin: "16px auto", display: "grid", justifyItems: "center", gap: 12 }}
       >
-        <NavatarCard src={draftUrl} title={name || "My Navatar"} />
+        <NavatarCard src={preview} title={name || "My Navatar"} />
         <textarea
           rows={4}
           placeholder="Describe your Navatar (e.g., friendly water-buffalo spirit)…"
           style={{ width: "100%" }}
           value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
+          onChange={(e) => {
+            setPrompt(e.target.value);
+            if (err) setErr(undefined);
+          }}
         />
         <input
           style={{ display: "block", width: "100%" }}
@@ -68,13 +112,33 @@ export default function GenerateNavatarPage() {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
-        <button className="pill pill--active" type="submit" style={{ marginTop: 8 }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, width: "100%" }}>
+          <button
+            type="button"
+            className="ai-btn"
+            onClick={handleGenerate}
+            disabled={loading}
+          >
+            {loading ? "Generating…" : "Generate with Stability AI"}
+          </button>
+          {err ? (
+            <span style={{ color: "#b91c1c", fontSize: "0.9rem", textAlign: "center" }}>{err}</span>
+          ) : null}
+        </div>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => {
+            setFile(e.target.files?.[0] || null);
+            if (err) setErr(undefined);
+          }}
+        />
+        <button className="pill pill--active" type="submit" style={{ marginTop: 8 }} disabled={!file || loading}>
           Save
         </button>
       </form>
       <p className="center" style={{ opacity: 0.8 }}>
-        AI art & edit coming soon.
+        Powered by Stability AI — free tier includes 25 generations/day.
       </p>
     </main>
   );


### PR DESCRIPTION
## Summary
- add a Netlify function that calls Stability AI's image generation endpoint with multipart form data and relays PNG payloads back to the client
- update the Navatar generation page to use the new function, surface fetch errors, and prepare generated images for saving
- add Stability AI attribution copy to the shared footer

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf89e0bbb88329a362671d73c5224a