### PR TITLE
Fix Stability proxy to send multipart form data

### DIFF
--- a/netlify/functions/stability-generate.ts
+++ b/netlify/functions/stability-generate.ts
@@ -1,0 +1,64 @@
+import type { Handler } from "@netlify/functions";
+
+export const handler: Handler = async (event) => {
+  try {
+    const API_KEY = process.env.STABILITY_API_KEY;
+    if (!API_KEY) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: "Missing STABILITY_API_KEY" }),
+        headers: { "Content-Type": "application/json" },
+      };
+    }
+
+    const { prompt } = JSON.parse(event.body || "{}");
+    if (!prompt || typeof prompt !== "string") {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: "Missing prompt" }),
+        headers: { "Content-Type": "application/json" },
+      };
+    }
+
+    // Build multipart form-data (let fetch set the Content-Type+boundary)
+    const form = new FormData();
+    form.append("prompt", prompt);
+    form.append("output_format", "png");
+
+    const resp = await fetch(
+      "https://api.stability.ai/v2beta/stable-image/generate/core",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${API_KEY}`,
+          // IMPORTANT: Accept must be image/* or application/json
+          Accept: "image/*",
+        },
+        body: form,
+      }
+    );
+
+    if (!resp.ok) {
+      const errTxt = await resp.text().catch(() => "");
+      return {
+        statusCode: resp.status,
+        body: JSON.stringify({ error: "stability_error", detail: errTxt }),
+        headers: { "Content-Type": "application/json" },
+      };
+    }
+
+    const buf = Buffer.from(await resp.arrayBuffer());
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "image/png", "Cache-Control": "no-store" },
+      body: buf.toString("base64"),
+      isBase64Encoded: true,
+    };
+  } catch (e: any) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "proxy_failure", detail: e?.message }),
+      headers: { "Content-Type": "application/json" },
+    };
+  }
+};

--- a/src/lib/navatar/stability.ts
+++ b/src/lib/navatar/stability.ts
@@ -1,0 +1,15 @@
+export async function generateWithStability(prompt: string): Promise<Blob> {
+  const resp = await fetch("/.netlify/functions/stability-generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt }),
+  });
+
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => null);
+    throw new Error(err?.detail || err?.error || `HTTP ${resp.status}`);
+  }
+
+  // Function returns image/png; fetch will give us a Blob directly
+  return await resp.blob();
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -7,6 +7,7 @@ import NavatarTabs from "../../components/NavatarTabs";
 import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
+import { generateWithStability } from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
 
 export default function GenerateNavatarPage() {
@@ -52,38 +53,11 @@ export default function GenerateNavatarPage() {
 
     setIsGenerating(true);
     try {
-      const res = await fetch("/.netlify/functions/generate-navatar", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ prompt }),
+      const blob = await generateWithStability(prompt);
+      const generatedFile = new File([blob], `navatar-${Date.now()}.png`, {
+        type: blob.type || "image/png",
       });
 
-      if (!res.ok) {
-        const message = await res.text();
-        throw new Error(message || "Failed to generate image");
-      }
-
-      const data: { image?: string } = await res.json();
-      if (!data?.image) {
-        throw new Error("No image returned");
-      }
-
-      // Convert base64 data URI to a File so existing upload flow works.
-      const base64 = data.image.split(",")[1];
-      if (!base64) {
-        throw new Error("Invalid image payload");
-      }
-
-      const binary = atob(base64);
-      const bytes = new Uint8Array(binary.length);
-      for (let i = 0; i < binary.length; i += 1) {
-        bytes[i] = binary.charCodeAt(i);
-      }
-
-      const blob = new Blob([bytes], { type: "image/png" });
-      const generatedFile = new File([blob], `navatar-${Date.now()}.png`, { type: "image/png" });
-
-      setDraftUrl(data.image);
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });
     } catch (error) {


### PR DESCRIPTION
## Summary
- add a Stability Netlify function that relays prompts as multipart/form-data and returns the generated PNG
- expose a client helper to call the proxy and update the Navatar generator to use the new endpoint

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf96323ae483299203fbe2b1a98900