### PR TITLE
Switch Navatar generation to Hugging Face Space backend

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,8 @@
 ACCELERATE_URL=
 DATABASE_URL=postgresql://postgres.gxewpstvuoofdqanhjzi:Turianthedurian2025$@aws-0-us-west-1.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1&sslmode=require
 DIRECT_URL=postgresql://postgres.gxewpstvuoofdqanhjzi:Turianthedurian2025$@aws-0-us-west-1.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1&sslmode=require
+HUGGINGFACE_SPACE_URL=https://turianmediacompany-naturverse-space.hf.space
+VITE_HUGGINGFACE_SPACE_URL=https://turianmediacompany-naturverse-space.hf.space
 VITE_SUPABASE_URL=https://gxewpstvuoofdqanhjzi.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imd4ZXdwc3R2dW9vZmRxYW5oanppIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwNjM1NzUsImV4cCI6MjA2OTYzOTU3NX0._W88NSjDmv4dXoE701SKMQ60J8D3DTCcRX5VVRJYr_E
 

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Supabase (client-side)
 VITE_SUPABASE_URL=your-url
 VITE_SUPABASE_ANON_KEY=your-anon-key
+HUGGINGFACE_SPACE_URL=https://turianmediacompany-naturverse-space.hf.space
+VITE_HUGGINGFACE_SPACE_URL=https://turianmediacompany-naturverse-space.hf.space
 NEXT_PUBLIC_SITE_URL=https://thenaturverse.com
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN=thenaturverse.com
 NEXT_PUBLIC_ENABLE_AUTO_STAMPS=true

--- a/src/lib/huggingface.ts
+++ b/src/lib/huggingface.ts
@@ -1,0 +1,40 @@
+const globalProcess = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+
+export async function generateWithHuggingFace(prompt: string, style: string) {
+  const spaceUrl =
+    import.meta.env.VITE_HUGGINGFACE_SPACE_URL ||
+    globalProcess?.env?.HUGGINGFACE_SPACE_URL ||
+    "";
+
+  if (!spaceUrl) {
+    throw new Error("HUGGINGFACE_SPACE_URL is not configured");
+  }
+
+  try {
+    const res = await fetch(`${spaceUrl}/run/predict`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        data: [`${prompt}, ${style}`],
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Space request failed: ${res.statusText}`);
+    }
+
+    const result = await res.json();
+    const output = result?.data?.[0];
+
+    if (!output) {
+      throw new Error("Space response missing data");
+    }
+
+    return output;
+  } catch (err) {
+    console.error("HF Space error:", err);
+    throw err;
+  }
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -8,13 +8,12 @@ import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import { useAuthUser } from "../../lib/useAuthUser";
-import { generateWithHF } from "../../lib/navatar/generate";
+import { generateWithHuggingFace } from "../../lib/huggingface";
 import {
   DEFAULT_NEGATIVE_PROMPT,
   DEFAULT_STYLE_ID,
   STYLE_PRESETS,
   buildPrompt,
-  seedFromUserId,
 } from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
 
@@ -76,8 +75,6 @@ export default function GenerateNavatarPage() {
     [styleId]
   );
 
-  const stableSeed = useMemo(() => (user?.id ? seedFromUserId(user.id) : undefined), [user?.id]);
-
   const alwaysFilteredPrompt = useMemo(
     () => (onBrand ? `${DEFAULT_NEGATIVE_PROMPT}, ${BRAND_NEGATIVE}` : DEFAULT_NEGATIVE_PROMPT),
     [onBrand]
@@ -109,19 +106,13 @@ export default function GenerateNavatarPage() {
     const promptForBrand = onBrand ? wrapWithBrandStyle(trimmedPrompt) : trimmedPrompt;
     const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
     const avoid = extraNegativePrompt.trim();
-    const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
-    const keepSeed = keepStyle && Boolean(user?.id);
-    const seed = keepSeed && typeof stableSeed === "number" ? stableSeed : undefined;
-
+    const avoidList = [alwaysFilteredPrompt, avoid].filter(Boolean).join(", ");
+    const promptWithAvoidance = avoidList ? `${finalPrompt}. Avoid: ${avoidList}` : finalPrompt;
     setIsGenerating(true);
     try {
-      const dataUrl = await generateWithHF({
-        prompt: promptWithAvoidance,
-        onBrand,
-        seed,
-        keepSeed,
-      });
-      const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
+      const stylePrompt = `${selectedStyle.label} — ${selectedStyle.prompt}`;
+      const imageUrl = await generateWithHuggingFace(promptWithAvoidance, stylePrompt);
+      const generatedFile = await dataUrlToFile(imageUrl, `navatar-${Date.now()}.png`);
 
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_SITE_URL?: string;
   readonly VITE_ENABLE_AI?: string;
   readonly VITE_ENABLE_AUTO_STAMPS?: string;
+  readonly VITE_HUGGINGFACE_SPACE_URL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- add Hugging Face Space environment variables for direct Space invocation
- create a client helper for hitting the naturverse Hugging Face Space and wire the Navatar generator to use it
- send the combined prompt/style text (including avoid list) straight to the Space when generating a Navatar

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d010de29a0832988dbb0297bee04e3