### PR TITLE
Enforce on-brand Stability prompts and UI controls

### DIFF
--- a/netlify/functions/stability-generate.ts
+++ b/netlify/functions/stability-generate.ts
@@ -1,5 +1,24 @@
 import type { Handler } from "@netlify/functions";
 
+const BRAND_STYLE = [
+  "cute character, navatar style, bright friendly palette,",
+  "big expressive eyes, rounded shapes, thick clean outlines,",
+  "storybook illustration, flat lighting, soft shading,",
+  "kid-friendly, sticker-ready, high contrast, no tiny details",
+].join(" ");
+
+const NEGATIVE = [
+  "photo, photorealistic, hyperrealistic,",
+  "text, caption, letters, logo, watermark, signature,",
+  "grain, noise, artifacts, extra limbs, deformed hands",
+].join(", ");
+
+const clampSeed = (seed: unknown): number | undefined => {
+  if (typeof seed !== "number" || !Number.isFinite(seed)) return undefined;
+  const clamped = Math.max(0, Math.min(0xffff_ffff, Math.floor(seed)));
+  return clamped;
+};
+
 export const handler: Handler = async (event) => {
   try {
     const API_KEY = process.env.STABILITY_API_KEY;
@@ -12,8 +31,18 @@ export const handler: Handler = async (event) => {
     }
 
     const body = JSON.parse(event.body || "{}");
-    const { prompt, negativePrompt, seed, size } = body ?? {};
-    if (!prompt || typeof prompt !== "string") {
+    const {
+      prompt,
+      negativePrompt,
+      avoid = "",
+      onBrand = true,
+      seed,
+      keepSeed,
+      stylePreset,
+      style,
+    } = body ?? {};
+
+    if (!prompt || typeof prompt !== "string" || !prompt.trim()) {
       return {
         statusCode: 400,
         body: JSON.stringify({ error: "Missing prompt" }),
@@ -21,42 +50,42 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Build multipart form-data (let fetch set the Content-Type+boundary)
-    const form = new FormData();
-    form.append("prompt", prompt);
-    form.append("output_format", "png");
+    const trimmedPrompt = prompt.trim();
+    const userNegative =
+      typeof avoid === "string" && avoid.trim()
+        ? avoid.trim()
+        : typeof negativePrompt === "string"
+        ? negativePrompt.trim()
+        : "";
 
-    if (negativePrompt && typeof negativePrompt === "string") {
-      form.append("negative_prompt", negativePrompt);
+    const brandEnabled = typeof onBrand === "boolean" ? onBrand : true;
+
+    const finalPrompt = brandEnabled
+      ? `${trimmedPrompt}. ${BRAND_STYLE}`
+      : trimmedPrompt;
+
+    const negative = brandEnabled
+      ? [NEGATIVE, userNegative].filter(Boolean).join(", ")
+      : userNegative || undefined;
+
+    const normalizedSeed = clampSeed(seed);
+    const shouldKeepSeed = Boolean(keepSeed && typeof normalizedSeed === "number");
+
+    const bodyPayload: Record<string, unknown> = {
+      model: "stable-image-ultra",
+      prompt: finalPrompt,
+      style_preset: typeof stylePreset === "string" ? stylePreset : typeof style === "string" ? style : "comic-book",
+      output_format: "png",
+      aspect_ratio: "1:1",
+    };
+
+    if (negative) {
+      bodyPayload.negative_prompt = negative;
     }
 
-    if (typeof seed === "number" && Number.isFinite(seed)) {
-      const clamped = Math.max(0, Math.min(0xffff_ffff, Math.floor(seed)));
-      form.append("seed", String(clamped));
+    if (shouldKeepSeed && typeof normalizedSeed === "number") {
+      bodyPayload.seed = normalizedSeed;
     }
-
-    let width: number | undefined;
-    let height: number | undefined;
-
-    if (size && typeof size === "string") {
-      const match = size.toLowerCase().split("x");
-      if (match.length === 2) {
-        const parsedWidth = Number(match[0]);
-        const parsedHeight = Number(match[1]);
-        if (Number.isFinite(parsedWidth) && Number.isFinite(parsedHeight)) {
-          width = Math.max(128, Math.min(2048, Math.floor(parsedWidth)));
-          height = Math.max(128, Math.min(2048, Math.floor(parsedHeight)));
-        }
-      }
-    }
-
-    if (!width || !height) {
-      width = 1024;
-      height = 1024;
-    }
-
-    form.append("width", String(width));
-    form.append("height", String(height));
 
     const resp = await fetch(
       "https://api.stability.ai/v2beta/stable-image/generate/core",
@@ -64,10 +93,11 @@ export const handler: Handler = async (event) => {
         method: "POST",
         headers: {
           Authorization: `Bearer ${API_KEY}`,
-          // IMPORTANT: Accept must be image/* or application/json
-          Accept: "image/*",
+          "Content-Type": "application/json",
+          // IMPORTANT: Accept must be image/png for this endpoint
+          Accept: "image/png",
         },
-        body: form,
+        body: JSON.stringify(bodyPayload),
       }
     );
 

--- a/src/lib/navatar/stability.ts
+++ b/src/lib/navatar/stability.ts
@@ -1,76 +1,35 @@
 export type StylePreset = {
   id: string;
   label: string;
-  prompt: string;
+  stylePreset: string;
   description: string;
 };
 
 export const STYLE_PRESETS: StylePreset[] = [
   {
-    id: "cute-creature",
-    label: "Cute Creature",
-    prompt:
-      "adorable creature design, plush textures, rounded silhouettes, cozy lighting, soft gradients",
-    description: "Soft, plushy friend with big eyes and cozy colors.",
+    id: "navatar-classic",
+    label: "Navatar Classic",
+    stylePreset: "comic-book",
+    description: "Bold outlines, bright palette, classic Naturverse vibe.",
   },
   {
-    id: "mythical-friend",
-    label: "Mythical Friend",
-    prompt:
-      "mythical companion, gentle glow, fantasy illustration, ornate patterns, flowing shapes",
-    description: "Sparkling fantasy companion with storybook magic.",
+    id: "storybook-soft",
+    label: "Storybook Soft",
+    stylePreset: "digital-art",
+    description: "Soft gradients and cozy light with painterly charm.",
   },
   {
-    id: "jungle-buddy",
-    label: "Jungle Buddy",
-    prompt:
-      "lush rainforest setting, tropical foliage, playful energy, vibrant greens and oranges, painterly strokes",
-    description: "Playful jungle explorer surrounded by tropical vibes.",
-  },
-  {
-    id: "ocean-guardian",
-    label: "Ocean Guardian",
-    prompt:
-      "underwater fantasy, coral-inspired shapes, shimmering light rays, teal and coral palette, smooth gradients",
-    description: "Glowing underwater hero with gentle waves.",
-  },
-  {
-    id: "forest-sprite",
-    label: "Forest Sprite",
-    prompt:
-      "mossy textures, dappled forest light, tiny guardian spirit, whimsical nature illustration, watercolor softness",
-    description: "Tiny woodland spirit with glowing leaves.",
-  },
-  {
-    id: "sky-traveler",
-    label: "Sky Traveler",
-    prompt:
-      "floating in clouds, warm sunlight, dynamic motion, airy composition, pastel blues and golds",
-    description: "Adventurer soaring through pastel skies.",
-  },
-  {
-    id: "crystal-beast",
-    label: "Crystal Beast",
-    prompt:
-      "faceted crystal forms, iridescent reflections, luminous core, high-contrast fantasy art, prismatic colors",
-    description: "Shimmering creature built from magical crystals.",
-  },
-  {
-    id: "robot-pal",
-    label: "Robot Pal",
-    prompt:
-      "friendly robot companion, smooth chrome panels, soft neon accents, rounded shapes, Pixar-like lighting",
-    description: "Helpful robo-buddy with glowing gadgets.",
+    id: "sticker-pop",
+    label: "Sticker Pop",
+    stylePreset: "fantasy-art",
+    description: "High-contrast colors and extra punchy highlights.",
   },
 ];
 
-export const DEFAULT_STYLE_ID = STYLE_PRESETS[0]?.id ?? "cute-creature";
-
-const GUARDED_PHRASE =
-  "family-friendly, wholesome, cheerful expression, bright color palette, soft lighting, clean background, no text, no watermark, no signatures, kid-safe";
+export const DEFAULT_STYLE_ID = STYLE_PRESETS[0]?.id ?? "navatar-classic";
 
 export const DEFAULT_NEGATIVE_PROMPT =
-  "realistic gore, violence, guns, logos, words, letters, watermark";
+  "photo, photorealistic, hyperrealistic, text, caption, letters, logo, watermark, signature, grain, noise, artifacts, extra limbs, deformed hands";
 
 export const MAX_SEED = 0xffff_ffff; // 4294967295
 
@@ -95,30 +54,27 @@ export class RateLimitError extends StabilityError {
 
 export const RATE_LIMIT_MESSAGE = "You’ve reached today’s free 25 Stability generations.";
 
-export function buildPrompt(userPrompt: string, style: StylePreset): string {
-  const trimmed = userPrompt.trim();
-  const parts = [
-    trimmed,
-    `Style: ${style.label} — ${style.prompt}`,
-    GUARDED_PHRASE,
-  ].filter(Boolean);
-  return parts.join("; ");
+export function buildPrompt(userPrompt: string): string {
+  return userPrompt.trim();
 }
 
 export function buildNegativePrompt(extra?: string): string {
-  const additions = extra?.trim();
-  if (!additions) return DEFAULT_NEGATIVE_PROMPT;
-  return `${DEFAULT_NEGATIVE_PROMPT}, ${additions}`;
+  return extra?.trim() ?? "";
 }
 
-export function seedFromUserId(userId: string): number {
+const seedFromString = (value: string): number => {
   let hash = 0;
-  for (let i = 0; i < userId.length; i += 1) {
-    hash = (hash << 5) - hash + userId.charCodeAt(i);
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
     hash |= 0; // force 32-bit
   }
   const normalized = (hash >>> 0) % MAX_SEED;
   return normalized === 0 ? 1 : normalized;
+};
+
+export function seedFromUserId(userId?: string): number {
+  const source = userId?.trim() || "naturverse";
+  return seedFromString(source);
 }
 
 export function normalizeSeed(seed: number | undefined): number | undefined {
@@ -136,10 +92,11 @@ function parseRemaining(header: string | null): number | null {
 
 export interface StabilityGenerateOptions {
   prompt: string;
-  negativePrompt?: string;
+  avoid?: string;
   seed?: number;
-  size?: string;
-  style?: string;
+  keepSeed?: boolean;
+  onBrand?: boolean;
+  stylePreset?: string;
   signal?: AbortSignal;
 }
 
@@ -150,26 +107,30 @@ export interface StabilityGenerateResult {
 
 export async function generateWithStability({
   prompt,
-  negativePrompt,
+  avoid,
   seed,
-  size,
-  style,
+  keepSeed,
+  onBrand,
+  stylePreset,
   signal,
 }: StabilityGenerateOptions): Promise<StabilityGenerateResult> {
   if (!prompt?.trim()) {
     throw new StabilityError("Prompt required");
   }
 
+  const normalizedSeed = normalizeSeed(seed);
+  const shouldKeepSeed = Boolean(keepSeed && typeof normalizedSeed === "number");
+
   const payload: Record<string, unknown> = {
-    prompt,
-    negativePrompt: negativePrompt?.trim() || undefined,
-    size,
-    style,
+    prompt: prompt.trim(),
+    avoid: avoid?.trim() || undefined,
+    stylePreset,
+    onBrand,
   };
 
-  const normalizedSeed = normalizeSeed(seed);
-  if (typeof normalizedSeed === "number") {
+  if (shouldKeepSeed && typeof normalizedSeed === "number") {
     payload.seed = normalizedSeed;
+    payload.keepSeed = true;
   }
 
   let resp: Response;

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -11,7 +11,6 @@ import { useAuthUser } from "../../lib/useAuthUser";
 import {
   DEFAULT_NEGATIVE_PROMPT,
   DEFAULT_STYLE_ID,
-  MAX_SEED,
   RATE_LIMIT_MESSAGE,
   RateLimitError,
   STYLE_PRESETS,
@@ -26,6 +25,7 @@ export default function GenerateNavatarPage() {
   const [prompt, setPrompt] = useState("");
   const [styleId, setStyleId] = useState(DEFAULT_STYLE_ID);
   const [extraNegativePrompt, setExtraNegativePrompt] = useState("");
+  const [onBrand, setOnBrand] = useState(true);
   const [keepStyle, setKeepStyle] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
@@ -58,7 +58,7 @@ export default function GenerateNavatarPage() {
     [styleId]
   );
 
-  const stableSeed = useMemo(() => (user?.id ? seedFromUserId(user.id) : undefined), [user?.id]);
+  const stableSeed = useMemo(() => seedFromUserId(user?.id), [user?.id]);
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
@@ -82,19 +82,16 @@ export default function GenerateNavatarPage() {
       return;
     }
 
-    const generationSeed =
-      keepStyle && typeof stableSeed === "number"
-        ? stableSeed
-        : Math.floor(Math.random() * MAX_SEED) || 1;
-
     setIsGenerating(true);
     try {
+      const shouldKeepSeed = keepStyle && Boolean(user?.id);
       const { blob, remaining } = await generateWithStability({
-        prompt: buildPrompt(prompt, selectedStyle),
-        negativePrompt: buildNegativePrompt(extraNegativePrompt),
-        seed: generationSeed,
-        size: "1024x1024",
-        style: selectedStyle.id,
+        prompt: buildPrompt(prompt),
+        avoid: buildNegativePrompt(extraNegativePrompt),
+        seed: shouldKeepSeed ? stableSeed : undefined,
+        keepSeed: shouldKeepSeed,
+        onBrand,
+        stylePreset: selectedStyle.stylePreset,
       });
       const generatedFile = new File([blob], `navatar-${Date.now()}.png`, {
         type: blob.type || "image/png",
@@ -141,10 +138,13 @@ export default function GenerateNavatarPage() {
           <textarea
             id="navatar-prompt"
             rows={4}
-            placeholder="Friendly nature guide, glowing shell, playful pose…"
+            placeholder="cheerful fox ranger with leafy cape, carrying a tiny acorn lantern"
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
           />
+          <small>
+            We’ll auto-apply Navatar style and remove text/logos.
+          </small>
         </div>
         <div className="navatar-field">
           <label htmlFor="navatar-style">Style preset</label>
@@ -168,6 +168,19 @@ export default function GenerateNavatarPage() {
             </div>
           </div>
         </div>
+        <label className="navatar-keep-style" htmlFor="navatar-on-brand">
+          <input
+            id="navatar-on-brand"
+            type="checkbox"
+            checked={onBrand}
+            onChange={(e) => setOnBrand(e.target.checked)}
+            disabled={isGenerating}
+          />
+          <span>
+            Keep on-brand
+            <small>Recommended. Ensures every Navatar stays cartoony and Naturverse-friendly.</small>
+          </span>
+        </label>
         <label
           className={`navatar-keep-style${!user?.id ? " navatar-keep-style--disabled" : ""}`}
           htmlFor="navatar-keep-style"
@@ -183,7 +196,7 @@ export default function GenerateNavatarPage() {
             Keep style consistent
             <small>
               {user?.id
-                ? "Uses your account seed so regenerations keep the same vibe."
+                ? "Locks to your account seed so regenerations keep the same vibe."
                 : "Sign in to lock a style seed to your Navatar."}
             </small>
           </span>
@@ -191,9 +204,11 @@ export default function GenerateNavatarPage() {
         <details className="navatar-advanced">
           <summary>Advanced prompt controls</summary>
           <div className="navatar-advanced__content">
-            <p>
-              We always filter out: <code>{DEFAULT_NEGATIVE_PROMPT}</code>
-            </p>
+            {onBrand ? (
+              <p>
+                On-brand mode filters out: <code>{DEFAULT_NEGATIVE_PROMPT}</code>
+              </p>
+            ) : null}
             <label htmlFor="navatar-negative">Add more things to avoid (optional)</label>
             <textarea
               id="navatar-negative"


### PR DESCRIPTION
## Summary
- add a branded prompt wrapper, strong negative prompt, and JSON request payload in the Stability proxy
- replace the legacy style presets with Stability style_preset values and deterministic account seeds
- refresh the generator UI with an on-brand toggle, updated style options, and clearer prompt guidance

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf9da346408329a530a6ce73bd3ce4