### PR TITLE
Short-poll Hugging Face result endpoint

### DIFF
--- a/netlify/functions/hf-space-result.ts
+++ b/netlify/functions/hf-space-result.ts
@@ -1,0 +1,77 @@
+import type { Handler } from "@netlify/functions";
+
+const spaceBase = process.env.HUGGINGFACE_SPACE_URL!;
+const TIMEOUT_MS = 8000; // keep each poll short
+
+export const handler: Handler = async (event) => {
+  const id = event.queryStringParameters?.id;
+  if (!id) return { statusCode: 400, body: "Missing id" };
+  if (!spaceBase) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ errors: ["HUGGINGFACE_SPACE_URL not set"] }),
+    };
+  }
+
+  // Short-poll the Space. If it takes too long, bail out with 202 so the client retries.
+  const ctrl = new AbortController();
+  const timeout = setTimeout(() => ctrl.abort("poll-timeout"), TIMEOUT_MS);
+
+  try {
+    const res = await fetch(
+      `${spaceBase}/gradio_api/call/infer/${encodeURIComponent(id)}`,
+      {
+        // Do NOT keep this open forever. Netlify will 504.
+        signal: ctrl.signal,
+        headers: { Accept: "application/json" },
+      },
+    );
+
+    const text = await res.text(); // Space returns JSON text
+    clearTimeout(timeout);
+
+    // If Space streams partials or “queued/in_progress”, treat as pending.
+    let json: any;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      // keep raw
+    }
+
+    // Done if we see a dataURL image in json.data
+    const image =
+      json && Array.isArray(json.data)
+        ? json.data.find(
+            (value: unknown) =>
+              typeof value === "string" && value.startsWith("data:image/"),
+          )
+        : null;
+
+    if (!image) {
+      // Not ready yet – keep polling from the client.
+      return {
+        statusCode: 202,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pending: true, last: json ?? text }),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pending: false, image, raw: json }),
+    };
+  } catch (err: any) {
+    clearTimeout(timeout);
+    // Abort = just means try again soon
+    if (err?.name === "AbortError" || String(err?.message).includes("poll-timeout")) {
+      return { statusCode: 202, body: JSON.stringify({ pending: true }) };
+    }
+    return {
+      statusCode: 502,
+      body: JSON.stringify({ errors: ["Result fetch failed"], detail: String(err) }),
+    };
+  }
+};
+
+export default handler;

--- a/src/lib/hfSpaceClient.ts
+++ b/src/lib/hfSpaceClient.ts
@@ -1,0 +1,26 @@
+export type PollResult =
+  | { done: false }
+  | { done: true; image: string; raw?: unknown };
+
+export async function pollResult(eventId: string): Promise<PollResult> {
+  const res = await fetch(
+    `/.netlify/functions/hf-space-result?id=${encodeURIComponent(eventId)}`,
+    {
+      cache: "no-store",
+    },
+  );
+
+  // 202 = still running; keep polling
+  if (res.status === 202) return { done: false };
+
+  if (!res.ok) {
+    throw new Error(`Space result error (${res.status})`);
+  }
+
+  const data = await res.json();
+  if (data?.image) {
+    return { done: true, image: data.image, raw: data.raw };
+  }
+
+  return { done: false };
+}


### PR DESCRIPTION
## Summary
- add an hf-space-result Netlify function that aborts the Hugging Face poll after 8s and returns 202 while work continues
- update the client pollResult helper to treat HTTP 202 responses as pending and keep polling

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0a39d81f48329ad439ae4c4751342