### PR TITLE
Use Gradio infer flow for navatar generation

### DIFF
--- a/netlify/functions/hf-space-result.ts
+++ b/netlify/functions/hf-space-result.ts
@@ -1,0 +1,92 @@
+import type { Handler } from "@netlify/functions";
+
+const getSpaceBase = () => {
+  const raw = process.env.HF_SPACE_URL || process.env.HUGGINGFACE_SPACE_URL || "";
+  return raw.replace(/\/+$/, "");
+};
+
+const json = (statusCode: number, data: unknown) => ({
+  statusCode,
+  headers: {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store",
+  },
+  body: JSON.stringify(data),
+});
+
+const normalizeImage = (value: unknown, space: string): string | null => {
+  if (!value) return null;
+  if (typeof value === "string") {
+    if (value.startsWith("data:image/")) return value;
+    if (/^https?:\/\//i.test(value)) return value;
+    if (value.startsWith("file=")) {
+      const path = value.replace(/^file=*/, "").replace(/^\/+/, "");
+      return `${space}/${path}`;
+    }
+    if (value.startsWith("/")) {
+      return `${space}${value}`;
+    }
+    return null;
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const candidates = [record.url, record.data, record.image, record.name];
+    for (const candidate of candidates) {
+      if (typeof candidate === "string") {
+        const normalized = normalizeImage(candidate, space);
+        if (normalized) {
+          return normalized;
+        }
+      }
+    }
+  }
+  return null;
+};
+
+const extractImageUrl = (payload: unknown, space: string): string | null => {
+  if (!payload || typeof payload !== "object") return null;
+  const record = payload as Record<string, unknown>;
+  const data = record.data;
+  if (!Array.isArray(data) || data.length === 0) return null;
+  return normalizeImage(data[0], space);
+};
+
+export const handler: Handler = async (event) => {
+  try {
+    const SPACE = getSpaceBase();
+    if (!SPACE) {
+      return json(500, { error: "HF_SPACE_URL not set" });
+    }
+    const id = event.queryStringParameters?.id;
+    if (!id) return json(400, { error: "Missing id" });
+
+    const deadline = Date.now() + 25_000;
+    let lastText = "";
+    while (Date.now() < deadline) {
+      const res = await fetch(`${SPACE}/gradio_api/call/infer/${encodeURIComponent(id)}`);
+      if (res.status === 200) {
+        const result = await res.json().catch(() => ({}));
+        const imageUrl = extractImageUrl(result, SPACE);
+        if (!imageUrl) {
+          return json(502, {
+            error: "Unexpected Space response",
+            details: JSON.stringify(result),
+          });
+        }
+        return json(200, { imageDataUrl: imageUrl });
+      }
+      lastText = await res.text().catch(() => "");
+      if (res.status === 202 || res.status === 204) {
+        await new Promise((resolve) => setTimeout(resolve, 900));
+        continue;
+      }
+      return json(502, {
+        error: `Space result error: ${res.status} ${res.statusText}`,
+        details: lastText,
+      });
+    }
+    return json(504, { error: "Timed out waiting for Space result" });
+  } catch (err: any) {
+    return json(500, { error: err?.message || "Unknown error" });
+  }
+};

--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,62 +1,58 @@
 import type { Handler } from "@netlify/functions";
 
-const SPACE = process.env.HF_SPACE_URL;
+const getSpaceBase = () => {
+  const raw =
+    process.env.HF_SPACE_URL ||
+    process.env.HUGGINGFACE_SPACE_URL ||
+    "";
+  return raw.replace(/\/+$/, "");
+};
+
+const json = (statusCode: number, data: unknown) => ({
+  statusCode,
+  headers: {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store",
+  },
+  body: JSON.stringify(data),
+});
 
 export const handler: Handler = async (event) => {
   try {
-    if (!SPACE) {
-      return resp(500, { errors: ["HF_SPACE_URL not set"] });
-    }
     if (event.httpMethod !== "POST") {
-      return resp(405, { errors: ["Method not allowed"] });
+      return json(405, { error: "Method Not Allowed" });
+    }
+    const SPACE = getSpaceBase();
+    if (!SPACE) {
+      return json(500, { error: "HF_SPACE_URL not set" });
     }
 
-    const { prompt } = JSON.parse(event.body || "{}");
-    if (!prompt || typeof prompt !== "string") {
-      return resp(400, { errors: ["Missing prompt"] });
+    const { prompt, negativePrompt = "", seed = 0, width = 1024, height = 1024, guidance = 0, steps = 1 } =
+      JSON.parse(event.body || "{}");
+
+    if (!prompt || typeof prompt !== "string" || !prompt.trim()) {
+      return json(400, { error: "Missing prompt" });
     }
 
-    const gradio = await fetch(`${SPACE}/api/predict/`, {
+    await fetch(`${SPACE}/`, { method: "GET" }).catch(() => {});
+
+    const post = await fetch(`${SPACE}/gradio_api/call/infer`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ data: [prompt] }),
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        data: [prompt, negativePrompt, seed, true, width, height, guidance, steps],
+      }),
     });
-
-    if (!gradio.ok) {
-      const raw = await gradio.text();
-      return resp(gradio.status, { errors: ["Space request failed"], raw });
+    if (!post.ok) {
+      const txt = await post.text().catch(() => "");
+      return json(502, {
+        error: `Space call failed: ${post.status} ${post.statusText}`,
+        details: txt,
+      });
     }
-
-    const data = await gradio.json();
-
-    let imageDataUrl: string | null = null;
-
-    if (Array.isArray(data?.data)) {
-      const first = data.data[0];
-      if (typeof first === "string" && first.startsWith("data:image/")) {
-        imageDataUrl = first;
-      } else if (first && typeof first === "object" && typeof first.name === "string") {
-        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
-      }
-    }
-
-    if (!imageDataUrl) {
-      return resp(502, { errors: ["Unexpected Space response"], raw: data });
-    }
-
-    return resp(200, { imageDataUrl });
+    const { event_id } = await post.json();
+    return json(200, { eventId: event_id });
   } catch (err: any) {
-    return resp(500, { errors: ["Unhandled error"], raw: String(err?.message || err) });
+    return json(500, { error: err?.message || "Unknown error" });
   }
 };
-
-function resp(status: number, body: unknown) {
-  return {
-    statusCode: status,
-    headers: {
-      "Content-Type": "application/json",
-      "Cache-Control": "no-store",
-    },
-    body: JSON.stringify(body),
-  };
-}

--- a/src/lib/hfSpaceClient.ts
+++ b/src/lib/hfSpaceClient.ts
@@ -1,0 +1,47 @@
+export type GenerateRequest = {
+  prompt: string;
+  negativePrompt?: string;
+  seed?: number;
+  width?: number;
+  height?: number;
+  guidance?: number;
+  steps?: number;
+};
+
+export type SpaceResult = {
+  imageDataUrl: string;
+};
+
+const parseJson = async (res: Response) => {
+  try {
+    return await res.json();
+  } catch {
+    return {} as Record<string, unknown>;
+  }
+};
+
+export async function callSpace(payload: GenerateRequest) {
+  const res = await fetch("/.netlify/functions/hf-space", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const json = await parseJson(res);
+  if (!res.ok) {
+    const message = typeof (json as any)?.error === "string" ? (json as any).error : "Space request failed";
+    const details = typeof (json as any)?.details === "string" && (json as any).details ? `\n${(json as any).details}` : "";
+    throw new Error(`${message}${details}`.trim());
+  }
+  return json as { eventId: string };
+}
+
+export async function pollSpace(eventId: string) {
+  const res = await fetch(`/.netlify/functions/hf-space-result?id=${encodeURIComponent(eventId)}`);
+  const json = await parseJson(res);
+  if (!res.ok) {
+    const base = typeof (json as any)?.error === "string" ? (json as any).error : "Space result failed";
+    const details = typeof (json as any)?.details === "string" && (json as any).details ? `\n${(json as any).details}` : "";
+    throw new Error(`${base}${details}`.trim());
+  }
+  return json as SpaceResult;
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,23 +1,16 @@
-export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ prompt }),
-  });
+import { callSpace, pollSpace, type GenerateRequest } from "../hfSpaceClient";
 
-  const json = await response.json().catch(() => ({}));
+export type HuggingFaceGenerateOptions = GenerateRequest;
 
-  if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
-    throw new Error(message);
+export async function generateWithHuggingFace(options: HuggingFaceGenerateOptions): Promise<string> {
+  const { prompt } = options;
+  if (!prompt || typeof prompt !== "string" || !prompt.trim()) {
+    throw new Error("Prompt required");
   }
 
-  const image = json?.imageDataUrl;
+  const { eventId } = await callSpace(options);
+  const result = await pollSpace(eventId);
+  const image = result?.imageDataUrl;
   if (typeof image !== "string" || !image) {
     throw new Error("Invalid image response from Hugging Face Space");
   }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -48,6 +48,7 @@ export default function GenerateNavatarPage() {
   const [name, setName] = useState("");
   const [draftUrl, setDraftUrl] = useState<string | undefined>();
   const [isGenerating, setIsGenerating] = useState(false);
+  const [errorDetail, setErrorDetail] = useState<string | null>(null);
   const nav = useNavigate();
   const toast = useToast();
   const { user } = useAuthUser();
@@ -106,17 +107,23 @@ export default function GenerateNavatarPage() {
     const promptForBrand = onBrand ? wrapWithBrandStyle(trimmedPrompt) : trimmedPrompt;
     const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
     const avoid = extraNegativePrompt.trim();
-    const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
+    const negativePrompt = avoid ? `${alwaysFilteredPrompt}, ${avoid}` : alwaysFilteredPrompt;
     setIsGenerating(true);
+    setErrorDetail(null);
     try {
-      const dataUrl = await generateWithHuggingFace(promptWithAvoidance);
+      const dataUrl = await generateWithHuggingFace({
+        prompt: finalPrompt,
+        negativePrompt,
+      });
       const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
 
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });
     } catch (error) {
       console.error(error);
-      const message = error instanceof Error ? error.message : "Error generating image";
+      const rawMessage = error instanceof Error ? error.message : "Error generating image";
+      const message = rawMessage.slice(0, 500) || "Space request failed";
+      setErrorDetail(message);
       toast({ text: message, kind: "err" });
     } finally {
       setIsGenerating(false);
@@ -230,6 +237,19 @@ export default function GenerateNavatarPage() {
         >
           {isGenerating ? "Generating…" : "Generate with Hugging Face"}
         </button>
+        {errorDetail && (
+          <p
+            role="status"
+            style={{
+              color: "#7a1e1e",
+              textAlign: "center",
+              whiteSpace: "pre-wrap",
+              maxWidth: "100%",
+            }}
+          >
+            {errorDetail}
+          </p>
+        )}
         <input
           style={{ display: "block", width: "100%" }}
           placeholder="Name (optional)"


### PR DESCRIPTION
## Summary
- warm the Hugging Face Space and call the /gradio_api/call/infer endpoints before polling results
- add a Netlify result handler that converts the Gradio payload into an image URL with clearer errors
- update the Navatar generator client/UI to use the new flow and surface backend error details

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0aca24a388329a2c79ab61779e94c