### PR TITLE
Switch Navatar generator to Hugging Face with Stability fallback

### DIFF
--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -1,0 +1,330 @@
+import type { Handler } from "@netlify/functions";
+
+const HF_URL = "https://api-inference.huggingface.co/models/black-forest-labs/FLUX.1-dev";
+const STABILITY_URL = "https://api.stability.ai/v2beta/stable-image/generate/core";
+const GUIDANCE_SCALE = 3.5;
+const DEFAULT_SIZE = { width: 1024, height: 1024 };
+const MAX_DIMENSION = 2048;
+const MIN_DIMENSION = 128;
+const MAX_SEED = 0xffff_ffff;
+
+type GeneratePayload = {
+  prompt?: unknown;
+  negativePrompt?: unknown;
+  seed?: unknown;
+  size?: unknown;
+  style?: unknown;
+  onBrand?: unknown;
+};
+
+type ImageResult = {
+  buffer: Buffer;
+  headers?: Record<string, string>;
+  statusCode?: number;
+  error?: string;
+};
+
+function jsonResponse(statusCode: number, body: Record<string, unknown>) {
+  return {
+    statusCode,
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  };
+}
+
+function imageResponse(result: ImageResult) {
+  const { buffer, headers } = result;
+  return {
+    statusCode: 200,
+    body: buffer.toString("base64"),
+    isBase64Encoded: true,
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": "no-store",
+      ...(headers ?? {}),
+    },
+  };
+}
+
+function clampDimension(value: number): number {
+  const limited = Math.max(MIN_DIMENSION, Math.min(MAX_DIMENSION, Math.floor(value)));
+  return Number.isFinite(limited) ? limited : DEFAULT_SIZE.width;
+}
+
+function parseSize(raw: unknown): { width: number; height: number } {
+  if (typeof raw !== "string") {
+    return DEFAULT_SIZE;
+  }
+
+  const pieces = raw.toLowerCase().split("x");
+  if (pieces.length !== 2) {
+    return DEFAULT_SIZE;
+  }
+
+  const parsedWidth = Number(pieces[0]);
+  const parsedHeight = Number(pieces[1]);
+
+  if (!Number.isFinite(parsedWidth) || !Number.isFinite(parsedHeight)) {
+    return DEFAULT_SIZE;
+  }
+
+  return {
+    width: clampDimension(parsedWidth),
+    height: clampDimension(parsedHeight),
+  };
+}
+
+function normalizeSeed(raw: unknown): number | undefined {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return undefined;
+  }
+  if (raw <= 0) return 0;
+  if (raw >= MAX_SEED) return MAX_SEED;
+  return Math.floor(raw);
+}
+
+async function tryHuggingFace(
+  token: string,
+  {
+    prompt,
+    negativePrompt,
+    seed,
+    width,
+    height,
+  }: {
+    prompt: string;
+    negativePrompt?: string;
+    seed?: number;
+    width: number;
+    height: number;
+  }
+): Promise<ImageResult | null> {
+  const parameters: Record<string, unknown> = {
+    guidance_scale: GUIDANCE_SCALE,
+    width,
+    height,
+  };
+
+  if (negativePrompt) {
+    parameters.negative_prompt = negativePrompt;
+  }
+
+  if (typeof seed === "number") {
+    parameters.seed = seed;
+  }
+
+  try {
+    const response = await fetch(HF_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "image/*",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        inputs: prompt,
+        parameters,
+        options: { wait_for_model: true },
+      }),
+    });
+
+    if (!response.ok) {
+      const detail = await extractErrorDetail(response);
+      return {
+        buffer: Buffer.alloc(0),
+        error: detail,
+        statusCode: response.status,
+        headers: { "x-ai-provider": "huggingface" },
+      };
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    return {
+      buffer,
+      headers: { "x-ai-provider": "huggingface" },
+    };
+  } catch (error: any) {
+    return {
+      buffer: Buffer.alloc(0),
+      error: error?.message ?? "huggingface_fetch_failed",
+      statusCode: 502,
+      headers: { "x-ai-provider": "huggingface" },
+    };
+  }
+}
+
+async function tryStability(
+  apiKey: string,
+  {
+    prompt,
+    negativePrompt,
+    seed,
+    width,
+    height,
+    style,
+  }: {
+    prompt: string;
+    negativePrompt?: string;
+    seed?: number;
+    width: number;
+    height: number;
+    style?: string;
+  }
+): Promise<ImageResult> {
+  const payload: Record<string, unknown> = {
+    prompt,
+    output_format: "png",
+    width,
+    height,
+  };
+
+  if (negativePrompt) {
+    payload.negative_prompt = negativePrompt;
+  }
+
+  if (typeof seed === "number") {
+    payload.seed = seed;
+  }
+
+  if (style) {
+    payload.style_preset = style;
+  }
+
+  const response = await fetch(STABILITY_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: "image/*",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    return {
+      buffer: Buffer.alloc(0),
+      error: detail || "stability_error",
+      statusCode: response.status,
+      headers: { "x-ai-provider": "stability" },
+    };
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const headers: Record<string, string> = { "x-ai-provider": "stability" };
+  const remaining = response.headers.get("x-ratelimit-remaining");
+  if (remaining) {
+    headers["x-ratelimit-remaining"] = remaining;
+  }
+
+  return {
+    buffer,
+    headers,
+  };
+}
+
+async function extractErrorDetail(response: Response): Promise<string> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      const data = await response.json();
+      if (data && typeof data === "object" && "error" in data) {
+        const errValue = (data as Record<string, unknown>).error;
+        if (typeof errValue === "string") {
+          return errValue;
+        }
+      }
+      return JSON.stringify(data);
+    } catch {
+      // fall through
+    }
+  }
+
+  try {
+    const text = await response.text();
+    if (text) {
+      return text;
+    }
+  } catch {
+    // ignore
+  }
+
+  return `HTTP ${response.status}`;
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return jsonResponse(405, { error: "Method not allowed" });
+  }
+
+  const hfToken = process.env.HF_TOKEN?.trim();
+  const stabilityKey = process.env.STABILITY_API_KEY?.trim();
+
+  let payload: GeneratePayload;
+  try {
+    payload = JSON.parse(event.body ?? "{}") as GeneratePayload;
+  } catch {
+    return jsonResponse(400, { error: "Invalid JSON payload" });
+  }
+
+  const prompt = typeof payload.prompt === "string" ? payload.prompt.trim() : "";
+  if (!prompt) {
+    return jsonResponse(400, { error: "Missing prompt" });
+  }
+
+  const negativePrompt =
+    typeof payload.negativePrompt === "string" && payload.negativePrompt.trim()
+      ? payload.negativePrompt.trim()
+      : undefined;
+
+  const { width, height } = parseSize(payload.size);
+  const seed = normalizeSeed(payload.seed);
+  const style = typeof payload.style === "string" && payload.style.trim() ? payload.style.trim() : undefined;
+
+  if (!hfToken && !stabilityKey) {
+    return jsonResponse(400, { error: "No AI provider configured" });
+  }
+
+  if (hfToken) {
+    const hfResult = await tryHuggingFace(hfToken, { prompt, negativePrompt, seed, width, height });
+    if (hfResult && !hfResult.error) {
+      return imageResponse(hfResult);
+    }
+
+    // If Hugging Face failed but Stability is available, fall through to Stability.
+    if (!stabilityKey) {
+      const statusCode = hfResult?.statusCode ?? 502;
+      return jsonResponse(statusCode, {
+        error: "huggingface_error",
+        detail: hfResult?.error ?? "Unknown Hugging Face error",
+      });
+    }
+  }
+
+  if (stabilityKey) {
+    try {
+      const stabilityResult = await tryStability(stabilityKey, {
+        prompt,
+        negativePrompt,
+        seed,
+        width,
+        height,
+        style,
+      });
+      if (!stabilityResult.error) {
+        return imageResponse(stabilityResult);
+      }
+      return jsonResponse(stabilityResult.statusCode ?? 502, {
+        error: "stability_error",
+        detail: stabilityResult.error,
+      });
+    } catch (error: any) {
+      return jsonResponse(502, {
+        error: "stability_error",
+        detail: error?.message ?? "Unknown Stability error",
+      });
+    }
+  }
+
+  return jsonResponse(500, { error: "ai_generation_failed" });
+};

--- a/src/lib/navatar/stability.ts
+++ b/src/lib/navatar/stability.ts
@@ -134,28 +134,31 @@ function parseRemaining(header: string | null): number | null {
   return Number.isFinite(value) ? value : null;
 }
 
-export interface StabilityGenerateOptions {
+export interface GenerateWithAIOptions {
   prompt: string;
   negativePrompt?: string;
   seed?: number;
   size?: string;
   style?: string;
   signal?: AbortSignal;
+  onBrand?: boolean;
 }
 
-export interface StabilityGenerateResult {
+export interface GenerateWithAIResult {
   blob: Blob;
   remaining?: number | null;
+  provider?: string | null;
 }
 
-export async function generateWithStability({
+export async function generateWithAI({
   prompt,
   negativePrompt,
   seed,
   size,
   style,
   signal,
-}: StabilityGenerateOptions): Promise<StabilityGenerateResult> {
+  onBrand,
+}: GenerateWithAIOptions): Promise<GenerateWithAIResult> {
   if (!prompt?.trim()) {
     throw new StabilityError("Prompt required");
   }
@@ -163,8 +166,8 @@ export async function generateWithStability({
   const payload: Record<string, unknown> = {
     prompt,
     negativePrompt: negativePrompt?.trim() || undefined,
-    size,
-    style,
+    size: size?.trim() || undefined,
+    style: style?.trim() || undefined,
   };
 
   const normalizedSeed = normalizeSeed(seed);
@@ -172,25 +175,45 @@ export async function generateWithStability({
     payload.seed = normalizedSeed;
   }
 
+  if (typeof onBrand === "boolean") {
+    payload.onBrand = onBrand;
+  }
+
   let resp: Response;
   try {
-    resp = await fetch("/.netlify/functions/stability-generate", {
+    resp = await fetch("/.netlify/functions/ai-generate", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
       signal,
     });
   } catch {
-    throw new StabilityError("Unable to reach Stability right now. Check your connection and try again.");
+    throw new StabilityError(
+      "Unable to reach the Navatar generator right now. Check your connection and try again."
+    );
   }
 
   const remaining = parseRemaining(resp.headers.get("x-ratelimit-remaining"));
+  const provider = resp.headers.get("x-ai-provider");
 
   if (!resp.ok) {
-    const err = await resp.json().catch(() => null);
-    const detail = typeof err === "object" && err
-      ? ("detail" in err ? String((err as any).detail) : "error" in err ? String((err as any).error) : null)
-      : null;
+    let detail: string | null = null;
+    const contentType = resp.headers.get("content-type") ?? "";
+
+    if (contentType.includes("application/json")) {
+      const err = await resp.json().catch(() => null);
+      if (err && typeof err === "object") {
+        if ("detail" in err && typeof (err as any).detail === "string") {
+          detail = (err as any).detail;
+        } else if ("error" in err && typeof (err as any).error === "string") {
+          detail = (err as any).error;
+        }
+      }
+    }
+
+    if (!detail) {
+      detail = await resp.text().catch(() => null);
+    }
 
     if (resp.status === 429 || (typeof remaining === "number" && remaining <= 0)) {
       throw new RateLimitError(RATE_LIMIT_MESSAGE, remaining);
@@ -200,5 +223,5 @@ export async function generateWithStability({
   }
 
   const blob = await resp.blob();
-  return { blob, remaining };
+  return { blob, remaining, provider: provider ?? null };
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -17,7 +17,7 @@ import {
   STYLE_PRESETS,
   buildNegativePrompt,
   buildPrompt,
-  generateWithStability,
+  generateWithAI,
   seedFromUserId,
 } from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
@@ -53,6 +53,7 @@ export default function GenerateNavatarPage() {
   const [name, setName] = useState("");
   const [draftUrl, setDraftUrl] = useState<string | undefined>();
   const [isGenerating, setIsGenerating] = useState(false);
+  const [generationMode, setGenerationMode] = useState<"generate" | "regenerate" | null>(null);
   const nav = useNavigate();
   const toast = useToast();
   const { user } = useAuthUser();
@@ -103,7 +104,7 @@ export default function GenerateNavatarPage() {
     }
   }
 
-  async function handleGenerate() {
+  async function runGeneration(mode: "generate" | "regenerate" = "generate") {
     const trimmedPrompt = prompt.trim();
     if (!trimmedPrompt) {
       toast({ text: "Describe your Navatar first", kind: "err" });
@@ -123,20 +124,32 @@ export default function GenerateNavatarPage() {
         : Math.floor(Math.random() * MAX_SEED) || 1;
 
     setIsGenerating(true);
+    setGenerationMode(mode);
     try {
-      const { blob, remaining } = await generateWithStability({
+      const { blob, remaining, provider } = await generateWithAI({
         prompt: finalPrompt,
         negativePrompt: combinedNegativePrompt,
         seed: generationSeed,
         size: "1024x1024",
         style: selectedStyle.id,
+        onBrand,
       });
       const generatedFile = new File([blob], `navatar-${Date.now()}.png`, {
         type: blob.type || "image/png",
       });
 
       setFile(generatedFile);
-      toast({ text: "Navatar generated ✓", kind: "ok" });
+      const providerName = provider?.toLowerCase();
+      const providerLabel =
+        providerName === "huggingface"
+          ? "Hugging Face"
+          : providerName === "stability"
+            ? "Stability AI"
+            : null;
+      toast({
+        text: providerLabel ? `Navatar generated with ${providerLabel} ✓` : "Navatar generated ✓",
+        kind: "ok",
+      });
 
       if (typeof remaining === "number" && remaining <= 0) {
         toast({ text: RATE_LIMIT_MESSAGE, kind: "warn" });
@@ -151,6 +164,7 @@ export default function GenerateNavatarPage() {
       }
     } finally {
       setIsGenerating(false);
+      setGenerationMode(null);
     }
   }
 
@@ -253,15 +267,27 @@ export default function GenerateNavatarPage() {
             />
           </div>
         </details>
-        <button
-          type="button"
-          className="pill"
-          onClick={handleGenerate}
-          disabled={isGenerating}
-          style={{ width: "100%" }}
-        >
-          {isGenerating ? "Generating…" : "Generate with Stability AI"}
-        </button>
+        {!file ? (
+          <button
+            type="button"
+            className="pill"
+            onClick={() => runGeneration("generate")}
+            disabled={isGenerating}
+            style={{ width: "100%" }}
+          >
+            {isGenerating && generationMode === "generate" ? "Generating…" : "Generate"}
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="pill"
+            onClick={() => runGeneration("regenerate")}
+            disabled={isGenerating}
+            style={{ width: "100%" }}
+          >
+            {isGenerating && generationMode === "regenerate" ? "Regenerating…" : "Regenerate"}
+          </button>
+        )}
         <input
           style={{ display: "block", width: "100%" }}
           placeholder="Name (optional)"
@@ -275,11 +301,11 @@ export default function GenerateNavatarPage() {
           disabled={isGenerating}
         />
         <button className="pill pill--active" type="submit" style={{ marginTop: 8 }} disabled={!canSave}>
-          {isGenerating ? "Generating…" : "Save"}
+          Use as Navatar
         </button>
       </form>
       <p className="center" style={{ opacity: 0.8 }}>
-        Powered by Stability AI – square 1024×1024 art, 25 generations/day on the free tier.
+        Powered by Hugging Face (FLUX.1 dev) with Stability AI fallback – single 1024×1024 art.
       </p>
     </main>
   );

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -18,18 +18,30 @@
   min-height: 40px;
   line-height: 1.2;
   border-radius: 999px;
-  border: 1px solid #cfe0ff;
-  background: #f6f9ff;
-  color: #1e4ed8;
+  border: 1px solid #4c6ef5;
+  background: linear-gradient(180deg, #eef3ff 0%, #d8e4ff 100%);
+  color: #0f1f5c;
   text-decoration: none;
   font-weight: 600;
-  box-shadow: 0 2px 0 rgba(0,0,0,.08);
+  box-shadow: 0 2px 6px rgba(30, 64, 175, 0.18);
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+.pill:hover {
+  background: linear-gradient(180deg, #e1ebff 0%, #c5d7ff 100%);
+  color: #0b1552;
+}
+.pill:focus-visible {
+  outline: 3px solid #facc15;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.35);
 }
 .pill--active {
   background: #1e4ed8;
   color: #fff;
   border-color: #1e4ed8;
   font-weight: 700;
+  box-shadow: 0 4px 12px rgba(30, 78, 216, 0.25);
 }
 
 /* --- Card: single source of truth for size & fit --- */

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,6 +6,8 @@ interface ImportMetaEnv {
   readonly VITE_SITE_URL?: string;
   readonly VITE_ENABLE_AI?: string;
   readonly VITE_ENABLE_AUTO_STAMPS?: string;
+  readonly HF_TOKEN?: string;
+  readonly STABILITY_API_KEY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- add a unified Netlify function that prefers Hugging Face FLUX.1 dev and falls back to Stability AI when needed
- update the Navatar generation helper and page to call the new endpoint, surface provider info, and refresh button copy
- refresh pill styling for better contrast/focus and extend Vite env typings for HF_TOKEN/STABILITY_API_KEY

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfdd9b55a483298b565588571c6132