### PR TITLE
Add retryable HF Space workflow and polling

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,14 @@
   included_files = []
   external_node_modules = []
 
+[functions."hf-space"]
+  timeout = 55
+  included_files = []
+
+[functions."hf-space-result"]
+  timeout = 55
+  included_files = []
+
 # SPA routing
 [[redirects]]
   from = "/*"

--- a/netlify/functions/hf-space-result.ts
+++ b/netlify/functions/hf-space-result.ts
@@ -1,0 +1,56 @@
+import type { Handler } from "@netlify/functions";
+import { HF_SPACE_HOST, fetchWithRetry, safeText } from "../../src/lib/_hf";
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+};
+
+export const handler: Handler = async (event) => {
+  const eventId = event.queryStringParameters?.eventId;
+  if (!eventId) {
+    return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: "Missing eventId" }) };
+  }
+
+  if (!HF_SPACE_HOST) {
+    return { statusCode: 500, headers: JSON_HEADERS, body: JSON.stringify({ error: "HF_SPACE_URL not configured" }) };
+  }
+
+  try {
+    const url = `${HF_SPACE_HOST}/gradio_api/call/infer/${eventId}`;
+    const res = await fetchWithRetry(url, { method: "GET" }, 6, 800);
+
+    if (!res.ok) {
+      const body = await safeText(res);
+      return {
+        statusCode: res.status,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ error: "HF poll failed", detail: body }),
+      };
+    }
+
+    const contentType = res.headers.get("content-type") || "";
+    if (!contentType.includes("application/json")) {
+      const body = await safeText(res);
+      return {
+        statusCode: 502,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          error: "Unexpected poll response (not JSON)",
+          detail: body.slice(0, 800),
+        }),
+      };
+    }
+
+    const json = await res.json();
+    const status =
+      json?.status || json?.data?.status || json?.state || json?.output?.status;
+    const outputs =
+      json?.data?.data || json?.output?.data || json?.result || json?.data;
+
+    return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ status, json, outputs }) };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return { statusCode: 500, headers: JSON_HEADERS, body: JSON.stringify({ error: message }) };
+  }
+};

--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,62 +1,69 @@
 import type { Handler } from "@netlify/functions";
+import { HF_SPACE_HOST, fetchWithRetry, safeText } from "../../src/lib/_hf";
 
-const SPACE = process.env.HF_SPACE_URL;
-
-export const handler: Handler = async (event) => {
-  try {
-    if (!SPACE) {
-      return resp(500, { errors: ["HF_SPACE_URL not set"] });
-    }
-    if (event.httpMethod !== "POST") {
-      return resp(405, { errors: ["Method not allowed"] });
-    }
-
-    const { prompt } = JSON.parse(event.body || "{}");
-    if (!prompt || typeof prompt !== "string") {
-      return resp(400, { errors: ["Missing prompt"] });
-    }
-
-    const gradio = await fetch(`${SPACE}/api/predict/`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ data: [prompt] }),
-    });
-
-    if (!gradio.ok) {
-      const raw = await gradio.text();
-      return resp(gradio.status, { errors: ["Space request failed"], raw });
-    }
-
-    const data = await gradio.json();
-
-    let imageDataUrl: string | null = null;
-
-    if (Array.isArray(data?.data)) {
-      const first = data.data[0];
-      if (typeof first === "string" && first.startsWith("data:image/")) {
-        imageDataUrl = first;
-      } else if (first && typeof first === "object" && typeof first.name === "string") {
-        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
-      }
-    }
-
-    if (!imageDataUrl) {
-      return resp(502, { errors: ["Unexpected Space response"], raw: data });
-    }
-
-    return resp(200, { imageDataUrl });
-  } catch (err: any) {
-    return resp(500, { errors: ["Unhandled error"], raw: String(err?.message || err) });
-  }
+const JSON_HEADERS = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
 };
 
-function resp(status: number, body: unknown) {
-  return {
-    statusCode: status,
-    headers: {
-      "Content-Type": "application/json",
-      "Cache-Control": "no-store",
-    },
-    body: JSON.stringify(body),
-  };
-}
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, headers: JSON_HEADERS, body: JSON.stringify({ error: "Method Not Allowed" }) };
+  }
+
+  if (!HF_SPACE_HOST) {
+    return { statusCode: 500, headers: JSON_HEADERS, body: JSON.stringify({ error: "HF_SPACE_URL not configured" }) };
+  }
+
+  try {
+    const payload = JSON.parse(event.body || "{}");
+    const data = payload?.data;
+    if (!data) {
+      return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: "Missing data payload" }) };
+    }
+
+    const url = `${HF_SPACE_HOST}/gradio_api/call/infer`;
+    const res = await fetchWithRetry(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ data }),
+    });
+
+    const contentType = res.headers.get("content-type") || "";
+    if (!res.ok) {
+      const body = await safeText(res);
+      return {
+        statusCode: res.status,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ error: "HF POST failed", detail: body }),
+      };
+    }
+
+    if (!contentType.includes("application/json")) {
+      const body = await safeText(res);
+      return {
+        statusCode: 502,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          error: "Unexpected response from Space (not JSON)",
+          detail: body.slice(0, 800),
+        }),
+      };
+    }
+
+    const json = await res.json();
+    const eventId = json?.event_id || json?.eventId || json?.data?.event_id;
+    if (!eventId) {
+      return {
+        statusCode: 502,
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ error: "Missing event_id from Space", json }),
+      };
+    }
+
+    return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ eventId }) };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return { statusCode: 500, headers: JSON_HEADERS, body: JSON.stringify({ error: message }) };
+  }
+};

--- a/src/lib/_hf.ts
+++ b/src/lib/_hf.ts
@@ -1,0 +1,50 @@
+const RAW_ENV =
+  process.env.HF_SPACE_URL || process.env.HUGGINGFACE_SPACE_URL || "";
+
+function normalizeSpaceUrl(u: string): string {
+  if (!u) return "";
+  let url = u.trim().replace(/\/+$/, "");
+  const m = url.match(/^https:\/\/huggingface\.co\/spaces\/([^/]+)\/([^/]+)$/i);
+  if (m) {
+    const org = m[1];
+    const space = m[2];
+    url = `https://${org}-${space}.hf.space`;
+  }
+  if (!/^https:\/\/.+\.hf\.space$/i.test(url)) {
+    throw new Error(
+      `Invalid HF Space URL: "${u}". Expected https://<org>-<space>.hf.space`
+    );
+  }
+  return url;
+}
+
+export const HF_SPACE_HOST = normalizeSpaceUrl(RAW_ENV);
+
+export async function fetchWithRetry(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  tries = 4,
+  baseDelayMs = 800
+): Promise<Response> {
+  let lastErr: unknown;
+  for (let i = 0; i < tries; i++) {
+    try {
+      const res = await fetch(input, init);
+      if (res.ok) return res;
+      if (res.status >= 500) throw new Error(`HTTP ${res.status}`);
+      return res;
+    } catch (e) {
+      lastErr = e;
+      await new Promise((r) => setTimeout(r, baseDelayMs * (i + 1)));
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}
+
+export async function safeText(res: Response) {
+  try {
+    return await res.text();
+  } catch {
+    return "";
+  }
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,26 +1,6 @@
+import { pollForImage, startGeneration } from "./hfClient";
+
 export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ prompt }),
-  });
-
-  const json = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
-    throw new Error(message);
-  }
-
-  const image = json?.imageDataUrl;
-  if (typeof image !== "string" || !image) {
-    throw new Error("Invalid image response from Hugging Face Space");
-  }
-
-  return image;
+  const eventId = await startGeneration([prompt]);
+  return pollForImage(eventId);
 }

--- a/src/lib/navatar/hfClient.ts
+++ b/src/lib/navatar/hfClient.ts
@@ -1,0 +1,96 @@
+type StartResponse = { eventId: string };
+type PollResponse = {
+  status?: string;
+  json: any;
+  outputs?: any;
+  error?: string;
+};
+
+type BuildGradioData = unknown;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function extractImageUrlFromOutputs(outputs: any): string | null {
+  if (!outputs) return null;
+
+  const first = Array.isArray(outputs) ? outputs[0] : outputs;
+  const candidate =
+    first?.url ||
+    first?.path ||
+    first?.data?.[0]?.url ||
+    first?.data?.url ||
+    null;
+
+  if (typeof candidate === "string") {
+    return candidate;
+  }
+
+  const b64 = first?.data?.[0]?.value || first?.value || null;
+  if (typeof b64 === "string" && b64.startsWith("data:image")) {
+    return b64;
+  }
+
+  return null;
+}
+
+export async function startGeneration(gradioData: BuildGradioData): Promise<string> {
+  const res = await fetch("/.netlify/functions/hf-space", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ data: gradioData }),
+  });
+
+  const json = (await res.json().catch(() => ({}))) as Partial<StartResponse> & { error?: string };
+
+  if (!res.ok) {
+    const message = typeof json?.error === "string" && json.error ? json.error : "Failed to start Space job";
+    throw new Error(message);
+  }
+
+  if (!json?.eventId) {
+    throw new Error("Space did not return eventId");
+  }
+
+  return json.eventId;
+}
+
+export async function pollForImage(eventId: string): Promise<string> {
+  let delay = 1000;
+  const deadline = Date.now() + 60_000;
+
+  while (Date.now() < deadline) {
+    const res = await fetch(`/.netlify/functions/hf-space-result?eventId=${encodeURIComponent(eventId)}`);
+    const json = (await res.json().catch(() => ({}))) as PollResponse;
+
+    if (!res.ok) {
+      const message =
+        typeof json?.error === "string" && json.error
+          ? json.error
+          : typeof json?.status === "string" && json.status
+          ? json.status
+          : "Poll failed";
+      throw new Error(message);
+    }
+
+    const status = (json.status || "").toLowerCase();
+    if (status.includes("complete") || status.includes("finished")) {
+      const url = extractImageUrlFromOutputs(json.outputs ?? json.json);
+      if (url) {
+        return url;
+      }
+      throw new Error("Completed but no image URL in outputs");
+    }
+
+    if (status.includes("error") || status.includes("failed")) {
+      const detail = json.json?.error || json.json?.detail || json.error;
+      throw new Error(typeof detail === "string" && detail ? detail : "Space reported an error");
+    }
+
+    await sleep(delay);
+    delay = Math.min(delay + 500, 3500);
+  }
+
+  throw new Error("Generation timed out — please try again.");
+}


### PR DESCRIPTION
## Summary
- normalize the Hugging Face Space URL from environment variables and add reusable fetch helpers with retries
- update the Hugging Face Netlify functions to call the gradio event API and expose a polling endpoint with longer timeouts
- wire Navatar generation through the new start/poll helpers so the UI waits for completed image jobs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d14ff0aeec8329acab4289fd48a5e4