### PR TITLE
Fix Stability fetch headers and response handling

### DIFF
--- a/netlify/functions/stability-generate.ts
+++ b/netlify/functions/stability-generate.ts
@@ -87,27 +87,39 @@ export const handler: Handler = async (event) => {
       bodyPayload.seed = normalizedSeed;
     }
 
-    const resp = await fetch(
-      "https://api.stability.ai/v2beta/stable-image/generate/core",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${API_KEY}`,
-          "Content-Type": "application/json",
-          // IMPORTANT: Accept must be image/png for this endpoint
-          Accept: "image/png",
-        },
-        body: JSON.stringify(bodyPayload),
-      }
-    );
+    const resp = await fetch("https://api.stability.ai/v2beta/stable-image/generate/core", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        Accept: "image/*",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(bodyPayload),
+    });
 
     const remaining = resp.headers.get("x-ratelimit-remaining");
+    const contentType = resp.headers.get("content-type") || "";
 
     if (!resp.ok) {
-      const errTxt = await resp.text().catch(() => "");
+      let errBody: unknown;
+      if (contentType.includes("application/json")) {
+        try {
+          errBody = await resp.json();
+        } catch {
+          errBody = { error: "stability_error" };
+        }
+      } else {
+        try {
+          const text = await resp.text();
+          errBody = { error: text || "stability_error" };
+        } catch {
+          errBody = { error: "stability_error" };
+        }
+      }
+
       return {
         statusCode: resp.status,
-        body: JSON.stringify({ error: "stability_error", detail: errTxt }),
+        body: JSON.stringify(errBody),
         headers: {
           "Content-Type": "application/json",
           ...(remaining ? { "x-ratelimit-remaining": remaining } : {}),
@@ -115,16 +127,27 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    const buf = Buffer.from(await resp.arrayBuffer());
+    if (contentType.startsWith("image/")) {
+      const buf = Buffer.from(await resp.arrayBuffer());
+      return {
+        statusCode: 200,
+        headers: {
+          "Content-Type": contentType,
+          "Cache-Control": "no-store",
+          ...(remaining ? { "x-ratelimit-remaining": remaining } : {}),
+        },
+        body: buf.toString("base64"),
+        isBase64Encoded: true,
+      };
+    }
+
     return {
-      statusCode: 200,
+      statusCode: 500,
+      body: JSON.stringify({ error: "Unexpected response from Stability" }),
       headers: {
-        "Content-Type": "image/png",
-        "Cache-Control": "no-store",
+        "Content-Type": "application/json",
         ...(remaining ? { "x-ratelimit-remaining": remaining } : {}),
       },
-      body: buf.toString("base64"),
-      isBase64Encoded: true,
     };
   } catch (e: any) {
     return {

--- a/src/lib/navatar/stability.ts
+++ b/src/lib/navatar/stability.ts
@@ -105,6 +105,30 @@ export interface StabilityGenerateResult {
   remaining?: number | null;
 }
 
+function messageFromErrorPayload(payload: unknown): string | null {
+  if (!payload) return null;
+  if (typeof payload === "string") {
+    return payload.trim() || null;
+  }
+  if (typeof payload === "object") {
+    const detail =
+      "detail" in payload && typeof (payload as any).detail === "string"
+        ? (payload as any).detail
+        : null;
+    if (detail?.trim()) {
+      return detail.trim();
+    }
+    const error =
+      "error" in payload && typeof (payload as any).error === "string"
+        ? (payload as any).error
+        : null;
+    if (error?.trim()) {
+      return error.trim();
+    }
+  }
+  return null;
+}
+
 export async function generateWithStability({
   prompt,
   avoid,
@@ -146,12 +170,17 @@ export async function generateWithStability({
   }
 
   const remaining = parseRemaining(resp.headers.get("x-ratelimit-remaining"));
+  const contentType = resp.headers.get("content-type") || "";
 
   if (!resp.ok) {
-    const err = await resp.json().catch(() => null);
-    const detail = typeof err === "object" && err
-      ? ("detail" in err ? String((err as any).detail) : "error" in err ? String((err as any).error) : null)
-      : null;
+    let payload: unknown = null;
+    if (contentType.includes("application/json")) {
+      payload = await resp.json().catch(() => null);
+    } else {
+      const text = await resp.text().catch(() => "");
+      payload = text ? { error: text } : null;
+    }
+    const detail = messageFromErrorPayload(payload);
 
     if (resp.status === 429 || (typeof remaining === "number" && remaining <= 0)) {
       throw new RateLimitError(RATE_LIMIT_MESSAGE, remaining);
@@ -160,6 +189,19 @@ export async function generateWithStability({
     throw new StabilityError(detail || `HTTP ${resp.status}`, resp.status, remaining);
   }
 
-  const blob = await resp.blob();
-  return { blob, remaining };
+  if (contentType.startsWith("image/")) {
+    const blob = await resp.blob();
+    return { blob, remaining };
+  }
+
+  let fallbackPayload: unknown = null;
+  if (contentType.includes("application/json")) {
+    fallbackPayload = await resp.json().catch(() => null);
+  } else {
+    const text = await resp.text().catch(() => "");
+    fallbackPayload = text ? { error: text } : null;
+  }
+
+  const message = messageFromErrorPayload(fallbackPayload) || "Unexpected response from Stability";
+  throw new StabilityError(message, resp.status || 500, remaining);
 }


### PR DESCRIPTION
## Summary
- update the Stability Netlify function to send JSON headers and defensively handle non-image responses
- tighten the client helper to surface Stability JSON errors when the response is not an image

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfbcea8e708329a0d84e695e18eba8