### PR TITLE
Make Hugging Face generation reliable (fix timeout + URL handling + clearer errors)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,10 @@
   included_files = []
   external_node_modules = []
 
+# Give the HF proxy enough time to finish a generation
+[functions."hf-space"]
+  timeout = 60
+
 # SPA routing
 [[redirects]]
   from = "/*"

--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,62 +1,317 @@
 import type { Handler } from "@netlify/functions";
 
-const SPACE = process.env.HF_SPACE_URL;
+type JsonBody = Record<string, unknown>;
+
+const HANDLER_DEADLINE_MS = 55_000;
+const INITIAL_POLL_INTERVAL_MS = 1_000;
+const MAX_POLL_INTERVAL_MS = 5_000;
+const BACKOFF_MULTIPLIER = 1.5;
+
+const readSpaceUrl = () =>
+  process.env.HUGGINGFACE_SPACE_URL?.trim() ||
+  process.env.HF_SPACE_URL?.trim() ||
+  "";
+
+if (!readSpaceUrl()) {
+  console.warn("No HUGGINGFACE_SPACE_URL or HF_SPACE_URL set.");
+}
 
 export const handler: Handler = async (event) => {
   try {
-    if (!SPACE) {
-      return resp(500, { errors: ["HF_SPACE_URL not set"] });
-    }
     if (event.httpMethod !== "POST") {
-      return resp(405, { errors: ["Method not allowed"] });
+      const notAllowed = jsonResponse(405, { error: "Only POST supported" });
+      notAllowed.headers = { ...notAllowed.headers, Allow: "POST" };
+      return notAllowed;
     }
 
-    const { prompt } = JSON.parse(event.body || "{}");
-    if (!prompt || typeof prompt !== "string") {
-      return resp(400, { errors: ["Missing prompt"] });
+    const rawSpaceUrl = readSpaceUrl();
+    if (!rawSpaceUrl) {
+      return jsonResponse(500, { error: "HF_SPACE_URL not set" });
     }
 
-    const gradio = await fetch(`${SPACE}/api/predict/`, {
+    let spaceBase: string;
+    try {
+      spaceBase = toHfSubdomain(rawSpaceUrl);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return jsonResponse(500, { error: message });
+    }
+
+    let parsedBody: Record<string, unknown>;
+    try {
+      parsedBody = JSON.parse(event.body ?? "{}");
+    } catch {
+      return jsonResponse(400, { error: "Invalid JSON body" });
+    }
+
+    const prompt = typeof parsedBody.prompt === "string" ? parsedBody.prompt : "";
+    if (!prompt.trim()) {
+      return jsonResponse(400, { error: "Prompt is required" });
+    }
+
+    const negativePrompt =
+      typeof parsedBody.negativePrompt === "string" ? parsedBody.negativePrompt : "";
+    const seed = toNumber(parsedBody.seed, 0);
+    const width = toNumber(parsedBody.width, 1024);
+    const height = toNumber(parsedBody.height, 1024);
+    const steps = toNumber(parsedBody.steps, 28);
+
+    const callUrl = `${spaceBase}/gradio_api/call/infer`;
+    const postResponse = await fetch(callUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ data: [prompt] }),
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        data: [prompt, negativePrompt, seed, width, height, 0, steps],
+      }),
     });
 
-    if (!gradio.ok) {
-      const raw = await gradio.text();
-      return resp(gradio.status, { errors: ["Space request failed"], raw });
+    if (!postResponse.ok) {
+      const text = await postResponse.text();
+      return jsonResponse(postResponse.status, {
+        error: `Space POST ${postResponse.status} ${postResponse.statusText}`.trim(),
+        details: truncate(text),
+      });
     }
 
-    const data = await gradio.json();
+    const postClone = postResponse.clone();
+    const postJson = await postClone.json().catch(() => null);
+    let eventId: string | undefined;
 
-    let imageDataUrl: string | null = null;
-
-    if (Array.isArray(data?.data)) {
-      const first = data.data[0];
-      if (typeof first === "string" && first.startsWith("data:image/")) {
-        imageDataUrl = first;
-      } else if (first && typeof first === "object" && typeof first.name === "string") {
-        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
+    if (postJson && typeof postJson === "object") {
+      const id = (postJson as Record<string, unknown>).event_id;
+      if (typeof id === "string" && id.trim()) {
+        eventId = id.trim();
       }
     }
 
-    if (!imageDataUrl) {
-      return resp(502, { errors: ["Unexpected Space response"], raw: data });
+    if (!eventId) {
+      const text = (await postResponse.text()).trim();
+      if (text) {
+        eventId = text;
+      }
     }
 
-    return resp(200, { imageDataUrl });
-  } catch (err: any) {
-    return resp(500, { errors: ["Unhandled error"], raw: String(err?.message || err) });
+    if (!eventId) {
+      return jsonResponse(502, { error: "Space did not return event_id" });
+    }
+
+    const deadline = Date.now() + HANDLER_DEADLINE_MS;
+    let delay = INITIAL_POLL_INTERVAL_MS;
+    let pollResult: Response | null = null;
+
+    while (Date.now() < deadline) {
+      await wait(delay);
+      const pollUrl = `${spaceBase}/gradio_api/call/infer/${eventId}`;
+      const pollResponse = await fetch(pollUrl, { method: "GET" });
+
+      if (pollResponse.status === 404) {
+        pollResult = pollResponse;
+        delay = Math.min(Math.round(delay * BACKOFF_MULTIPLIER), MAX_POLL_INTERVAL_MS);
+        continue;
+      }
+
+      if (pollResponse.ok) {
+        pollResult = pollResponse;
+        break;
+      }
+
+      const text = await pollResponse.text();
+      return jsonResponse(pollResponse.status, {
+        error: `Space GET ${pollResponse.status} ${pollResponse.statusText}`.trim(),
+        details: truncate(text),
+      });
+    }
+
+    if (!pollResult || !pollResult.ok) {
+      return jsonResponse(504, { error: "Space result timeout" });
+    }
+
+    const resultText = await pollResult.text();
+    let resultPayload: unknown = null;
+    try {
+      resultPayload = resultText ? JSON.parse(resultText) : null;
+    } catch {
+      resultPayload = resultText;
+    }
+
+    if (resultPayload && typeof resultPayload === "object") {
+      const errorMessage = (resultPayload as Record<string, unknown>).error;
+      if (typeof errorMessage === "string" && errorMessage.trim()) {
+        const serialized = JSON.stringify(resultPayload) ?? "";
+        return jsonResponse(502, {
+          error: `Space error: ${errorMessage.trim()}`,
+          details: truncate(serialized),
+        });
+      }
+    }
+
+    const imageDataUrl = extractImageDataUrl(resultPayload, spaceBase);
+    if (!imageDataUrl) {
+      const detailSource =
+        typeof resultPayload === "string"
+          ? resultPayload
+          : JSON.stringify(resultPayload);
+      return jsonResponse(502, {
+        error: "Space result missing image",
+        details: truncate(detailSource ?? ""),
+      });
+    }
+
+    const responseBody: JsonBody = { imageDataUrl };
+    if (resultPayload && typeof resultPayload === "object" && resultPayload !== null) {
+      responseBody.raw = resultPayload;
+    }
+
+    return jsonResponse(200, responseBody);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return jsonResponse(500, { error: message });
   }
 };
 
-function resp(status: number, body: unknown) {
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function toHfSubdomain(raw: string) {
+  const url = new URL(raw);
+  if (url.hostname.endsWith(".hf.space")) {
+    return `https://${url.hostname}`;
+  }
+
+  if (url.hostname === "huggingface.co") {
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts[0] !== "spaces" || parts.length < 3) {
+      throw new Error(
+        "HUGGINGFACE_SPACE_URL must be like https://huggingface.co/spaces/<org>/<space>",
+      );
+    }
+    const org = parts[1];
+    const space = parts[2];
+    return `https://${org}-${space}.hf.space`;
+  }
+
+  throw new Error(
+    "Unsupported Hugging Face Space URL. Use https://huggingface.co/spaces/<org>/<space> or https://<org>-<space>.hf.space",
+  );
+}
+
+function extractImageDataUrl(source: unknown, spaceBase: string): string | undefined {
+  if (typeof source === "string") {
+    return normalizeImageReference(source, spaceBase);
+  }
+
+  if (Array.isArray(source)) {
+    for (const item of source) {
+      const result = extractImageDataUrl(item, spaceBase);
+      if (result) {
+        return result;
+      }
+    }
+    return undefined;
+  }
+
+  if (source && typeof source === "object") {
+    const record = source as Record<string, unknown>;
+
+    const directKeys: Array<keyof typeof record> = [
+      "imageDataUrl",
+      "image",
+      "url",
+      "name",
+      "data",
+      "value",
+    ];
+
+    for (const key of directKeys) {
+      const value = record[key];
+      if (typeof value === "string") {
+        const normalized = normalizeImageReference(value, spaceBase);
+        if (normalized) {
+          return normalized;
+        }
+      }
+    }
+
+    const nestedKeys: Array<keyof typeof record> = [
+      "raw",
+      "data",
+      "value",
+      "output",
+      "outputs",
+      "result",
+      "images",
+    ];
+
+    for (const key of nestedKeys) {
+      const nested = record[key];
+      if (nested && typeof nested !== "string") {
+        const result = extractImageDataUrl(nested, spaceBase);
+        if (result) {
+          return result;
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeImageReference(value: string, spaceBase: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const withoutFilePrefix = trimmed.replace(/^file=*/, "").trim();
+  if (!withoutFilePrefix) {
+    return undefined;
+  }
+
+  if (withoutFilePrefix.startsWith("data:image/")) {
+    return withoutFilePrefix;
+  }
+
+  if (/^https?:\/\//i.test(withoutFilePrefix)) {
+    return withoutFilePrefix;
+  }
+
+  const path = withoutFilePrefix.startsWith("/")
+    ? withoutFilePrefix
+    : `/${withoutFilePrefix}`;
+
+  try {
+    return new URL(path, spaceBase).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function jsonResponse(statusCode: number, body: JsonBody) {
   return {
-    statusCode: status,
+    statusCode,
     headers: {
       "Content-Type": "application/json",
       "Cache-Control": "no-store",
     },
     body: JSON.stringify(body),
   };
+}
+
+function truncate(value: string, maxLength = 500) {
+  if (!value) {
+    return value;
+  }
+  return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value;
+}
+
+function toNumber(value: unknown, fallback: number) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
 }

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,5 +1,7 @@
+const FUNCTION_URL = "/.netlify/functions/hf-space";
+
 export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
+  const response = await fetch(FUNCTION_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -8,19 +10,129 @@ export async function generateWithHuggingFace(prompt: string): Promise<string> {
     body: JSON.stringify({ prompt }),
   });
 
-  const json = await response.json().catch(() => ({}));
+  const text = await response.text();
+  let payload: unknown = null;
 
-  if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
-    throw new Error(message);
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
   }
 
-  const image = json?.imageDataUrl;
-  if (typeof image !== "string" || !image) {
+  if (!response.ok) {
+    throw new Error(buildErrorMessage(response.status, payload));
+  }
+
+  const image = extractImageFromPayload(payload);
+  if (!image) {
     throw new Error("Invalid image response from Hugging Face Space");
   }
 
   return image;
+}
+
+function buildErrorMessage(status: number, payload: unknown): string {
+  if (payload && typeof payload === "object") {
+    const record = payload as Record<string, unknown>;
+    const baseMessage =
+      typeof record.error === "string" && record.error.trim()
+        ? record.error.trim()
+        : `HF proxy ${status}`;
+
+    const detail =
+      typeof record.details === "string" && record.details.trim()
+        ? ` (${record.details.trim()})`
+        : "";
+
+    return `${baseMessage}${detail}`;
+  }
+
+  if (typeof payload === "string" && payload.trim()) {
+    const snippet = payload.trim().slice(0, 200);
+    return `HF proxy ${status}: ${snippet}`;
+  }
+
+  return `HF proxy ${status}`;
+}
+
+function extractImageFromPayload(payload: unknown, visited = new Set<unknown>()): string | null {
+  if (!payload) {
+    return null;
+  }
+
+  if (typeof payload === "string") {
+    return isImageReference(payload) ? payload : null;
+  }
+
+  if (Array.isArray(payload)) {
+    if (visited.has(payload)) {
+      return null;
+    }
+    visited.add(payload);
+    for (const item of payload) {
+      const nested = extractImageFromPayload(item, visited);
+      if (nested) {
+        return nested;
+      }
+    }
+    return null;
+  }
+
+  if (typeof payload === "object") {
+    if (visited.has(payload)) {
+      return null;
+    }
+    visited.add(payload);
+    const record = payload as Record<string, unknown>;
+
+    const directKeys: Array<keyof typeof record> = [
+      "imageDataUrl",
+      "image",
+      "url",
+      "data",
+      "value",
+    ];
+
+    for (const key of directKeys) {
+      const value = record[key];
+      if (typeof value === "string" && isImageReference(value)) {
+        return value;
+      }
+    }
+
+    const nestedKeys: Array<keyof typeof record> = [
+      "raw",
+      "data",
+      "value",
+      "output",
+      "outputs",
+      "result",
+      "images",
+    ];
+
+    for (const key of nestedKeys) {
+      const nested = record[key];
+      if (nested !== undefined) {
+        const result = extractImageFromPayload(nested, visited);
+        if (result) {
+          return result;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function isImageReference(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed.startsWith("data:image/")) {
+    return true;
+  }
+  return /^https?:\/\//i.test(trimmed);
 }


### PR DESCRIPTION
## Summary
- configure the hf-space Netlify function with an explicit 60s timeout so long generations finish before the platform cuts out
- harden the hf-space proxy to normalise Hugging Face URLs, poll the gradio infer endpoint with backoff, and return detailed JSON errors alongside the resolved image URL
- update the Navatar client helper to surface proxy errors and work with the richer response payload

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d0e4071c2c83298746a6a2f9494593