### PR TITLE
Switch Stability navatar generator to JSON API

### DIFF
--- a/src/lib/ai/stability.ts
+++ b/src/lib/ai/stability.ts
@@ -1,0 +1,43 @@
+// src/lib/ai/stability.ts
+// JSON-based Stability text-to-image (no multipart)
+
+const STABILITY_URL =
+  "https://api.stability.ai/v1/generation/stable-diffusion-v1-6/text-to-image";
+
+export async function generateStabilityPng(prompt: string): Promise<Blob> {
+  const apiKey = import.meta.env.VITE_STABILITY_API_KEY as string | undefined;
+  if (!apiKey) throw new Error("Missing VITE_STABILITY_API_KEY");
+
+  const res = await fetch(STABILITY_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      text_prompts: [{ text: prompt }],
+      // You can tweak these to taste, these are safe defaults.
+      cfg_scale: 7,
+      height: 768,
+      width: 768,
+      steps: 30,
+      samples: 1,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Stability API ${res.status}: ${text}`);
+  }
+
+  const data = await res.json();
+  const b64 = data?.artifacts?.[0]?.base64;
+  if (!b64) throw new Error("No image data returned from Stability");
+
+  // Convert base64 -> Blob (PNG)
+  const bytes = atob(b64);
+  const arr = new Uint8Array(bytes.length);
+  for (let i = 0; i < bytes.length; i++) arr[i] = bytes.charCodeAt(i);
+  return new Blob([arr], { type: "image/png" });
+}

--- a/src/lib/navatar/useSupabase.ts
+++ b/src/lib/navatar/useSupabase.ts
@@ -16,14 +16,24 @@ export async function listAvatarsByUser(userId: string) {
 
 // Storage bucket also **avatars**
 export async function uploadAvatarImage(userId: string, file: File) {
-  const path = `${userId}/${Date.now()}-${file.name}`;
-  const { data, error } = await supabase
+  const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
+  const uniqueId = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const path = `navatars/${userId}/${uniqueId}.${ext}`;
+  const { error: uploadError } = await supabase
     .storage
     .from('avatars')
-    .upload(path, file, { upsert: false });
-  if (error) throw error;
+    .upload(path, file, {
+      upsert: false,
+      contentType: file.type || 'image/png',
+      cacheControl: '3600',
+    });
+  if (uploadError) throw uploadError;
+
   const { data: pub } = await supabase.storage
     .from('avatars')
     .getPublicUrl(path);
-  return pub.publicUrl; // public URL for card
+
+  return { publicUrl: pub?.publicUrl ?? null, path };
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -4,9 +4,11 @@ import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
 import BackToMyNavatar from "../../components/BackToMyNavatar";
 import NavatarTabs from "../../components/NavatarTabs";
-import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
+import { generateStabilityPng } from "@/lib/ai/stability";
+import { uploadAvatarImage, saveAvatarRow } from "@/lib/navatar/useSupabase";
+import { useAuthUser } from "@/lib/useAuthUser";
 import "../../styles/navatar.css";
 
 export default function GenerateNavatarPage() {
@@ -15,8 +17,11 @@ export default function GenerateNavatarPage() {
   const [name, setName] = useState("");
   const [draftUrl, setDraftUrl] = useState<string | undefined>();
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [generatedPrompt, setGeneratedPrompt] = useState<string | null>(null);
   const nav = useNavigate();
   const toast = useToast();
+  const { user } = useAuthUser();
 
   useEffect(() => {
     if (!file) {
@@ -30,72 +35,77 @@ export default function GenerateNavatarPage() {
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
+    if (!user?.id) {
+      toast({ text: "Please log in first", kind: "err" });
+      return;
+    }
     if (!file) {
       toast({ text: "Add or generate an image first", kind: "err" });
       return;
     }
+    setIsSaving(true);
     try {
-      const row = await uploadNavatar(file, name || undefined);
-      setActiveNavatarId(row.id);
+      const { publicUrl, path } = await uploadAvatarImage(user.id, file);
+      if (!publicUrl) {
+        throw new Error("Upload failed");
+      }
+
+      const { data, error } = await saveAvatarRow({
+        owner_id: user.id,
+        name: name.trim() || null,
+        image_url: publicUrl,
+        image_path: path,
+        meta: generatedPrompt ? { source: "stability", prompt: generatedPrompt } : null,
+      });
+
+      if (error) throw error;
+      if (!data?.id) {
+        throw new Error("Failed to save Navatar");
+      }
+
+      setActiveNavatarId(data.id);
       toast({ text: "Saved ✓", kind: "ok" });
       nav("/navatar");
-    } catch {
-      toast({ text: "Save failed", kind: "err" });
+    } catch (error) {
+      console.error(error);
+      const message = error instanceof Error ? error.message : "Save failed";
+      toast({ text: message, kind: "err" });
+    } finally {
+      setIsSaving(false);
     }
   }
 
   async function handleGenerate() {
-    if (!prompt.trim()) {
+    const trimmedPrompt = prompt.trim();
+    if (!trimmedPrompt) {
       toast({ text: "Describe your Navatar first", kind: "err" });
+      return;
+    }
+    if (!user?.id) {
+      toast({ text: "Please log in first", kind: "err" });
       return;
     }
 
     setIsGenerating(true);
     try {
-      const res = await fetch("/.netlify/functions/generate-navatar", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ prompt }),
-      });
-
-      if (!res.ok) {
-        const message = await res.text();
-        throw new Error(message || "Failed to generate image");
-      }
-
-      const data: { image?: string } = await res.json();
-      if (!data?.image) {
-        throw new Error("No image returned");
-      }
-
-      // Convert base64 data URI to a File so existing upload flow works.
-      const base64 = data.image.split(",")[1];
-      if (!base64) {
-        throw new Error("Invalid image payload");
-      }
-
-      const binary = atob(base64);
-      const bytes = new Uint8Array(binary.length);
-      for (let i = 0; i < binary.length; i += 1) {
-        bytes[i] = binary.charCodeAt(i);
-      }
-
-      const blob = new Blob([bytes], { type: "image/png" });
+      toast({ text: "Generating image with Stability…", kind: "warn" });
+      const blob = await generateStabilityPng(trimmedPrompt);
       const generatedFile = new File([blob], `navatar-${Date.now()}.png`, { type: "image/png" });
 
-      setDraftUrl(data.image);
       setFile(generatedFile);
+      setGeneratedPrompt(trimmedPrompt);
       toast({ text: "Navatar generated ✓", kind: "ok" });
     } catch (error) {
       console.error(error);
       const message = error instanceof Error ? error.message : "Error generating image";
       toast({ text: message, kind: "err" });
+      setGeneratedPrompt(null);
     } finally {
       setIsGenerating(false);
     }
   }
 
-  const canSave = Boolean(file) && !isGenerating;
+  const canSave = Boolean(file) && !isGenerating && !isSaving;
 
   return (
     <main className="page-pad mx-auto max-w-4xl p-4">
@@ -123,7 +133,7 @@ export default function GenerateNavatarPage() {
           type="button"
           className="pill"
           onClick={handleGenerate}
-          disabled={isGenerating}
+          disabled={isGenerating || isSaving}
           style={{ width: "100%" }}
         >
           {isGenerating ? "Generating…" : "Generate with Stability AI"}
@@ -137,11 +147,14 @@ export default function GenerateNavatarPage() {
         <input
           type="file"
           accept="image/*"
-          onChange={(e) => setFile(e.target.files?.[0] || null)}
-          disabled={isGenerating}
+          onChange={(e) => {
+            setFile(e.target.files?.[0] || null);
+            setGeneratedPrompt(null);
+          }}
+          disabled={isGenerating || isSaving}
         />
         <button className="pill pill--active" type="submit" style={{ marginTop: 8 }} disabled={!canSave}>
-          {isGenerating ? "Generating…" : "Save"}
+          {isSaving ? "Saving…" : isGenerating ? "Generating…" : "Save"}
         </button>
       </form>
       <p className="center" style={{ opacity: 0.8 }}>


### PR DESCRIPTION
## Summary
- add a Stability v1 text-to-image helper that speaks JSON from the client
- swap the Navatar generator to call the helper, track auth state, and save uploads with metadata
- store generated files in the avatars/navatars folder with content type metadata for Supabase

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf90599adc8329a157443010e8c562