### PR TITLE
Add DiceBear option to Navatar generator

### DIFF
--- a/src/lib/navatar/dicebear.ts
+++ b/src/lib/navatar/dicebear.ts
@@ -1,0 +1,128 @@
+import { supabase } from '@/lib/supabaseClient';
+import { NAVATAR_BUCKET, NAVATAR_PREFIX, getSessionUserId, pickNavatar, type NavatarRow } from '@/lib/navatar';
+
+export type DicebearStyle =
+  | 'adventurer'
+  | 'adventurer-neutral'
+  | 'avataaars'
+  | 'big-ears'
+  | 'big-ears-neutral'
+  | 'big-smile'
+  | 'bottts'
+  | 'croodles'
+  | 'croodles-neutral'
+  | 'fun-emoji'
+  | 'icons'
+  | 'identicon'
+  | 'initials'
+  | 'lorelei'
+  | 'micah'
+  | 'miniavs'
+  | 'notionists'
+  | 'open-peeps'
+  | 'personas'
+  | 'pixel-art'
+  | 'pixel-art-neutral'
+  | 'shapes'
+  | 'thumbs';
+
+export type DicebearOptions = {
+  style: DicebearStyle;
+  seed?: string;
+  size?: number;
+  backgroundColor?: string;
+  hair?: string;
+  eyes?: string;
+  mouth?: string;
+  format?: 'svg' | 'png';
+};
+
+const API_VERSION = '9.x';
+
+function cleanHex(value?: string | null) {
+  return value ? value.replace(/^#/, '').trim() : undefined;
+}
+
+function safeSeed(seed?: string | null) {
+  if (!seed) return 'seed';
+  const cleaned = seed.replace(/[^a-z0-9-_]/gi, '').slice(0, 48);
+  return cleaned.length > 0 ? cleaned : 'seed';
+}
+
+export function buildDicebearUrl(opts: DicebearOptions) {
+  const {
+    style,
+    seed = 'naturverse',
+    size = 1024,
+    backgroundColor,
+    hair,
+    eyes,
+    mouth,
+    format = 'svg',
+  } = opts;
+
+  const base = `https://api.dicebear.com/${API_VERSION}/${style}/${format}`;
+  const params = new URLSearchParams();
+
+  params.set('seed', seed);
+
+  if (format === 'png') {
+    params.set('size', String(size));
+  }
+
+  const bg = cleanHex(backgroundColor);
+  if (bg) {
+    params.set('backgroundColor', bg);
+  }
+
+  if (hair) params.set('hair', hair);
+  if (eyes) params.set('eyes', eyes);
+  if (mouth) params.set('mouth', mouth);
+
+  return `${base}?${params.toString()}`;
+}
+
+export type DicebearCreationResult = {
+  row: NavatarRow;
+  storagePath: string;
+  publicUrl: string | null;
+  sourceUrl: string;
+};
+
+export async function createDicebearAvatar(
+  options: DicebearOptions,
+  name?: string
+): Promise<DicebearCreationResult> {
+  const ownerId = await getSessionUserId();
+  const format = (options.format ?? 'svg').toLowerCase() === 'png' ? 'png' : 'svg';
+
+  const sourceUrl = buildDicebearUrl({ ...options, format });
+  const response = await fetch(sourceUrl);
+  if (!response.ok) {
+    throw new Error(`DiceBear fetch failed: ${response.status}`);
+  }
+
+  const blob = await response.blob();
+  const ext = format === 'svg' ? 'svg' : 'png';
+  const filename = `${safeSeed(options.seed)}-${options.style}-${Date.now()}.${ext}`;
+  const storagePath = `${NAVATAR_PREFIX}/${ownerId}/${filename}`;
+
+  const { error } = await supabase.storage
+    .from(NAVATAR_BUCKET)
+    .upload(storagePath, blob, {
+      contentType: format === 'svg' ? 'image/svg+xml' : 'image/png',
+      upsert: true,
+    });
+
+  if (error) throw error;
+
+  const row = await pickNavatar(storagePath, name);
+  const { data } = supabase.storage.from(NAVATAR_BUCKET).getPublicUrl(storagePath);
+
+  return {
+    row,
+    storagePath,
+    publicUrl: data?.publicUrl ?? null,
+    sourceUrl,
+  };
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -8,6 +8,7 @@ import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import { useAuthUser } from "../../lib/useAuthUser";
+import { buildDicebearUrl, createDicebearAvatar, type DicebearStyle } from "../../lib/navatar/dicebear";
 import {
   DEFAULT_STYLE_ID,
   RATE_LIMIT_MESSAGE,
@@ -20,6 +21,23 @@ import {
   seedFromUserId,
 } from "../../lib/navatar/stability";
 import "../../styles/navatar.css";
+
+type GeneratorMode = "stability" | "dicebear";
+
+const DICEBEAR_STYLE_OPTIONS: { value: DicebearStyle; label: string }[] = [
+  { value: "adventurer", label: "Adventurer" },
+  { value: "adventurer-neutral", label: "Adventurer Neutral" },
+  { value: "avataaars", label: "Avataaars" },
+  { value: "micah", label: "Micah" },
+  { value: "open-peeps", label: "Open Peeps" },
+  { value: "pixel-art", label: "Pixel Art" },
+  { value: "pixel-art-neutral", label: "Pixel Art Neutral" },
+  { value: "fun-emoji", label: "Fun Emoji" },
+  { value: "notionists", label: "Notionists" },
+  { value: "shapes", label: "Shapes" },
+];
+
+const DEFAULT_DICEBEAR_STYLE = DICEBEAR_STYLE_OPTIONS[0]?.value ?? "adventurer";
 
 const BRAND_STYLE = [
   "cute character, navatar style, bright friendly palette,",
@@ -43,6 +61,7 @@ function wrapWithBrandStyle(raw: string): string {
 }
 
 export default function GenerateNavatarPage() {
+  const [mode, setMode] = useState<GeneratorMode>("stability");
   const [prompt, setPrompt] = useState("");
   const [styleId, setStyleId] = useState(DEFAULT_STYLE_ID);
   const [extraNegativePrompt, setExtraNegativePrompt] = useState("");
@@ -50,19 +69,24 @@ export default function GenerateNavatarPage() {
   const [onBrand, setOnBrand] = useState(true);
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
-  const [draftUrl, setDraftUrl] = useState<string | undefined>();
+  const [stabilityPreviewUrl, setStabilityPreviewUrl] = useState<string | undefined>();
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [dicebearStyle, setDicebearStyle] = useState<DicebearStyle>(DEFAULT_DICEBEAR_STYLE);
+  const [dicebearSeed, setDicebearSeed] = useState("");
+  const [dicebearBackground, setDicebearBackground] = useState("");
+  const [dicebearSeedTouched, setDicebearSeedTouched] = useState(false);
   const nav = useNavigate();
   const toast = useToast();
   const { user } = useAuthUser();
 
   useEffect(() => {
     if (!file) {
-      setDraftUrl(undefined);
+      setStabilityPreviewUrl(undefined);
       return;
     }
     const url = URL.createObjectURL(file);
-    setDraftUrl(url);
+    setStabilityPreviewUrl(url);
     return () => URL.revokeObjectURL(url);
   }, [file]);
 
@@ -74,6 +98,12 @@ export default function GenerateNavatarPage() {
     }
   }, [user?.id]);
 
+  useEffect(() => {
+    if (user?.id && !dicebearSeedTouched) {
+      setDicebearSeed(user.id);
+    }
+  }, [user?.id, dicebearSeedTouched]);
+
   const selectedStyle = useMemo(
     () => STYLE_PRESETS.find((preset) => preset.id === styleId) ?? STYLE_PRESETS[0],
     [styleId]
@@ -84,12 +114,63 @@ export default function GenerateNavatarPage() {
     [onBrand]
   );
 
+  const dicebearSeedValue = dicebearSeed.trim() || user?.id || "naturverse";
+  const dicebearBackgroundValue = dicebearBackground.trim().replace(/^#/, "");
+
+  const dicebearPreviewUrl = useMemo(
+    () =>
+      buildDicebearUrl({
+        style: dicebearStyle,
+        seed: dicebearSeedValue || "naturverse",
+        backgroundColor: dicebearBackgroundValue || undefined,
+        format: "svg",
+      }),
+    [dicebearStyle, dicebearSeedValue, dicebearBackgroundValue]
+  );
+
+  const previewUrl = mode === "stability" ? stabilityPreviewUrl : dicebearPreviewUrl;
+  const isDicebear = mode === "dicebear";
+  const isStability = mode === "stability";
+
+  const canSave = isDicebear ? !isSaving : Boolean(file) && !isGenerating && !isSaving;
+  const saveLabel = isSaving ? "Saving…" : isStability && isGenerating ? "Generating…" : "Save";
+  const cardTitle = name || (isDicebear ? dicebearSeedValue : "My Navatar");
+
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
+    if (isSaving) return;
+
+    if (mode === "dicebear") {
+      setIsSaving(true);
+      try {
+        const { row } = await createDicebearAvatar(
+          {
+            style: dicebearStyle,
+            seed: dicebearSeedValue || "naturverse",
+            backgroundColor: dicebearBackgroundValue || undefined,
+            format: "png",
+            size: 1024,
+          },
+          name || undefined
+        );
+        setActiveNavatarId(row.id);
+        toast({ text: "Saved ✓", kind: "ok" });
+        nav("/navatar");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Save failed";
+        toast({ text: message, kind: "err" });
+      } finally {
+        setIsSaving(false);
+      }
+      return;
+    }
+
     if (!file) {
       toast({ text: "Add or generate an image first", kind: "err" });
       return;
     }
+
+    setIsSaving(true);
     try {
       const row = await uploadNavatar(file, name || undefined);
       setActiveNavatarId(row.id);
@@ -97,6 +178,8 @@ export default function GenerateNavatarPage() {
       nav("/navatar");
     } catch {
       toast({ text: "Save failed", kind: "err" });
+    } finally {
+      setIsSaving(false);
     }
   }
 
@@ -145,8 +228,6 @@ export default function GenerateNavatarPage() {
     }
   }
 
-  const canSave = Boolean(file) && !isGenerating;
-
   return (
     <main className="page-pad mx-auto max-w-4xl p-4">
       <div className="bcRow">
@@ -161,115 +242,187 @@ export default function GenerateNavatarPage() {
         onSubmit={onSave}
         style={{ maxWidth: 520, margin: "16px auto", display: "grid", justifyItems: "center", gap: 12 }}
       >
-        <NavatarCard src={draftUrl} title={name || "My Navatar"} />
-        <div className="navatar-field">
-          <label htmlFor="navatar-prompt">Describe your Navatar</label>
-          <textarea
-            id="navatar-prompt"
-            rows={4}
-            placeholder="Friendly nature guide, glowing shell, playful pose…"
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-          />
+        <div className="navatar-generator-switch" role="group" aria-label="Navatar creation mode">
+          <button
+            type="button"
+            className={`pill${isStability ? " pill--active" : ""}`}
+            onClick={() => setMode("stability")}
+            aria-pressed={isStability}
+          >
+            AI (Stability)
+          </button>
+          <button
+            type="button"
+            className={`pill${isDicebear ? " pill--active" : ""}`}
+            onClick={() => setMode("dicebear")}
+            aria-pressed={isDicebear}
+          >
+            Free (DiceBear)
+          </button>
         </div>
-        <label className="navatar-toggle" htmlFor="navatar-brand-style">
-          <input
-            id="navatar-brand-style"
-            type="checkbox"
-            checked={onBrand}
-            onChange={(e) => setOnBrand(e.target.checked)}
-            disabled={isGenerating}
-          />
-          <span>
-            Naturverse Navatar style
-            <small>Wraps your prompt in our bright, friendly brand art direction.</small>
-          </span>
-        </label>
-        <div className="navatar-field">
-          <label htmlFor="navatar-style">Style preset</label>
-          <div className="navatar-style-picker">
-            <select
-              id="navatar-style"
-              className="navatar-style-select"
-              value={selectedStyle.id}
-              onChange={(e) => setStyleId(e.target.value)}
-              disabled={isGenerating}
-            >
-              {STYLE_PRESETS.map((preset) => (
-                <option key={preset.id} value={preset.id}>
-                  {preset.label}
-                </option>
-              ))}
-            </select>
-            <div className="navatar-style-preview">
-              <strong>{selectedStyle.label}</strong>
-              <p>{selectedStyle.description}</p>
+        <NavatarCard src={previewUrl} title={cardTitle} />
+        {isDicebear ? (
+          <>
+            <div className="navatar-field">
+              <label htmlFor="dicebear-style">Style</label>
+              <select
+                id="dicebear-style"
+                className="navatar-style-select"
+                value={dicebearStyle}
+                onChange={(e) => setDicebearStyle(e.target.value as DicebearStyle)}
+                disabled={isSaving}
+              >
+                {DICEBEAR_STYLE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
             </div>
-          </div>
-        </div>
-        <label
-          className={`navatar-keep-style${!user?.id ? " navatar-keep-style--disabled" : ""}`}
-          htmlFor="navatar-keep-style"
-        >
-          <input
-            id="navatar-keep-style"
-            type="checkbox"
-            checked={keepStyle && Boolean(user?.id)}
-            onChange={(e) => setKeepStyle(e.target.checked)}
-            disabled={!user?.id || isGenerating}
-          />
-          <span>
-            Keep style consistent
-            <small>
-              {user?.id
-                ? "Uses your account seed so regenerations keep the same vibe."
-                : "Sign in to lock a style seed to your Navatar."}
-            </small>
-          </span>
-        </label>
-        <details className="navatar-advanced">
-          <summary>Advanced prompt controls</summary>
-          <div className="navatar-advanced__content">
-            <p>
-              We always filter out: <code>{alwaysFilteredPrompt}</code>
-            </p>
-            <label htmlFor="navatar-negative">Add more things to avoid (optional)</label>
-            <textarea
-              id="navatar-negative"
-              rows={3}
-              placeholder="e.g., spooky shadows, cluttered background"
-              value={extraNegativePrompt}
-              onChange={(e) => setExtraNegativePrompt(e.target.value)}
-              disabled={isGenerating}
+            <div className="navatar-field">
+              <label htmlFor="dicebear-seed">Seed (name or handle)</label>
+              <input
+                id="dicebear-seed"
+                value={dicebearSeed}
+                onChange={(e) => {
+                  setDicebearSeed(e.target.value);
+                  setDicebearSeedTouched(true);
+                }}
+                placeholder={dicebearSeedValue}
+                disabled={isSaving}
+                style={{ width: "100%" }}
+              />
+              <small style={{ color: "#1e3a8a" }}>Same seed = same avatar every time.</small>
+            </div>
+            <div className="navatar-field">
+              <label htmlFor="dicebear-bg">Background color (optional)</label>
+              <input
+                id="dicebear-bg"
+                value={dicebearBackground}
+                onChange={(e) => setDicebearBackground(e.target.value)}
+                placeholder="#b6e3f4"
+                disabled={isSaving}
+                style={{ width: "100%" }}
+              />
+              <small style={{ color: "#1e3a8a" }}>Hex color, with or without the #.</small>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="navatar-field">
+              <label htmlFor="navatar-prompt">Describe your Navatar</label>
+              <textarea
+                id="navatar-prompt"
+                rows={4}
+                placeholder="Friendly nature guide, glowing shell, playful pose…"
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                disabled={isGenerating || isSaving}
+              />
+            </div>
+            <label className="navatar-toggle" htmlFor="navatar-brand-style">
+              <input
+                id="navatar-brand-style"
+                type="checkbox"
+                checked={onBrand}
+                onChange={(e) => setOnBrand(e.target.checked)}
+                disabled={isGenerating || isSaving}
+              />
+              <span>
+                Naturverse Navatar style
+                <small>Wraps your prompt in our bright, friendly brand art direction.</small>
+              </span>
+            </label>
+            <div className="navatar-field">
+              <label htmlFor="navatar-style">Style preset</label>
+              <div className="navatar-style-picker">
+                <select
+                  id="navatar-style"
+                  className="navatar-style-select"
+                  value={selectedStyle.id}
+                  onChange={(e) => setStyleId(e.target.value)}
+                  disabled={isGenerating || isSaving}
+                >
+                  {STYLE_PRESETS.map((preset) => (
+                    <option key={preset.id} value={preset.id}>
+                      {preset.label}
+                    </option>
+                  ))}
+                </select>
+                <div className="navatar-style-preview">
+                  <strong>{selectedStyle.label}</strong>
+                  <p>{selectedStyle.description}</p>
+                </div>
+              </div>
+            </div>
+            <label
+              className={`navatar-keep-style${!user?.id ? " navatar-keep-style--disabled" : ""}`}
+              htmlFor="navatar-keep-style"
+            >
+              <input
+                id="navatar-keep-style"
+                type="checkbox"
+                checked={keepStyle && Boolean(user?.id)}
+                onChange={(e) => setKeepStyle(e.target.checked)}
+                disabled={!user?.id || isGenerating || isSaving}
+              />
+              <span>
+                Keep style consistent
+                <small>
+                  {user?.id
+                    ? "Uses your account seed so regenerations keep the same vibe."
+                    : "Sign in to lock a style seed to your Navatar."}
+                </small>
+              </span>
+            </label>
+            <details className="navatar-advanced">
+              <summary>Advanced prompt controls</summary>
+              <div className="navatar-advanced__content">
+                <p>
+                  We always filter out: <code>{alwaysFilteredPrompt}</code>
+                </p>
+                <label htmlFor="navatar-negative">Add more things to avoid (optional)</label>
+                <textarea
+                  id="navatar-negative"
+                  rows={3}
+                  placeholder="e.g., spooky shadows, cluttered background"
+                  value={extraNegativePrompt}
+                  onChange={(e) => setExtraNegativePrompt(e.target.value)}
+                  disabled={isGenerating || isSaving}
+                />
+              </div>
+            </details>
+            <button
+              type="button"
+              className="generate-btn w-full rounded-xl px-5 py-3 text-base font-semibold text-white bg-blue-600 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={handleGenerate}
+              disabled={isGenerating || isSaving}
+            >
+              {isGenerating ? "Generating…" : "Generate with Stability AI"}
+            </button>
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => setFile(e.target.files?.[0] || null)}
+              disabled={isGenerating || isSaving}
             />
-          </div>
-        </details>
-        <button
-          type="button"
-          className="generate-btn w-full rounded-xl px-5 py-3 text-base font-semibold text-white bg-blue-600 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
-          onClick={handleGenerate}
-          disabled={isGenerating}
-        >
-          {isGenerating ? "Generating…" : "Generate with Stability AI"}
-        </button>
+          </>
+        )}
         <input
           style={{ display: "block", width: "100%" }}
           placeholder="Name (optional)"
           value={name}
           onChange={(e) => setName(e.target.value)}
-        />
-        <input
-          type="file"
-          accept="image/*"
-          onChange={(e) => setFile(e.target.files?.[0] || null)}
-          disabled={isGenerating}
+          disabled={isSaving}
         />
         <button className="pill pill--active" type="submit" style={{ marginTop: 8 }} disabled={!canSave}>
-          {isGenerating ? "Generating…" : "Save"}
+          {saveLabel}
         </button>
       </form>
       <p className="center" style={{ opacity: 0.8 }}>
-        Powered by Stability AI (Stable Image Core) – square 512×512 art.
+        {isStability
+          ? "Powered by Stability AI (Stable Image Core) – square 512×512 art."
+          : "Powered by DiceBear avatars — saved straight to your Supabase storage."}
       </p>
     </main>
   );

--- a/src/styles/navatar.css
+++ b/src/styles/navatar.css
@@ -32,6 +32,18 @@
   font-weight: 700;
 }
 
+.navatar-generator-switch {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin: 0 auto 8px;
+}
+
+.navatar-generator-switch button {
+  cursor: pointer;
+}
+
 /* --- Card: single source of truth for size & fit --- */
 .nav-card {
   --nav-card-w: 260px;    /* change this once to resize everywhere */


### PR DESCRIPTION
## Summary
- add a DiceBear helper that builds avatar URLs and saves the image into Supabase storage
- update the Navatar generator page with a DiceBear vs Stability toggle, dicebear form controls, and shared save handling
- tweak Navatar styles to support the new generator switch UI

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d25b425cc88329a41a6caa85b5de54