### PR TITLE
Use Hugging Face inference API for Navatar generation

### DIFF
--- a/netlify/functions/hf-generate.ts
+++ b/netlify/functions/hf-generate.ts
@@ -1,0 +1,64 @@
+import type { Handler } from "@netlify/functions";
+
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod === "OPTIONS") {
+      return { statusCode: 204, headers: cors() } as const;
+    }
+    if (event.httpMethod !== "POST") {
+      return json(405, { error: "Use POST" });
+    }
+
+    const { prompt } = JSON.parse(event.body || "{}");
+    if (!prompt) return json(400, { error: "Missing prompt" });
+
+    const model = process.env.HF_MODEL_ID || "black-forest-labs/FLUX.1-dev";
+    const token = process.env.HF_API_TOKEN;
+    if (!token) return json(500, { error: "HF_API_TOKEN not set" });
+
+    // Call Hugging Face Inference API
+    const response = await fetch(
+      `https://api-inference.huggingface.co/models/${model}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          inputs: prompt,
+          options: { wait_for_model: true },
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const txt = await response.text();
+      return json(response.status, { error: "HF API failed", detail: txt });
+    }
+
+    // HF returns raw binary (image) for text-to-image models
+    const arrayBuffer = await response.arrayBuffer();
+    const base64 = Buffer.from(arrayBuffer).toString("base64");
+    const dataUrl = `data:image/png;base64,${base64}`;
+
+    return json(200, { image: dataUrl });
+  } catch (err: any) {
+    return json(500, { error: err?.message || String(err) });
+  }
+};
+
+function json(status: number, obj: any) {
+  return {
+    statusCode: status,
+    headers: { "Content-Type": "application/json", ...cors() },
+    body: JSON.stringify(obj),
+  };
+}
+function cors() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+  };
+}

--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,25 +1,24 @@
 export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
+  const response = await fetch("/.netlify/functions/hf-generate", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Accept: "application/json",
     },
     body: JSON.stringify({ prompt }),
   });
 
-  const json = await response.json().catch(() => ({}));
+  const json = await response.json().catch(() => null);
 
   if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
+    const message =
+      (json && typeof json.error === "string" && json.error) ||
+      "Hugging Face API error";
     throw new Error(message);
   }
 
-  const image = json?.imageDataUrl;
-  if (typeof image !== "string" || !image) {
-    throw new Error("Invalid image response from Hugging Face Space");
+  const image = json && typeof json.image === "string" ? json.image : null;
+  if (!image) {
+    throw new Error("Invalid image response from Hugging Face");
   }
 
   return image;


### PR DESCRIPTION
## Summary
- add a Netlify function that calls the Hugging Face inference API and returns a base64 image payload
- update the Navatar generation client helper to invoke the new function and surface API errors cleanly

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d23f6db9ac8329b4d86c32ca2be9c3