### PR TITLE
Show generated image and robust Space polling

### DIFF
--- a/netlify/functions/hf-space-result.ts
+++ b/netlify/functions/hf-space-result.ts
@@ -1,0 +1,70 @@
+import type { Handler } from "@netlify/functions";
+
+function normalizeSpaceUrl(raw?: string | null) {
+  if (!raw) return "";
+  const trimmed = raw.trim();
+  const withProto = trimmed.startsWith("http") ? trimmed : `https://${trimmed}`;
+  return withProto.replace(/\/+$/, "");
+}
+
+const SPACE_URL =
+  normalizeSpaceUrl(process.env.HF_SPACE_URL) ||
+  normalizeSpaceUrl(process.env.HUGGINGFACE_SPACE_URL);
+
+export const handler: Handler = async (event) => {
+  try {
+    if (!SPACE_URL) {
+      return json(500, { error: "HF_SPACE_URL not set" });
+    }
+
+    const id = event.queryStringParameters?.id;
+    if (!id) {
+      return json(400, { error: "Missing id" });
+    }
+
+    const res = await fetch(`${SPACE_URL}/gradio_api/call/infer/${id}`, {
+      method: "GET",
+    });
+
+    if (res.status === 202) {
+      return json(202, { pending: true });
+    }
+
+    if (!res.ok) {
+      const text = await res.text();
+      return json(502, { error: text || "Space result failed" });
+    }
+
+    const data = await res.json();
+    const first = data?.data?.[0];
+    const candidate =
+      (typeof first === "string" && first) ||
+      first?.url ||
+      first?.path ||
+      first?.image?.url ||
+      null;
+
+    if (!candidate || typeof candidate !== "string") {
+      return json(502, { error: "No image in Space response" });
+    }
+
+    const imageUrl = candidate.startsWith("http") || candidate.startsWith("data:image/")
+      ? candidate
+      : `${SPACE_URL}/${candidate.replace(/^\/+/, "")}`;
+
+    return json(200, { imageUrl });
+  } catch (err: any) {
+    return json(500, { error: err?.message || "Unknown error" });
+  }
+};
+
+function json(statusCode: number, body: unknown) {
+  return {
+    statusCode,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+    body: JSON.stringify(body),
+  };
+}

--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,22 +1,38 @@
 import type { Handler } from "@netlify/functions";
 
-const SPACE = process.env.HF_SPACE_URL;
+function normalizeSpaceUrl(raw?: string | null) {
+  if (!raw) return "";
+  const trimmed = raw.trim();
+  const withProto = trimmed.startsWith("http") ? trimmed : `https://${trimmed}`;
+  return withProto.replace(/\/+$/, "");
+}
+
+const SPACE_URL =
+  normalizeSpaceUrl(process.env.HF_SPACE_URL) ||
+  normalizeSpaceUrl(process.env.HUGGINGFACE_SPACE_URL);
 
 export const handler: Handler = async (event) => {
   try {
-    if (!SPACE) {
+    if (!SPACE_URL) {
       return resp(500, { errors: ["HF_SPACE_URL not set"] });
     }
     if (event.httpMethod !== "POST") {
       return resp(405, { errors: ["Method not allowed"] });
     }
 
-    const { prompt } = JSON.parse(event.body || "{}");
-    if (!prompt || typeof prompt !== "string") {
+    let prompt: string | undefined;
+    try {
+      const payload = JSON.parse(event.body || "{}");
+      prompt = typeof payload?.prompt === "string" ? payload.prompt.trim() : undefined;
+    } catch {
+      return resp(400, { errors: ["Invalid JSON body"] });
+    }
+
+    if (!prompt) {
       return resp(400, { errors: ["Missing prompt"] });
     }
 
-    const gradio = await fetch(`${SPACE}/api/predict/`, {
+    const gradio = await fetch(`${SPACE_URL}/gradio_api/call/infer`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Accept: "application/json" },
       body: JSON.stringify({ data: [prompt] }),
@@ -27,24 +43,20 @@ export const handler: Handler = async (event) => {
       return resp(gradio.status, { errors: ["Space request failed"], raw });
     }
 
-    const data = await gradio.json();
+    const data = await gradio.json().catch(() => null);
+    const rawId = (data as any)?.event_id ?? (data as any)?.eventId ?? (data as any)?.id;
+    const id =
+      typeof rawId === "string"
+        ? rawId
+        : typeof rawId === "number"
+        ? String(rawId)
+        : null;
 
-    let imageDataUrl: string | null = null;
-
-    if (Array.isArray(data?.data)) {
-      const first = data.data[0];
-      if (typeof first === "string" && first.startsWith("data:image/")) {
-        imageDataUrl = first;
-      } else if (first && typeof first === "object" && typeof first.name === "string") {
-        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
-      }
+    if (!id) {
+      return resp(502, { errors: ["Missing event id from Space"], raw: data });
     }
 
-    if (!imageDataUrl) {
-      return resp(502, { errors: ["Unexpected Space response"], raw: data });
-    }
-
-    return resp(200, { imageDataUrl });
+    return resp(200, { id });
   } catch (err: any) {
     return resp(500, { errors: ["Unhandled error"], raw: String(err?.message || err) });
   }

--- a/src/lib/hf.ts
+++ b/src/lib/hf.ts
@@ -1,0 +1,93 @@
+export function normalizeSpaceUrl(raw?: string) {
+  if (!raw) return "";
+  const trimmed = raw.trim();
+  const withProto = trimmed.startsWith("http") ? trimmed : `https://${trimmed}`;
+  return withProto.replace(/\/+$/, "");
+}
+
+export function getSpaceUrl() {
+  const env =
+    import.meta.env?.HF_SPACE_URL ||
+    import.meta.env?.VITE_HF_SPACE_URL ||
+    import.meta.env?.HUGGINGFACE_SPACE_URL ||
+    import.meta.env?.VITE_HUGGINGFACE_SPACE_URL;
+  return normalizeSpaceUrl(env);
+}
+
+export async function startGeneration(payload: any) {
+  const res = await fetch("/.netlify/functions/hf-space", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const message = (await safeText(res)) || "Space request failed";
+    throw new Error(message);
+  }
+  const json = await res.json().catch(() => ({}));
+  const rawId = json?.id ?? json?.eventId;
+  const id =
+    typeof rawId === "string"
+      ? rawId
+      : typeof rawId === "number"
+      ? String(rawId)
+      : null;
+  if (!id) {
+    throw new Error("No EVENT_ID from Space");
+  }
+  return id;
+}
+
+export async function pollResult(
+  id: string,
+  { timeoutMs = 120_000, intervalMs = 2_000 }: { timeoutMs?: number; intervalMs?: number } = {}
+) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const response = await fetch(`/.netlify/functions/hf-space-result?id=${encodeURIComponent(id)}`);
+    if (response.status === 202) {
+      await wait(intervalMs);
+      continue;
+    }
+    if (!response.ok) {
+      throw new Error(await safeText(response) || "Space result failed");
+    }
+    const json = await response.json().catch(() => ({}));
+    if (json?.imageUrl) {
+      return json.imageUrl as string;
+    }
+    throw new Error("Malformed result from Space");
+  }
+  throw new Error("Space result timed out");
+}
+
+async function safeText(response: Response) {
+  try {
+    const text = await response.text();
+    try {
+      const json = JSON.parse(text);
+      if (json && typeof json === "object") {
+        if (typeof json.error === "string" && json.error) {
+          return json.error;
+        }
+        if (Array.isArray(json.errors) && json.errors.length > 0) {
+          const first = json.errors.find(
+            (entry: unknown): entry is string => typeof entry === "string"
+          );
+          if (first) return first;
+        }
+      }
+    } catch {
+      // Ignore JSON parse errors and fall back to raw text
+    }
+    return text;
+  } catch {
+    return "";
+  }
+}
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => resolve(), ms);
+  });
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,26 +1,6 @@
+import { pollResult, startGeneration } from "../hf";
+
 export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ prompt }),
-  });
-
-  const json = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
-    throw new Error(message);
-  }
-
-  const image = json?.imageDataUrl;
-  if (typeof image !== "string" || !image) {
-    throw new Error("Invalid image response from Hugging Face Space");
-  }
-
-  return image;
+  const id = await startGeneration({ prompt });
+  return pollResult(id);
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -107,15 +107,22 @@ export default function GenerateNavatarPage() {
     const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
     const avoid = extraNegativePrompt.trim();
     const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
+    const previousDraft = draftUrl;
+    let nextDraft: string | undefined;
     setIsGenerating(true);
     try {
-      const dataUrl = await generateWithHuggingFace(promptWithAvoidance);
-      const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
+      const imageUrl = await generateWithHuggingFace(promptWithAvoidance);
+      nextDraft = imageUrl;
+      setDraftUrl(imageUrl);
+      const generatedFile = await urlToFile(imageUrl, `navatar-${Date.now()}.png`);
 
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });
     } catch (error) {
       console.error(error);
+      if (nextDraft && previousDraft !== nextDraft) {
+        setDraftUrl(previousDraft);
+      }
       const message = error instanceof Error ? error.message : "Error generating image";
       toast({ text: message, kind: "err" });
     } finally {
@@ -253,9 +260,13 @@ export default function GenerateNavatarPage() {
   );
 }
 
-async function dataUrlToFile(dataUrl: string, filename: string) {
-  const res = await fetch(dataUrl);
-  const blob = await res.blob();
-  return new File([blob], filename, { type: blob.type || "image/png" });
+async function urlToFile(imageUrl: string, filename: string) {
+  const response = await fetch(imageUrl);
+  if (!response.ok) {
+    throw new Error("Failed to download generated image");
+  }
+  const blob = await response.blob();
+  const type = blob.type || "image/png";
+  return new File([blob], filename, { type });
 }
 


### PR DESCRIPTION
## Summary
- normalize the Hugging Face Space URL for both start and result functions and add a result endpoint that returns clean image URLs
- add shared helpers to start a Space generation, poll for results with error handling, and consume them from the navatar generator
- update the navatar generation UI to poll until an image is ready, render the preview, and surface clear success or failure toasts

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d124e58a7c83299a981062be0643b3