### PR TITLE
Fix Netlify config parsing; set per-function timeouts for HF proxy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,13 @@
   included_files = []
   external_node_modules = []
 
+# Set timeouts per function (max 26s)
+[functions."ai-generate"]
+  timeout = 26
+
+[functions."hf-space"]
+  timeout = 26
+
 # SPA routing
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Summary
- add per-function Netlify timeout configuration for the ai-generate and hf-space functions so they can run up to 26 seconds
- leave the bundler, directory, and other function defaults untouched

## Testing
- not run (config only)


------
https://chatgpt.com/codex/tasks/task_e_68d0aa7070088329b5dab93c0254f032