### PR TITLE
Add Supabase wishlist persistence and avatar fallback

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,9 @@
   included_files = []
   external_node_modules = []
 
+[functions."generate-avatar"]
+  timeout = 26
+
 # SPA routing
 [[redirects]]
   from = "/*"

--- a/netlify/functions/generate-avatar.ts
+++ b/netlify/functions/generate-avatar.ts
@@ -1,0 +1,127 @@
+import type { Handler } from "@netlify/functions";
+import { randomBytes } from "node:crypto";
+
+const STABILITY_KEY = process.env.STABILITY_API_KEY;
+const DICEBEAR_STYLE = process.env.DICEBEAR_STYLE ?? "adventurer";
+const DICEBEAR_FORMAT = process.env.DICEBEAR_FORMAT ?? "png";
+const IMG_SIZE = Number.parseInt(process.env.AVATAR_SIZE ?? "1024", 10) || 1024;
+
+type JsonBody = { statusCode: number; headers: Record<string, string>; body: string };
+
+const json = (status: number, body: unknown): JsonBody => ({
+  statusCode: status,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(body),
+});
+
+interface GeneratePayload {
+  prompt?: string;
+  negativePrompt?: string;
+  seed?: string | number;
+}
+
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod !== "POST") {
+      return json(405, { error: "method_not_allowed" });
+    }
+
+    let payload: GeneratePayload;
+    try {
+      payload = JSON.parse(event.body ?? "{}") as GeneratePayload;
+    } catch {
+      return json(400, { error: "invalid_json" });
+    }
+
+    const prompt = typeof payload.prompt === "string" ? payload.prompt.trim() : "";
+    const negativePrompt =
+      typeof payload.negativePrompt === "string" ? payload.negativePrompt.trim() : "";
+    const seed =
+      payload.seed !== undefined && payload.seed !== null && `${payload.seed}`.trim() !== ""
+        ? `${payload.seed}`
+        : undefined;
+
+    if (STABILITY_KEY && prompt) {
+      try {
+        const form = new FormData();
+        form.set("prompt", prompt);
+        form.set("output_format", "webp");
+        form.set("aspect_ratio", "1:1");
+        form.set("mode", "text-to-image");
+        form.set("width", String(IMG_SIZE));
+        form.set("height", String(IMG_SIZE));
+        if (negativePrompt) {
+          form.set("negative_prompt", negativePrompt);
+        }
+        if (seed) {
+          form.set("seed", seed);
+        }
+
+        const response = await fetch("https://api.stability.ai/v2beta/stable-image/generate/core", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${STABILITY_KEY}`,
+            Accept: "application/json",
+          },
+          body: form,
+        });
+
+        if (response.ok) {
+          const output = (await response.json()) as any;
+          const imageBase64: string | undefined =
+            typeof output?.image === "string"
+              ? output.image
+              : Array.isArray(output?.images) && typeof output.images[0]?.image === "string"
+              ? output.images[0]?.image
+              : undefined;
+
+          if (imageBase64) {
+            return json(200, {
+              source: "stability",
+              mime: "image/webp",
+              imageBase64,
+            });
+          }
+        } else if (response.status !== 400 && response.status !== 401) {
+          // Allow fallback for credits, rate limits, and server errors.
+        } else {
+          // client error — fall through to fallback avatar
+        }
+      } catch (err) {
+        console.error("stability_generate_error", err);
+      }
+    }
+
+    const seedValue = seed ?? randomHex();
+    const dicebearUrl =
+      `https://api.dicebear.com/9.x/${encodeURIComponent(DICEBEAR_STYLE)}/${DICEBEAR_FORMAT}` +
+      `?seed=${encodeURIComponent(seedValue)}` +
+      `&size=${IMG_SIZE}&radius=0&backgroundType=none`;
+
+    const dicebearResponse = await fetch(dicebearUrl);
+    if (!dicebearResponse.ok) {
+      return json(502, { error: "dicebear_failed" });
+    }
+
+    const buffer = Buffer.from(await dicebearResponse.arrayBuffer());
+    const mime =
+      DICEBEAR_FORMAT === "svg"
+        ? "image/svg+xml"
+        : DICEBEAR_FORMAT === "webp"
+        ? "image/webp"
+        : "image/png";
+
+    return json(200, {
+      source: "dicebear",
+      mime,
+      imageBase64: buffer.toString("base64"),
+    });
+  } catch (error: any) {
+    console.error("generate_avatar_error", error);
+    return json(500, { error: "server_error", message: error?.message ?? "unknown" });
+  }
+};
+
+function randomHex(): string {
+  return randomBytes(16).toString("hex");
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from 'react-router-dom';
 import { router } from './router';
 import { organizationLd, websiteLd } from './lib/jsonld';
 import { CartProvider } from './lib/cart';
+import { WishlistProvider } from './context/WishlistContext';
 import ToasterListener from './components/Toaster';
 import RouteFX from './components/RouteFX';
 import TurianAssistant from './components/TurianAssistant';
@@ -20,7 +21,7 @@ export default function App() {
   }, []);
   return (
     <CartProvider>
-      <>
+      <WishlistProvider>
         {/* Global route side-effects (scroll & focus) */}
         <RouteFX />
         <script
@@ -38,7 +39,7 @@ export default function App() {
         </main>
         <ToasterListener />
         <TurianAssistant isAuthed={isAuthed} />
-      </>
+      </WishlistProvider>
     </CartProvider>
   );
 }

--- a/src/components/SaveButton.tsx
+++ b/src/components/SaveButton.tsx
@@ -1,5 +1,8 @@
-import { get, set } from "../utils/storage";
 import { useEffect, useState } from "react";
+
+import { useWishlist } from "@/context/WishlistContext";
+
+import { get, set } from "../utils/storage";
 import { useToast } from "./Toast";
 
 type Item = { id: string; kind: "world" | "zone" | "product" | "navatar"; title: string; href?: string; payload?: unknown; }
@@ -20,10 +23,55 @@ export function useLibrary() {
 
 export default function SaveButton(props: Item) {
   const toast = useToast();
-  const items = get<Item[]>(KEY, []);
-  const exists = items.some(i => i.id === props.id);
+  const wishlist = useWishlist();
+  const [busy, setBusy] = useState(false);
 
-  function persist(next: Item[]) { set(KEY, next); }
+  if (props.kind === "product") {
+    const slug = props.id.startsWith("product:") ? props.id.slice("product:".length) : props.id;
+    const saved = wishlist.has(slug);
+
+    const handleClick = async () => {
+      if (busy) return;
+      try {
+        setBusy(true);
+        const next = await wishlist.toggle(slug);
+        toast({
+          text: next ? "Saved to Wishlist ⭐" : "Removed from Wishlist",
+          kind: next ? "ok" : "warn",
+        });
+      } catch (error: any) {
+        const message = error?.message ?? "";
+        if (message === "not_signed_in") {
+          toast({ text: "Sign in to save items", kind: "warn" });
+        } else {
+          toast({ text: "Unable to update wishlist", kind: "err" });
+        }
+      } finally {
+        setBusy(false);
+      }
+    };
+
+    return (
+      <button
+        className="btn save-btn"
+        onClick={() => {
+          void handleClick();
+        }}
+        aria-pressed={saved}
+        disabled={wishlist.loading || busy}
+        title={saved ? "Remove from Wishlist" : "Save to Wishlist"}
+      >
+        {saved ? "Saved" : "Save"}
+      </button>
+    );
+  }
+
+  const items = get<Item[]>(KEY, []);
+  const exists = items.some((i) => i.id === props.id);
+
+  function persist(next: Item[]) {
+    set(KEY, next);
+  }
 
   return (
     <button
@@ -31,7 +79,7 @@ export default function SaveButton(props: Item) {
       onClick={() => {
         const list = get<Item[]>(KEY, []);
         if (exists) {
-          persist(list.filter(i => i.id !== props.id));
+          persist(list.filter((i) => i.id !== props.id));
           toast({ text: "Removed from Library", kind: "warn" });
         } else {
           persist([{ ...props }, ...list].slice(0, 200));

--- a/src/context/WishlistContext.tsx
+++ b/src/context/WishlistContext.tsx
@@ -1,25 +1,92 @@
-import { createContext, useContext, useState, ReactNode } from "react";
-import { load, save } from "../lib/commerce/storage";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 
-type Wish = {
+import { supabase } from "@/lib/supabaseClient";
+import { getWishlistMap, toggleWishlist } from "@/services/wishlist";
+
+type WishlistContextValue = {
   items: string[];
-  toggle: (slug: string) => void;
   has: (slug: string) => boolean;
+  toggle: (slug: string) => Promise<boolean>;
+  loading: boolean;
+  refresh: () => Promise<void>;
 };
 
-const Ctx = createContext<Wish>(null!);
+const WishlistContext = createContext<WishlistContextValue | undefined>(undefined);
 
-export const WishlistProvider = ({ children }: { children: ReactNode }) => {
-  const [items, set] = useState<string[]>(() => load("wishlist", []));
-  const toggle = (slug: string) => {
-    const v = items.includes(slug)
-      ? items.filter((s) => s !== slug)
-      : [...items, slug];
-    set(v);
-    save("wishlist", v);
-  };
-  const has = (slug: string) => items.includes(slug);
-  return <Ctx.Provider value={{ items, toggle, has }}>{children}</Ctx.Provider>;
-};
+export function WishlistProvider({ children }: { children: ReactNode }) {
+  const [map, setMap] = useState<Record<string, boolean>>({});
+  const [loading, setLoading] = useState(true);
 
-export const useWishlist = () => useContext(Ctx);
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const next = await getWishlistMap();
+      setMap(next);
+    } catch (error) {
+      console.error("wishlist_refresh_failed", error);
+      setMap({});
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        void refresh();
+      } else {
+        setMap({});
+        setLoading(false);
+      }
+    });
+
+    return () => {
+      data.subscription.unsubscribe();
+    };
+  }, [refresh]);
+
+  const toggle = useCallback(async (slug: string) => {
+    const saved = await toggleWishlist(slug);
+    setMap((prev) => {
+      const next = { ...prev };
+      if (saved) {
+        next[slug] = true;
+      } else {
+        delete next[slug];
+      }
+      return next;
+    });
+    return saved;
+  }, []);
+
+  const has = useCallback((slug: string) => Boolean(map[slug]), [map]);
+
+  const items = useMemo(() => Object.keys(map), [map]);
+
+  const value = useMemo(
+    () => ({ items, has, toggle, loading, refresh }),
+    [items, has, toggle, loading, refresh],
+  );
+
+  return <WishlistContext.Provider value={value}>{children}</WishlistContext.Provider>;
+}
+
+export function useWishlist(): WishlistContextValue {
+  const ctx = useContext(WishlistContext);
+  if (!ctx) {
+    throw new Error("useWishlist must be used within a WishlistProvider");
+  }
+  return ctx;
+}

--- a/src/lib/navatar/stability.ts
+++ b/src/lib/navatar/stability.ts
@@ -128,12 +128,6 @@ export function normalizeSeed(seed: number | undefined): number | undefined {
   return Math.floor(seed);
 }
 
-function parseRemaining(header: string | null): number | null {
-  if (!header) return null;
-  const value = Number(header);
-  return Number.isFinite(value) ? value : null;
-}
-
 export interface StabilityGenerateOptions {
   prompt: string;
   negativePrompt?: string;
@@ -145,7 +139,9 @@ export interface StabilityGenerateOptions {
 
 export interface StabilityGenerateResult {
   blob: Blob;
-  remaining?: number | null;
+  mime: string;
+  source: "stability" | "dicebear";
+  imageBase64: string;
 }
 
 export async function generateWithStability({
@@ -174,7 +170,7 @@ export async function generateWithStability({
 
   let resp: Response;
   try {
-    resp = await fetch("/.netlify/functions/stability-generate", {
+    resp = await fetch("/.netlify/functions/generate-avatar", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
@@ -184,21 +180,41 @@ export async function generateWithStability({
     throw new StabilityError("Unable to reach Stability right now. Check your connection and try again.");
   }
 
-  const remaining = parseRemaining(resp.headers.get("x-ratelimit-remaining"));
+  const data = await resp.json().catch(() => null);
 
   if (!resp.ok) {
-    const err = await resp.json().catch(() => null);
-    const detail = typeof err === "object" && err
-      ? ("detail" in err ? String((err as any).detail) : "error" in err ? String((err as any).error) : null)
-      : null;
-
-    if (resp.status === 429 || (typeof remaining === "number" && remaining <= 0)) {
-      throw new RateLimitError(RATE_LIMIT_MESSAGE, remaining);
-    }
-
-    throw new StabilityError(detail || `HTTP ${resp.status}`, resp.status, remaining);
+    const detail =
+      typeof data === "object" && data && "error" in data
+        ? String((data as Record<string, unknown>).error)
+        : `HTTP ${resp.status}`;
+    throw new StabilityError(detail, resp.status);
   }
 
-  const blob = await resp.blob();
-  return { blob, remaining };
+  const imageBase64 =
+    typeof data === "object" && data && typeof (data as any).imageBase64 === "string"
+      ? ((data as any).imageBase64 as string)
+      : null;
+  if (!imageBase64) {
+    throw new StabilityError("Invalid image response from generator");
+  }
+
+  const mime =
+    typeof (data as any).mime === "string" && (data as any).mime
+      ? ((data as any).mime as string)
+      : "image/webp";
+  const source: "stability" | "dicebear" = (data as any).source === "dicebear" ? "dicebear" : "stability";
+
+  const blob = base64ToBlob(imageBase64, mime);
+
+  return { blob, mime, source, imageBase64 };
+}
+
+function base64ToBlob(base64: string, mime: string): Blob {
+  const binary = atob(base64);
+  const len = binary.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: mime });
 }

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -1,8 +1,94 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+
+import AddToCartButton from "../../components/AddToCartButton";
 import MarketTabs from "../../components/MarketTabs";
+import SaveButton from "../../components/SaveButton";
+import { useWishlist } from "../../context/WishlistContext";
+import { useAuth } from "../../lib/auth-context";
+import { listWishlistProducts, type WishlistProduct } from "../../services/wishlist";
 import "../../styles/marketplace.css";
 
 export default function MarketplaceWishlist() {
+  const { ready, user } = useAuth();
+  const wishlist = useWishlist();
+  const [items, setItems] = useState<WishlistProduct[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      setItems([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    listWishlistProducts()
+      .then((rows) => setItems(rows))
+      .catch((err) => {
+        console.error("wishlist_fetch_failed", err);
+        setError("Unable to load your wishlist right now.");
+        setItems([]);
+      })
+      .finally(() => setLoading(false));
+  }, [user, wishlist.items]);
+
+  let content: JSX.Element;
+  if (!ready) {
+    content = <p style={{ textAlign: "center", marginTop: "1.5rem" }}>Loading your wishlist…</p>;
+  } else if (!user) {
+    content = (
+      <p style={{ textAlign: "center", marginTop: "1.5rem" }}>
+        Sign in to save items to your wishlist.
+      </p>
+    );
+  } else if (loading) {
+    content = <p style={{ textAlign: "center", marginTop: "1.5rem" }}>Loading your wishlist…</p>;
+  } else if (error) {
+    content = (
+      <p style={{ textAlign: "center", marginTop: "1.5rem" }}>
+        {error}
+      </p>
+    );
+  } else if (items.length === 0) {
+    content = <p style={{ textAlign: "center", marginTop: "1.5rem" }}>No saved items yet.</p>;
+  } else {
+    content = (
+      <div className="mp-grid nv-card-grid">
+        {items.map((product) => {
+          const price = product.priceCents / 100;
+          return (
+            <article key={product.slug} className="mp-card nv-card">
+              <div className="mp-image nv-image">
+                <img src={product.imageUrl} alt={product.title} loading="lazy" />
+              </div>
+              <h3>
+                <Link to={`/marketplace/${product.slug}`}>{product.title}</Link>
+              </h3>
+              <p className="price">${price.toFixed(2)}</p>
+              <div className="actions">
+                <AddToCartButton
+                  id={product.slug}
+                  name={product.title}
+                  price={price}
+                  image={product.imageUrl}
+                />
+                <SaveButton
+                  id={`product:${product.slug}`}
+                  kind="product"
+                  title={product.title}
+                  href={`/marketplace/${product.slug}`}
+                />
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <main className="container">
       <div className="mk-head">
@@ -13,9 +99,7 @@ export default function MarketplaceWishlist() {
       </div>
 
       <MarketTabs />
-      <p style={{ textAlign: "center", marginTop: "1.5rem" }}>
-        Wishlist — coming soon.
-      </p>
+      {content}
     </main>
   );
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -13,7 +13,6 @@ import { generateDicebearAndSave } from "../../lib/navatar/dicebear";
 import {
   DEFAULT_STYLE_ID,
   RATE_LIMIT_MESSAGE,
-  RateLimitError,
   STYLE_PRESETS,
   StabilityError,
   buildNegativePrompt,
@@ -299,24 +298,28 @@ export default function GenerateNavatarPage() {
     const seed = keepStyle && user?.id ? seedFromUserId(user.id) : undefined;
     setIsGenerating(true);
     try {
-      const { blob } = await generateWithStability({
+      const { blob, mime, source } = await generateWithStability({
         prompt: finalPrompt,
         negativePrompt,
         seed,
         style: selectedStyle.id,
       });
 
-      const generatedFile = new File([blob], `navatar-${Date.now()}.png`, {
-        type: blob.type || "image/png",
+      const extension = mime.split("/")[1]?.split(";")[0] || "png";
+      const fileType = mime || blob.type || "image/png";
+      const generatedFile = new File([blob], `navatar-${Date.now()}.${extension}`, {
+        type: fileType,
       });
 
       setFile(generatedFile);
-      toast({ text: "Navatar generated ✓", kind: "ok" });
+      if (source === "dicebear") {
+        toast({ text: RATE_LIMIT_MESSAGE, kind: "warn" });
+      } else {
+        toast({ text: "Navatar generated ✓", kind: "ok" });
+      }
     } catch (error) {
       console.error(error);
-      if (error instanceof RateLimitError) {
-        toast({ text: error.message || RATE_LIMIT_MESSAGE, kind: "err" });
-      } else if (error instanceof StabilityError) {
+      if (error instanceof StabilityError) {
         toast({ text: error.message, kind: "err" });
       } else if (error instanceof Error) {
         toast({ text: error.message, kind: "err" });

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,3 +8,4 @@ export * from '../lib/queries';
 export * from '../lib/xp';
 export * from '../lib/quizzes';
 export * from '../lib/feedback';
+export * from './wishlist';

--- a/src/services/wishlist.ts
+++ b/src/services/wishlist.ts
@@ -1,0 +1,156 @@
+import { supabase } from "@/lib/supabaseClient";
+
+const productIdCache = new Map<string, string>();
+
+export type WishlistProduct = {
+  id: string;
+  slug: string;
+  title: string;
+  priceCents: number;
+  imageUrl: string;
+};
+
+type WishlistMapRow = {
+  product_id: string | null;
+  products: { slug: string | null } | null;
+};
+
+type WishlistProductRow = {
+  product_id: string | null;
+  products: {
+    slug: string | null;
+    title: string | null;
+    price_cents: number | null;
+    image_url: string | null;
+  } | null;
+};
+
+async function ensureProductId(slug: string): Promise<string> {
+  const cached = productIdCache.get(slug);
+  if (cached) return cached;
+
+  const { data, error } = await supabase
+    .from("products")
+    .select("id")
+    .eq("slug", slug)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data?.id) {
+    throw new Error("product_not_found");
+  }
+
+  productIdCache.set(slug, data.id);
+  return data.id;
+}
+
+export async function getWishlistMap(): Promise<Record<string, boolean>> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return {};
+  }
+
+  const { data, error } = await supabase
+    .from("wishlist_items")
+    .select("product_id, products ( slug )")
+    .eq("user_id", user.id);
+
+  if (error) throw error;
+
+  const map: Record<string, boolean> = {};
+  const rows = (data ?? []) as unknown as WishlistMapRow[];
+  for (const row of rows) {
+    const slug = row.products?.slug ?? undefined;
+    if (slug) {
+      map[slug] = true;
+      if (row.product_id) {
+        productIdCache.set(slug, row.product_id);
+      }
+    }
+  }
+
+  return map;
+}
+
+export async function toggleWishlist(slug: string): Promise<boolean> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error("not_signed_in");
+  }
+
+  const productId = await ensureProductId(slug);
+
+  const existing = await supabase
+    .from("wishlist_items")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("product_id", productId)
+    .maybeSingle();
+
+  if (existing.error) throw existing.error;
+
+  if (existing.data) {
+    const { error } = await supabase
+      .from("wishlist_items")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("product_id", productId);
+
+    if (error) throw error;
+    productIdCache.delete(slug);
+    return false;
+  }
+
+  const { error } = await supabase
+    .from("wishlist_items")
+    .insert({ user_id: user.id, product_id: productId });
+
+  if (error) throw error;
+  productIdCache.set(slug, productId);
+  return true;
+}
+
+export async function listWishlistProducts(): Promise<WishlistProduct[]> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from("wishlist_items")
+    .select(
+      "product_id, products ( slug, title, price_cents, image_url )"
+    )
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+
+  const items: WishlistProduct[] = [];
+  const rows = (data ?? []) as unknown as WishlistProductRow[];
+  for (const row of rows) {
+    const product = row.products;
+    if (!product?.slug) continue;
+    if (row.product_id) {
+      productIdCache.set(product.slug, row.product_id);
+    }
+    items.push({
+      id: row.product_id ?? product.slug,
+      slug: product.slug,
+      title: product.title ?? product.slug,
+      priceCents: product.price_cents ?? 0,
+      imageUrl: product.image_url ?? "",
+    });
+  }
+
+  return items;
+}


### PR DESCRIPTION
## Summary
- add a Netlify avatar generator function that uses Stability first and falls back to DiceBear when unavailable
- replace the local wishlist storage with Supabase-backed helpers, provider, and UI updates for the marketplace
- update Navatar generation to consume the new function and surface DiceBear fallback messaging

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d3460443b88329b3fd93090d554388