### PR TITLE
Handle Hugging Face image responses

### DIFF
--- a/src/lib/hfResult.ts
+++ b/src/lib/hfResult.ts
@@ -1,0 +1,47 @@
+// Tries to extract a single image URL or data URL from a variety of HF/Gradio responses
+export function pickHFImage(payload: any): string | null {
+  if (!payload) return null;
+
+  // Case A: our Netlify function already normalized -> { imageBase64, mime }
+  if (payload.imageBase64) {
+    const mime = payload.mime || "image/png";
+    return `data:${mime};base64,${payload.imageBase64}`;
+  }
+
+  if (typeof payload.imageDataUrl === "string" && payload.imageDataUrl) {
+    return payload.imageDataUrl;
+  }
+
+  if (typeof payload.imageUrl === "string" && payload.imageUrl) {
+    return payload.imageUrl;
+  }
+
+  // Case B: raw Gradio /call/infer result -> { data: [...] }
+  const d = payload.data || payload.outputs || payload.output || null;
+
+  // Sometimes it's { data: ["data:image/png;base64,...."] }
+  if (Array.isArray(d)) {
+    // Flatten one level if items are arrays/objects
+    for (const item of d.flat?.() ?? d) {
+      if (typeof item === "string" && item.startsWith("data:image/")) return item;
+      if (typeof item === "string" && /^https?:\/\//.test(item)) return item;
+
+      if (item && typeof item === "object") {
+        // Common shapes
+        if (typeof item.url === "string") return item.url; // { url: "https://..." }
+        if (item.image && typeof item.image.url === "string") return item.image.url;
+        if (typeof item.data === "string" && item.data.startsWith("data:image/")) return item.data;
+        if (typeof item.base64 === "string") {
+          const mime = item.mime || "image/png";
+          return `data:${mime};base64,${item.base64}`;
+        }
+      }
+    }
+  }
+
+  // Case C: some Spaces return { url: "..." } at the root
+  if (typeof payload.url === "string") return payload.url;
+
+  return null;
+}
+

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,4 +1,4 @@
-export async function generateWithHuggingFace(prompt: string): Promise<string> {
+export async function generateWithHuggingFace(prompt: string): Promise<any> {
   const response = await fetch("/.netlify/functions/hf-space", {
     method: "POST",
     headers: {
@@ -16,11 +16,5 @@ export async function generateWithHuggingFace(prompt: string): Promise<string> {
       : "Hugging Face Space error";
     throw new Error(message);
   }
-
-  const image = json?.imageDataUrl;
-  if (typeof image !== "string" || !image) {
-    throw new Error("Invalid image response from Hugging Face Space");
-  }
-
-  return image;
+  return json;
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
@@ -8,6 +8,7 @@ import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import { useAuthUser } from "../../lib/useAuthUser";
+import { pickHFImage } from "../../lib/hfResult";
 import { generateWithHuggingFace } from "../../lib/navatar/generate";
 import {
   DEFAULT_NEGATIVE_PROMPT,
@@ -46,21 +47,34 @@ export default function GenerateNavatarPage() {
   const [onBrand, setOnBrand] = useState(true);
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
-  const [draftUrl, setDraftUrl] = useState<string | undefined>();
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const previewObjectUrlRef = useRef<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const nav = useNavigate();
   const toast = useToast();
   const { user } = useAuthUser();
 
-  useEffect(() => {
-    if (!file) {
-      setDraftUrl(undefined);
-      return;
+  const updatePreview = (next: string | null, trackObjectUrl = false) => {
+    const current = previewObjectUrlRef.current;
+    if (current && current !== next) {
+      URL.revokeObjectURL(current);
+      previewObjectUrlRef.current = null;
     }
-    const url = URL.createObjectURL(file);
-    setDraftUrl(url);
-    return () => URL.revokeObjectURL(url);
-  }, [file]);
+    setPreviewUrl(next);
+    if (trackObjectUrl && next && next.startsWith("blob:")) {
+      previewObjectUrlRef.current = next;
+    } else if (!trackObjectUrl) {
+      previewObjectUrlRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (previewObjectUrlRef.current) {
+        URL.revokeObjectURL(previewObjectUrlRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (user?.id) {
@@ -109,10 +123,21 @@ export default function GenerateNavatarPage() {
     const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
     setIsGenerating(true);
     try {
-      const dataUrl = await generateWithHuggingFace(promptWithAvoidance);
-      const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
+      const payload = await generateWithHuggingFace(promptWithAvoidance);
+      const imageSrc = pickHFImage(payload);
 
+      if (!imageSrc) {
+        throw new Error("No image returned from Space");
+      }
+
+      updatePreview(imageSrc);
+
+      const generatedFile = await dataUrlToFile(imageSrc, `navatar-${Date.now()}.png`);
       setFile(generatedFile);
+
+      const objectUrl = URL.createObjectURL(generatedFile);
+      updatePreview(objectUrl, true);
+
       toast({ text: "Navatar generated ✓", kind: "ok" });
     } catch (error) {
       console.error(error);
@@ -139,7 +164,7 @@ export default function GenerateNavatarPage() {
         onSubmit={onSave}
         style={{ maxWidth: 520, margin: "16px auto", display: "grid", justifyItems: "center", gap: 12 }}
       >
-        <NavatarCard src={draftUrl} title={name || "My Navatar"} />
+        <NavatarCard src={previewUrl ?? undefined} title={name || "My Navatar"} />
         <div className="navatar-field">
           <label htmlFor="navatar-prompt">Describe your Navatar</label>
           <textarea
@@ -239,7 +264,16 @@ export default function GenerateNavatarPage() {
         <input
           type="file"
           accept="image/*"
-          onChange={(e) => setFile(e.target.files?.[0] || null)}
+          onChange={(e) => {
+            const selected = e.target.files?.[0] || null;
+            setFile(selected);
+            if (selected) {
+              const objectUrl = URL.createObjectURL(selected);
+              updatePreview(objectUrl, true);
+            } else {
+              updatePreview(null);
+            }
+          }}
           disabled={isGenerating}
         />
         <button className="pill pill--active" type="submit" style={{ marginTop: 8 }} disabled={!canSave}>


### PR DESCRIPTION
## Summary
- add a helper that extracts the first image URL/data URI from common Hugging Face Space payloads
- return the raw Space payload from the Navatar generator fetch so the UI can inspect it
- update the Navatar generator page to parse the payload, update the preview image, and manage object URLs safely

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0e7ae676883298dacdec84d30e83c