### PR TITLE
Add start/poll Hugging Face proxy and update Navatar flow

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,5 @@
+# Netlify config (merge-ready)
+
 [build]
   command = "npm run build"
   publish = "dist"
@@ -7,6 +9,15 @@
   directory = "netlify/functions"
   included_files = []
   external_node_modules = []
+
+# Give our HF proxy enough time to finish
+[functions."hf-space"]
+  timeout = 26
+  memory  = 1024
+
+[functions."hf-space-result"]
+  timeout = 26
+  memory  = 1024
 
 # SPA routing
 [[redirects]]

--- a/netlify/functions/_hf.ts
+++ b/netlify/functions/_hf.ts
@@ -1,0 +1,80 @@
+// Shared HF helpers (Netlify Functions runtime)
+
+const SPACE_ENV_KEYS = ["HF_SPACE_URL", "HUGGINGFACE_SPACE_URL"] as const;
+
+export function getSpaceUrl(): string {
+  for (const k of SPACE_ENV_KEYS) {
+    const v = (process.env as any)[k];
+    if (v && typeof v === "string" && v.trim()) {
+      return normalizeSpaceUrl(v);
+    }
+  }
+  throw new Error(
+    "Missing HF Space URL. Set HF_SPACE_URL (preferred) or HUGGINGFACE_SPACE_URL in Netlify env vars."
+  );
+}
+
+export function normalizeSpaceUrl(u: string): string {
+  // Accept plain space URL or the .hf.space domain — both normalize to the human URL
+  // Examples accepted:
+  //   https://huggingface.co/spaces/turianmediacompany/naturverse-space
+  //   https://turianmediacompany-naturverse-space.hf.space
+  const trimmed = u.trim().replace(/\/+$/, "");
+  if (trimmed.includes(".hf.space")) {
+    // Convert subdomain form -> human form if desired; but Gradio API works on either.
+    return trimmed; // Keep as-is; API paths below are relative.
+  }
+  // Must look like huggingface.co/spaces/owner/name
+  if (!/^https?:\/\/huggingface\.co\/spaces\/[^/]+\/[^/]+$/i.test(trimmed)) {
+    throw new Error(`HF Space URL looks wrong: ${u}`);
+  }
+  return trimmed;
+}
+
+export async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  { retries = 2, backoffMs = 750 }: { retries?: number; backoffMs?: number } = {}
+): Promise<Response> {
+  let lastErr: any;
+  for (let i = 0; i <= retries; i++) {
+    try {
+      const res = await fetch(url, init);
+      if (res.ok || (res.status >= 400 && res.status < 500)) {
+        return res;
+      }
+      lastErr = new Error(`HTTP ${res.status}`);
+    } catch (e) {
+      lastErr = e;
+    }
+    if (i < retries) await new Promise(r => setTimeout(r, backoffMs * (i + 1)));
+  }
+  throw lastErr;
+}
+
+export type StartResponse =
+  | { ok: true; eventId: string }
+  | { ok: false; error: string };
+
+export type PollResponse =
+  | { ok: true; done: true; imageUrl: string }
+  | { ok: true; done: false }
+  | { ok: false; error: string };
+
+// Extract event ID from Gradio call response body (it’s usually a JSON with an id, or a
+// small text line containing it). We support both typical shapes.
+export async function extractEventId(res: Response): Promise<string | null> {
+  const text = await res.text();
+  try {
+    const j = JSON.parse(text);
+    // Common shapes seen:
+    // { "event_id": "..."} or {"id":"..."} or {"queue": {"event_id":"..."}}
+    const id =
+      j?.event_id ?? j?.id ?? j?.queue?.event_id ?? j?.queue?.id ?? null;
+    if (typeof id === "string" && id) return id;
+  } catch {
+    // not JSON; try to pull a token-like id
+  }
+  const m = text.match(/[a-f0-9]{8,}-[a-f0-9-]{10,}/i) || text.match(/"(\w{8,})"/);
+  return m ? (m[0].replace(/"/g, "")) : null;
+}

--- a/netlify/functions/hf-space-result.ts
+++ b/netlify/functions/hf-space-result.ts
@@ -1,0 +1,62 @@
+// GET /.netlify/functions/hf-space-result?eventId=...
+// Polls the Space for the result, returns {done,imageUrl} | {done:false}
+
+import type { Handler } from "@netlify/functions";
+import { getSpaceUrl, fetchWithRetry, type PollResponse } from "./_hf";
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+};
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "GET") {
+    return json({ ok: false, error: "Method Not Allowed" }, 405);
+  }
+
+  const eventId = event.queryStringParameters?.eventId ?? "";
+  if (!eventId) {
+    return json({ ok: false, error: "Missing eventId" }, 400);
+  }
+
+  try {
+    const space = getSpaceUrl();
+    const url = `${space}/gradio_api/call/infer/${encodeURIComponent(eventId)}`;
+
+    const res = await fetchWithRetry(url, { method: "GET" });
+    if (!res.ok) {
+      return json({ ok: false, error: `HF poll failed: ${res.status}` }, res.status);
+    }
+
+    const j = await res.json().catch(() => null);
+    const out: PollResponse = parseGradioResult(j);
+    return json(out, 200);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return json({ ok: false, error: message }, 500);
+  }
+};
+
+function parseGradioResult(j: any): PollResponse {
+  if (!j || (j.status && String(j.status).toUpperCase() !== "COMPLETE" && !j.data)) {
+    return { ok: true, done: false };
+  }
+  const data0 = Array.isArray(j?.data) ? j.data[0] : null;
+  const url: string | undefined = data0?.url || data0?.path;
+  if (url && /^https?:\/\//.test(url)) {
+    return { ok: true, done: true, imageUrl: url };
+  }
+  const b64 = data0?.data || data0?.base64;
+  if (b64 && typeof b64 === "string") {
+    return { ok: true, done: true, imageUrl: `data:image/png;base64,${b64}` };
+  }
+  return { ok: true, done: false };
+}
+
+function json(data: any, status = 200) {
+  return {
+    statusCode: status,
+    headers: JSON_HEADERS,
+    body: JSON.stringify(data),
+  };
+}

--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,62 +1,52 @@
-import type { Handler } from "@netlify/functions";
+// POST /.netlify/functions/hf-space
+// Starts a generation job on the HF Space and returns {eventId}
 
-const SPACE = process.env.HF_SPACE_URL;
+import type { Handler } from "@netlify/functions";
+import { getSpaceUrl, fetchWithRetry, extractEventId, type StartResponse } from "./_hf";
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+};
 
 export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return json({ ok: false, error: "Method Not Allowed" }, 405);
+  }
+
   try {
-    if (!SPACE) {
-      return resp(500, { errors: ["HF_SPACE_URL not set"] });
-    }
-    if (event.httpMethod !== "POST") {
-      return resp(405, { errors: ["Method not allowed"] });
-    }
+    const space = getSpaceUrl();
 
-    const { prompt } = JSON.parse(event.body || "{}");
-    if (!prompt || typeof prompt !== "string") {
-      return resp(400, { errors: ["Missing prompt"] });
-    }
+    const rawBody = event.isBase64Encoded && event.body
+      ? Buffer.from(event.body, "base64").toString("utf8")
+      : event.body || "";
 
-    const gradio = await fetch(`${SPACE}/api/predict/`, {
+    const url = `${space}/gradio_api/call/infer`;
+    const res = await fetchWithRetry(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ data: [prompt] }),
+      headers: { "Content-Type": "application/json" },
+      body: rawBody,
     });
 
-    if (!gradio.ok) {
-      const raw = await gradio.text();
-      return resp(gradio.status, { errors: ["Space request failed"], raw });
+    if (!res.ok) {
+      return json({ ok: false, error: `HF start failed: ${res.status}` }, res.status);
     }
-
-    const data = await gradio.json();
-
-    let imageDataUrl: string | null = null;
-
-    if (Array.isArray(data?.data)) {
-      const first = data.data[0];
-      if (typeof first === "string" && first.startsWith("data:image/")) {
-        imageDataUrl = first;
-      } else if (first && typeof first === "object" && typeof first.name === "string") {
-        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
-      }
+    const eventId = await extractEventId(res);
+    if (!eventId) {
+      return json({ ok: false, error: "Could not parse eventId from HF." }, 502);
     }
-
-    if (!imageDataUrl) {
-      return resp(502, { errors: ["Unexpected Space response"], raw: data });
-    }
-
-    return resp(200, { imageDataUrl });
-  } catch (err: any) {
-    return resp(500, { errors: ["Unhandled error"], raw: String(err?.message || err) });
+    const out: StartResponse = { ok: true, eventId };
+    return json(out, 200);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return json({ ok: false, error: message }, 500);
   }
 };
 
-function resp(status: number, body: unknown) {
+function json(data: any, status = 200) {
   return {
     statusCode: status,
-    headers: {
-      "Content-Type": "application/json",
-      "Cache-Control": "no-store",
-    },
-    body: JSON.stringify(body),
+    headers: JSON_HEADERS,
+    body: JSON.stringify(data),
   };
 }

--- a/src/lib/hf.ts
+++ b/src/lib/hf.ts
@@ -1,0 +1,25 @@
+// Browser utilities used by the Navatar page
+
+export type StartOk = { ok: true; eventId: string };
+export type StartErr = { ok: false; error: string };
+export type StartResp = StartOk | StartErr;
+
+export type PollDone = { ok: true; done: true; imageUrl: string };
+export type PollWait = { ok: true; done: false };
+export type PollErr  = { ok: false; error: string };
+export type PollResp = PollDone | PollWait | PollErr;
+
+export async function startJob(payload: any): Promise<StartResp> {
+  const res = await fetch("/.netlify/functions/hf-space", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof payload === "string" ? payload : JSON.stringify(payload),
+  });
+  return res.json();
+}
+
+export async function pollJob(eventId: string): Promise<PollResp> {
+  const url = `/.netlify/functions/hf-space-result?eventId=${encodeURIComponent(eventId)}`;
+  const res = await fetch(url, { method: "GET", cache: "no-store" });
+  return res.json();
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,26 +1,94 @@
-export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ prompt }),
-  });
+import { pollJob, startJob, type PollResp, type StartResp } from "../hf";
 
-  const json = await response.json().catch(() => ({}));
+export type HfStatus = "starting" | "polling";
 
-  if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
-    throw new Error(message);
+export interface HuggingFaceGenerateOptions {
+  prompt: string;
+  negativePrompt?: string;
+  seed?: number;
+  randomizeSeed?: boolean;
+  width?: number;
+  height?: number;
+  guidanceScale?: number;
+  steps?: number;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  onStatusChange?: (status: HfStatus) => void;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_POLL_INTERVAL_MS = 1_200;
+const FALLBACK_PROMPT = "Hello!!";
+
+export async function generateWithHuggingFace(options: HuggingFaceGenerateOptions): Promise<string> {
+  const {
+    prompt,
+    negativePrompt = "",
+    seed = 0,
+    randomizeSeed = true,
+    width = 1024,
+    height = 1024,
+    guidanceScale = 0,
+    steps = 2,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    onStatusChange,
+  } = options;
+
+  const payload = {
+    data: [
+      prompt?.trim() ? prompt : FALLBACK_PROMPT,
+      typeof negativePrompt === "string" ? negativePrompt : "",
+      Number.isFinite(seed) ? seed : 0,
+      Boolean(randomizeSeed),
+      Number.isFinite(width) ? width : 1024,
+      Number.isFinite(height) ? height : 1024,
+      Number.isFinite(guidanceScale) ? guidanceScale : 0,
+      Number.isFinite(steps) ? steps : 2,
+    ],
+  };
+
+  onStatusChange?.("starting");
+
+  let startResp: StartResp;
+  try {
+    startResp = await startJob(payload);
+  } catch {
+    throw new Error("Unable to reach Hugging Face. Please try again.");
   }
 
-  const image = json?.imageDataUrl;
-  if (typeof image !== "string" || !image) {
-    throw new Error("Invalid image response from Hugging Face Space");
+  if (!startResp.ok) {
+    throw new Error(startResp.error || "Failed to start Hugging Face generation.");
   }
 
-  return image;
+  onStatusChange?.("polling");
+
+  const startAt = Date.now();
+  while (Date.now() - startAt < timeoutMs) {
+    let pollResp: PollResp;
+    try {
+      pollResp = await pollJob(startResp.eventId);
+    } catch {
+      throw new Error("Unable to reach Hugging Face. Please try again.");
+    }
+
+    if (!pollResp.ok) {
+      throw new Error(pollResp.error || "Hugging Face polling failed.");
+    }
+
+    if (pollResp.done) {
+      if (typeof pollResp.imageUrl === "string" && pollResp.imageUrl) {
+        return pollResp.imageUrl;
+      }
+      throw new Error("Hugging Face returned an invalid image URL.");
+    }
+
+    await delay(pollIntervalMs);
+  }
+
+  throw new Error("Generation timed out — please try again.");
+}
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -8,12 +8,13 @@ import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import { useAuthUser } from "../../lib/useAuthUser";
-import { generateWithHuggingFace } from "../../lib/navatar/generate";
+import { generateWithHuggingFace, type HfStatus } from "../../lib/navatar/generate";
 import {
   DEFAULT_NEGATIVE_PROMPT,
   DEFAULT_STYLE_ID,
   STYLE_PRESETS,
   buildPrompt,
+  seedFromUserId,
 } from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
 
@@ -47,10 +48,12 @@ export default function GenerateNavatarPage() {
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
   const [draftUrl, setDraftUrl] = useState<string | undefined>();
-  const [isGenerating, setIsGenerating] = useState(false);
+  type LoadingState = "idle" | HfStatus;
+  const [loadingState, setLoadingState] = useState<LoadingState>("idle");
   const nav = useNavigate();
   const toast = useToast();
   const { user } = useAuthUser();
+  const isGenerating = loadingState !== "idle";
 
   useEffect(() => {
     if (!file) {
@@ -106,10 +109,22 @@ export default function GenerateNavatarPage() {
     const promptForBrand = onBrand ? wrapWithBrandStyle(trimmedPrompt) : trimmedPrompt;
     const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
     const avoid = extraNegativePrompt.trim();
-    const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
-    setIsGenerating(true);
+    const baseNegative = alwaysFilteredPrompt;
+    const negativePrompt = avoid ? `${baseNegative}, ${avoid}` : baseNegative;
+    const shouldLockSeed = keepStyle && Boolean(user?.id);
+
+    setLoadingState("starting");
     try {
-      const dataUrl = await generateWithHuggingFace(promptWithAvoidance);
+      const dataUrl = await generateWithHuggingFace({
+        prompt: finalPrompt,
+        negativePrompt,
+        seed: shouldLockSeed && user?.id ? seedFromUserId(user.id) : 0,
+        randomizeSeed: !shouldLockSeed,
+        width: 1024,
+        height: 1024,
+        onStatusChange: (status) => setLoadingState(status),
+      });
+
       const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
 
       setFile(generatedFile);
@@ -118,9 +133,8 @@ export default function GenerateNavatarPage() {
       console.error(error);
       const message = error instanceof Error ? error.message : "Error generating image";
       toast({ text: message, kind: "err" });
-    } finally {
-      setIsGenerating(false);
     }
+    setLoadingState("idle");
   }
 
   const canSave = Boolean(file) && !isGenerating;
@@ -228,8 +242,19 @@ export default function GenerateNavatarPage() {
           onClick={handleGenerate}
           disabled={isGenerating}
         >
-          {isGenerating ? "Generating…" : "Generate with Hugging Face"}
+          {loadingState === "idle"
+            ? "Generate with Hugging Face"
+            : loadingState === "starting"
+              ? "Starting Hugging Face job…"
+              : "Waiting for Hugging Face…"}
         </button>
+        {isGenerating && (
+          <p className="center" style={{ marginTop: 8, opacity: 0.75 }}>
+            {loadingState === "starting"
+              ? "Contacting the Space…"
+              : "Waiting for the Space to finish…"}
+          </p>
+        )}
         <input
           style={{ display: "block", width: "100%" }}
           placeholder="Name (optional)"


### PR DESCRIPTION
## Summary
- add shared Netlify Hugging Face helpers and extend Netlify function timeouts for the hf-space proxies
- create a polling hf-space-result function plus browser helpers to drive the start/poll workflow
- update the Navatar generator to send full payloads, support deterministic seeds, and surface richer loading states

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d14b37c7ec8329b26bc7e4f2f70eac