### PR TITLE
Fix Hugging Face generator flow

### DIFF
--- a/src/lib/navatar/generate.ts
+++ b/src/lib/navatar/generate.ts
@@ -1,25 +1,49 @@
-export async function generateWithHuggingFace(prompt: string): Promise<string> {
-  const response = await fetch("/.netlify/functions/hf-space", {
+export type GenerateOpts = {
+  prompt: string;
+  onBrand?: boolean;
+  seed?: number;
+  keepSeed?: boolean;
+};
+
+type SuccessResponse = {
+  ok: true;
+  image: string;
+  provider?: string;
+};
+
+type ErrorResponse = {
+  ok: false;
+  error?: string;
+  raw?: string;
+};
+
+type GenerateResponseBody = Record<string, unknown>;
+
+export async function generateWithHF(opts: GenerateOpts): Promise<string> {
+  const response = await fetch("/.netlify/functions/ai-generate", {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ prompt }),
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(opts),
   });
 
-  const json = await response.json().catch(() => ({}));
+  const data = (await response.json().catch(() => ({}))) as GenerateResponseBody;
+
+  const errorText = typeof data.error === "string" ? data.error : undefined;
+  const rawText = typeof data.raw === "string" ? data.raw : undefined;
 
   if (!response.ok) {
-    const message = Array.isArray(json?.errors) && json.errors.length > 0
-      ? json.errors[0]
-      : "Hugging Face Space error";
-    throw new Error(message);
+    const errorMessage = errorText || `HTTP ${response.status}`;
+    throw new Error(rawText ? `${errorMessage}: ${rawText}` : errorMessage);
   }
 
-  const image = json?.imageDataUrl;
-  if (typeof image !== "string" || !image) {
-    throw new Error("Invalid image response from Hugging Face Space");
+  if (data.ok !== true) {
+    const message = errorText || "Invalid response from generator";
+    throw new Error(rawText ? `${message}: ${rawText}` : message);
+  }
+
+  const image = typeof data.image === "string" ? data.image : undefined;
+  if (!image) {
+    throw new Error("Invalid image payload from generator");
   }
 
   return image;

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -8,41 +8,22 @@ import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import { useAuthUser } from "../../lib/useAuthUser";
-import { generateWithHuggingFace } from "../../lib/navatar/generate";
-import {
-  DEFAULT_NEGATIVE_PROMPT,
-  DEFAULT_STYLE_ID,
-  STYLE_PRESETS,
-  buildPrompt,
-} from "../../lib/navatar/stability";
+import { generateWithHF } from "../../lib/navatar/generate";
+import { DEFAULT_STYLE_ID, STYLE_PRESETS, buildPrompt } from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
 
-const BRAND_STYLE = [
-  "cute character, navatar style, bright friendly palette,",
-  "big expressive eyes, rounded shapes, thick clean outlines,",
-  "storybook illustration, flat lighting, soft shading,",
-  "kid-friendly, sticker-ready, high contrast, no tiny details",
-].join(" ");
-
-const BRAND_NEGATIVE = [
-  "photo, photorealistic, hyperrealistic,",
-  "text, caption, letters, logo, watermark, signature,",
-  "grain, noise, artifacts, extra limbs, deformed hands",
+const ALWAYS_FILTERED_PROMPT = [
+  "photo, photorealistic, hyperrealistic",
+  "text, caption, letters, logo, watermark, signature",
+  "grain, noise, artifacts, extra limbs, deformed hands, gore, violence, guns",
 ].join(", ");
-
-function wrapWithBrandStyle(raw: string): string {
-  const trimmed = raw.trim();
-  if (!trimmed) return "";
-  const needsPeriod = !/[.!?]$/.test(trimmed);
-  const base = needsPeriod ? `${trimmed}.` : trimmed;
-  return `${base} ${BRAND_STYLE}`;
-}
 
 export default function GenerateNavatarPage() {
   const [prompt, setPrompt] = useState("");
   const [styleId, setStyleId] = useState(DEFAULT_STYLE_ID);
   const [extraNegativePrompt, setExtraNegativePrompt] = useState("");
-  const [keepStyle, setKeepStyle] = useState(false);
+  const [keepSeed, setKeepSeed] = useState(false);
+  const [seed, setSeed] = useState<number | undefined>(undefined);
   const [onBrand, setOnBrand] = useState(true);
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
@@ -64,20 +45,24 @@ export default function GenerateNavatarPage() {
 
   useEffect(() => {
     if (user?.id) {
-      setKeepStyle((prev) => (prev ? prev : true));
+      setKeepSeed((prev) => (prev ? prev : true));
     } else {
-      setKeepStyle(false);
+      setKeepSeed(false);
+      setSeed(undefined);
     }
   }, [user?.id]);
+
+  useEffect(() => {
+    if (user?.id && keepSeed) {
+      setSeed(seedFromUserId(user.id));
+    } else if (!keepSeed) {
+      setSeed(undefined);
+    }
+  }, [user?.id, keepSeed]);
 
   const selectedStyle = useMemo(
     () => STYLE_PRESETS.find((preset) => preset.id === styleId) ?? STYLE_PRESETS[0],
     [styleId]
-  );
-
-  const alwaysFilteredPrompt = useMemo(
-    () => (onBrand ? `${DEFAULT_NEGATIVE_PROMPT}, ${BRAND_NEGATIVE}` : DEFAULT_NEGATIVE_PROMPT),
-    [onBrand]
   );
 
   async function onSave(e: React.FormEvent) {
@@ -103,13 +88,18 @@ export default function GenerateNavatarPage() {
       return;
     }
 
-    const promptForBrand = onBrand ? wrapWithBrandStyle(trimmedPrompt) : trimmedPrompt;
-    const finalPrompt = buildPrompt(promptForBrand, selectedStyle);
+    const finalPrompt = buildPrompt(trimmedPrompt, selectedStyle);
     const avoid = extraNegativePrompt.trim();
     const promptWithAvoidance = avoid ? `${finalPrompt}. Avoid: ${avoid}` : finalPrompt;
+    const deterministicSeed = keepSeed ? seed : undefined;
     setIsGenerating(true);
     try {
-      const dataUrl = await generateWithHuggingFace(promptWithAvoidance);
+      const dataUrl = await generateWithHF({
+        prompt: promptWithAvoidance,
+        onBrand,
+        seed: deterministicSeed,
+        keepSeed: keepSeed && typeof deterministicSeed === "number",
+      });
       const generatedFile = await dataUrlToFile(dataUrl, `navatar-${Date.now()}.png`);
 
       setFile(generatedFile);
@@ -192,8 +182,8 @@ export default function GenerateNavatarPage() {
           <input
             id="navatar-keep-style"
             type="checkbox"
-            checked={keepStyle && Boolean(user?.id)}
-            onChange={(e) => setKeepStyle(e.target.checked)}
+            checked={keepSeed && Boolean(user?.id)}
+            onChange={(e) => setKeepSeed(e.target.checked)}
             disabled={!user?.id || isGenerating}
           />
           <span>
@@ -209,7 +199,7 @@ export default function GenerateNavatarPage() {
           <summary>Advanced prompt controls</summary>
           <div className="navatar-advanced__content">
             <p>
-              We always filter out: <code>{alwaysFilteredPrompt}</code>
+              We always filter out: <code>{ALWAYS_FILTERED_PROMPT}</code>
             </p>
             <label htmlFor="navatar-negative">Add more things to avoid (optional)</label>
             <textarea
@@ -226,7 +216,7 @@ export default function GenerateNavatarPage() {
           type="button"
           className="generate-btn w-full rounded-xl px-5 py-3 text-base font-semibold text-white bg-blue-600 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
           onClick={handleGenerate}
-          disabled={isGenerating}
+          disabled={isGenerating || !prompt.trim()}
         >
           {isGenerating ? "Generating…" : "Generate with Hugging Face"}
         </button>
@@ -257,5 +247,15 @@ async function dataUrlToFile(dataUrl: string, filename: string) {
   const res = await fetch(dataUrl);
   const blob = await res.blob();
   return new File([blob], filename, { type: blob.type || "image/png" });
+}
+
+function seedFromUserId(userId: string): number {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i += 1) {
+    hash = (hash << 5) - hash + userId.charCodeAt(i);
+    hash |= 0;
+  }
+  const normalized = (hash >>> 0) % 0xffff_ffff;
+  return normalized === 0 ? 1 : normalized;
 }
 


### PR DESCRIPTION
## Summary
- replace the navatar client generator helper with a JSON-based call to the ai-generate Netlify function and surface structured errors
- wire the generate page up to the new helper, send Hugging Face brand/seed options, and keep deterministic seeding for signed-in users
- show the updated always-filtered negative prompt list in the advanced UI and disable generation when no prompt is provided

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d24f38e7d0832983a3fb03f9f1b325