### PR TITLE
Route navatar generation through HF Space

### DIFF
--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,0 +1,62 @@
+import type { Handler } from "@netlify/functions";
+
+const SPACE = process.env.HF_SPACE_URL;
+
+export const handler: Handler = async (event) => {
+  try {
+    if (!SPACE) {
+      return resp(500, { errors: ["HF_SPACE_URL not set"] });
+    }
+    if (event.httpMethod !== "POST") {
+      return resp(405, { errors: ["Method not allowed"] });
+    }
+
+    const { prompt } = JSON.parse(event.body || "{}");
+    if (!prompt || typeof prompt !== "string") {
+      return resp(400, { errors: ["Missing prompt"] });
+    }
+
+    const gradio = await fetch(`${SPACE}/api/predict/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ data: [prompt] }),
+    });
+
+    if (!gradio.ok) {
+      const raw = await gradio.text();
+      return resp(gradio.status, { errors: ["Space request failed"], raw });
+    }
+
+    const data = await gradio.json();
+
+    let imageDataUrl: string | null = null;
+
+    if (Array.isArray(data?.data)) {
+      const first = data.data[0];
+      if (typeof first === "string" && first.startsWith("data:image/")) {
+        imageDataUrl = first;
+      } else if (first && typeof first === "object" && typeof first.name === "string") {
+        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
+      }
+    }
+
+    if (!imageDataUrl) {
+      return resp(502, { errors: ["Unexpected Space response"], raw: data });
+    }
+
+    return resp(200, { imageDataUrl });
+  } catch (err: any) {
+    return resp(500, { errors: ["Unhandled error"], raw: String(err?.message || err) });
+  }
+};
+
+function resp(status: number, body: unknown) {
+  return {
+    statusCode: status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+    body: JSON.stringify(body),
+  };
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,24 +1,26 @@
-export type GenerateOpts = {
-  prompt: string;
-  onBrand?: boolean;
-  seed?: number;
-  keepSeed?: boolean;
-};
-
-export async function generateWithHF(opts: GenerateOpts): Promise<string> {
-  const res = await fetch("/.netlify/functions/ai-generate", {
+export async function generateWithHuggingFace(prompt: string): Promise<string> {
+  const response = await fetch("/.netlify/functions/hf-space", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(opts),
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ prompt }),
   });
 
-  const data = await res.json().catch(() => ({}));
+  const json = await response.json().catch(() => ({}));
 
-  if (!res.ok || !data?.ok) {
-    const msg = data?.error || `HTTP ${res.status}`;
-    const raw = data?.raw;
-    throw new Error(raw ? `${msg}: ${raw}` : msg);
+  if (!response.ok) {
+    const message = Array.isArray(json?.errors) && json.errors.length > 0
+      ? json.errors[0]
+      : "Hugging Face Space error";
+    throw new Error(message);
   }
 
-  return data.image as string;
+  const image = json?.imageDataUrl;
+  if (typeof image !== "string" || !image) {
+    throw new Error("Invalid image response from Hugging Face Space");
+  }
+
+  return image;
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -8,13 +8,12 @@ import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import { useAuthUser } from "../../lib/useAuthUser";
-import { generateWithHF } from "../../lib/navatar/generate";
+import { generateWithHuggingFace } from "../../lib/navatar/generate";
 import {
   DEFAULT_NEGATIVE_PROMPT,
   DEFAULT_STYLE_ID,
   STYLE_PRESETS,
   buildPrompt,
-  seedFromUserId,
 } from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
 
@@ -76,8 +75,6 @@ export default function GenerateNavatarPage() {
     [styleId]
   );
 
-  const stableSeed = useMemo(() => (user?.id ? seedFromUserId(user.id) : undefined), [user?.id]);
-
   const alwaysFilteredPrompt = useMemo(
     () => (onBrand ? `${DEFAULT_NEGATIVE_PROMPT}, ${BRAND_NEGATIVE}` : DEFAULT_NEGATIVE_PROMPT),
     [onBrand]
@@ -110,17 +107,9 @@ export default function GenerateNavatarPage() {
     const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
     const avoid = extraNegativePrompt.trim();
     const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
-    const keepSeed = keepStyle && Boolean(user?.id);
-    const seed = keepSeed && typeof stableSeed === "number" ? stableSeed : undefined;
-
     setIsGenerating(true);
     try {
-      const dataUrl = await generateWithHF({
-        prompt: promptWithAvoidance,
-        onBrand,
-        seed,
-        keepSeed,
-      });
+      const dataUrl = await generateWithHuggingFace(promptWithAvoidance);
       const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
 
       setFile(generatedFile);
@@ -235,10 +224,9 @@ export default function GenerateNavatarPage() {
         </details>
         <button
           type="button"
-          className="pill"
+          className="generate-btn w-full rounded-xl px-5 py-3 text-base font-semibold text-white bg-blue-600 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
           onClick={handleGenerate}
           disabled={isGenerating}
-          style={{ width: "100%" }}
         >
           {isGenerating ? "Generating…" : "Generate with Hugging Face"}
         </button>

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -338,3 +338,9 @@
   }
 }
 
+/* Ensure generate button is always shown */
+.generate-btn {
+  opacity: 1;
+  visibility: visible;
+}
+


### PR DESCRIPTION
## Summary
- add a Netlify function that posts prompts to the configured Hugging Face Space and normalizes its responses
- update the navatar generator helper and page to call the new function while keeping the Generate button visible
- enforce visibility of the generate button in shared navatar styles

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d08c473a908329ba02e2aa941d5811