### PR TITLE
Switch navatar generator to JSON HF-first flow

### DIFF
--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -1,0 +1,124 @@
+import type { Handler } from "@netlify/functions";
+
+const BRAND_STYLE = [
+  "cute character, navatar style, bright friendly palette,",
+  "big expressive eyes, rounded shapes, thick clean outlines,",
+  "storybook illustration, flat lighting, soft shading,",
+  "kid-friendly, sticker-ready, high contrast, no tiny details",
+].join(" ");
+
+const NEGATIVE = [
+  "photo, photorealistic, hyperrealistic,",
+  "text, caption, letters, logo, watermark, signature,",
+  "grain, noise, artifacts, extra limbs, deformed hands",
+].join(", ");
+
+const pngResponse = async (res: Response) => {
+  const buf = Buffer.from(await res.arrayBuffer());
+  return {
+    statusCode: 200,
+    isBase64Encoded: true,
+    headers: { "Content-Type": "image/png", "Cache-Control": "no-store" },
+    body: buf.toString("base64"),
+  };
+};
+
+const errorJson = (statusCode: number, message: string, raw?: unknown) => ({
+  statusCode,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ errors: [message], raw }),
+});
+
+export const handler: Handler = async (event) => {
+  try {
+    const HF_TOKEN = process.env.HUGGINGFACE_TOKEN;
+    const STAB_KEY = process.env.STABILITY_API_KEY;
+
+    const { prompt, avoid = "", keepSeed, seed, onBrand = true, stylePreset } =
+      JSON.parse(event.body || "{}");
+
+    if (!prompt || typeof prompt !== "string" || !prompt.trim()) {
+      return errorJson(400, "Missing prompt");
+    }
+
+    const finalPrompt = onBrand ? `${prompt.trim()}. ${BRAND_STYLE}` : prompt.trim();
+    const negative_prompt = [NEGATIVE, avoid].filter(Boolean).join(", ");
+
+    const effectiveSeed =
+      keepSeed && typeof seed === "number" ? seed : undefined;
+
+    if (HF_TOKEN) {
+      try {
+        const hfRes = await fetch(
+          "https://api-inference.huggingface.co/models/black-forest-labs/FLUX.1-dev",
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${HF_TOKEN}`,
+              "Content-Type": "application/json",
+              Accept: "image/png",
+            },
+            body: JSON.stringify({
+              inputs: finalPrompt,
+              parameters: {
+                guidance_scale: 3,
+                num_inference_steps: 28,
+                negative_prompt,
+                width: 1024,
+                height: 1024,
+                seed: effectiveSeed,
+              },
+            }),
+          }
+        );
+
+        if (hfRes.ok && hfRes.headers.get("content-type")?.includes("image")) {
+          return pngResponse(hfRes);
+        }
+
+        const raw = await hfRes.text();
+        console.warn("HF error:", raw);
+      } catch (e) {
+        console.warn("HF call failed:", e);
+      }
+    }
+
+    if (STAB_KEY) {
+      const bodyPayload: Record<string, unknown> = {
+        model: "stable-image-ultra",
+        prompt: finalPrompt,
+        negative_prompt,
+        output_format: "png",
+        aspect_ratio: "1:1",
+      };
+      if (typeof effectiveSeed === "number") bodyPayload.seed = effectiveSeed;
+      if (typeof stylePreset === "string") bodyPayload.style_preset = stylePreset;
+
+      const stRes = await fetch(
+        "https://api.stability.ai/v2beta/stable-image/generate/core",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${STAB_KEY}`,
+            "Content-Type": "application/json",
+            Accept: "image/*",
+          },
+          body: JSON.stringify(bodyPayload),
+        }
+      );
+
+      if (stRes.ok && stRes.headers.get("content-type")?.includes("image")) {
+        return pngResponse(stRes);
+      }
+
+      const raw = await stRes.text();
+      console.error("Stability error:", raw);
+      return errorJson(502, "Stability fallback failed", raw);
+    }
+
+    return errorJson(502, "No AI provider available (set HUGGINGFACE_TOKEN or STABILITY_API_KEY).");
+  } catch (err: any) {
+    console.error(err);
+    return errorJson(500, "Server error", String(err));
+  }
+};

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,0 +1,27 @@
+export type GenerateOptions = {
+  prompt: string;
+  avoid?: string;
+  keepSeed?: boolean;
+  seed?: number;
+  onBrand?: boolean;
+  stylePreset?: string;
+};
+
+export async function generateWithNaturverseAI(opts: GenerateOptions): Promise<Blob> {
+  const res = await fetch("/.netlify/functions/ai-generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "image/png" },
+    body: JSON.stringify(opts),
+  });
+
+  const ct = res.headers.get("content-type") || "";
+  if (!res.ok) {
+    const raw = await res.text();
+    throw new Error(raw || `HTTP ${res.status}`);
+  }
+  if (!ct.includes("image")) {
+    const raw = await res.text();
+    throw new Error(raw || "No image returned");
+  }
+  return await res.blob();
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -8,40 +8,42 @@ import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import { useAuthUser } from "../../lib/useAuthUser";
+import { generateWithNaturverseAI } from "@/lib/navatar/generate";
 import {
-  DEFAULT_NEGATIVE_PROMPT,
   DEFAULT_STYLE_ID,
-  MAX_SEED,
-  RATE_LIMIT_MESSAGE,
-  RateLimitError,
   STYLE_PRESETS,
-  buildNegativePrompt,
   buildPrompt,
-  generateWithStability,
   seedFromUserId,
 } from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
 
-const BRAND_STYLE = [
-  "cute character, navatar style, bright friendly palette,",
-  "big expressive eyes, rounded shapes, thick clean outlines,",
-  "storybook illustration, flat lighting, soft shading,",
-  "kid-friendly, sticker-ready, high contrast, no tiny details",
-].join(" ");
-
-const BRAND_NEGATIVE = [
-  "photo, photorealistic, hyperrealistic,",
-  "text, caption, letters, logo, watermark, signature,",
-  "grain, noise, artifacts, extra limbs, deformed hands",
+const BASE_NEGATIVE_PROMPT = [
+  "photo",
+  "photorealistic",
+  "hyperrealistic",
+  "text",
+  "caption",
+  "letters",
+  "logo",
+  "watermark",
+  "signature",
+  "grain",
+  "noise",
+  "artifacts",
+  "extra limbs",
+  "deformed hands",
 ].join(", ");
 
-function wrapWithBrandStyle(raw: string): string {
-  const trimmed = raw.trim();
-  if (!trimmed) return "";
-  const needsPeriod = !/[.!?]$/.test(trimmed);
-  const base = needsPeriod ? `${trimmed}.` : trimmed;
-  return `${base} ${BRAND_STYLE}`;
-}
+const STABILITY_STYLE_MAP: Record<string, string | undefined> = {
+  "cute-creature": "digital-art",
+  "mythical-friend": "fantasy-art",
+  "jungle-buddy": "digital-art",
+  "ocean-guardian": "digital-art",
+  "forest-sprite": "fantasy-art",
+  "sky-traveler": "comic-book",
+  "crystal-beast": "digital-art",
+  "robot-pal": "3d-model",
+};
 
 export default function GenerateNavatarPage() {
   const [prompt, setPrompt] = useState("");
@@ -82,10 +84,12 @@ export default function GenerateNavatarPage() {
 
   const stableSeed = useMemo(() => (user?.id ? seedFromUserId(user.id) : undefined), [user?.id]);
 
-  const alwaysFilteredPrompt = useMemo(
-    () => (onBrand ? `${DEFAULT_NEGATIVE_PROMPT}, ${BRAND_NEGATIVE}` : DEFAULT_NEGATIVE_PROMPT),
-    [onBrand]
+  const stylePresetForFallback = useMemo(
+    () => STABILITY_STYLE_MAP[selectedStyle.id],
+    [selectedStyle.id]
   );
+
+  const alwaysFilteredPrompt = BASE_NEGATIVE_PROMPT;
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
@@ -110,26 +114,20 @@ export default function GenerateNavatarPage() {
       return;
     }
 
-    const promptForBrand = onBrand ? wrapWithBrandStyle(trimmedPrompt) : trimmedPrompt;
-    const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
-    const baseNegativePrompt = buildNegativePrompt(extraNegativePrompt);
-    const combinedNegativePrompt = onBrand
-      ? `${baseNegativePrompt}, ${BRAND_NEGATIVE}`
-      : baseNegativePrompt;
-
-    const generationSeed =
-      keepStyle && typeof stableSeed === "number"
-        ? stableSeed
-        : Math.floor(Math.random() * MAX_SEED) || 1;
+    const finalPrompt = buildPrompt(trimmedPrompt, selectedStyle);
+    const trimmedAvoid = extraNegativePrompt.trim();
+    const shouldKeepSeed = keepStyle && typeof stableSeed === "number";
+    const generationSeed = shouldKeepSeed ? stableSeed : undefined;
 
     setIsGenerating(true);
     try {
-      const { blob, remaining } = await generateWithStability({
+      const blob = await generateWithNaturverseAI({
         prompt: finalPrompt,
-        negativePrompt: combinedNegativePrompt,
+        avoid: trimmedAvoid || undefined,
+        keepSeed: shouldKeepSeed,
         seed: generationSeed,
-        size: "1024x1024",
-        style: selectedStyle.id,
+        onBrand,
+        stylePreset: stylePresetForFallback,
       });
       const generatedFile = new File([blob], `navatar-${Date.now()}.png`, {
         type: blob.type || "image/png",
@@ -137,18 +135,10 @@ export default function GenerateNavatarPage() {
 
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });
-
-      if (typeof remaining === "number" && remaining <= 0) {
-        toast({ text: RATE_LIMIT_MESSAGE, kind: "warn" });
-      }
     } catch (error) {
       console.error(error);
-      if (error instanceof RateLimitError) {
-        toast({ text: error.message, kind: "warn" });
-      } else {
-        const message = error instanceof Error ? error.message : "Error generating image";
-        toast({ text: message, kind: "err" });
-      }
+      const message = error instanceof Error ? error.message : "Error generating image";
+      toast({ text: message, kind: "err" });
     } finally {
       setIsGenerating(false);
     }
@@ -255,12 +245,11 @@ export default function GenerateNavatarPage() {
         </details>
         <button
           type="button"
-          className="pill"
+          className="pill button-generate"
           onClick={handleGenerate}
           disabled={isGenerating}
-          style={{ width: "100%" }}
         >
-          {isGenerating ? "Generating…" : "Generate with Stability AI"}
+          {isGenerating ? "Generating…" : "Generate"}
         </button>
         <input
           style={{ display: "block", width: "100%" }}
@@ -279,7 +268,7 @@ export default function GenerateNavatarPage() {
         </button>
       </form>
       <p className="center" style={{ opacity: 0.8 }}>
-        Powered by Stability AI – square 1024×1024 art, 25 generations/day on the free tier.
+        Powered by Hugging Face FLUX with Stability fallback – square 1024×1024 art.
       </p>
     </main>
   );

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -18,18 +18,26 @@
   min-height: 40px;
   line-height: 1.2;
   border-radius: 999px;
-  border: 1px solid #cfe0ff;
+  border: 1px solid var(--gray-300, #d1d5db);
   background: #f6f9ff;
-  color: #1e4ed8;
+  color: var(--gray-900, #111827);
   text-decoration: none;
   font-weight: 600;
   box-shadow: 0 2px 0 rgba(0,0,0,.08);
+}
+.pill:focus-visible {
+  outline: 2px solid var(--blue-500, #3b82f6);
+  outline-offset: 2px;
 }
 .pill--active {
   background: #1e4ed8;
   color: #fff;
   border-color: #1e4ed8;
   font-weight: 700;
+}
+.button-generate {
+  display: flex;
+  width: 100%;
 }
 
 /* --- Card: single source of truth for size & fit --- */

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,6 +6,8 @@ interface ImportMetaEnv {
   readonly VITE_SITE_URL?: string;
   readonly VITE_ENABLE_AI?: string;
   readonly VITE_ENABLE_AUTO_STAMPS?: string;
+  readonly HUGGINGFACE_TOKEN?: string;
+  readonly STABILITY_API_KEY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- add a Netlify ai-generate function that targets Hugging Face FLUX first and falls back to Stability's JSON core endpoint
- update the Navatar generator client to post JSON through a new helper and refresh the button copy and messaging
- tweak navatar styles and env typings to match the new flow

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfe650d86883298f72991b2c6056eb