### PR TITLE
Wire “Generate with Hugging Face” to Space via Netlify function

### DIFF
--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,58 +1,20 @@
 import type { Handler } from "@netlify/functions";
 
-const SPACE = process.env.HF_SPACE_URL;
+type InferResp =
+  | { event_id: string }
+  | { data: unknown[] }
+  | { detail?: unknown }
+  | Record<string, unknown>;
 
-export const handler: Handler = async (event) => {
-  try {
-    if (!SPACE) {
-      return resp(500, { errors: ["HF_SPACE_URL not set"] });
-    }
-    if (event.httpMethod !== "POST") {
-      return resp(405, { errors: ["Method not allowed"] });
-    }
+const spaceBase = process.env.HUGGINGFACE_SPACE_URL;
 
-    const { prompt } = JSON.parse(event.body || "{}");
-    if (!prompt || typeof prompt !== "string") {
-      return resp(400, { errors: ["Missing prompt"] });
-    }
+if (!spaceBase) {
+  console.warn("HUGGINGFACE_SPACE_URL not set");
+}
 
-    const gradio = await fetch(`${SPACE}/api/predict/`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ data: [prompt] }),
-    });
-
-    if (!gradio.ok) {
-      const raw = await gradio.text();
-      return resp(gradio.status, { errors: ["Space request failed"], raw });
-    }
-
-    const data = await gradio.json();
-
-    let imageDataUrl: string | null = null;
-
-    if (Array.isArray(data?.data)) {
-      const first = data.data[0];
-      if (typeof first === "string" && first.startsWith("data:image/")) {
-        imageDataUrl = first;
-      } else if (first && typeof first === "object" && typeof first.name === "string") {
-        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
-      }
-    }
-
-    if (!imageDataUrl) {
-      return resp(502, { errors: ["Unexpected Space response"], raw: data });
-    }
-
-    return resp(200, { imageDataUrl });
-  } catch (err: any) {
-    return resp(500, { errors: ["Unhandled error"], raw: String(err?.message || err) });
-  }
-};
-
-function resp(status: number, body: unknown) {
+function json(statusCode: number, body: unknown) {
   return {
-    statusCode: status,
+    statusCode,
     headers: {
       "Content-Type": "application/json",
       "Cache-Control": "no-store",
@@ -60,3 +22,100 @@ function resp(status: number, body: unknown) {
     body: JSON.stringify(body),
   };
 }
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return json(405, { errors: ["Method Not Allowed"] });
+  }
+
+  if (!spaceBase) {
+    return json(500, { errors: ["HUGGINGFACE_SPACE_URL not set"] });
+  }
+
+  try {
+    const parsed = JSON.parse(event.body || "{}") as Record<string, unknown>;
+
+    const prompt = typeof parsed.prompt === "string" ? parsed.prompt : "";
+    if (!prompt.trim()) {
+      return json(400, { errors: ["Prompt required"] });
+    }
+
+    const negativePrompt =
+      typeof parsed.negativePrompt === "string" ? parsed.negativePrompt : "";
+    const seed = typeof parsed.seed === "number" ? parsed.seed : 0;
+    const width = typeof parsed.width === "number" ? parsed.width : 1024;
+    const height = typeof parsed.height === "number" ? parsed.height : 1024;
+    const guidance =
+      typeof parsed.guidance === "number" ? parsed.guidance : 0;
+    const steps = typeof parsed.steps === "number" ? parsed.steps : 1;
+
+    const postRes = await fetch(`${spaceBase}/gradio_api/call/infer`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        data: [
+          prompt,
+          negativePrompt,
+          seed,
+          true,
+          width,
+          height,
+          guidance,
+          steps,
+        ],
+      }),
+    });
+
+    if (!postRes.ok) {
+      const text = await postRes.text();
+      return json(postRes.status, {
+        errors: ["Space POST failed"],
+        detail: text,
+      });
+    }
+
+    const postJson: InferResp = await postRes.json();
+    const eventId =
+      typeof (postJson as { event_id?: unknown }).event_id === "string"
+        ? (postJson as { event_id: string }).event_id
+        : null;
+
+    if (!eventId) {
+      return json(502, {
+        errors: ["Space did not return event_id"],
+        detail: postJson,
+      });
+    }
+
+    const getRes = await fetch(`${spaceBase}/gradio_api/call/infer/${eventId}`);
+    if (!getRes.ok) {
+      const text = await getRes.text();
+      return json(getRes.status, {
+        errors: ["Space GET failed"],
+        detail: text,
+      });
+    }
+
+    const getJson: InferResp = await getRes.json();
+
+    const data = (getJson as { data?: unknown }).data;
+    const image = Array.isArray(data)
+      ? (data as unknown[]).find(
+          (item) => typeof item === "string" && item.startsWith("data:image/")
+        )
+      : undefined;
+
+    return json(200, { image, raw: getJson });
+  } catch (err: unknown) {
+    const message =
+      typeof err === "object" && err && "message" in err
+        ? String((err as { message?: unknown }).message)
+        : String(err);
+    return json(500, {
+      errors: ["Unhandled error"],
+      detail: message,
+    });
+  }
+};
+
+export default handler;

--- a/src/lib/hfSpaceClient.ts
+++ b/src/lib/hfSpaceClient.ts
@@ -1,0 +1,47 @@
+export type GenerateArgs = {
+  prompt: string;
+  negativePrompt?: string;
+  seed?: number;
+  width?: number;
+  height?: number;
+  guidance?: number;
+  steps?: number;
+};
+
+type SpaceResponse = {
+  image?: string;
+  raw?: unknown;
+  errors?: string[];
+  detail?: unknown;
+};
+
+export async function generateWithSpace(args: GenerateArgs) {
+  const res = await fetch("/.netlify/functions/hf-space", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args),
+  });
+
+  const text = await res.text();
+  let data: SpaceResponse | null = null;
+
+  if (text) {
+    try {
+      data = JSON.parse(text) as SpaceResponse;
+    } catch {
+      data = null;
+    }
+  }
+
+  if (!res.ok) {
+    if (data?.errors?.length) {
+      throw new Error(String(data.errors[0]));
+    }
+    if (data?.detail) {
+      throw new Error(String(data.detail));
+    }
+    throw new Error(text || `Request failed: ${res.status}`);
+  }
+
+  return data ?? {};
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,26 +1,15 @@
+import { generateWithSpace } from "../hfSpaceClient";
+
 export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ prompt }),
-  });
+  const result = await generateWithSpace({ prompt });
 
-  const json = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
-    throw new Error(message);
+  if (typeof result.image === "string" && result.image) {
+    return result.image;
   }
 
-  const image = json?.imageDataUrl;
-  if (typeof image !== "string" || !image) {
-    throw new Error("Invalid image response from Hugging Face Space");
+  if (result.errors?.length) {
+    throw new Error(String(result.errors[0]));
   }
 
-  return image;
+  throw new Error("Invalid image response from Hugging Face Space");
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -8,7 +8,7 @@ import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import { useAuthUser } from "../../lib/useAuthUser";
-import { generateWithHuggingFace } from "../../lib/navatar/generate";
+import { generateWithSpace } from "@/lib/hfSpaceClient";
 import {
   DEFAULT_NEGATIVE_PROMPT,
   DEFAULT_STYLE_ID,
@@ -106,10 +106,25 @@ export default function GenerateNavatarPage() {
     const promptForBrand = onBrand ? wrapWithBrandStyle(trimmedPrompt) : trimmedPrompt;
     const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
     const avoid = extraNegativePrompt.trim();
+    const negativePrompt = avoid ? `${alwaysFilteredPrompt}, ${avoid}` : alwaysFilteredPrompt;
     const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
     setIsGenerating(true);
     try {
-      const dataUrl = await generateWithHuggingFace(promptWithAvoidance);
+      const result = await generateWithSpace({
+        prompt: promptWithAvoidance,
+        negativePrompt,
+        seed: 0,
+        width: 1024,
+        height: 1024,
+        guidance: 0,
+        steps: 1,
+      });
+
+      const dataUrl = typeof result.image === "string" ? result.image : null;
+      if (!dataUrl) {
+        throw new Error("No image returned from Space");
+      }
+
       const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
 
       setFile(generatedFile);


### PR DESCRIPTION
## Summary
- replace the Netlify hf-space proxy with a Space-aware call/response flow driven by the HUGGINGFACE_SPACE_URL env var
- add a small client helper for posting generation requests and normalizing error responses
- update the Navatar generate page (and helper wrapper) to call the new client, forward negative prompts, and guard against missing images

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d09df1a2f48329a81d768e32a7131b