### PR TITLE
fix: make generate button always visible

### DIFF
--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -235,7 +235,7 @@ export default function GenerateNavatarPage() {
         </details>
         <button
           type="button"
-          className="pill"
+          className="pill generate-btn"
           onClick={handleGenerate}
           disabled={isGenerating}
           style={{ width: "100%" }}

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -25,6 +25,11 @@
   font-weight: 600;
   box-shadow: 0 2px 0 rgba(0,0,0,.08);
 }
+.generate-btn {
+  opacity: 1 !important;
+  visibility: visible !important;
+  transition: none;
+}
 .pill--active {
   background: #1e4ed8;
   color: #fff;


### PR DESCRIPTION
## Summary
- ensure the Navatar generate button uses a dedicated class so it remains visible
- override the button styles to keep opacity and visibility fully enabled

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d01edf22088329bf3df9d1acef996d