### PR TITLE
Add navatar style presets and prompt guardrails

### DIFF
--- a/netlify/functions/stability-generate.ts
+++ b/netlify/functions/stability-generate.ts
@@ -11,7 +11,8 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    const { prompt } = JSON.parse(event.body || "{}");
+    const body = JSON.parse(event.body || "{}");
+    const { prompt, negativePrompt, seed, size } = body ?? {};
     if (!prompt || typeof prompt !== "string") {
       return {
         statusCode: 400,
@@ -24,6 +25,38 @@ export const handler: Handler = async (event) => {
     const form = new FormData();
     form.append("prompt", prompt);
     form.append("output_format", "png");
+
+    if (negativePrompt && typeof negativePrompt === "string") {
+      form.append("negative_prompt", negativePrompt);
+    }
+
+    if (typeof seed === "number" && Number.isFinite(seed)) {
+      const clamped = Math.max(0, Math.min(0xffff_ffff, Math.floor(seed)));
+      form.append("seed", String(clamped));
+    }
+
+    let width: number | undefined;
+    let height: number | undefined;
+
+    if (size && typeof size === "string") {
+      const match = size.toLowerCase().split("x");
+      if (match.length === 2) {
+        const parsedWidth = Number(match[0]);
+        const parsedHeight = Number(match[1]);
+        if (Number.isFinite(parsedWidth) && Number.isFinite(parsedHeight)) {
+          width = Math.max(128, Math.min(2048, Math.floor(parsedWidth)));
+          height = Math.max(128, Math.min(2048, Math.floor(parsedHeight)));
+        }
+      }
+    }
+
+    if (!width || !height) {
+      width = 1024;
+      height = 1024;
+    }
+
+    form.append("width", String(width));
+    form.append("height", String(height));
 
     const resp = await fetch(
       "https://api.stability.ai/v2beta/stable-image/generate/core",
@@ -38,19 +71,28 @@ export const handler: Handler = async (event) => {
       }
     );
 
+    const remaining = resp.headers.get("x-ratelimit-remaining");
+
     if (!resp.ok) {
       const errTxt = await resp.text().catch(() => "");
       return {
         statusCode: resp.status,
         body: JSON.stringify({ error: "stability_error", detail: errTxt }),
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...(remaining ? { "x-ratelimit-remaining": remaining } : {}),
+        },
       };
     }
 
     const buf = Buffer.from(await resp.arrayBuffer());
     return {
       statusCode: 200,
-      headers: { "Content-Type": "image/png", "Cache-Control": "no-store" },
+      headers: {
+        "Content-Type": "image/png",
+        "Cache-Control": "no-store",
+        ...(remaining ? { "x-ratelimit-remaining": remaining } : {}),
+      },
       body: buf.toString("base64"),
       isBase64Encoded: true,
     };

--- a/src/lib/navatar/stability.ts
+++ b/src/lib/navatar/stability.ts
@@ -1,15 +1,204 @@
-export async function generateWithStability(prompt: string): Promise<Blob> {
-  const resp = await fetch("/.netlify/functions/stability-generate", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ prompt }),
-  });
+export type StylePreset = {
+  id: string;
+  label: string;
+  prompt: string;
+  description: string;
+};
+
+export const STYLE_PRESETS: StylePreset[] = [
+  {
+    id: "cute-creature",
+    label: "Cute Creature",
+    prompt:
+      "adorable creature design, plush textures, rounded silhouettes, cozy lighting, soft gradients",
+    description: "Soft, plushy friend with big eyes and cozy colors.",
+  },
+  {
+    id: "mythical-friend",
+    label: "Mythical Friend",
+    prompt:
+      "mythical companion, gentle glow, fantasy illustration, ornate patterns, flowing shapes",
+    description: "Sparkling fantasy companion with storybook magic.",
+  },
+  {
+    id: "jungle-buddy",
+    label: "Jungle Buddy",
+    prompt:
+      "lush rainforest setting, tropical foliage, playful energy, vibrant greens and oranges, painterly strokes",
+    description: "Playful jungle explorer surrounded by tropical vibes.",
+  },
+  {
+    id: "ocean-guardian",
+    label: "Ocean Guardian",
+    prompt:
+      "underwater fantasy, coral-inspired shapes, shimmering light rays, teal and coral palette, smooth gradients",
+    description: "Glowing underwater hero with gentle waves.",
+  },
+  {
+    id: "forest-sprite",
+    label: "Forest Sprite",
+    prompt:
+      "mossy textures, dappled forest light, tiny guardian spirit, whimsical nature illustration, watercolor softness",
+    description: "Tiny woodland spirit with glowing leaves.",
+  },
+  {
+    id: "sky-traveler",
+    label: "Sky Traveler",
+    prompt:
+      "floating in clouds, warm sunlight, dynamic motion, airy composition, pastel blues and golds",
+    description: "Adventurer soaring through pastel skies.",
+  },
+  {
+    id: "crystal-beast",
+    label: "Crystal Beast",
+    prompt:
+      "faceted crystal forms, iridescent reflections, luminous core, high-contrast fantasy art, prismatic colors",
+    description: "Shimmering creature built from magical crystals.",
+  },
+  {
+    id: "robot-pal",
+    label: "Robot Pal",
+    prompt:
+      "friendly robot companion, smooth chrome panels, soft neon accents, rounded shapes, Pixar-like lighting",
+    description: "Helpful robo-buddy with glowing gadgets.",
+  },
+];
+
+export const DEFAULT_STYLE_ID = STYLE_PRESETS[0]?.id ?? "cute-creature";
+
+const GUARDED_PHRASE =
+  "family-friendly, wholesome, cheerful expression, bright color palette, soft lighting, clean background, no text, no watermark, no signatures, kid-safe";
+
+export const DEFAULT_NEGATIVE_PROMPT =
+  "realistic gore, violence, guns, logos, words, letters, watermark";
+
+export const MAX_SEED = 0xffff_ffff; // 4294967295
+
+export class StabilityError extends Error {
+  status?: number;
+  remaining?: number | null;
+
+  constructor(message: string, status?: number, remaining?: number | null) {
+    super(message);
+    this.name = "StabilityError";
+    this.status = status;
+    this.remaining = remaining ?? null;
+  }
+}
+
+export class RateLimitError extends StabilityError {
+  constructor(message: string, remaining?: number | null) {
+    super(message, 429, remaining ?? null);
+    this.name = "RateLimitError";
+  }
+}
+
+export const RATE_LIMIT_MESSAGE = "You’ve reached today’s free 25 Stability generations.";
+
+export function buildPrompt(userPrompt: string, style: StylePreset): string {
+  const trimmed = userPrompt.trim();
+  const parts = [
+    trimmed,
+    `Style: ${style.label} — ${style.prompt}`,
+    GUARDED_PHRASE,
+  ].filter(Boolean);
+  return parts.join("; ");
+}
+
+export function buildNegativePrompt(extra?: string): string {
+  const additions = extra?.trim();
+  if (!additions) return DEFAULT_NEGATIVE_PROMPT;
+  return `${DEFAULT_NEGATIVE_PROMPT}, ${additions}`;
+}
+
+export function seedFromUserId(userId: string): number {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i += 1) {
+    hash = (hash << 5) - hash + userId.charCodeAt(i);
+    hash |= 0; // force 32-bit
+  }
+  const normalized = (hash >>> 0) % MAX_SEED;
+  return normalized === 0 ? 1 : normalized;
+}
+
+export function normalizeSeed(seed: number | undefined): number | undefined {
+  if (typeof seed !== "number" || !Number.isFinite(seed)) return undefined;
+  if (seed < 0) return 0;
+  if (seed > MAX_SEED) return MAX_SEED;
+  return Math.floor(seed);
+}
+
+function parseRemaining(header: string | null): number | null {
+  if (!header) return null;
+  const value = Number(header);
+  return Number.isFinite(value) ? value : null;
+}
+
+export interface StabilityGenerateOptions {
+  prompt: string;
+  negativePrompt?: string;
+  seed?: number;
+  size?: string;
+  style?: string;
+  signal?: AbortSignal;
+}
+
+export interface StabilityGenerateResult {
+  blob: Blob;
+  remaining?: number | null;
+}
+
+export async function generateWithStability({
+  prompt,
+  negativePrompt,
+  seed,
+  size,
+  style,
+  signal,
+}: StabilityGenerateOptions): Promise<StabilityGenerateResult> {
+  if (!prompt?.trim()) {
+    throw new StabilityError("Prompt required");
+  }
+
+  const payload: Record<string, unknown> = {
+    prompt,
+    negativePrompt: negativePrompt?.trim() || undefined,
+    size,
+    style,
+  };
+
+  const normalizedSeed = normalizeSeed(seed);
+  if (typeof normalizedSeed === "number") {
+    payload.seed = normalizedSeed;
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch("/.netlify/functions/stability-generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal,
+    });
+  } catch {
+    throw new StabilityError("Unable to reach Stability right now. Check your connection and try again.");
+  }
+
+  const remaining = parseRemaining(resp.headers.get("x-ratelimit-remaining"));
 
   if (!resp.ok) {
     const err = await resp.json().catch(() => null);
-    throw new Error(err?.detail || err?.error || `HTTP ${resp.status}`);
+    const detail = typeof err === "object" && err
+      ? ("detail" in err ? String((err as any).detail) : "error" in err ? String((err as any).error) : null)
+      : null;
+
+    if (resp.status === 429 || (typeof remaining === "number" && remaining <= 0)) {
+      throw new RateLimitError(RATE_LIMIT_MESSAGE, remaining);
+    }
+
+    throw new StabilityError(detail || `HTTP ${resp.status}`, resp.status, remaining);
   }
 
-  // Function returns image/png; fetch will give us a Blob directly
-  return await resp.blob();
+  const blob = await resp.blob();
+  return { blob, remaining };
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
@@ -7,17 +7,33 @@ import NavatarTabs from "../../components/NavatarTabs";
 import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
-import { generateWithStability } from "../../lib/navatar/stability";
+import { useAuthUser } from "../../lib/useAuthUser";
+import {
+  DEFAULT_NEGATIVE_PROMPT,
+  DEFAULT_STYLE_ID,
+  MAX_SEED,
+  RATE_LIMIT_MESSAGE,
+  RateLimitError,
+  STYLE_PRESETS,
+  buildNegativePrompt,
+  buildPrompt,
+  generateWithStability,
+  seedFromUserId,
+} from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
 
 export default function GenerateNavatarPage() {
   const [prompt, setPrompt] = useState("");
+  const [styleId, setStyleId] = useState(DEFAULT_STYLE_ID);
+  const [extraNegativePrompt, setExtraNegativePrompt] = useState("");
+  const [keepStyle, setKeepStyle] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
   const [draftUrl, setDraftUrl] = useState<string | undefined>();
   const [isGenerating, setIsGenerating] = useState(false);
   const nav = useNavigate();
   const toast = useToast();
+  const { user } = useAuthUser();
 
   useEffect(() => {
     if (!file) {
@@ -28,6 +44,21 @@ export default function GenerateNavatarPage() {
     setDraftUrl(url);
     return () => URL.revokeObjectURL(url);
   }, [file]);
+
+  useEffect(() => {
+    if (user?.id) {
+      setKeepStyle((prev) => (prev ? prev : true));
+    } else {
+      setKeepStyle(false);
+    }
+  }, [user?.id]);
+
+  const selectedStyle = useMemo(
+    () => STYLE_PRESETS.find((preset) => preset.id === styleId) ?? STYLE_PRESETS[0],
+    [styleId]
+  );
+
+  const stableSeed = useMemo(() => (user?.id ? seedFromUserId(user.id) : undefined), [user?.id]);
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
@@ -51,19 +82,38 @@ export default function GenerateNavatarPage() {
       return;
     }
 
+    const generationSeed =
+      keepStyle && typeof stableSeed === "number"
+        ? stableSeed
+        : Math.floor(Math.random() * MAX_SEED) || 1;
+
     setIsGenerating(true);
     try {
-      const blob = await generateWithStability(prompt);
+      const { blob, remaining } = await generateWithStability({
+        prompt: buildPrompt(prompt, selectedStyle),
+        negativePrompt: buildNegativePrompt(extraNegativePrompt),
+        seed: generationSeed,
+        size: "1024x1024",
+        style: selectedStyle.id,
+      });
       const generatedFile = new File([blob], `navatar-${Date.now()}.png`, {
         type: blob.type || "image/png",
       });
 
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });
+
+      if (typeof remaining === "number" && remaining <= 0) {
+        toast({ text: RATE_LIMIT_MESSAGE, kind: "warn" });
+      }
     } catch (error) {
       console.error(error);
-      const message = error instanceof Error ? error.message : "Error generating image";
-      toast({ text: message, kind: "err" });
+      if (error instanceof RateLimitError) {
+        toast({ text: error.message, kind: "warn" });
+      } else {
+        const message = error instanceof Error ? error.message : "Error generating image";
+        toast({ text: message, kind: "err" });
+      }
     } finally {
       setIsGenerating(false);
     }
@@ -86,13 +136,75 @@ export default function GenerateNavatarPage() {
         style={{ maxWidth: 520, margin: "16px auto", display: "grid", justifyItems: "center", gap: 12 }}
       >
         <NavatarCard src={draftUrl} title={name || "My Navatar"} />
-        <textarea
-          rows={4}
-          placeholder="Describe your Navatar (e.g., friendly water-buffalo spirit)…"
-          style={{ width: "100%" }}
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-        />
+        <div className="navatar-field">
+          <label htmlFor="navatar-prompt">Describe your Navatar</label>
+          <textarea
+            id="navatar-prompt"
+            rows={4}
+            placeholder="Friendly nature guide, glowing shell, playful pose…"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+        </div>
+        <div className="navatar-field">
+          <label htmlFor="navatar-style">Style preset</label>
+          <div className="navatar-style-picker">
+            <select
+              id="navatar-style"
+              className="navatar-style-select"
+              value={selectedStyle.id}
+              onChange={(e) => setStyleId(e.target.value)}
+              disabled={isGenerating}
+            >
+              {STYLE_PRESETS.map((preset) => (
+                <option key={preset.id} value={preset.id}>
+                  {preset.label}
+                </option>
+              ))}
+            </select>
+            <div className="navatar-style-preview">
+              <strong>{selectedStyle.label}</strong>
+              <p>{selectedStyle.description}</p>
+            </div>
+          </div>
+        </div>
+        <label
+          className={`navatar-keep-style${!user?.id ? " navatar-keep-style--disabled" : ""}`}
+          htmlFor="navatar-keep-style"
+        >
+          <input
+            id="navatar-keep-style"
+            type="checkbox"
+            checked={keepStyle && Boolean(user?.id)}
+            onChange={(e) => setKeepStyle(e.target.checked)}
+            disabled={!user?.id || isGenerating}
+          />
+          <span>
+            Keep style consistent
+            <small>
+              {user?.id
+                ? "Uses your account seed so regenerations keep the same vibe."
+                : "Sign in to lock a style seed to your Navatar."}
+            </small>
+          </span>
+        </label>
+        <details className="navatar-advanced">
+          <summary>Advanced prompt controls</summary>
+          <div className="navatar-advanced__content">
+            <p>
+              We always filter out: <code>{DEFAULT_NEGATIVE_PROMPT}</code>
+            </p>
+            <label htmlFor="navatar-negative">Add more things to avoid (optional)</label>
+            <textarea
+              id="navatar-negative"
+              rows={3}
+              placeholder="e.g., spooky shadows, cluttered background"
+              value={extraNegativePrompt}
+              onChange={(e) => setExtraNegativePrompt(e.target.value)}
+              disabled={isGenerating}
+            />
+          </div>
+        </details>
         <button
           type="button"
           className="pill"
@@ -119,7 +231,7 @@ export default function GenerateNavatarPage() {
         </button>
       </form>
       <p className="center" style={{ opacity: 0.8 }}>
-        Powered by Stability AI – free tier includes 25 generations/day.
+        Powered by Stability AI – square 1024×1024 art, 25 generations/day on the free tier.
       </p>
     </main>
   );

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -110,6 +110,116 @@
   display: grid;
   gap: 12px;
 }
+.navatar-field {
+  width: 100%;
+  display: grid;
+  gap: 6px;
+  text-align: left;
+}
+.navatar-field label {
+  font-weight: 700;
+  color: var(--nv-blue-700, #1e40af);
+}
+.navatar-field textarea,
+.navatar-field select {
+  width: 100%;
+}
+.navatar-style-picker {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid #dbeafe;
+  border-radius: 12px;
+  background: #f8fbff;
+}
+.navatar-style-select {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #c7d2fe;
+  background: #fff;
+  font-weight: 600;
+  color: #1e3a8a;
+}
+.navatar-style-preview {
+  border-radius: 10px;
+  background: #eef2ff;
+  padding: 10px 12px;
+  line-height: 1.4;
+  color: #1e3a8a;
+  font-size: 0.9rem;
+}
+.navatar-style-preview strong {
+  display: block;
+  margin-bottom: 4px;
+  font-weight: 700;
+}
+.navatar-keep-style {
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  text-align: left;
+  color: #111827;
+}
+.navatar-keep-style input {
+  margin-top: 4px;
+}
+.navatar-keep-style small {
+  display: block;
+  margin-top: 2px;
+  color: #6b7280;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+.navatar-keep-style--disabled {
+  opacity: 0.6;
+}
+.navatar-advanced {
+  width: 100%;
+  border: 1px solid #dbeafe;
+  border-radius: 12px;
+  background: #f8fbff;
+  text-align: left;
+}
+.navatar-advanced summary {
+  padding: 10px 14px;
+  cursor: pointer;
+  font-weight: 700;
+  color: #1e40af;
+  list-style: none;
+}
+.navatar-advanced summary::-webkit-details-marker {
+  display: none;
+}
+.navatar-advanced[open] summary {
+  border-bottom: 1px solid #dbeafe;
+}
+.navatar-advanced__content {
+  padding: 12px 14px 16px;
+  display: grid;
+  gap: 12px;
+}
+.navatar-advanced__content p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+.navatar-advanced__content code {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: rgba(30, 78, 216, 0.12);
+  color: #1e3a8a;
+  font-size: 0.75rem;
+}
+.navatar-advanced textarea {
+  width: 100%;
+  min-height: 64px;
+}
 .ai-actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add Stability style presets, guardrailed prompt builder, and seed helpers
- update the navatar generate page with style picker, advanced negative prompt, and rate-limit messaging
- extend the Stability proxy to accept structured options and forward quota headers, plus polish navatar styles

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf99d86fd083299ca33a715c9a8060