### PR TITLE
Expand DiceBear options and controls

### DIFF
--- a/src/lib/dicebear.ts
+++ b/src/lib/dicebear.ts
@@ -1,0 +1,60 @@
+export type DicebearStyle =
+  | 'adventurer'
+  | 'adventurer-neutral'
+  | 'avataaars'
+  | 'big-ears'
+  | 'big-ears-neutral'
+  | 'big-smile'
+  | 'bottts'
+  | 'croodles'
+  | 'croodles-neutral'
+  | 'fun-emoji'
+  | 'identicon'
+  | 'initials'
+  | 'lorelei'
+  | 'lorelei-neutral'
+  | 'micah'
+  | 'notionists'
+  | 'notionists-neutral';
+
+export type DicebearOpts = {
+  seed: string;
+  size?: number;
+  backgroundType?: 'solid' | 'gradientLinear' | 'gradientRadial';
+  backgroundColor?: string[];
+  radius?: number;
+  flip?: boolean;
+  scale?: number;
+  translateX?: number;
+  translateY?: number;
+};
+
+const BASE = 'https://api.dicebear.com/9.x';
+
+export function dicebearUrl(
+  style: DicebearStyle,
+  {
+    seed,
+    size = 1024,
+    backgroundType,
+    backgroundColor,
+    radius,
+    flip,
+    scale,
+    translateX,
+    translateY,
+  }: DicebearOpts,
+  format: 'png' | 'svg' = 'png'
+) {
+  const u = new URL(`${BASE}/${style}/${format}`);
+  u.searchParams.set('seed', seed);
+  u.searchParams.set('size', String(size));
+  if (backgroundType) u.searchParams.set('backgroundType', backgroundType);
+  if (backgroundColor?.length) u.searchParams.set('backgroundColor', backgroundColor.join(','));
+  if (radius != null) u.searchParams.set('radius', String(radius));
+  if (flip) u.searchParams.set('flip', 'true');
+  if (scale != null) u.searchParams.set('scale', String(scale));
+  if (translateX != null) u.searchParams.set('translateX', String(translateX));
+  if (translateY != null) u.searchParams.set('translateY', String(translateY));
+  return u.toString();
+}

--- a/src/lib/navatar/dicebear.ts
+++ b/src/lib/navatar/dicebear.ts
@@ -1,86 +1,20 @@
 import { supabase } from '@/lib/supabaseClient';
-import { NAVATAR_BUCKET, NAVATAR_PREFIX, getSessionUserId, pickNavatar, type NavatarRow } from '@/lib/navatar';
+import {
+  NAVATAR_BUCKET,
+  NAVATAR_PREFIX,
+  getSessionUserId,
+  pickNavatar,
+  type NavatarRow,
+} from '@/lib/navatar';
+import { dicebearUrl, type DicebearOpts, type DicebearStyle } from '@/lib/dicebear';
 
-export type DicebearStyle =
-  | 'adventurer'
-  | 'adventurer-neutral'
-  | 'avataaars'
-  | 'big-ears'
-  | 'big-ears-neutral'
-  | 'big-smile'
-  | 'bottts'
-  | 'croodles'
-  | 'croodles-neutral'
-  | 'fun-emoji'
-  | 'icons'
-  | 'identicon'
-  | 'initials'
-  | 'lorelei'
-  | 'micah'
-  | 'miniavs'
-  | 'notionists'
-  | 'open-peeps'
-  | 'personas'
-  | 'pixel-art'
-  | 'pixel-art-neutral'
-  | 'shapes'
-  | 'thumbs';
+const DEFAULT_SEED = 'naturverse';
+const DEFAULT_SIZE = 1024;
 
-export type DicebearOptions = {
+export type DicebearGenerateOptions = DicebearOpts & {
   style: DicebearStyle;
-  seed?: string;
-  size?: number;
-  backgroundColor?: string;
-  hair?: string;
-  eyes?: string;
-  mouth?: string;
-  format?: 'svg' | 'png';
+  name?: string;
 };
-
-const API_VERSION = '9.x';
-
-function cleanHex(value?: string | null) {
-  return value ? value.replace(/^#/, '').trim() : undefined;
-}
-
-function safeSeed(seed?: string | null) {
-  if (!seed) return 'seed';
-  const cleaned = seed.replace(/[^a-z0-9-_]/gi, '').slice(0, 48);
-  return cleaned.length > 0 ? cleaned : 'seed';
-}
-
-export function buildDicebearUrl(opts: DicebearOptions) {
-  const {
-    style,
-    seed = 'naturverse',
-    size = 1024,
-    backgroundColor,
-    hair,
-    eyes,
-    mouth,
-    format = 'svg',
-  } = opts;
-
-  const base = `https://api.dicebear.com/${API_VERSION}/${style}/${format}`;
-  const params = new URLSearchParams();
-
-  params.set('seed', seed);
-
-  if (format === 'png') {
-    params.set('size', String(size));
-  }
-
-  const bg = cleanHex(backgroundColor);
-  if (bg) {
-    params.set('backgroundColor', bg);
-  }
-
-  if (hair) params.set('hair', hair);
-  if (eyes) params.set('eyes', eyes);
-  if (mouth) params.set('mouth', mouth);
-
-  return `${base}?${params.toString()}`;
-}
 
 export type DicebearCreationResult = {
   row: NavatarRow;
@@ -89,30 +23,63 @@ export type DicebearCreationResult = {
   sourceUrl: string;
 };
 
-export async function createDicebearAvatar(
-  options: DicebearOptions,
-  name?: string
-): Promise<DicebearCreationResult> {
-  const ownerId = await getSessionUserId();
-  const format = (options.format ?? 'svg').toLowerCase() === 'png' ? 'png' : 'svg';
+function safeSeed(seed?: string | null) {
+  if (!seed) return 'seed';
+  const cleaned = seed.replace(/[^a-z0-9-_]/gi, '').slice(0, 48);
+  return cleaned.length > 0 ? cleaned : 'seed';
+}
 
-  const sourceUrl = buildDicebearUrl({ ...options, format });
+function normalizeSeed(raw?: string) {
+  const trimmed = raw?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : DEFAULT_SEED;
+}
+
+export async function generateDicebearAndSave({
+  style,
+  seed,
+  size = DEFAULT_SIZE,
+  backgroundType,
+  backgroundColor,
+  radius,
+  flip,
+  scale,
+  translateX,
+  translateY,
+  name,
+}: DicebearGenerateOptions): Promise<DicebearCreationResult> {
+  const ownerId = await getSessionUserId();
+  const normalizedSeed = normalizeSeed(seed);
+  const fileSeed = safeSeed(normalizedSeed);
+
+  const sourceUrl = dicebearUrl(
+    style,
+    {
+      seed: normalizedSeed,
+      size,
+      backgroundType,
+      backgroundColor,
+      radius,
+      flip,
+      scale,
+      translateX,
+      translateY,
+    },
+    'png'
+  );
+
   const response = await fetch(sourceUrl);
   if (!response.ok) {
     throw new Error(`DiceBear fetch failed: ${response.status}`);
   }
 
   const blob = await response.blob();
-  const ext = format === 'svg' ? 'svg' : 'png';
-  const filename = `${safeSeed(options.seed)}-${options.style}-${Date.now()}.${ext}`;
+  const filename = `${fileSeed}-${style}-${Date.now()}.png`;
   const storagePath = `${NAVATAR_PREFIX}/${ownerId}/${filename}`;
 
-  const { error } = await supabase.storage
-    .from(NAVATAR_BUCKET)
-    .upload(storagePath, blob, {
-      contentType: format === 'svg' ? 'image/svg+xml' : 'image/png',
-      upsert: true,
-    });
+  const { error } = await supabase.storage.from(NAVATAR_BUCKET).upload(storagePath, blob, {
+    contentType: 'image/png',
+    upsert: true,
+  });
 
   if (error) throw error;
 
@@ -126,3 +93,5 @@ export async function createDicebearAvatar(
     sourceUrl,
   };
 }
+
+export const createDicebearAvatar = generateDicebearAndSave;

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -8,7 +8,8 @@ import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
 import { useAuthUser } from "../../lib/useAuthUser";
-import { buildDicebearUrl, createDicebearAvatar, type DicebearStyle } from "../../lib/navatar/dicebear";
+import { dicebearUrl, type DicebearStyle } from "../../lib/dicebear";
+import { generateDicebearAndSave } from "../../lib/navatar/dicebear";
 import {
   DEFAULT_STYLE_ID,
   RATE_LIMIT_MESSAGE,
@@ -23,21 +24,41 @@ import {
 import "../../styles/navatar.css";
 
 type GeneratorMode = "stability" | "dicebear";
+type DicebearBackgroundSelection = "none" | "solid" | "gradientLinear" | "gradientRadial";
 
 const DICEBEAR_STYLE_OPTIONS: { value: DicebearStyle; label: string }[] = [
   { value: "adventurer", label: "Adventurer" },
   { value: "adventurer-neutral", label: "Adventurer Neutral" },
   { value: "avataaars", label: "Avataaars" },
-  { value: "micah", label: "Micah" },
-  { value: "open-peeps", label: "Open Peeps" },
-  { value: "pixel-art", label: "Pixel Art" },
-  { value: "pixel-art-neutral", label: "Pixel Art Neutral" },
+  { value: "big-ears", label: "Big Ears" },
+  { value: "big-ears-neutral", label: "Big Ears Neutral" },
+  { value: "big-smile", label: "Big Smile" },
+  { value: "bottts", label: "Bottts" },
+  { value: "croodles", label: "Croodles" },
+  { value: "croodles-neutral", label: "Croodles Neutral" },
   { value: "fun-emoji", label: "Fun Emoji" },
+  { value: "identicon", label: "Identicon" },
+  { value: "initials", label: "Initials" },
+  { value: "lorelei", label: "Lorelei" },
+  { value: "lorelei-neutral", label: "Lorelei Neutral" },
+  { value: "micah", label: "Micah" },
   { value: "notionists", label: "Notionists" },
-  { value: "shapes", label: "Shapes" },
+  { value: "notionists-neutral", label: "Notionists Neutral" },
 ];
 
 const DEFAULT_DICEBEAR_STYLE = DICEBEAR_STYLE_OPTIONS[0]?.value ?? "adventurer";
+const DICEBEAR_SIZE_OPTIONS = [256, 512, 1024, 2048] as const;
+const DEFAULT_DICEBEAR_SIZE = 1024;
+const DEFAULT_DICEBEAR_RADIUS = 0;
+const DEFAULT_DICEBEAR_SCALE = 100;
+const DEFAULT_DICEBEAR_TRANSLATE = 0;
+
+const DICEBEAR_BACKGROUND_OPTIONS: { value: DicebearBackgroundSelection; label: string }[] = [
+  { value: "none", label: "None (transparent)" },
+  { value: "solid", label: "Solid" },
+  { value: "gradientLinear", label: "Gradient (linear)" },
+  { value: "gradientRadial", label: "Gradient (radial)" },
+];
 
 const BRAND_STYLE = [
   "cute character, navatar style, bright friendly palette,",
@@ -74,8 +95,15 @@ export default function GenerateNavatarPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [dicebearStyle, setDicebearStyle] = useState<DicebearStyle>(DEFAULT_DICEBEAR_STYLE);
   const [dicebearSeed, setDicebearSeed] = useState("");
-  const [dicebearBackground, setDicebearBackground] = useState("");
   const [dicebearSeedTouched, setDicebearSeedTouched] = useState(false);
+  const [dicebearBackgroundType, setDicebearBackgroundType] =
+    useState<DicebearBackgroundSelection>("none");
+  const [dicebearBackgroundColors, setDicebearBackgroundColors] = useState("");
+  const [dicebearSize, setDicebearSize] = useState<number>(DEFAULT_DICEBEAR_SIZE);
+  const [dicebearRadius, setDicebearRadius] = useState<number>(DEFAULT_DICEBEAR_RADIUS);
+  const [dicebearScale, setDicebearScale] = useState<number>(DEFAULT_DICEBEAR_SCALE);
+  const [dicebearTranslateX, setDicebearTranslateX] = useState<number>(DEFAULT_DICEBEAR_TRANSLATE);
+  const [dicebearTranslateY, setDicebearTranslateY] = useState<number>(DEFAULT_DICEBEAR_TRANSLATE);
   const nav = useNavigate();
   const toast = useToast();
   const { user } = useAuthUser();
@@ -115,17 +143,60 @@ export default function GenerateNavatarPage() {
   );
 
   const dicebearSeedValue = dicebearSeed.trim() || user?.id || "naturverse";
-  const dicebearBackgroundValue = dicebearBackground.trim().replace(/^#/, "");
+  const dicebearBackgroundColorList = useMemo(
+    () =>
+      dicebearBackgroundColors
+        .split(",")
+        .map((color) => color.trim())
+        .filter(Boolean)
+        .map((color) => color.replace(/^#/, "").toLowerCase()),
+    [dicebearBackgroundColors]
+  );
+  const dicebearBackgroundTypeValue =
+    dicebearBackgroundType === "none" ? undefined : dicebearBackgroundType;
+  const dicebearBackgroundColorsValue =
+    dicebearBackgroundTypeValue && dicebearBackgroundColorList.length
+      ? dicebearBackgroundColorList
+      : undefined;
+  const isGradientBackground =
+    dicebearBackgroundType === "gradientLinear" || dicebearBackgroundType === "gradientRadial";
+  const canReverseBackgroundColors =
+    isGradientBackground && dicebearBackgroundColorList.length > 1;
+  const dicebearBackgroundPlaceholder = isGradientBackground ? "b6e3f4,c0aede" : "#b6e3f4";
+  const dicebearBackgroundHelper =
+    dicebearBackgroundType === "none"
+      ? "Transparent background keeps the sprite floating on your cards."
+      : isGradientBackground
+        ? "Comma-separated hex colors (e.g. b6e3f4,c0aede). Reverse swaps the gradient order."
+        : "Hex color, with or without the #.";
 
   const dicebearPreviewUrl = useMemo(
     () =>
-      buildDicebearUrl({
-        style: dicebearStyle,
-        seed: dicebearSeedValue || "naturverse",
-        backgroundColor: dicebearBackgroundValue || undefined,
-        format: "svg",
-      }),
-    [dicebearStyle, dicebearSeedValue, dicebearBackgroundValue]
+      dicebearUrl(
+        dicebearStyle,
+        {
+          seed: dicebearSeedValue || "naturverse",
+          size: dicebearSize,
+          backgroundType: dicebearBackgroundTypeValue,
+          backgroundColor: dicebearBackgroundColorsValue,
+          radius: dicebearRadius,
+          scale: dicebearScale,
+          translateX: dicebearTranslateX,
+          translateY: dicebearTranslateY,
+        },
+        "png"
+      ),
+    [
+      dicebearStyle,
+      dicebearSeedValue,
+      dicebearSize,
+      dicebearBackgroundTypeValue,
+      dicebearBackgroundColorsValue,
+      dicebearRadius,
+      dicebearScale,
+      dicebearTranslateX,
+      dicebearTranslateY,
+    ]
   );
 
   const previewUrl = mode === "stability" ? stabilityPreviewUrl : dicebearPreviewUrl;
@@ -136,6 +207,33 @@ export default function GenerateNavatarPage() {
   const saveLabel = isSaving ? "Saving…" : isStability && isGenerating ? "Generating…" : "Save";
   const cardTitle = name || (isDicebear ? dicebearSeedValue : "My Navatar");
 
+  function handleRandomDicebearSeed() {
+    const randomSeedValue = Math.random().toString(36).slice(2, 10);
+    setDicebearSeed(randomSeedValue);
+    setDicebearSeedTouched(true);
+  }
+
+  function handleReverseBackgroundColors() {
+    const values = dicebearBackgroundColors
+      .split(",")
+      .map((color) => color.trim())
+      .filter(Boolean);
+    if (values.length > 1) {
+      setDicebearBackgroundColors(values.reverse().join(", "));
+    }
+  }
+
+  function handleClearBackground() {
+    setDicebearBackgroundType("none");
+    setDicebearBackgroundColors("");
+  }
+
+  function handleResetCanvas() {
+    setDicebearScale(DEFAULT_DICEBEAR_SCALE);
+    setDicebearTranslateX(DEFAULT_DICEBEAR_TRANSLATE);
+    setDicebearTranslateY(DEFAULT_DICEBEAR_TRANSLATE);
+  }
+
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
     if (isSaving) return;
@@ -143,16 +241,18 @@ export default function GenerateNavatarPage() {
     if (mode === "dicebear") {
       setIsSaving(true);
       try {
-        const { row } = await createDicebearAvatar(
-          {
-            style: dicebearStyle,
-            seed: dicebearSeedValue || "naturverse",
-            backgroundColor: dicebearBackgroundValue || undefined,
-            format: "png",
-            size: 1024,
-          },
-          name || undefined
-        );
+        const { row } = await generateDicebearAndSave({
+          style: dicebearStyle,
+          seed: dicebearSeedValue || "naturverse",
+          size: dicebearSize,
+          backgroundType: dicebearBackgroundTypeValue,
+          backgroundColor: dicebearBackgroundColorsValue,
+          radius: dicebearRadius,
+          scale: dicebearScale,
+          translateX: dicebearTranslateX,
+          translateY: dicebearTranslateY,
+          name: name || undefined,
+        });
         setActiveNavatarId(row.id);
         toast({ text: "Saved ✓", kind: "ok" });
         nav("/navatar");
@@ -281,31 +381,174 @@ export default function GenerateNavatarPage() {
             </div>
             <div className="navatar-field">
               <label htmlFor="dicebear-seed">Seed (name or handle)</label>
-              <input
-                id="dicebear-seed"
-                value={dicebearSeed}
-                onChange={(e) => {
-                  setDicebearSeed(e.target.value);
-                  setDicebearSeedTouched(true);
-                }}
-                placeholder={dicebearSeedValue}
-                disabled={isSaving}
-                style={{ width: "100%" }}
-              />
-              <small style={{ color: "#1e3a8a" }}>Same seed = same avatar every time.</small>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 8, width: "100%" }}>
+                <input
+                  id="dicebear-seed"
+                  value={dicebearSeed}
+                  onChange={(e) => {
+                    setDicebearSeed(e.target.value);
+                    setDicebearSeedTouched(true);
+                  }}
+                  placeholder={dicebearSeedValue}
+                  disabled={isSaving}
+                  style={{ flex: "1 1 200px", minWidth: 0 }}
+                />
+                <button
+                  type="button"
+                  className="pill"
+                  onClick={handleRandomDicebearSeed}
+                  disabled={isSaving}
+                  style={{ flex: "0 0 auto" }}
+                >
+                  Randomize
+                </button>
+              </div>
+              <small style={{ color: "#1e3a8a" }}>
+                Seed = same look every time. Try your handle or tap Randomize for a new vibe.
+              </small>
             </div>
             <div className="navatar-field">
-              <label htmlFor="dicebear-bg">Background color (optional)</label>
+              <label htmlFor="dicebear-bg-type">Background</label>
+              <select
+                id="dicebear-bg-type"
+                value={dicebearBackgroundType}
+                onChange={(e) => setDicebearBackgroundType(e.target.value as DicebearBackgroundSelection)}
+                disabled={isSaving}
+              >
+                {DICEBEAR_BACKGROUND_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="navatar-field">
+              <label htmlFor="dicebear-bg">Background colors</label>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 8, width: "100%" }}>
+                <input
+                  id="dicebear-bg"
+                  value={dicebearBackgroundColors}
+                  onChange={(e) => setDicebearBackgroundColors(e.target.value)}
+                  placeholder={dicebearBackgroundPlaceholder}
+                  disabled={isSaving || dicebearBackgroundType === "none"}
+                  style={{ flex: "1 1 200px", minWidth: 0 }}
+                />
+                <button
+                  type="button"
+                  className="pill"
+                  onClick={handleReverseBackgroundColors}
+                  disabled={isSaving || !canReverseBackgroundColors}
+                  style={{ flex: "0 0 auto" }}
+                >
+                  Reverse colors
+                </button>
+                <button
+                  type="button"
+                  className="pill"
+                  onClick={handleClearBackground}
+                  disabled={isSaving || dicebearBackgroundType === "none"}
+                  style={{ flex: "0 0 auto" }}
+                >
+                  Transparent
+                </button>
+              </div>
+              <small style={{ color: "#1e3a8a" }}>{dicebearBackgroundHelper}</small>
+            </div>
+            <div className="navatar-field">
+              <label htmlFor="dicebear-size">Size</label>
+              <select
+                id="dicebear-size"
+                value={dicebearSize}
+                onChange={(e) => setDicebearSize(Number(e.target.value))}
+                disabled={isSaving}
+              >
+                {DICEBEAR_SIZE_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option} px
+                  </option>
+                ))}
+              </select>
+              <small style={{ color: "#1e3a8a" }}>
+                Quality tip: choose 1024 or 2048 for crisper marketplace cards.
+              </small>
+            </div>
+            <div className="navatar-field">
+              <label htmlFor="dicebear-radius">Corner radius ({dicebearRadius}px)</label>
               <input
-                id="dicebear-bg"
-                value={dicebearBackground}
-                onChange={(e) => setDicebearBackground(e.target.value)}
-                placeholder="#b6e3f4"
+                id="dicebear-radius"
+                type="range"
+                min={0}
+                max={50}
+                step={1}
+                value={dicebearRadius}
+                onChange={(e) => setDicebearRadius(Number(e.target.value))}
                 disabled={isSaving}
                 style={{ width: "100%" }}
               />
-              <small style={{ color: "#1e3a8a" }}>Hex color, with or without the #.</small>
+              <small style={{ color: "#1e3a8a" }}>
+                Soft corners help your Navatar sit nicely in rounded frames.
+              </small>
             </div>
+            <details className="navatar-advanced">
+              <summary>Canvas controls (zoom &amp; pan)</summary>
+              <div className="navatar-advanced__content">
+                <label htmlFor="dicebear-scale">Scale (zoom) {dicebearScale}%</label>
+                <input
+                  id="dicebear-scale"
+                  type="range"
+                  min={50}
+                  max={200}
+                  step={1}
+                  value={dicebearScale}
+                  onChange={(e) => setDicebearScale(Number(e.target.value))}
+                  disabled={isSaving}
+                  style={{ width: "100%" }}
+                />
+                <small style={{ color: "#1e3a8a" }}>
+                  Lower numbers zoom out to reveal more of the sprite when the style supports it.
+                </small>
+                <label htmlFor="dicebear-translate-x">
+                  Horizontal shift ({dicebearTranslateX})
+                </label>
+                <input
+                  id="dicebear-translate-x"
+                  type="range"
+                  min={-100}
+                  max={100}
+                  step={1}
+                  value={dicebearTranslateX}
+                  onChange={(e) => setDicebearTranslateX(Number(e.target.value))}
+                  disabled={isSaving}
+                  style={{ width: "100%" }}
+                />
+                <label htmlFor="dicebear-translate-y">
+                  Vertical shift ({dicebearTranslateY})
+                </label>
+                <input
+                  id="dicebear-translate-y"
+                  type="range"
+                  min={-100}
+                  max={100}
+                  step={1}
+                  value={dicebearTranslateY}
+                  onChange={(e) => setDicebearTranslateY(Number(e.target.value))}
+                  disabled={isSaving}
+                  style={{ width: "100%" }}
+                />
+                <small style={{ color: "#1e3a8a" }}>
+                  Nudge the art inside the frame to recenter full-body poses.
+                </small>
+                <button
+                  type="button"
+                  className="pill"
+                  onClick={handleResetCanvas}
+                  disabled={isSaving}
+                  style={{ marginTop: 8 }}
+                >
+                  Reset canvas
+                </button>
+              </div>
+            </details>
           </>
         ) : (
           <>


### PR DESCRIPTION
## Summary
- add a reusable DiceBear URL helper with the expanded v9 style list
- update the Navatar DiceBear save flow to use the new helper and richer options
- refresh the DiceBear UI with background/size/canvas controls plus helpful tips

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d261b071e88329a9730572a0ea664f