### PR TITLE
Fix Stability AI generation for navatar creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Supabase (client-side)
 VITE_SUPABASE_URL=your-url
 VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_STABILITY_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx
 NEXT_PUBLIC_SITE_URL=https://thenaturverse.com
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN=thenaturverse.com
 NEXT_PUBLIC_ENABLE_AUTO_STAMPS=true

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run build"
   publish = "dist"
 
+[build.environment]
+  VITE_STABILITY_API_KEY = "set-in-dashboard"
+
 [functions]
   node_bundler = "esbuild"
   directory = "netlify/functions"

--- a/src/lib/ai/stability.ts
+++ b/src/lib/ai/stability.ts
@@ -1,0 +1,68 @@
+export type StabilityImageResponse = {
+  image: string;
+  seed?: number;
+  finish_reason?: string;
+};
+
+export async function generateImageWithStability(
+  prompt: string,
+  opts?: { width?: number; height?: number }
+): Promise<StabilityImageResponse> {
+  const key =
+    import.meta.env.VITE_STABILITY_API_KEY ||
+    (typeof process !== "undefined" ? process.env.STABILITY_API_KEY : undefined);
+
+  if (!key) {
+    throw new Error("Missing STABILITY_API_KEY");
+  }
+
+  const width = opts?.width ?? 512;
+  const height = opts?.height ?? 512;
+
+  const res = await fetch("https://api.stability.ai/v2beta/stable-image/generate/core", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      prompt,
+      width,
+      height,
+      output_format: "png",
+    }),
+  });
+
+  if (!res.ok) {
+    let message = `Stability error (${res.status})`;
+
+    try {
+      const errJson = await res.json();
+      if (Array.isArray(errJson?.errors) && errJson.errors.length > 0) {
+        message = errJson.errors.join("; ");
+      } else if (typeof errJson?.message === "string" && errJson.message.trim()) {
+        message = errJson.message;
+      }
+    } catch {
+      // ignore JSON parse issues
+    }
+
+    throw new Error(message);
+  }
+
+  const data = await res.json();
+
+  const imageBase64 =
+    typeof data?.image === "string" && data.image ? data.image :
+    data?.artifacts?.[0]?.base64 ??
+    null;
+
+  if (!imageBase64) {
+    throw new Error("Stability returned no image data");
+  }
+
+  const seed = data?.seed ?? data?.artifacts?.[0]?.seed;
+
+  return { image: imageBase64, seed };
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -4,6 +4,7 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
 import NavatarTabs from "../../components/NavatarTabs";
+import { generateImageWithStability } from "../../lib/ai/stability";
 import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
@@ -45,45 +46,22 @@ export default function GenerateNavatarPage() {
   }
 
   async function handleGenerate() {
-    if (!prompt.trim()) {
+    const trimmed = prompt.trim();
+    if (!trimmed) {
       toast({ text: "Describe your Navatar first", kind: "err" });
       return;
     }
 
     setIsGenerating(true);
     try {
-      const res = await fetch("/.netlify/functions/generate-navatar", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ prompt }),
-      });
+      toast({ text: "Generating image with Stability…", kind: "warn" });
 
-      if (!res.ok) {
-        const message = await res.text();
-        throw new Error(message || "Failed to generate image");
-      }
+      const { image } = await generateImageWithStability(trimmed, { width: 768, height: 1024 });
+      const dataUrl = `data:image/png;base64,${image}`;
+      const pngBlob = await (await fetch(dataUrl)).blob();
+      const generatedFile = new File([pngBlob], `navatar-${Date.now()}.png`, { type: "image/png" });
 
-      const data: { image?: string } = await res.json();
-      if (!data?.image) {
-        throw new Error("No image returned");
-      }
-
-      // Convert base64 data URI to a File so existing upload flow works.
-      const base64 = data.image.split(",")[1];
-      if (!base64) {
-        throw new Error("Invalid image payload");
-      }
-
-      const binary = atob(base64);
-      const bytes = new Uint8Array(binary.length);
-      for (let i = 0; i < binary.length; i += 1) {
-        bytes[i] = binary.charCodeAt(i);
-      }
-
-      const blob = new Blob([bytes], { type: "image/png" });
-      const generatedFile = new File([blob], `navatar-${Date.now()}.png`, { type: "image/png" });
-
-      setDraftUrl(data.image);
+      setDraftUrl(dataUrl);
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });
     } catch (error) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL: string;
   readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly VITE_STABILITY_API_KEY?: string;
   readonly VITE_SITE_URL?: string;
   readonly VITE_ENABLE_AI?: string;
   readonly VITE_ENABLE_AUTO_STAMPS?: string;


### PR DESCRIPTION
## Summary
- add a Stability AI JSON helper that works with the free tier core endpoint
- update the navatar generator page to call the helper and surface toast status updates
- document the new VITE_STABILITY_API_KEY env var for local builds and Netlify

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf8d14ccbc832996cf6c0d8b6c06ec