### PR TITLE
Switch navatar generation to new AI endpoint

### DIFF
--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -1,0 +1,139 @@
+import type { Handler } from "@netlify/functions";
+
+const HF_URL =
+  "https://api-inference.huggingface.co/models/black-forest-labs/FLUX.1-dev";
+const STABILITY_URL =
+  "https://api.stability.ai/v2beta/stable-image/generate/core";
+
+const BRAND_STYLE = [
+  "cute character, navatar style, bright friendly palette,",
+  "big expressive eyes, rounded shapes, thick clean outlines,",
+  "storybook illustration, flat lighting, soft shading,",
+  "kid-friendly, sticker-ready, high contrast, no tiny details",
+].join(" ");
+
+const NEGATIVE = [
+  "photo, photorealistic, hyperrealistic,",
+  "text, caption, letters, logo, watermark, signature,",
+  "grain, noise, artifacts, extra limbs, deformed hands",
+].join(", ");
+
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod !== "POST") {
+      return { statusCode: 405, body: "Method Not Allowed" };
+    }
+
+    const {
+      prompt = "",
+      avoid = "",
+      keepSeed,
+      seed,
+      onBrand = true,
+    } = JSON.parse(event.body || "{}");
+
+    const finalPrompt = onBrand ? `${prompt}. ${BRAND_STYLE}` : prompt;
+    const negative_prompt = [NEGATIVE, avoid].filter(Boolean).join(", ");
+
+    const HF_TOKEN = process.env.HF_TOKEN;
+    if (HF_TOKEN) {
+      const res = await fetch(HF_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${HF_TOKEN}`,
+          "Content-Type": "application/json",
+          Accept: "image/*",
+        },
+        body: JSON.stringify({
+          inputs: finalPrompt,
+          parameters: {
+            negative_prompt,
+            guidance_scale: 3.5,
+          },
+          options: { wait_for_model: true },
+        }),
+      });
+
+      const ct = res.headers.get("content-type") || "";
+      if (res.ok && ct.startsWith("image/")) {
+        const buf = Buffer.from(await res.arrayBuffer());
+        return {
+          statusCode: 200,
+          headers: { "Content-Type": ct },
+          body: buf.toString("base64"),
+          isBase64Encoded: true,
+        };
+      }
+
+      const msg = await safeErr(res);
+      if (!process.env.STABILITY_API_KEY) {
+        return jsonErr(502, msg || "HF failed and no fallback is configured");
+      }
+    }
+
+    const STABILITY_API_KEY = process.env.STABILITY_API_KEY;
+    if (!STABILITY_API_KEY) {
+      return jsonErr(400, "No AI provider configured");
+    }
+
+    const effectiveSeed =
+      keepSeed && typeof seed === "number" ? seed : undefined;
+
+    const bodyPayload: Record<string, unknown> = {
+      model: "stable-image-ultra",
+      prompt: finalPrompt,
+      negative_prompt,
+      output_format: "png",
+      aspect_ratio: "1:1",
+    };
+
+    if (typeof effectiveSeed === "number") bodyPayload.seed = effectiveSeed;
+
+    const sres = await fetch(STABILITY_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${STABILITY_API_KEY}`,
+        "Content-Type": "application/json",
+        Accept: "image/*, application/json",
+      },
+      body: JSON.stringify(bodyPayload),
+    });
+
+    const sct = sres.headers.get("content-type") || "";
+    if (sres.ok && sct.startsWith("image/")) {
+      const buf = Buffer.from(await sres.arrayBuffer());
+      return {
+        statusCode: 200,
+        headers: { "Content-Type": sct },
+        body: buf.toString("base64"),
+        isBase64Encoded: true,
+      };
+    }
+
+    const smsg = await safeErr(sres);
+    return jsonErr(sres.status || 500, smsg || "Stability request failed");
+  } catch (e: any) {
+    return jsonErr(500, e?.message || "Server error");
+  }
+};
+
+function jsonErr(code: number, error: string) {
+  return {
+    statusCode: code,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ error }),
+  };
+}
+
+async function safeErr(res: Response) {
+  try {
+    const ct = res.headers.get("content-type") || "";
+    if (ct.includes("application/json")) {
+      const j = await res.json();
+      return j?.error || j?.message || JSON.stringify(j);
+    }
+    return await res.text();
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}

--- a/src/lib/navatar/stability.ts
+++ b/src/lib/navatar/stability.ts
@@ -74,27 +74,6 @@ export const DEFAULT_NEGATIVE_PROMPT =
 
 export const MAX_SEED = 0xffff_ffff; // 4294967295
 
-export class StabilityError extends Error {
-  status?: number;
-  remaining?: number | null;
-
-  constructor(message: string, status?: number, remaining?: number | null) {
-    super(message);
-    this.name = "StabilityError";
-    this.status = status;
-    this.remaining = remaining ?? null;
-  }
-}
-
-export class RateLimitError extends StabilityError {
-  constructor(message: string, remaining?: number | null) {
-    super(message, 429, remaining ?? null);
-    this.name = "RateLimitError";
-  }
-}
-
-export const RATE_LIMIT_MESSAGE = "You’ve reached today’s free 25 Stability generations.";
-
 export function buildPrompt(userPrompt: string, style: StylePreset): string {
   const trimmed = userPrompt.trim();
   const parts = [
@@ -128,77 +107,45 @@ export function normalizeSeed(seed: number | undefined): number | undefined {
   return Math.floor(seed);
 }
 
-function parseRemaining(header: string | null): number | null {
-  if (!header) return null;
-  const value = Number(header);
-  return Number.isFinite(value) ? value : null;
-}
-
-export interface StabilityGenerateOptions {
+export type GenerateWithAIOptions = {
   prompt: string;
-  negativePrompt?: string;
+  avoid?: string;
+  keepSeed?: boolean;
   seed?: number;
-  size?: string;
-  style?: string;
-  signal?: AbortSignal;
-}
+  onBrand?: boolean;
+};
 
-export interface StabilityGenerateResult {
-  blob: Blob;
-  remaining?: number | null;
-}
+export async function generateWithAI(options: GenerateWithAIOptions): Promise<Blob> {
+  const res = await fetch("/.netlify/functions/ai-generate", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "image/*, application/json",
+    },
+    body: JSON.stringify(options),
+  });
 
-export async function generateWithStability({
-  prompt,
-  negativePrompt,
-  seed,
-  size,
-  style,
-  signal,
-}: StabilityGenerateOptions): Promise<StabilityGenerateResult> {
-  if (!prompt?.trim()) {
-    throw new StabilityError("Prompt required");
-  }
+  const ct = res.headers.get("content-type") || "";
 
-  const payload: Record<string, unknown> = {
-    prompt,
-    negativePrompt: negativePrompt?.trim() || undefined,
-    size,
-    style,
-  };
-
-  const normalizedSeed = normalizeSeed(seed);
-  if (typeof normalizedSeed === "number") {
-    payload.seed = normalizedSeed;
-  }
-
-  let resp: Response;
-  try {
-    resp = await fetch("/.netlify/functions/stability-generate", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-      signal,
-    });
-  } catch {
-    throw new StabilityError("Unable to reach Stability right now. Check your connection and try again.");
-  }
-
-  const remaining = parseRemaining(resp.headers.get("x-ratelimit-remaining"));
-
-  if (!resp.ok) {
-    const err = await resp.json().catch(() => null);
-    const detail = typeof err === "object" && err
-      ? ("detail" in err ? String((err as any).detail) : "error" in err ? String((err as any).error) : null)
-      : null;
-
-    if (resp.status === 429 || (typeof remaining === "number" && remaining <= 0)) {
-      throw new RateLimitError(RATE_LIMIT_MESSAGE, remaining);
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`;
+    if (ct.includes("application/json")) {
+      const payload = await res.json().catch(() => ({}));
+      if (payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string") {
+        message = payload.error;
+      }
     }
-
-    throw new StabilityError(detail || `HTTP ${resp.status}`, resp.status, remaining);
+    throw new Error(message);
   }
 
-  const blob = await resp.blob();
-  return { blob, remaining };
+  if (!ct.startsWith("image/")) {
+    const payload = await res.json().catch(() => ({}));
+    const message =
+      payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string"
+        ? payload.error
+        : "AI did not return an image.";
+    throw new Error(message);
+  }
+
+  return await res.blob();
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -12,36 +12,19 @@ import {
   DEFAULT_NEGATIVE_PROMPT,
   DEFAULT_STYLE_ID,
   MAX_SEED,
-  RATE_LIMIT_MESSAGE,
-  RateLimitError,
   STYLE_PRESETS,
   buildNegativePrompt,
   buildPrompt,
-  generateWithStability,
+  generateWithAI,
   seedFromUserId,
 } from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
-
-const BRAND_STYLE = [
-  "cute character, navatar style, bright friendly palette,",
-  "big expressive eyes, rounded shapes, thick clean outlines,",
-  "storybook illustration, flat lighting, soft shading,",
-  "kid-friendly, sticker-ready, high contrast, no tiny details",
-].join(" ");
 
 const BRAND_NEGATIVE = [
   "photo, photorealistic, hyperrealistic,",
   "text, caption, letters, logo, watermark, signature,",
   "grain, noise, artifacts, extra limbs, deformed hands",
 ].join(", ");
-
-function wrapWithBrandStyle(raw: string): string {
-  const trimmed = raw.trim();
-  if (!trimmed) return "";
-  const needsPeriod = !/[.!?]$/.test(trimmed);
-  const base = needsPeriod ? `${trimmed}.` : trimmed;
-  return `${base} ${BRAND_STYLE}`;
-}
 
 export default function GenerateNavatarPage() {
   const [prompt, setPrompt] = useState("");
@@ -110,26 +93,25 @@ export default function GenerateNavatarPage() {
       return;
     }
 
-    const promptForBrand = onBrand ? wrapWithBrandStyle(trimmedPrompt) : trimmedPrompt;
-    const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
+    const finalPrompt = buildPrompt(trimmedPrompt, selectedStyle);
     const baseNegativePrompt = buildNegativePrompt(extraNegativePrompt);
     const combinedNegativePrompt = onBrand
       ? `${baseNegativePrompt}, ${BRAND_NEGATIVE}`
       : baseNegativePrompt;
 
-    const generationSeed =
-      keepStyle && typeof stableSeed === "number"
-        ? stableSeed
-        : Math.floor(Math.random() * MAX_SEED) || 1;
+    const shouldKeepSeed = keepStyle && typeof stableSeed === "number";
+    const generationSeed = shouldKeepSeed
+      ? stableSeed
+      : Math.floor(Math.random() * MAX_SEED) || 1;
 
     setIsGenerating(true);
     try {
-      const { blob, remaining } = await generateWithStability({
+      const blob = await generateWithAI({
         prompt: finalPrompt,
-        negativePrompt: combinedNegativePrompt,
+        avoid: combinedNegativePrompt,
+        keepSeed: shouldKeepSeed,
         seed: generationSeed,
-        size: "1024x1024",
-        style: selectedStyle.id,
+        onBrand,
       });
       const generatedFile = new File([blob], `navatar-${Date.now()}.png`, {
         type: blob.type || "image/png",
@@ -137,18 +119,10 @@ export default function GenerateNavatarPage() {
 
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });
-
-      if (typeof remaining === "number" && remaining <= 0) {
-        toast({ text: RATE_LIMIT_MESSAGE, kind: "warn" });
-      }
     } catch (error) {
       console.error(error);
-      if (error instanceof RateLimitError) {
-        toast({ text: error.message, kind: "warn" });
-      } else {
-        const message = error instanceof Error ? error.message : "Error generating image";
-        toast({ text: message, kind: "err" });
-      }
+      const message = error instanceof Error ? error.message : "Error generating image";
+      toast({ text: message, kind: "err" });
     } finally {
       setIsGenerating(false);
     }
@@ -260,7 +234,7 @@ export default function GenerateNavatarPage() {
           disabled={isGenerating}
           style={{ width: "100%" }}
         >
-          {isGenerating ? "Generating…" : "Generate with Stability AI"}
+          {isGenerating ? "Generating…" : "Generate with Naturverse AI"}
         </button>
         <input
           style={{ display: "block", width: "100%" }}
@@ -272,14 +246,15 @@ export default function GenerateNavatarPage() {
           type="file"
           accept="image/*"
           onChange={(e) => setFile(e.target.files?.[0] || null)}
-          disabled={isGenerating}
+          disabled
+          style={{ display: "none" }}
         />
         <button className="pill pill--active" type="submit" style={{ marginTop: 8 }} disabled={!canSave}>
           {isGenerating ? "Generating…" : "Save"}
         </button>
       </form>
       <p className="center" style={{ opacity: 0.8 }}>
-        Powered by Stability AI – square 1024×1024 art, 25 generations/day on the free tier.
+        Powered by Hugging Face FLUX with a Stability AI fallback – square 1024×1024 art.
       </p>
     </main>
   );


### PR DESCRIPTION
## Summary
- add a new Netlify function that calls Hugging Face FLUX and falls back to Stability using JSON requests
- replace the navatar client helper so the generator posts JSON to the new endpoint and validates image responses
- update the Navatar generator page to use the helper, refresh button copy, and hide the old file upload control

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfe13d989083299779fd6104e90574