### PR TITLE
Switch Stability feature gating to public toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ VITE_SUPABASE_ANON_KEY=…
 
 Also set the same variables in Netlify → Site settings → Environment variables.
 
+- Stability generation: server env `STABILITY_API_KEY` and public toggle `VITE_ENABLE_STABILITY=1`.
+
 ### NaturBank
 - Page: `/naturbank`
 - Demo wallet label/address; NATUR balance computed from transactions; grant/spend buttons.

--- a/netlify/functions/generate-navatar.ts
+++ b/netlify/functions/generate-navatar.ts
@@ -9,7 +9,10 @@ export const handler: Handler = async (event) => {
 
   const apiKey = process.env.STABILITY_API_KEY;
   if (!apiKey) {
-    return { statusCode: 500, body: "Missing STABILITY_API_KEY" };
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "STABILITY_API_KEY not set" }),
+    };
   }
 
   let prompt: string | undefined;

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -9,6 +9,10 @@ import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import "../../styles/navatar.css";
 
+const hasStability =
+  import.meta.env.VITE_ENABLE_STABILITY === "1" ||
+  import.meta.env.VITE_ENABLE_STABILITY === "true";
+
 export default function GenerateNavatarPage() {
   const [prompt, setPrompt] = useState("");
   const [file, setFile] = useState<File | null>(null);
@@ -45,6 +49,11 @@ export default function GenerateNavatarPage() {
   }
 
   async function handleGenerate() {
+    if (!hasStability) {
+      toast({ text: "Stability not configured", kind: "err" });
+      return;
+    }
+
     if (!prompt.trim()) {
       toast({ text: "Describe your Navatar first", kind: "err" });
       return;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_SITE_URL?: string;
   readonly VITE_ENABLE_AI?: string;
   readonly VITE_ENABLE_AUTO_STAMPS?: string;
+  readonly VITE_ENABLE_STABILITY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- gate the navatar generator on `VITE_ENABLE_STABILITY` and show a clear error when Stability is disabled
- return a JSON error when `STABILITY_API_KEY` is missing in the `generate-navatar` Netlify function
- document the Stability environment variables and add the new toggle to the Vite env typings

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf93fb10d88329b25347b1579aa9da