### PR TITLE
Wire Navatar generation through Netlify Hugging Face proxy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,23 @@
 [build]
   command = "npm run build"
   publish = "dist"
+  functions = "netlify/functions"
 
 [functions]
   node_bundler = "esbuild"
-  directory = "netlify/functions"
   included_files = []
   external_node_modules = []
+
+# ── Hugging Face proxy functions ─────────────────────────────
+# Generation submit is quick (returns an event_id)
+[functions."hf-space"]
+  timeout = 10
+  memory = 256
+
+# Result polling can take longer; give it time
+[functions."hf-space-result"]
+  timeout = 60
+  memory = 256
 
 # SPA routing
 [[redirects]]
@@ -26,6 +37,14 @@
   for = "/.netlify/functions/ai"
   [headers.values]
     Access-Control-Allow-Origin = "*"
+
+# (Optional) Allow CORS for these functions if you preview locally
+[[headers]]
+  for = "/.netlify/functions/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods = "GET, POST, OPTIONS"
+    Access-Control-Allow-Headers = "Content-Type, Authorization"
 
 [[headers]]
   for = "/*"

--- a/netlify/functions/hf-space-result.ts
+++ b/netlify/functions/hf-space-result.ts
@@ -1,0 +1,85 @@
+// netlify/functions/hf-space-result.ts
+import type { Handler } from "@netlify/functions";
+import { getSpaceBase, extractImageUrl, resultUrls } from "../../src/lib/_hf";
+
+export const handler: Handler = async (event) => {
+  try {
+    const { httpMethod, queryStringParameters } = event;
+    if (httpMethod === "OPTIONS") return { statusCode: 204, headers: cors() } as const;
+    if (httpMethod !== "GET") return json(405, { error: "Use GET" });
+
+    const eventId = (queryStringParameters?.eventId || "").trim();
+    if (!eventId) return json(400, { error: "Missing eventId" });
+
+    const base = getSpaceBase();
+    // Try JSON endpoint first
+    for (const url of resultUrls(base, eventId)) {
+      const r = await fetch(url, { method: "GET" });
+
+      // Some Spaces send SSE (text/event-stream); prefer JSON when available
+      const ctype = r.headers.get("content-type") || "";
+      const bodyText = await r.text();
+
+      if (ctype.includes("application/json") || bodyText.trim().startsWith("{") || bodyText.trim().startsWith("[")) {
+        const data = safeJson(bodyText);
+        if (!data) continue;
+
+        // Common shapes:
+        // { "data": [ {url|path|base64...}, ... ] }
+        // or [ {url|path|base64...}, ... ]
+        const payload = (data.data ?? data) as any;
+        const img = extractImageUrl(base, payload);
+
+        return json(200, {
+          status: "complete",
+          imageUrl: img,
+          raw: data, // keep for debugging until you’re happy
+        });
+      }
+
+      // SSE fallback: look for `event: complete` with `data: ...`
+      const maybe = parseSseForComplete(bodyText);
+      if (maybe) {
+        const img = extractImageUrl(base, maybe);
+        return json(200, { status: "complete", imageUrl: img, raw: maybe });
+      }
+    }
+
+    return json(502, { status: "pending", error: "No JSON or complete SSE found yet" });
+  } catch (err: any) {
+    return json(500, { error: err?.message || String(err) });
+  }
+};
+
+function parseSseForComplete(s: string): any | null {
+  // naive but effective: find the last `event: complete` block, parse the next `data: ...` as JSON
+  const blocks = s.split(/\n\n+/);
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const b = blocks[i];
+    if (/\bevent:\s*complete\b/i.test(b)) {
+      const m = b.match(/data:\s*(.+)$/m);
+      if (!m) return null;
+      return safeJson(m[1]);
+    }
+  }
+  return null;
+}
+
+function safeJson(txt: string): any | null {
+  try { return JSON.parse(txt); } catch { return null; }
+}
+
+function json(status: number, obj: any) {
+  return {
+    statusCode: status,
+    headers: { "Content-Type": "application/json", ...cors() },
+    body: JSON.stringify(obj),
+  };
+}
+function cors() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+  };
+}

--- a/netlify/functions/hf-space.ts
+++ b/netlify/functions/hf-space.ts
@@ -1,62 +1,55 @@
+// netlify/functions/hf-space.ts
 import type { Handler } from "@netlify/functions";
-
-const SPACE = process.env.HF_SPACE_URL;
+import { getSpaceBase } from "../../src/lib/_hf";
 
 export const handler: Handler = async (event) => {
   try {
-    if (!SPACE) {
-      return resp(500, { errors: ["HF_SPACE_URL not set"] });
+    if (event.httpMethod === "OPTIONS") {
+      return { statusCode: 204, headers: cors() } as const;
     }
     if (event.httpMethod !== "POST") {
-      return resp(405, { errors: ["Method not allowed"] });
+      return json(405, { error: "Use POST" });
     }
 
-    const { prompt } = JSON.parse(event.body || "{}");
-    if (!prompt || typeof prompt !== "string") {
-      return resp(400, { errors: ["Missing prompt"] });
-    }
+    const base = getSpaceBase();
+    const body = JSON.parse(event.body || "{}");
 
-    const gradio = await fetch(`${SPACE}/api/predict/`, {
+    // Forward to Gradio /call/infer
+    const r = await fetch(`${base}/gradio_api/call/infer`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ data: [prompt] }),
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
     });
 
-    if (!gradio.ok) {
-      const raw = await gradio.text();
-      return resp(gradio.status, { errors: ["Space request failed"], raw });
+    if (!r.ok) {
+      const text = await r.text();
+      return json(r.status, { error: "Space call failed", detail: text });
     }
 
-    const data = await gradio.json();
-
-    let imageDataUrl: string | null = null;
-
-    if (Array.isArray(data?.data)) {
-      const first = data.data[0];
-      if (typeof first === "string" && first.startsWith("data:image/")) {
-        imageDataUrl = first;
-      } else if (first && typeof first === "object" && typeof first.name === "string") {
-        imageDataUrl = `${SPACE}/${first.name.replace(/^file=*/, "")}`;
-      }
+    const data = await r.json().catch(async () => ({ text: await r.text() }));
+    // Expect { event_id: "..." }
+    const event_id = (data && (data as any).event_id) || null;
+    if (!event_id) {
+      return json(502, { error: "No event_id from Space", data });
     }
 
-    if (!imageDataUrl) {
-      return resp(502, { errors: ["Unexpected Space response"], raw: data });
-    }
-
-    return resp(200, { imageDataUrl });
+    return json(200, { event_id, space: base });
   } catch (err: any) {
-    return resp(500, { errors: ["Unhandled error"], raw: String(err?.message || err) });
+    return json(500, { error: err?.message || String(err) });
   }
 };
 
-function resp(status: number, body: unknown) {
+function json(status: number, obj: any) {
   return {
     statusCode: status,
-    headers: {
-      "Content-Type": "application/json",
-      "Cache-Control": "no-store",
-    },
-    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", ...cors() },
+    body: JSON.stringify(obj),
+  };
+}
+function cors() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
   };
 }

--- a/src/lib/_hf.ts
+++ b/src/lib/_hf.ts
@@ -1,0 +1,56 @@
+// src/lib/_hf.ts
+export function getSpaceBase(): string {
+  const url =
+    process.env.HF_SPACE_URL ||
+    process.env.HUGGINGFACE_SPACE_URL ||
+    "";
+  if (!url) throw new Error("HF_SPACE_URL is not set");
+  // normalize: strip trailing slash
+  return url.replace(/\/+$/, "");
+}
+
+export type GradioFile =
+  | { url?: string; path?: string; base64?: string; [k: string]: any }
+  | string; // some Spaces return string URL
+
+export function extractImageUrl(base: string, out: any): string | null {
+  // out can be: single object, array of objects, tuple, etc.
+  const candidates: GradioFile[] = Array.isArray(out) ? out : [out];
+
+  for (const item of candidates) {
+    if (item == null) continue;
+
+    if (typeof item === "string") {
+      if (item.startsWith("http")) return item;
+      if (item.startsWith("/")) return `${base}/gradio_api/file=${item}`;
+      // data URL
+      if (item.startsWith("data:")) return item;
+      continue;
+    }
+
+    if (typeof item === "object") {
+      if (item.url && typeof item.url === "string") return item.url;
+      if (item.base64 && typeof item.base64 === "string")
+        return `data:image/png;base64,${item.base64}`;
+      if (item.path && typeof item.path === "string") {
+        // HF returns /tmp/gradio/.... Use the Space file gateway
+        return `${base}/gradio_api/file=${item.path}`;
+      }
+      // Some Spaces nest the file under {"data":[...]} etc.
+      if ("data" in item) {
+        const nested = extractImageUrl(base, (item as any).data);
+        if (nested) return nested;
+      }
+    }
+  }
+
+  return null;
+}
+
+// Helper: try both result endpoints (query & path)
+export function resultUrls(base: string, eventId: string): string[] {
+  return [
+    `${base}/gradio_api/call/result?event_id=${encodeURIComponent(eventId)}`,
+    `${base}/gradio_api/call/result/${encodeURIComponent(eventId)}`,
+  ];
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,26 +1,87 @@
-export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
+export type HuggingFaceNavatarPayload = {
+  prompt: string;
+  negative_prompt?: string;
+  seed?: number;
+  randomize_seed?: boolean;
+  width?: number;
+  height?: number;
+  guidance_scale?: number;
+  num_inference_steps?: number;
+  [key: string]: unknown;
+};
+
+export type GenerateWithHuggingFaceOptions = {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+};
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_POLL_INTERVAL_MS = 1_500;
+
+export async function generateWithHuggingFace(
+  payload: HuggingFaceNavatarPayload,
+  options: GenerateWithHuggingFaceOptions = {}
+): Promise<string> {
+  if (!payload || typeof payload.prompt !== "string" || !payload.prompt.trim()) {
+    throw new Error("Prompt is required");
+  }
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  // 1) submit to Netlify (fast)
+  const startRes = await fetch("/.netlify/functions/hf-space", {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ prompt }),
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
   });
-
-  const json = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
+  const startJson = await startRes.json().catch(() => ({}));
+  if (!startRes.ok) {
+    const message =
+      (startJson && typeof startJson === "object" && "error" in startJson && typeof (startJson as any).error === "string"
+        ? (startJson as any).error
+        : null) || "Start failed";
     throw new Error(message);
   }
 
-  const image = json?.imageDataUrl;
-  if (typeof image !== "string" || !image) {
-    throw new Error("Invalid image response from Hugging Face Space");
+  const event_id =
+    startJson && typeof startJson === "object" && "event_id" in startJson
+      ? (startJson as any).event_id
+      : null;
+  if (!event_id || typeof event_id !== "string") {
+    throw new Error("Space did not return an event_id");
   }
 
-  return image;
+  // 2) poll the Netlify result endpoint (which polls the Space)
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: string | null = null;
+
+  while (Date.now() < deadline) {
+    const url = `/.netlify/functions/hf-space-result?eventId=${encodeURIComponent(event_id)}`;
+    const r = await fetch(url, { method: "GET" });
+    const ctype = r.headers.get("content-type") || "";
+    const text = await r.text();
+
+    if (!ctype.includes("application/json")) {
+      lastErr = "Unexpected response from server";
+    } else {
+      try {
+        const j = JSON.parse(text);
+        if (j?.status === "complete") {
+          if (j.imageUrl) {
+            return j.imageUrl as string;
+          }
+          lastErr = "Completed but no image URL in response.";
+        } else if (j?.error) {
+          lastErr = typeof j.error === "string" ? j.error : "Generation failed";
+        }
+      } catch (err) {
+        lastErr = "Invalid JSON response from server";
+      }
+    }
+
+    await new Promise((res) => setTimeout(res, pollIntervalMs));
+  }
+
+  throw new Error(lastErr || "Generation timed out — please try again.");
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -107,10 +107,19 @@ export default function GenerateNavatarPage() {
     const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
     const avoid = extraNegativePrompt.trim();
     const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
+    const negativePrompt = avoid ? `${alwaysFilteredPrompt}, ${avoid}` : alwaysFilteredPrompt;
     setIsGenerating(true);
     try {
-      const dataUrl = await generateWithHuggingFace(promptWithAvoidance);
-      const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
+      const imageUrl = await generateWithHuggingFace({
+        prompt: promptWithAvoidance,
+        negative_prompt: negativePrompt,
+        randomize_seed: true,
+        width: 1024,
+        height: 1024,
+        guidance_scale: 0,
+        num_inference_steps: 2,
+      });
+      const generatedFile = await imageUrlToFile(imageUrl, `navatar-${Date.now()}.png`);
 
       setFile(generatedFile);
       toast({ text: "Navatar generated ✓", kind: "ok" });
@@ -253,8 +262,8 @@ export default function GenerateNavatarPage() {
   );
 }
 
-async function dataUrlToFile(dataUrl: string, filename: string) {
-  const res = await fetch(dataUrl);
+async function imageUrlToFile(imageUrl: string, filename: string) {
+  const res = await fetch(imageUrl);
   const blob = await res.blob();
   return new File([blob], filename, { type: blob.type || "image/png" });
 }


### PR DESCRIPTION
## Summary
- add shared Hugging Face helper utilities and new Netlify proxy functions for submission and result polling
- configure Netlify timeouts and CORS for the Hugging Face proxy endpoints
- update the Navatar generation client flow to submit payloads, poll for results, and handle normalized image URLs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d166731c848329934f268f55c54957