### PR TITLE
Improve Hugging Face Space integration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,12 @@
   included_files = []
   external_node_modules = []
 
+[functions."hf-space"]
+  timeout = 26
+
+[functions."hf-space-result"]
+  timeout = 26
+
 # SPA routing
 [[redirects]]
   from = "/*"

--- a/netlify/functions/_hf.ts
+++ b/netlify/functions/_hf.ts
@@ -1,0 +1,64 @@
+export function getSpaceBaseUrl() {
+  const raw =
+    process.env.HF_SPACE_URL ||
+    process.env.HUGGINGFACE_SPACE_URL ||
+    "";
+
+  if (!raw) throw new Error("HF_SPACE_URL not set");
+
+  const trimmed = raw.trim().replace(/\/+$/, "");
+
+  const match = trimmed.match(/huggingface\.co\/spaces\/([^/]+)\/([^/?#]+)/i);
+  if (match) {
+    const owner = match[1];
+    const repo = match[2];
+    return `https://${owner}-${repo}.hf.space`;
+  }
+
+  return trimmed;
+}
+
+export function getApiKey() {
+  return (
+    process.env.HF_API_TOKEN ||
+    process.env.HUGGINGFACE_API_KEY ||
+    ""
+  );
+}
+
+export async function hfFetch(
+  path: string,
+  init: RequestInit & { retries?: number; retryDelayMs?: number } = {}
+) {
+  const base = getSpaceBaseUrl();
+  const url = `${base}${path}`;
+  const retries = init.retries ?? 2;
+  const retryDelayMs = init.retryDelayMs ?? 1200;
+
+  const headers = new Headers(init.headers || {});
+  headers.set("Content-Type", "application/json");
+
+  const key = getApiKey();
+  if (key && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${key}`);
+  }
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url, { ...init, headers });
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`${response.status} ${response.statusText} :: ${text}`);
+      }
+      return response;
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      }
+    }
+  }
+
+  throw lastError;
+}

--- a/netlify/functions/hf-space-result.ts
+++ b/netlify/functions/hf-space-result.ts
@@ -1,0 +1,112 @@
+import type { Handler } from "@netlify/functions";
+import { getSpaceBaseUrl, hfFetch } from "./_hf";
+
+type SpaceResult = {
+  imageDataUrl: string | null;
+  raw: unknown;
+};
+
+export const handler: Handler = async (event) => {
+  try {
+    const id = event.queryStringParameters?.id;
+    if (!id) {
+      return jsonResponse(400, { error: "Missing id" });
+    }
+
+    const response = await hfFetch(`/gradio_api/call/infer/${encodeURIComponent(id)}`, {
+      method: "GET",
+      retries: 0,
+    });
+
+    const json = await response.json();
+    const base = getSpaceBaseUrl();
+    const normalized = appendImageData(json, base);
+    return jsonResponse(200, normalized);
+  } catch (error: any) {
+    return jsonResponse(500, { error: String(error?.message || error) });
+  }
+};
+
+function appendImageData(raw: any, baseUrl: string) {
+  const payload = raw?.data?.data ?? raw?.data;
+  const imageDataUrl = extractImageData(payload, baseUrl);
+
+  if (raw && typeof raw === "object") {
+    return { ...raw, imageDataUrl };
+  }
+
+  const fallback: SpaceResult = { imageDataUrl, raw };
+  return fallback;
+}
+
+function extractImageData(data: unknown, baseUrl: string): string | null {
+  if (!Array.isArray(data)) {
+    return null;
+  }
+
+  for (const item of data) {
+    const image = resolveImageItem(item, baseUrl);
+    if (image) {
+      return image;
+    }
+  }
+
+  return null;
+}
+
+function resolveImageItem(item: unknown, baseUrl: string): string | null {
+  if (typeof item === "string") {
+    return normalizePotentialImage(item, baseUrl);
+  }
+
+  if (item && typeof item === "object") {
+    const candidate =
+      getString((item as Record<string, unknown>).imageDataUrl) ||
+      getString((item as Record<string, unknown>).url) ||
+      getString((item as Record<string, unknown>).path) ||
+      getString((item as Record<string, unknown>).name) ||
+      getString((item as Record<string, unknown>).data);
+
+    if (candidate) {
+      return normalizePotentialImage(candidate, baseUrl);
+    }
+  }
+
+  return null;
+}
+
+function normalizePotentialImage(value: string, baseUrl: string): string | null {
+  if (!value) {
+    return null;
+  }
+
+  if (value.startsWith("data:image/")) {
+    return value;
+  }
+
+  if (/^https?:\/\//i.test(value)) {
+    return value;
+  }
+
+  if (value.startsWith("file=")) {
+    const suffix = value.replace(/^file=*/, "").replace(/^\/+/, "");
+    return `${baseUrl}/${suffix}`;
+  }
+
+  return null;
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function jsonResponse(statusCode: number, body: unknown) {
+  return {
+    statusCode,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+    body: JSON.stringify(body),
+  };
+}

--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,62 +1,78 @@
 import type { Handler } from "@netlify/functions";
+import { hfFetch } from "./_hf";
 
-const SPACE = process.env.HF_SPACE_URL;
+type GenerationInput = {
+  prompt?: unknown;
+  negative_prompt?: unknown;
+  seed?: unknown;
+  randomize_seed?: unknown;
+  width?: unknown;
+  height?: unknown;
+  guidance_scale?: unknown;
+  num_inference_steps?: unknown;
+};
 
 export const handler: Handler = async (event) => {
   try {
-    if (!SPACE) {
-      return resp(500, { errors: ["HF_SPACE_URL not set"] });
-    }
     if (event.httpMethod !== "POST") {
-      return resp(405, { errors: ["Method not allowed"] });
+      return jsonResponse(405, { error: "Method Not Allowed" });
     }
 
-    const { prompt } = JSON.parse(event.body || "{}");
-    if (!prompt || typeof prompt !== "string") {
-      return resp(400, { errors: ["Missing prompt"] });
-    }
-
-    const gradio = await fetch(`${SPACE}/api/predict/`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ data: [prompt] }),
-    });
-
-    if (!gradio.ok) {
-      const raw = await gradio.text();
-      return resp(gradio.status, { errors: ["Space request failed"], raw });
-    }
-
-    const data = await gradio.json();
-
-    let imageDataUrl: string | null = null;
-
-    if (Array.isArray(data?.data)) {
-      const first = data.data[0];
-      if (typeof first === "string" && first.startsWith("data:image/")) {
-        imageDataUrl = first;
-      } else if (first && typeof first === "object" && typeof first.name === "string") {
-        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
+    let input: GenerationInput = {};
+    if (event.body) {
+      try {
+        input = JSON.parse(event.body);
+      } catch {
+        return jsonResponse(400, { error: "Invalid JSON" });
       }
     }
 
-    if (!imageDataUrl) {
-      return resp(502, { errors: ["Unexpected Space response"], raw: data });
-    }
+    const payload = {
+      data: [
+        typeof input.prompt === "string" ? input.prompt : "",
+        typeof input.negative_prompt === "string" ? input.negative_prompt : "",
+        toNumber(input.seed, 0),
+        Boolean(input.randomize_seed ?? true),
+        toNumber(input.width, 1024),
+        toNumber(input.height, 1024),
+        toNumber(input.guidance_scale, 0),
+        toNumber(input.num_inference_steps, 2),
+      ],
+    };
 
-    return resp(200, { imageDataUrl });
-  } catch (err: any) {
-    return resp(500, { errors: ["Unhandled error"], raw: String(err?.message || err) });
+    const response = await hfFetch("/gradio_api/call/infer", {
+      method: "POST",
+      body: JSON.stringify(payload),
+      retries: 1,
+    });
+
+    const json = await response.json();
+    return jsonResponse(200, json);
+  } catch (error: any) {
+    return jsonResponse(500, { error: String(error?.message || error) });
   }
 };
 
-function resp(status: number, body: unknown) {
+function jsonResponse(statusCode: number, body: unknown) {
   return {
-    statusCode: status,
+    statusCode,
     headers: {
       "Content-Type": "application/json",
       "Cache-Control": "no-store",
     },
     body: JSON.stringify(body),
   };
+}
+
+function toNumber(value: unknown, fallback: number) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
 }

--- a/src/lib/hfSpaceClient.ts
+++ b/src/lib/hfSpaceClient.ts
@@ -1,0 +1,36 @@
+export type GenerationParams = {
+  prompt: string;
+  negative_prompt?: string;
+  seed?: number;
+  randomize_seed?: boolean;
+  width?: number;
+  height?: number;
+  guidance_scale?: number;
+  num_inference_steps?: number;
+};
+
+export async function requestGeneration(params: GenerationParams) {
+  const response = await fetch("/.netlify/functions/hf-space", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  return response.json();
+}
+
+export async function fetchResult(eventId: string) {
+  const response = await fetch(
+    `/.netlify/functions/hf-space-result?id=${encodeURIComponent(eventId)}`
+  );
+
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  return response.json();
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,26 +1,148 @@
+import { fetchResult, requestGeneration } from "../hfSpaceClient";
+
+const POLL_INTERVAL_MS = 1200;
+const MAX_POLLS = 25;
+const FAILURE_STATUSES = new Set(["FAILED", "CANCELLED", "ERROR"]);
+
 export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ prompt }),
-  });
+  const trimmedPrompt = typeof prompt === "string" ? prompt : "";
+  const generation = await requestGeneration({ prompt: trimmedPrompt });
+  const eventId = extractEventId(generation);
 
-  const json = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
-    throw new Error(message);
+  if (!eventId) {
+    throw new Error("Space request failed: missing event id");
   }
 
-  const image = json?.imageDataUrl;
-  if (typeof image !== "string" || !image) {
-    throw new Error("Invalid image response from Hugging Face Space");
+  for (let attempt = 0; attempt < MAX_POLLS; attempt++) {
+    const result = await fetchResult(eventId);
+
+    const image = extractImageFromResult(result);
+    if (image) {
+      return image;
+    }
+
+    const status = getStatus(result);
+    if (status && FAILURE_STATUSES.has(status)) {
+      throw new Error(getErrorMessage(result) ?? "Hugging Face Space request failed");
+    }
+
+    if (status === "COMPLETE" || status === "SUCCESS") {
+      throw new Error("Hugging Face Space returned no image");
+    }
+
+    await delay(POLL_INTERVAL_MS);
   }
 
-  return image;
+  throw new Error("Timed out waiting for Hugging Face Space");
+}
+
+function extractEventId(raw: unknown): string | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+
+  const direct = getString((raw as Record<string, unknown>).event_id);
+  if (direct) {
+    return direct;
+  }
+
+  const alt = getString((raw as Record<string, unknown>).id);
+  if (alt) {
+    return alt;
+  }
+
+  const event = (raw as Record<string, unknown>).event;
+  if (event && typeof event === "object") {
+    const nestedId = getString((event as Record<string, unknown>).id);
+    if (nestedId) {
+      return nestedId;
+    }
+  }
+
+  return null;
+}
+
+function extractImageFromResult(result: unknown): string | null {
+  if (result && typeof result === "object") {
+    const record = result as Record<string, unknown>;
+    const direct = getString(record.imageDataUrl);
+    if (direct) {
+      return direct;
+    }
+
+    const payload = Array.isArray(record.data)
+      ? record.data
+      : Array.isArray((record.data as Record<string, unknown> | undefined)?.data)
+      ? ((record.data as Record<string, unknown>).data as unknown[])
+      : null;
+
+    if (Array.isArray(payload)) {
+      for (const item of payload) {
+        if (typeof item === "string" && looksLikeImage(item)) {
+          return item;
+        }
+        if (item && typeof item === "object") {
+          const candidate =
+            getString((item as Record<string, unknown>).imageDataUrl) ||
+            getString((item as Record<string, unknown>).url) ||
+            getString((item as Record<string, unknown>).data);
+          if (candidate && looksLikeImage(candidate)) {
+            return candidate;
+          }
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function getStatus(result: unknown): string | undefined {
+  if (result && typeof result === "object") {
+    const status = (result as Record<string, unknown>).status;
+    if (typeof status === "string" && status) {
+      return status.toUpperCase();
+    }
+  }
+  return undefined;
+}
+
+function getErrorMessage(result: unknown): string | undefined {
+  if (result && typeof result === "object") {
+    const record = result as Record<string, unknown>;
+    const direct = getString(record.error) || getString(record.detail);
+    if (direct) {
+      return direct;
+    }
+
+    const eventError =
+      record.event && typeof record.event === "object"
+        ? getString((record.event as Record<string, unknown>).error)
+        : undefined;
+    if (eventError) {
+      return eventError;
+    }
+
+    const dataError =
+      record.data && typeof record.data === "object"
+        ? getString((record.data as Record<string, unknown>).error)
+        : undefined;
+    if (dataError) {
+      return dataError;
+    }
+  }
+
+  return undefined;
+}
+
+function looksLikeImage(value: string) {
+  return value.startsWith("data:image/") || /^https?:\/\//i.test(value);
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === "string" && value ? value : null;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
## Summary
- normalize Hugging Face Space environment variables and add retriable fetch helper for Netlify functions
- update hf-space and new hf-space-result functions to use the helper and return consistent JSON including image URLs
- add a browser-side client with polling so Navatar generation waits for the Space result, and extend Netlify timeouts for the functions

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0ecfe36508329b0e38c9682e3bf79