### PR TITLE
Switch Navatar generator to Hugging Face (free) with Stability fallback + UI polish

### DIFF
--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -1,0 +1,191 @@
+import type { Handler } from "@netlify/functions";
+
+/**
+ * One function for both providers.
+ * - Uses Hugging Face if HUGGINGFACE_API_KEY is set.
+ * - Falls back to Stability if not.
+ * Returns image/png or JSON error.
+ */
+
+const BRAND_STYLE = [
+  "cute character, navatar style, bright friendly palette,",
+  "big expressive eyes, rounded shapes, thick clean outlines,",
+  "storybook illustration, flat lighting, soft shading,",
+  "kid-friendly, sticker-ready, high contrast, no tiny details",
+].join(" ");
+
+const NEGATIVE = [
+  "photo, photorealistic, hyperrealistic,",
+  "text, caption, letters, logo, watermark, signature,",
+  "grain, noise, artifacts, extra limbs, deformed hands",
+].join(", ");
+
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod !== "POST") {
+      return { statusCode: 405, body: "Method Not Allowed" };
+    }
+
+    const {
+      prompt: rawPrompt = "",
+      keepSeed = true,
+      seed,
+      onBrand = true,
+      avoid = "",
+    } = JSON.parse(event.body || "{}");
+
+    const prompt = String(rawPrompt || "").trim();
+    if (!prompt) {
+      return json(400, { error: "Missing prompt" });
+    }
+
+    const finalPrompt = onBrand ? `${prompt}. ${BRAND_STYLE}` : prompt;
+    const negativePrompt = [NEGATIVE, String(avoid || "").trim()]
+      .filter(Boolean)
+      .join(", ");
+
+    const hfKey = process.env.HUGGINGFACE_API_KEY;
+    if (hfKey) {
+      // ------- Hugging Face (Text-to-Image) -------
+      // A widely available, free-friendly cartoon capable model
+      // You can swap the model id later without touching the frontend
+      const modelId = "Lykon/dreamshaper-8"; // good at stylized/illustrative
+      const body = {
+        inputs: finalPrompt,
+        parameters: {
+          negative_prompt: negativePrompt,
+          guidance_scale: 7,
+          num_inference_steps: 28,
+          width: 1024,
+          height: 1024,
+          seed: keepSeed && typeof seed === "number" ? seed : undefined,
+        },
+      };
+
+      const res = await fetch(
+        `https://api-inference.huggingface.co/models/${modelId}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${hfKey}`,
+            "Content-Type": "application/json",
+            // Ask for raw image back when supported
+            Accept: "image/png,application/json",
+          },
+          body: JSON.stringify(body),
+        }
+      );
+
+      const ct = res.headers.get("content-type") || "";
+      if (!res.ok) {
+        const msg =
+          ct.includes("application/json") ? await res.json() : await res.text();
+        return json(res.status, { provider: "huggingface", error: msg });
+      }
+
+      if (ct.startsWith("image/")) {
+        const buf = Buffer.from(await res.arrayBuffer());
+        return {
+          statusCode: 200,
+          headers: { "Content-Type": "image/png", "Cache-Control": "no-store" },
+          body: buf.toString("base64"),
+          isBase64Encoded: true,
+        };
+      }
+
+      // Some HF models return JSON { "generated_image": "data:image/png;base64,..." }
+      const payload: any = await res.json();
+      const b64 =
+        payload?.generated_image?.split(",")?.pop?.() ||
+        payload?.[0]?.generated_image?.split(",")?.pop?.();
+
+      if (b64) {
+        return {
+          statusCode: 200,
+          headers: { "Content-Type": "image/png", "Cache-Control": "no-store" },
+          body: b64,
+          isBase64Encoded: true,
+        };
+      }
+
+      return json(502, {
+        provider: "huggingface",
+        error: "Unexpected response format from model",
+      });
+    }
+
+    // ------- Stability fallback (kept as-is) -------
+    const key = process.env.STABILITY_API_KEY;
+    if (!key) {
+      return json(400, {
+        error:
+          "No provider configured. Set HUGGINGFACE_API_KEY or STABILITY_API_KEY.",
+      });
+    }
+
+    const body = {
+      model: "stable-image-ultra",
+      prompt: finalPrompt,
+      negative_prompt: negativePrompt,
+      output_format: "png",
+      aspect_ratio: "1:1",
+      seed: keepSeed && typeof seed === "number" ? seed : undefined,
+    };
+
+    const resp = await fetch(
+      "https://api.stability.ai/v2beta/stable-image/generate/core",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${key}`,
+          "Content-Type": "application/json",
+          Accept: "image/*,application/json",
+        },
+        body: JSON.stringify(body),
+      }
+    );
+
+    const ct = resp.headers.get("content-type") || "";
+    const remaining = resp.headers.get("x-ratelimit-remaining");
+    if (!resp.ok) {
+      const err =
+        ct.includes("application/json")
+          ? await resp.json()
+          : await resp.text();
+      return json(resp.status, { provider: "stability", error: err }, remaining || undefined);
+    }
+
+    if (ct.startsWith("image/")) {
+      const buf = Buffer.from(await resp.arrayBuffer());
+      return {
+        statusCode: 200,
+        headers: {
+          "Content-Type": "image/png",
+          "Cache-Control": "no-store",
+          ...(remaining ? { "x-ratelimit-remaining": remaining } : {}),
+        },
+        body: buf.toString("base64"),
+        isBase64Encoded: true,
+      };
+    }
+
+    return json(502, {
+      provider: "stability",
+      error: "Unexpected response format from Stability",
+    });
+  } catch (e: any) {
+    return json(500, { error: e?.message || "Server error" });
+  }
+};
+
+function json(statusCode: number, obj: unknown, remaining?: string) {
+  return {
+    statusCode,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      ...(remaining ? { "x-ratelimit-remaining": remaining } : {}),
+    },
+    body: JSON.stringify(obj),
+  };
+}

--- a/src/lib/navatar/stability.ts
+++ b/src/lib/navatar/stability.ts
@@ -93,7 +93,7 @@ export class RateLimitError extends StabilityError {
   }
 }
 
-export const RATE_LIMIT_MESSAGE = "You’ve reached today’s free 25 Stability generations.";
+export const RATE_LIMIT_MESSAGE = "You’ve reached today’s free Stability fallback limit.";
 
 export function buildPrompt(userPrompt: string, style: StylePreset): string {
   const trimmed = userPrompt.trim();
@@ -140,6 +140,8 @@ export interface StabilityGenerateOptions {
   seed?: number;
   size?: string;
   style?: string;
+  keepSeed?: boolean;
+  onBrand?: boolean;
   signal?: AbortSignal;
 }
 
@@ -152,8 +154,8 @@ export async function generateWithStability({
   prompt,
   negativePrompt,
   seed,
-  size,
-  style,
+  keepSeed,
+  onBrand = true,
   signal,
 }: StabilityGenerateOptions): Promise<StabilityGenerateResult> {
   if (!prompt?.trim()) {
@@ -162,35 +164,50 @@ export async function generateWithStability({
 
   const payload: Record<string, unknown> = {
     prompt,
-    negativePrompt: negativePrompt?.trim() || undefined,
-    size,
-    style,
+    avoid: negativePrompt?.trim() || undefined,
+    onBrand,
   };
 
   const normalizedSeed = normalizeSeed(seed);
   if (typeof normalizedSeed === "number") {
     payload.seed = normalizedSeed;
+    payload.keepSeed = keepSeed ?? true;
+  } else if (typeof keepSeed === "boolean") {
+    payload.keepSeed = keepSeed;
   }
 
   let resp: Response;
   try {
-    resp = await fetch("/.netlify/functions/stability-generate", {
+    resp = await fetch("/.netlify/functions/ai-generate", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
       signal,
     });
   } catch {
-    throw new StabilityError("Unable to reach Stability right now. Check your connection and try again.");
+    throw new StabilityError(
+      "Unable to reach the Navatar generator right now. Check your connection and try again.",
+    );
   }
 
   const remaining = parseRemaining(resp.headers.get("x-ratelimit-remaining"));
+  const contentType = resp.headers.get("content-type") || "";
 
   if (!resp.ok) {
-    const err = await resp.json().catch(() => null);
-    const detail = typeof err === "object" && err
-      ? ("detail" in err ? String((err as any).detail) : "error" in err ? String((err as any).error) : null)
-      : null;
+    let detail: string | null = null;
+
+    if (contentType.includes("application/json")) {
+      const err = await resp.json().catch(() => null);
+      if (err && typeof err === "object") {
+        const source = (err as any).error ?? (err as any).message ?? (err as any).detail;
+        if (typeof source === "string") {
+          detail = source;
+        }
+      }
+    } else {
+      const text = await resp.text().catch(() => "");
+      detail = text || null;
+    }
 
     if (resp.status === 429 || (typeof remaining === "number" && remaining <= 0)) {
       throw new RateLimitError(RATE_LIMIT_MESSAGE, remaining);
@@ -200,5 +217,14 @@ export async function generateWithStability({
   }
 
   const blob = await resp.blob();
+  if (!contentType.startsWith("image/")) {
+    const text = await blob.text().catch(() => "");
+    throw new StabilityError(
+      text || "Unexpected response format from generator",
+      resp.status,
+      remaining,
+    );
+  }
+
   return { blob, remaining };
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -11,7 +11,6 @@ import { useAuthUser } from "../../lib/useAuthUser";
 import {
   DEFAULT_NEGATIVE_PROMPT,
   DEFAULT_STYLE_ID,
-  MAX_SEED,
   RATE_LIMIT_MESSAGE,
   RateLimitError,
   STYLE_PRESETS,
@@ -21,27 +20,6 @@ import {
   seedFromUserId,
 } from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
-
-const BRAND_STYLE = [
-  "cute character, navatar style, bright friendly palette,",
-  "big expressive eyes, rounded shapes, thick clean outlines,",
-  "storybook illustration, flat lighting, soft shading,",
-  "kid-friendly, sticker-ready, high contrast, no tiny details",
-].join(" ");
-
-const BRAND_NEGATIVE = [
-  "photo, photorealistic, hyperrealistic,",
-  "text, caption, letters, logo, watermark, signature,",
-  "grain, noise, artifacts, extra limbs, deformed hands",
-].join(", ");
-
-function wrapWithBrandStyle(raw: string): string {
-  const trimmed = raw.trim();
-  if (!trimmed) return "";
-  const needsPeriod = !/[.!?]$/.test(trimmed);
-  const base = needsPeriod ? `${trimmed}.` : trimmed;
-  return `${base} ${BRAND_STYLE}`;
-}
 
 export default function GenerateNavatarPage() {
   const [prompt, setPrompt] = useState("");
@@ -82,10 +60,7 @@ export default function GenerateNavatarPage() {
 
   const stableSeed = useMemo(() => (user?.id ? seedFromUserId(user.id) : undefined), [user?.id]);
 
-  const alwaysFilteredPrompt = useMemo(
-    () => (onBrand ? `${DEFAULT_NEGATIVE_PROMPT}, ${BRAND_NEGATIVE}` : DEFAULT_NEGATIVE_PROMPT),
-    [onBrand]
-  );
+  const alwaysFilteredPrompt = useMemo(() => DEFAULT_NEGATIVE_PROMPT, []);
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
@@ -110,26 +85,19 @@ export default function GenerateNavatarPage() {
       return;
     }
 
-    const promptForBrand = onBrand ? wrapWithBrandStyle(trimmedPrompt) : trimmedPrompt;
-    const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
+    const finalPrompt = buildPrompt(trimmedPrompt, selectedStyle);
     const baseNegativePrompt = buildNegativePrompt(extraNegativePrompt);
-    const combinedNegativePrompt = onBrand
-      ? `${baseNegativePrompt}, ${BRAND_NEGATIVE}`
-      : baseNegativePrompt;
-
-    const generationSeed =
-      keepStyle && typeof stableSeed === "number"
-        ? stableSeed
-        : Math.floor(Math.random() * MAX_SEED) || 1;
+    const shouldKeepSeed = keepStyle && typeof stableSeed === "number";
+    const seedToUse = shouldKeepSeed ? stableSeed : undefined;
 
     setIsGenerating(true);
     try {
       const { blob, remaining } = await generateWithStability({
         prompt: finalPrompt,
-        negativePrompt: combinedNegativePrompt,
-        seed: generationSeed,
-        size: "1024x1024",
-        style: selectedStyle.id,
+        negativePrompt: baseNegativePrompt,
+        seed: seedToUse,
+        keepSeed: shouldKeepSeed,
+        onBrand,
       });
       const generatedFile = new File([blob], `navatar-${Date.now()}.png`, {
         type: blob.type || "image/png",
@@ -260,7 +228,7 @@ export default function GenerateNavatarPage() {
           disabled={isGenerating}
           style={{ width: "100%" }}
         >
-          {isGenerating ? "Generating…" : "Generate with Stability AI"}
+          {isGenerating ? "Generating…" : "Generate Navatar"}
         </button>
         <input
           style={{ display: "block", width: "100%" }}
@@ -274,12 +242,17 @@ export default function GenerateNavatarPage() {
           onChange={(e) => setFile(e.target.files?.[0] || null)}
           disabled={isGenerating}
         />
-        <button className="pill pill--active" type="submit" style={{ marginTop: 8 }} disabled={!canSave}>
-          {isGenerating ? "Generating…" : "Save"}
+        <button
+          className="btn btn-primary"
+          type="submit"
+          style={{ marginTop: 8, width: "100%" }}
+          disabled={!canSave}
+        >
+          Use as Navatar
         </button>
       </form>
       <p className="center" style={{ opacity: 0.8 }}>
-        Powered by Stability AI – square 1024×1024 art, 25 generations/day on the free tier.
+        Powered by Hugging Face (free) with a Stability fallback — square 1024×1024 art.
       </p>
     </main>
   );

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -14,22 +14,29 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 8px 14px;
-  min-height: 40px;
+  gap: 6px;
+  padding: 10px 18px;
+  min-height: 44px;
   line-height: 1.2;
   border-radius: 999px;
-  border: 1px solid #cfe0ff;
-  background: #f6f9ff;
-  color: #1e4ed8;
+  border: 1px solid #c7d2fe;
+  background: #eef2ff;
+  color: #1e3a8a;
   text-decoration: none;
   font-weight: 600;
-  box-shadow: 0 2px 0 rgba(0,0,0,.08);
+  box-shadow: inset 0 -1px 0 rgba(30, 64, 175, 0.16);
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+.pill:focus-visible {
+  outline: 2px solid #1d4ed8;
+  outline-offset: 2px;
 }
 .pill--active {
-  background: #1e4ed8;
+  background: #1e3a8a;
   color: #fff;
-  border-color: #1e4ed8;
+  border-color: #1e3a8a;
   font-weight: 700;
+  box-shadow: inset 0 -1px 0 rgba(15, 23, 42, 0.25);
 }
 
 /* --- Card: single source of truth for size & fit --- */

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,6 +6,9 @@ interface ImportMetaEnv {
   readonly VITE_SITE_URL?: string;
   readonly VITE_ENABLE_AI?: string;
   readonly VITE_ENABLE_AUTO_STAMPS?: string;
+  // Server-only environment variables (available to Netlify functions)
+  readonly HUGGINGFACE_API_KEY?: string;
+  readonly STABILITY_API_KEY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- add a unified `ai-generate` Netlify function that prefers Hugging Face when `HUGGINGFACE_API_KEY` is available and falls back to Stability while returning image/png responses (and propagating rate-limit headers)
- update the Navatar generation helper to call the new endpoint, pass brand flags, and surface richer error handling while keeping style seed behaviour
- refresh the Navatar generator UI with the new single-image flow, a full-width “Use as Navatar” action, clearer defaults, and higher-contrast pill styling; type the new environment variables

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfd9c3b5e48329a1c0b92efd4d9c3f