### PR TITLE
Fix HF Space URL sanitization & friendlier error

### DIFF
--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,11 +1,13 @@
 import type { Handler } from "@netlify/functions";
-
-const SPACE = process.env.HF_SPACE_URL;
+import { normalizeSpaceUrl } from "../../src/lib/normalizeUrl";
 
 export const handler: Handler = async (event) => {
   try {
-    if (!SPACE) {
-      return resp(500, { errors: ["HF_SPACE_URL not set"] });
+    const space = normalizeSpaceUrl(
+      process.env.HUGGINGFACE_SPACE_URL || process.env.HF_SPACE_URL
+    );
+    if (!space) {
+      return resp(500, { errors: ["HUGGINGFACE_SPACE_URL is not set"] });
     }
     if (event.httpMethod !== "POST") {
       return resp(405, { errors: ["Method not allowed"] });
@@ -16,7 +18,7 @@ export const handler: Handler = async (event) => {
       return resp(400, { errors: ["Missing prompt"] });
     }
 
-    const gradio = await fetch(`${SPACE}/api/predict/`, {
+    const gradio = await fetch(`${space}/api/predict/`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Accept: "application/json" },
       body: JSON.stringify({ data: [prompt] }),
@@ -36,7 +38,7 @@ export const handler: Handler = async (event) => {
       if (typeof first === "string" && first.startsWith("data:image/")) {
         imageDataUrl = first;
       } else if (first && typeof first === "object" && typeof first.name === "string") {
-        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
+        imageDataUrl = `${space}/${first.name.replace(/^file=*/, "")}`;
       }
     }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,1 @@
+export { normalizeSpaceUrl } from "./normalizeUrl";

--- a/src/lib/normalizeUrl.ts
+++ b/src/lib/normalizeUrl.ts
@@ -1,0 +1,19 @@
+// Normalizes a base URL for Hugging Face Spaces.
+// - removes accidental double "https://https://"
+// - trims whitespace
+// - strips trailing slashes
+export function normalizeSpaceUrl(raw?: string): string | null {
+  if (!raw) return null;
+  let url = raw.trim();
+
+  // collapse duplicate protocols (https://https://…)
+  url = url.replace(/^https?:\/\/https?:\/\//i, "https://");
+
+  // if someone pasted the API path, keep only the base space URL
+  url = url.replace(/\/gradio_api\/.*$/i, "");
+
+  // no trailing slash
+  url = url.replace(/\/+$/, "");
+
+  return url || null;
+}


### PR DESCRIPTION
## Summary
- add a reusable `normalizeSpaceUrl` helper that trims whitespace, duplicate protocols, and trailing slashes from the configured Space URL.
- use the normalizer in the Netlify HF Space proxy so both `HUGGINGFACE_SPACE_URL` and `HF_SPACE_URL` env vars are supported and report a clearer error when missing.

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d096e7db188329b39e220b3d395c13