### PR TITLE
Avoid 504 by splitting Space call into POST + client polling

### DIFF
--- a/netlify/functions/hf-space-result.ts
+++ b/netlify/functions/hf-space-result.ts
@@ -1,0 +1,84 @@
+import type { Handler } from "@netlify/functions";
+
+const SPACE = process.env.HUGGINGFACE_SPACE_URL ?? process.env.HF_SPACE_URL;
+
+export const handler: Handler = async (event) => {
+  const id = event.queryStringParameters?.id;
+
+  if (!id) {
+    return resp(400, { errors: ["Missing id"] });
+  }
+
+  if (!SPACE) {
+    return resp(500, { errors: ["HUGGINGFACE_SPACE_URL not set"] });
+  }
+
+  try {
+    const res = await fetch(`${SPACE}/gradio_api/call/infer/${encodeURIComponent(id)}`);
+    const text = await res.text();
+    const body = transformBody(text);
+
+    return {
+      statusCode: res.status,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      },
+      body,
+    };
+  } catch (err: any) {
+    return resp(500, { errors: ["Result fetch failed"], detail: String(err?.message || err) });
+  }
+};
+
+function transformBody(text: string) {
+  if (!text) {
+    return text;
+  }
+
+  try {
+    const json = JSON.parse(text);
+
+    if (Array.isArray(json?.data)) {
+      const spaceBase = SPACE?.replace(/\/$/, "");
+      json.data = json.data.map((item: any) => {
+        if (!item || typeof item !== "object") {
+          return item;
+        }
+
+        if (typeof item.url === "string") {
+          return item;
+        }
+
+        if (item.image && typeof item.image.url === "string") {
+          return item;
+        }
+
+        if (spaceBase && typeof item.name === "string") {
+          const cleaned = item.name.replace(/^file=*/, "");
+          const url = `${spaceBase}/${cleaned}`;
+          return { ...item, url };
+        }
+
+        return item;
+      });
+    }
+
+    return JSON.stringify(json);
+  } catch {
+    return text;
+  }
+}
+
+function resp(status: number, body: unknown) {
+  return {
+    statusCode: status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+export default handler;

--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,52 +1,54 @@
 import type { Handler } from "@netlify/functions";
 
-const SPACE = process.env.HF_SPACE_URL;
+const SPACE = process.env.HUGGINGFACE_SPACE_URL ?? process.env.HF_SPACE_URL;
 
 export const handler: Handler = async (event) => {
-  try {
-    if (!SPACE) {
-      return resp(500, { errors: ["HF_SPACE_URL not set"] });
-    }
-    if (event.httpMethod !== "POST") {
-      return resp(405, { errors: ["Method not allowed"] });
-    }
+  if (event.httpMethod !== "POST") {
+    return resp(405, { errors: ["Method not allowed"] });
+  }
 
-    const { prompt } = JSON.parse(event.body || "{}");
+  if (!SPACE) {
+    return resp(500, { errors: ["HUGGINGFACE_SPACE_URL not set"] });
+  }
+
+  try {
+    const {
+      prompt,
+      negativePrompt = "",
+      seed = 0,
+      width = 1024,
+      height = 1024,
+      guidance = 0,
+      steps = 1,
+    } = JSON.parse(event.body || "{}");
+
     if (!prompt || typeof prompt !== "string") {
       return resp(400, { errors: ["Missing prompt"] });
     }
 
-    const gradio = await fetch(`${SPACE}/api/predict/`, {
+    const postRes = await fetch(`${SPACE}/gradio_api/call/infer`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ data: [prompt] }),
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        data: [prompt, negativePrompt, seed, true, width, height, guidance, steps],
+      }),
     });
 
-    if (!gradio.ok) {
-      const raw = await gradio.text();
-      return resp(gradio.status, { errors: ["Space request failed"], raw });
+    if (!postRes.ok) {
+      const detail = await postRes.text();
+      return resp(postRes.status, { errors: ["Space POST failed"], detail });
     }
 
-    const data = await gradio.json();
+    const json = await postRes.json();
+    const eventId = json?.event_id;
 
-    let imageDataUrl: string | null = null;
-
-    if (Array.isArray(data?.data)) {
-      const first = data.data[0];
-      if (typeof first === "string" && first.startsWith("data:image/")) {
-        imageDataUrl = first;
-      } else if (first && typeof first === "object" && typeof first.name === "string") {
-        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
-      }
+    if (!eventId || typeof eventId !== "string") {
+      return resp(502, { errors: ["Space did not return event_id"], detail: json });
     }
 
-    if (!imageDataUrl) {
-      return resp(502, { errors: ["Unexpected Space response"], raw: data });
-    }
-
-    return resp(200, { imageDataUrl });
+    return resp(200, { eventId });
   } catch (err: any) {
-    return resp(500, { errors: ["Unhandled error"], raw: String(err?.message || err) });
+    return resp(500, { errors: ["Unhandled error"], detail: String(err?.message || err) });
   }
 };
 
@@ -60,3 +62,5 @@ function resp(status: number, body: unknown) {
     body: JSON.stringify(body),
   };
 }
+
+export default handler;

--- a/src/lib/hfSpaceClient.ts
+++ b/src/lib/hfSpaceClient.ts
@@ -1,0 +1,94 @@
+export type GenerateArgs = {
+  prompt: string;
+  negativePrompt?: string;
+  seed?: number;
+  width?: number;
+  height?: number;
+  guidance?: number;
+  steps?: number;
+};
+
+export async function startGeneration(args: GenerateArgs): Promise<string> {
+  const res = await fetch("/.netlify/functions/hf-space", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args),
+  });
+
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+
+  const data = (await res.json()) as { eventId?: string };
+  if (!data.eventId) {
+    throw new Error("Space did not return an event id");
+  }
+
+  return data.eventId;
+}
+
+export async function pollResult(eventId: string) {
+  const res = await fetch(`/.netlify/functions/hf-space-result?id=${encodeURIComponent(eventId)}`);
+  const text = await res.text();
+
+  if (!res.ok) {
+    throw new Error(text || `Space result error (${res.status})`);
+  }
+
+  let json: unknown = null;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch {
+      throw new Error("Invalid JSON from Space result");
+    }
+  }
+
+  const image = extractImage(json);
+
+  return { done: Boolean(image), image, raw: json };
+}
+
+export async function waitForImage(
+  eventId: string,
+  { timeoutMs = 120_000, intervalMs = 1_500 } = {}
+): Promise<{ image: string; raw: unknown }> {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const { done, image, raw } = await pollResult(eventId);
+    if (done && image) {
+      return { image, raw };
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error("Timed out waiting for Space result");
+}
+
+function extractImage(json: any): string | null {
+  if (!Array.isArray(json?.data)) {
+    return null;
+  }
+
+  const fromDataUrl = json.data.find((item: unknown) => typeof item === "string" && item.startsWith("data:image/"));
+  if (typeof fromDataUrl === "string") {
+    return fromDataUrl;
+  }
+
+  const fromObject = json.data.find(
+    (item: any) => item && typeof item === "object" && typeof item.url === "string"
+  );
+  if (fromObject) {
+    return fromObject.url;
+  }
+
+  const fromImageProp = json.data.find(
+    (item: any) => item && typeof item === "object" && item.image && typeof item.image.url === "string"
+  );
+  if (fromImageProp) {
+    return fromImageProp.image.url;
+  }
+
+  return null;
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,23 +1,9 @@
+import { startGeneration, waitForImage } from "../hfSpaceClient";
+
 export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ prompt }),
-  });
+  const eventId = await startGeneration({ prompt, width: 1024, height: 1024 });
+  const { image } = await waitForImage(eventId);
 
-  const json = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
-    throw new Error(message);
-  }
-
-  const image = json?.imageDataUrl;
   if (typeof image !== "string" || !image) {
     throw new Error("Invalid image response from Hugging Face Space");
   }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -8,7 +8,7 @@ import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import { useAuthUser } from "../../lib/useAuthUser";
-import { generateWithHuggingFace } from "../../lib/navatar/generate";
+import { startGeneration, waitForImage } from "../../lib/hfSpaceClient";
 import {
   DEFAULT_NEGATIVE_PROMPT,
   DEFAULT_STYLE_ID,
@@ -109,8 +109,13 @@ export default function GenerateNavatarPage() {
     const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
     setIsGenerating(true);
     try {
-      const dataUrl = await generateWithHuggingFace(promptWithAvoidance);
-      const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
+      const eventId = await startGeneration({ prompt: promptWithAvoidance, width: 1024, height: 1024 });
+      const { image } = await waitForImage(eventId);
+      if (!image) {
+        throw new Error("No image from Space");
+      }
+
+      const generatedFile = await dataUrlToFile(image, `navatar-${Date.now()}.png`);
 
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });


### PR DESCRIPTION
## Summary
- update the hf-space Netlify function to enqueue generation with Gradio and return the event id immediately
- add a lightweight hf-space-result function that fetches the Space result and normalizes file URLs
- introduce a reusable hfSpaceClient helper and update Navatar generation to poll until the image is ready

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0a10b297483299327b0976403fa19