### PR TITLE
Switch navatar generation to Hugging Face

### DIFF
--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -1,0 +1,118 @@
+import type { Handler } from "@netlify/functions";
+
+const HF_MODEL = "black-forest-labs/FLUX.1-dev";
+
+type ReqBody = {
+  prompt?: string;
+  onBrand?: boolean;
+  seed?: number;
+  keepSeed?: boolean;
+};
+
+const BRAND_STYLE = [
+  "cute character, navatar style, bright friendly palette",
+  "big expressive eyes, rounded shapes, thick clean outlines",
+  "storybook illustration, flat lighting, soft shading",
+  "kid-friendly, sticker-ready, high contrast, no tiny details",
+].join(", ");
+
+const NEGATIVE = [
+  "photo, photorealistic, hyperrealistic",
+  "text, caption, letters, logo, watermark, signature",
+  "grain, noise, artifacts, extra limbs, deformed hands, gore, violence, guns",
+].join(", ");
+
+function clampSeed(v: unknown) {
+  if (typeof v !== "number" || !Number.isFinite(v)) return undefined;
+  const n = Math.max(0, Math.min(0xffff_ffff, Math.floor(v)));
+  return n;
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return {
+      statusCode: 204,
+      headers: corsHeaders(),
+      body: "",
+    };
+  }
+
+  try {
+    const API_KEY =
+      process.env.HUGGINGFACE_API_KEY || process.env.HF_API_TOKEN || "";
+    if (!API_KEY) {
+      return json({ ok: false, error: "Missing HUGGINGFACE_API_KEY" }, 500);
+    }
+
+    const { prompt, onBrand = true, seed, keepSeed }: ReqBody =
+      JSON.parse(event.body || "{}");
+
+    if (!prompt || typeof prompt !== "string" || !prompt.trim()) {
+      return json({ ok: false, error: "Missing prompt" }, 400);
+    }
+
+    const finalPrompt = onBrand ? `${prompt.trim()}. ${BRAND_STYLE}` : prompt.trim();
+    const negativePrompt = NEGATIVE;
+    const effectiveSeed = keepSeed ? clampSeed(seed) : undefined;
+
+    const res = await fetch(
+      `https://api-inference.huggingface.co/models/${HF_MODEL}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${API_KEY}`,
+          "Content-Type": "application/json",
+          Accept: "image/png",
+        },
+        body: JSON.stringify({
+          inputs: finalPrompt,
+          parameters: {
+            negative_prompt: negativePrompt,
+            width: 1024,
+            height: 1024,
+            num_inference_steps: 28,
+            guidance_scale: 5,
+            seed: effectiveSeed,
+          },
+        }),
+      }
+    );
+
+    const ct = res.headers.get("content-type") || "";
+
+    if (!res.ok) {
+      let raw = "";
+      try {
+        raw = await res.text();
+      } catch {}
+      return json({ ok: false, error: "Hugging Face error", raw }, res.status);
+    }
+
+    if (ct.startsWith("image/")) {
+      const buf = Buffer.from(await res.arrayBuffer());
+      const dataUrl = `data:image/png;base64,${buf.toString("base64")}`;
+      return json({ ok: true, image: dataUrl, provider: "huggingface" });
+    }
+
+    const raw = await res.text();
+    return json({ ok: false, error: "Unexpected response", raw }, 502);
+  } catch (err: any) {
+    return json({ ok: false, error: String(err?.message || err) }, 500);
+  }
+};
+
+function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+    "Access-Control-Allow-Headers": "content-type,authorization",
+  };
+}
+
+function json(body: any, statusCode = 200) {
+  return {
+    statusCode,
+    headers: { "Content-Type": "application/json", ...corsHeaders() },
+    body: JSON.stringify(body),
+  };
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,0 +1,24 @@
+export type GenerateOpts = {
+  prompt: string;
+  onBrand?: boolean;
+  seed?: number;
+  keepSeed?: boolean;
+};
+
+export async function generateWithHF(opts: GenerateOpts): Promise<string> {
+  const res = await fetch("/.netlify/functions/ai-generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(opts),
+  });
+
+  const data = await res.json().catch(() => ({}));
+
+  if (!res.ok || !data?.ok) {
+    const msg = data?.error || `HTTP ${res.status}`;
+    const raw = data?.raw;
+    throw new Error(raw ? `${msg}: ${raw}` : msg);
+  }
+
+  return data.image as string;
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -8,16 +8,12 @@ import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import { useAuthUser } from "../../lib/useAuthUser";
+import { generateWithHF } from "../../lib/navatar/generate";
 import {
   DEFAULT_NEGATIVE_PROMPT,
   DEFAULT_STYLE_ID,
-  MAX_SEED,
-  RATE_LIMIT_MESSAGE,
-  RateLimitError,
   STYLE_PRESETS,
-  buildNegativePrompt,
   buildPrompt,
-  generateWithStability,
   seedFromUserId,
 } from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
@@ -112,43 +108,27 @@ export default function GenerateNavatarPage() {
 
     const promptForBrand = onBrand ? wrapWithBrandStyle(trimmedPrompt) : trimmedPrompt;
     const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
-    const baseNegativePrompt = buildNegativePrompt(extraNegativePrompt);
-    const combinedNegativePrompt = onBrand
-      ? `${baseNegativePrompt}, ${BRAND_NEGATIVE}`
-      : baseNegativePrompt;
-
-    const generationSeed =
-      keepStyle && typeof stableSeed === "number"
-        ? stableSeed
-        : Math.floor(Math.random() * MAX_SEED) || 1;
+    const avoid = extraNegativePrompt.trim();
+    const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
+    const keepSeed = keepStyle && Boolean(user?.id);
+    const seed = keepSeed && typeof stableSeed === "number" ? stableSeed : undefined;
 
     setIsGenerating(true);
     try {
-      const { blob, remaining } = await generateWithStability({
-        prompt: finalPrompt,
-        negativePrompt: combinedNegativePrompt,
-        seed: generationSeed,
-        size: "1024x1024",
-        style: selectedStyle.id,
+      const dataUrl = await generateWithHF({
+        prompt: promptWithAvoidance,
+        onBrand,
+        seed,
+        keepSeed,
       });
-      const generatedFile = new File([blob], `navatar-${Date.now()}.png`, {
-        type: blob.type || "image/png",
-      });
+      const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
 
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });
-
-      if (typeof remaining === "number" && remaining <= 0) {
-        toast({ text: RATE_LIMIT_MESSAGE, kind: "warn" });
-      }
     } catch (error) {
       console.error(error);
-      if (error instanceof RateLimitError) {
-        toast({ text: error.message, kind: "warn" });
-      } else {
-        const message = error instanceof Error ? error.message : "Error generating image";
-        toast({ text: message, kind: "err" });
-      }
+      const message = error instanceof Error ? error.message : "Error generating image";
+      toast({ text: message, kind: "err" });
     } finally {
       setIsGenerating(false);
     }
@@ -260,7 +240,7 @@ export default function GenerateNavatarPage() {
           disabled={isGenerating}
           style={{ width: "100%" }}
         >
-          {isGenerating ? "Generating…" : "Generate with Stability AI"}
+          {isGenerating ? "Generating…" : "Generate with Hugging Face"}
         </button>
         <input
           style={{ display: "block", width: "100%" }}
@@ -279,9 +259,15 @@ export default function GenerateNavatarPage() {
         </button>
       </form>
       <p className="center" style={{ opacity: 0.8 }}>
-        Powered by Stability AI – square 1024×1024 art, 25 generations/day on the free tier.
+        Powered by Hugging Face Inference (FLUX.1-dev) – square 1024×1024 art.
       </p>
     </main>
   );
+}
+
+async function dataUrlToFile(dataUrl: string, filename: string) {
+  const res = await fetch(dataUrl);
+  const blob = await res.blob();
+  return new File([blob], filename, { type: blob.type || "image/png" });
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated Netlify function that calls Hugging Face FLUX.1 with the proper Accept header and JSON envelope
- expose a client helper that posts to the new function and surfaces errors consistently
- update the Navatar generate page to use the Hugging Face flow, convert the data URL into a file, and refresh the UI copy

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d008131e508329966b41ecfdf40979