### PR TITLE
Fix HF Space generation polling and preview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,12 @@
   included_files = []
   external_node_modules = []
 
+[functions."hf-space"]
+  timeout = 26
+
+[functions."hf-space-result"]
+  timeout = 10
+
 # SPA routing
 [[redirects]]
   from = "/*"

--- a/netlify/functions/hf-space-result.ts
+++ b/netlify/functions/hf-space-result.ts
@@ -1,0 +1,68 @@
+import type { Handler } from "@netlify/functions";
+import { getSpaceBaseUrl, getBearer, retryingFetch, extractImageUrl } from "../../src/lib/_hf";
+
+const jsonHeaders = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+};
+
+async function fetchWithSoftTimeout(url: string, headers: Record<string, string>, softMs = 7000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), softMs);
+  try {
+    const res = await retryingFetch(url, { headers, signal: controller.signal });
+    clearTimeout(timer);
+    return { ok: true as const, res };
+  } catch (err) {
+    clearTimeout(timer);
+    return { ok: false as const, err };
+  }
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "GET") {
+    return { statusCode: 405, headers: jsonHeaders, body: JSON.stringify({ error: "Method Not Allowed" }) };
+  }
+
+  const base = getSpaceBaseUrl();
+  if (!base) {
+    return { statusCode: 500, headers: jsonHeaders, body: JSON.stringify({ error: "HF_SPACE_URL not set" }) };
+  }
+
+  const eventId = event.queryStringParameters?.eventId;
+  if (!eventId) {
+    return { statusCode: 400, headers: jsonHeaders, body: JSON.stringify({ error: "Missing eventId" }) };
+  }
+
+  const bearer = getBearer();
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (bearer) {
+    headers.Authorization = bearer;
+  }
+
+  const url = `${base}/gradio_api/call/infer/${encodeURIComponent(eventId)}?t=${Date.now()}`;
+  const result = await fetchWithSoftTimeout(url, headers, 7000);
+
+  if (!result.ok) {
+    return { statusCode: 200, headers: jsonHeaders, body: JSON.stringify({ ok: true, status: "pending" }) };
+  }
+
+  try {
+    if (result.res.status === 202) {
+      return { statusCode: 200, headers: jsonHeaders, body: JSON.stringify({ ok: true, status: "pending" }) };
+    }
+
+    const imageUrl = await extractImageUrl(result.res);
+    if (!imageUrl) {
+      return { statusCode: 200, headers: jsonHeaders, body: JSON.stringify({ ok: true, status: "pending" }) };
+    }
+
+    return {
+      statusCode: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({ ok: true, status: "done", imageUrl }),
+    };
+  } catch {
+    return { statusCode: 200, headers: jsonHeaders, body: JSON.stringify({ ok: true, status: "pending" }) };
+  }
+};

--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,62 +1,61 @@
 import type { Handler } from "@netlify/functions";
+import { getSpaceBaseUrl, getBearer, retryingFetch } from "../../src/lib/_hf";
 
-const SPACE = process.env.HF_SPACE_URL;
-
-export const handler: Handler = async (event) => {
-  try {
-    if (!SPACE) {
-      return resp(500, { errors: ["HF_SPACE_URL not set"] });
-    }
-    if (event.httpMethod !== "POST") {
-      return resp(405, { errors: ["Method not allowed"] });
-    }
-
-    const { prompt } = JSON.parse(event.body || "{}");
-    if (!prompt || typeof prompt !== "string") {
-      return resp(400, { errors: ["Missing prompt"] });
-    }
-
-    const gradio = await fetch(`${SPACE}/api/predict/`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ data: [prompt] }),
-    });
-
-    if (!gradio.ok) {
-      const raw = await gradio.text();
-      return resp(gradio.status, { errors: ["Space request failed"], raw });
-    }
-
-    const data = await gradio.json();
-
-    let imageDataUrl: string | null = null;
-
-    if (Array.isArray(data?.data)) {
-      const first = data.data[0];
-      if (typeof first === "string" && first.startsWith("data:image/")) {
-        imageDataUrl = first;
-      } else if (first && typeof first === "object" && typeof first.name === "string") {
-        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
-      }
-    }
-
-    if (!imageDataUrl) {
-      return resp(502, { errors: ["Unexpected Space response"], raw: data });
-    }
-
-    return resp(200, { imageDataUrl });
-  } catch (err: any) {
-    return resp(500, { errors: ["Unhandled error"], raw: String(err?.message || err) });
-  }
+const jsonHeaders = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
 };
 
-function resp(status: number, body: unknown) {
-  return {
-    statusCode: status,
-    headers: {
-      "Content-Type": "application/json",
-      "Cache-Control": "no-store",
-    },
-    body: JSON.stringify(body),
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, headers: jsonHeaders, body: JSON.stringify({ error: "Method Not Allowed" }) };
+  }
+
+  const base = getSpaceBaseUrl();
+  if (!base) {
+    return { statusCode: 500, headers: jsonHeaders, body: JSON.stringify({ error: "HF_SPACE_URL not set" }) };
+  }
+
+  const bearer = getBearer();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
   };
-}
+  if (bearer) {
+    headers.Authorization = bearer;
+  }
+
+  const body = event.body ? JSON.parse(event.body) : {};
+  const url = `${base}/gradio_api/call/infer`;
+
+  try {
+    const res = await retryingFetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        data: [
+          body.prompt ?? "",
+          body.negative_prompt ?? "",
+          body.seed ?? 0,
+          body.randomize_seed ?? true,
+          body.width ?? 1024,
+          body.height ?? 1024,
+          body.guidance_scale ?? 0,
+          body.num_inference_steps ?? 2,
+        ],
+      }),
+    });
+
+    const json = await res.json().catch(() => ({}));
+    const eventId: string | undefined = json?.event_id || json?.eventId || json?.id;
+
+    if (!eventId) {
+      return { statusCode: 502, headers: jsonHeaders, body: JSON.stringify({ error: "No eventId from Space" }) };
+    }
+
+    return { statusCode: 200, headers: jsonHeaders, body: JSON.stringify({ ok: true, eventId }) };
+  } catch (err: any) {
+    const message = err?.message ? String(err.message) : String(err);
+    return { statusCode: 502, headers: jsonHeaders, body: JSON.stringify({ error: message }) };
+  }
+};

--- a/src/lib/_hf.ts
+++ b/src/lib/_hf.ts
@@ -1,0 +1,58 @@
+export function getSpaceBaseUrl(): string {
+  const raw =
+    process.env.HF_SPACE_URL ||
+    process.env.HUGGINGFACE_SPACE_URL ||
+    "";
+  const value = raw.trim().replace(/\/+$/, "");
+
+  if (!value) return "";
+
+  const match = value.match(/^https?:\/\/huggingface\.co\/spaces\/([^/]+)\/([^/]+)$/i);
+  if (match) {
+    const [, org, space] = match;
+    return `https://${org}-${space}.hf.space`;
+  }
+
+  return value;
+}
+
+export function getBearer(): string | null {
+  const apiKey = process.env.HF_API_TOKEN || process.env.HUGGINGFACE_API_KEY || "";
+  return apiKey ? `Bearer ${apiKey}` : null;
+}
+
+export async function retryingFetch(input: RequestInfo, init?: RequestInit, tries = 3): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < tries; attempt++) {
+    try {
+      const response = await fetch(input as any, init);
+      if (response.status >= 500) {
+        throw new Error(`HF ${response.status}`);
+      }
+      return response;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 300 * (attempt + 1)));
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+export async function extractImageUrl(res: Response): Promise<string | null> {
+  const data = await res.json().catch(() => null);
+  if (!data) return null;
+
+  const first = data?.data?.[0];
+  if (first?.url) {
+    return first.url as string;
+  }
+
+  if (first?.data) {
+    const b64 = String(first.data);
+    return `data:image/png;base64,${b64}`;
+  }
+
+  return null;
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,26 +1,116 @@
-export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
+export type SubmitPayload = {
+  prompt: string;
+  negative_prompt?: string;
+  seed?: number;
+  randomize_seed?: boolean;
+  width?: number;
+  height?: number;
+  guidance_scale?: number;
+  num_inference_steps?: number;
+};
+
+type PollResult =
+  | { status: "pending" }
+  | { status: "done"; imageUrl: string }
+  | { status: "error"; error: string };
+
+type GenerateOptions = {
+  onTick?: (attempt: number) => void;
+  intervalMs?: number;
+  maxTries?: number;
+};
+
+const DEFAULT_INTERVAL_MS = 1500;
+const DEFAULT_MAX_TRIES = 120;
+
+async function submitToSpace(payload: SubmitPayload): Promise<string> {
+  const res = await fetch("/.netlify/functions/hf-space", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
     },
-    body: JSON.stringify({ prompt }),
+    body: JSON.stringify(payload),
   });
 
-  const json = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok || !json?.ok) {
+    const message = typeof json?.error === "string" ? json.error : "Hugging Face Space error";
     throw new Error(message);
   }
 
-  const image = json?.imageDataUrl;
-  if (typeof image !== "string" || !image) {
-    throw new Error("Invalid image response from Hugging Face Space");
+  const eventId = typeof json.eventId === "string" ? json.eventId : undefined;
+  if (!eventId) {
+    throw new Error("No eventId returned from Space");
   }
 
-  return image;
+  return eventId;
+}
+
+async function pollSpace(eventId: string): Promise<PollResult> {
+  try {
+    const res = await fetch(`/.netlify/functions/hf-space-result?eventId=${encodeURIComponent(eventId)}`, {
+      method: "GET",
+      headers: {
+        "cache-control": "no-store",
+        Accept: "application/json",
+      },
+    });
+
+    const json = await res.json().catch(() => ({}));
+
+    if (!res.ok) {
+      const message = typeof json?.error === "string" ? json.error : `Space poll failed (${res.status})`;
+      return { status: "error", error: message };
+    }
+
+    if (json?.status === "done" && typeof json.imageUrl === "string" && json.imageUrl) {
+      return { status: "done", imageUrl: json.imageUrl };
+    }
+
+    if (json?.status === "pending") {
+      return { status: "pending" };
+    }
+
+    if (typeof json?.error === "string" && json.error) {
+      return { status: "error", error: json.error };
+    }
+
+    return { status: "pending" };
+  } catch (error) {
+    return { status: "pending" };
+  }
+}
+
+export async function generateWithHuggingFace(
+  payload: SubmitPayload,
+  options: GenerateOptions = {}
+): Promise<string> {
+  if (!payload?.prompt?.trim()) {
+    throw new Error("Describe your Navatar first");
+  }
+
+  const eventId = await submitToSpace(payload);
+  const interval = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const maxTries = options.maxTries ?? DEFAULT_MAX_TRIES;
+
+  for (let attempt = 0; attempt < maxTries; attempt++) {
+    const result = await pollSpace(eventId);
+
+    if (result.status === "done") {
+      return result.imageUrl;
+    }
+
+    if (result.status === "error") {
+      throw new Error(result.error);
+    }
+
+    options.onTick?.(attempt + 1);
+
+    if (attempt < maxTries - 1) {
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+  }
+
+  throw new Error("Generation timed out");
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -106,11 +106,19 @@ export default function GenerateNavatarPage() {
     const promptForBrand = onBrand ? wrapWithBrandStyle(trimmedPrompt) : trimmedPrompt;
     const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
     const avoid = extraNegativePrompt.trim();
-    const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
+    const negativePrompt = avoid ? `${alwaysFilteredPrompt}, ${avoid}` : alwaysFilteredPrompt;
     setIsGenerating(true);
     try {
-      const dataUrl = await generateWithHuggingFace(promptWithAvoidance);
-      const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
+      const imageUrl = await generateWithHuggingFace({
+        prompt: finalPrompt,
+        negative_prompt: negativePrompt,
+        width: 1024,
+        height: 1024,
+        guidance_scale: 0,
+        num_inference_steps: 2,
+      });
+      setDraftUrl(imageUrl);
+      const generatedFile = await dataUrlToFile(imageUrl, `navatar-${Date.now()}.png`);
 
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });


### PR DESCRIPTION
## Summary
- add a shared Hugging Face helper to normalize the Space URL, build auth headers, retry fetches, and parse returned images
- refactor the hf-space Netlify function and add a hf-space-result poller so submits go through a single eventId workflow with soft timeouts
- update the Navatar generator to use the new polling workflow, pass through negative prompts, and display the returned image URL
- configure Netlify timeouts for the hf-space submit and poll functions to avoid Netlify 504s

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d130357e048329a18cdcc0dacb30a4