### PR TITLE
Add Supabase wishlist persistence and avatar fallback

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,9 @@
   included_files = []
   external_node_modules = []
 
+[functions."generate-avatar"]
+  timeout = 26
+
 # SPA routing
 [[redirects]]
   from = "/*"

--- a/netlify/functions/generate-avatar.ts
+++ b/netlify/functions/generate-avatar.ts
@@ -1,0 +1,232 @@
+import type { Handler } from '@netlify/functions';
+import { randomBytes } from 'node:crypto';
+
+const STABILITY_KEY = process.env.STABILITY_API_KEY ?? '';
+const DICEBEAR_STYLE = process.env.DICEBEAR_STYLE || 'adventurer';
+const DICEBEAR_FORMAT = process.env.DICEBEAR_FORMAT || 'png';
+const DEFAULT_SIZE = 1024;
+const parsedSize = Number.parseInt(process.env.AVATAR_SIZE || String(DEFAULT_SIZE), 10);
+const IMG_SIZE = clampSize(Number.isFinite(parsedSize) ? parsedSize : DEFAULT_SIZE, DEFAULT_SIZE);
+
+const json = (status: number, body: unknown) => ({
+  statusCode: status,
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+type GeneratePayload = {
+  prompt?: string;
+  seed?: string | number;
+  negativePrompt?: string;
+  width?: number;
+  height?: number;
+  size?: string;
+};
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return json(405, { error: 'method_not_allowed' });
+  }
+
+  let payload: GeneratePayload = {};
+  if (event.body) {
+    try {
+      payload = JSON.parse(event.body);
+    } catch {
+      return json(400, { error: 'invalid_json' });
+    }
+  }
+
+  const prompt = typeof payload.prompt === 'string' ? payload.prompt.trim() : '';
+  const seedValue = normalizeSeed(payload.seed);
+  const negativePrompt =
+    typeof payload.negativePrompt === 'string' ? payload.negativePrompt.trim() : undefined;
+  const dims = parseDimensions(payload.width, payload.height, payload.size);
+
+  const stabilityResult = await maybeGenerateWithStability({
+    prompt,
+    negativePrompt,
+    seed: seedValue,
+    width: dims.width,
+    height: dims.height,
+  });
+
+  if (stabilityResult?.ok) {
+    return json(200, stabilityResult.payload);
+  }
+
+  return await generateWithDicebear(seedValue);
+};
+
+type StabilityRequest = {
+  prompt: string;
+  negativePrompt?: string;
+  seed?: string;
+  width: number;
+  height: number;
+};
+
+type StabilitySuccess = {
+  ok: true;
+  payload: {
+    source: 'stability';
+    mime: string;
+    imageBase64: string;
+    remaining?: number | null;
+  };
+};
+
+type StabilityFailure = { ok: false };
+
+type StabilityResult = StabilitySuccess | StabilityFailure;
+
+async function maybeGenerateWithStability(options: StabilityRequest): Promise<StabilityResult> {
+  if (!STABILITY_KEY || !options.prompt) {
+    return { ok: false };
+  }
+
+  try {
+    const form = new FormData();
+    form.set('prompt', options.prompt);
+    form.set('output_format', 'webp');
+    form.set('mode', 'text-to-image');
+    form.set('aspect_ratio', '1:1');
+    form.set('width', String(options.width));
+    form.set('height', String(options.height));
+
+    if (options.negativePrompt) {
+      form.set('negative_prompt', options.negativePrompt);
+    }
+
+    if (options.seed) {
+      form.set('seed', options.seed);
+    }
+
+    const resp = await fetch('https://api.stability.ai/v2beta/stable-image/generate/core', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${STABILITY_KEY}`,
+        Accept: 'application/json',
+      },
+      body: form,
+    });
+
+    const remainingHeader = resp.headers.get('x-ratelimit-remaining');
+    const remaining = remainingHeader ? Number(remainingHeader) : undefined;
+
+    if (resp.ok) {
+      const data = (await resp.json()) as any;
+      const imageBase64 = data?.image ?? data?.images?.[0]?.image;
+      if (imageBase64) {
+        return {
+          ok: true,
+          payload: {
+            source: 'stability',
+            mime: 'image/webp',
+            imageBase64,
+            remaining: Number.isFinite(remaining) ? remaining : undefined,
+          },
+        };
+      }
+    } else {
+      const detail = await resp.text().catch(() => '');
+      console.warn('Stability response not OK', resp.status, detail);
+    }
+  } catch (error) {
+    console.error('Stability generate failed, using fallback', error);
+  }
+
+  return { ok: false };
+}
+
+type DicebearResult = {
+  source: 'dicebear';
+  mime: string;
+  imageBase64: string;
+};
+
+async function generateWithDicebear(seed?: string) {
+  const finalSeed = seed || cryptoRandomString();
+  const url =
+    `https://api.dicebear.com/9.x/${encodeURIComponent(DICEBEAR_STYLE)}/${encodeURIComponent(
+      DICEBEAR_FORMAT,
+    )}` +
+    `?seed=${encodeURIComponent(finalSeed)}&size=${IMG_SIZE}&radius=0&backgroundType=none`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    return json(502, { error: 'dicebear_failed' });
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const mime =
+    DICEBEAR_FORMAT === 'svg'
+      ? 'image/svg+xml'
+      : DICEBEAR_FORMAT === 'webp'
+        ? 'image/webp'
+        : 'image/png';
+
+  const payload: DicebearResult = {
+    source: 'dicebear',
+    mime,
+    imageBase64: buffer.toString('base64'),
+  };
+
+  return json(200, payload);
+}
+
+function normalizeSeed(seed: string | number | undefined): string | undefined {
+  if (typeof seed === 'number') {
+    if (Number.isFinite(seed)) return String(Math.floor(seed));
+    return undefined;
+  }
+  if (typeof seed === 'string') {
+    const trimmed = seed.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  return undefined;
+}
+
+function parseDimensions(
+  widthRaw: unknown,
+  heightRaw: unknown,
+  sizeRaw: unknown,
+): { width: number; height: number } {
+  let width = Number(widthRaw);
+  let height = Number(heightRaw);
+
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    if (typeof sizeRaw === 'string') {
+      const parts = sizeRaw.toLowerCase().split('x');
+      if (parts.length === 2) {
+        const [w, h] = parts.map((p) => Number(p));
+        if (Number.isFinite(w)) width = w;
+        if (Number.isFinite(h)) height = h;
+      }
+    }
+  }
+
+  if (!Number.isFinite(width)) width = IMG_SIZE;
+  if (!Number.isFinite(height)) height = IMG_SIZE;
+
+  return {
+    width: clampSize(Math.floor(width), IMG_SIZE),
+    height: clampSize(Math.floor(height), IMG_SIZE),
+  };
+}
+
+function clampSize(value: number, fallback: number) {
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  if (value < 128) return 128;
+  if (value > 2048) return 2048;
+  return value;
+}
+
+function cryptoRandomString() {
+  if (typeof globalThis.crypto?.getRandomValues === 'function') {
+    const arr = new Uint8Array(16);
+    globalThis.crypto.getRandomValues(arr);
+    return Array.from(arr, (b) => b.toString(16).padStart(2, '0')).join('');
+  }
+  return randomBytes(16).toString('hex');
+}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Product } from "../lib/commerce/types";
 
@@ -6,7 +7,7 @@ type CardProduct = Product & { saved?: boolean };
 type Props = {
   product: CardProduct;
   onAddToCart?: (p: Product) => void;
-  onToggleSave?: (p: Product) => void;
+  onToggleSave?: (p: Product) => Promise<boolean>;
   showCartButton?: boolean;
   showSaveButton?: boolean;
 };
@@ -18,6 +19,31 @@ export default function ProductCard({
   showCartButton = true,
   showSaveButton = true,
 }: Props) {
+  const [saved, setSaved] = useState(Boolean(product.saved));
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    setSaved(Boolean(product.saved));
+  }, [product.saved]);
+
+  async function handleToggle() {
+    if (!onToggleSave || busy) return;
+    setBusy(true);
+    try {
+      const next = await onToggleSave(product);
+      setSaved(Boolean(next));
+    } catch (err) {
+      console.error("Wishlist toggle failed", err);
+      const message =
+        err instanceof Error && err.message === "not_signed_in"
+          ? "Please sign in to update your wishlist"
+          : "Unable to update wishlist";
+      alert(message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <div className="rounded-2xl border border-blue-200/60 p-4 shadow-sm">
       <div className="rounded-2xl bg-blue-50/40 p-4">
@@ -52,10 +78,11 @@ export default function ProductCard({
         {showSaveButton && (
           <button
             className="flex-1 rounded-xl bg-blue-600 px-4 py-3 font-semibold text-white shadow-sm active:translate-y-[1px]"
-            onClick={() => onToggleSave?.(product)}
-            aria-pressed={!!product.saved}
+            onClick={handleToggle}
+            aria-pressed={saved}
+            disabled={busy}
           >
-            {product.saved ? "Saved" : "Save"}
+            {saved ? "Saved" : "Save"}
           </button>
         )}
       </div>

--- a/src/components/commerce/WishlistButton.tsx
+++ b/src/components/commerce/WishlistButton.tsx
@@ -1,13 +1,34 @@
+import { useState } from "react";
 import { useWishlist } from "../../context/WishlistContext";
 
-export default function WishlistButton({ slug }: { slug: string }) {
+export default function WishlistButton({ productId }: { productId: string }) {
   const { has, toggle } = useWishlist();
-  const on = has(slug);
+  const [busy, setBusy] = useState(false);
+  const on = has(productId);
+
+  async function handleClick() {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await toggle(productId);
+    } catch (err) {
+      console.error("Wishlist toggle failed", err);
+      const message =
+        err instanceof Error && err.message === "not_signed_in"
+          ? "Please sign in to update your wishlist"
+          : "Unable to update wishlist";
+      alert(message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <button
       aria-pressed={on}
-      onClick={() => toggle(slug)}
+      onClick={handleClick}
       className="btn btn-secondary"
+      disabled={busy}
     >
       {on ? "♥ Saved" : "♡ Save"}
     </button>

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -14,7 +14,21 @@ type Cart = {
 const Ctx = createContext<Cart>(null!);
 
 export const CartProvider = ({ children }: { children: ReactNode }) => {
-  const [items, set] = useState<Item[]>(() => load("cart", []));
+  const [items, set] = useState<Item[]>(() => {
+    const raw = load<Item[]>("cart", []);
+    if (!Array.isArray(raw)) return [];
+    return raw.map((entry) => {
+      const product = entry?.product;
+      if (!product) return entry;
+      return {
+        ...entry,
+        product: {
+          ...product,
+          id: product.id ?? product.slug,
+        },
+      } satisfies Item;
+    });
+  });
   const persist = (v: Item[]) => {
     set(v);
     save("cart", v);

--- a/src/context/WishlistContext.tsx
+++ b/src/context/WishlistContext.tsx
@@ -1,25 +1,139 @@
-import { createContext, useContext, useState, ReactNode } from "react";
-import { load, save } from "../lib/commerce/storage";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useAuthUser } from "../lib/useAuthUser";
+import {
+  fetchWishlistEntries,
+  toggleWishlist as toggleWishlistItem,
+  type WishlistEntry,
+  type WishlistMap,
+} from "@/services/wishlist";
 
 type Wish = {
   items: string[];
-  toggle: (slug: string) => void;
-  has: (slug: string) => boolean;
+  loading: boolean;
+  has: (productId: string) => boolean;
+  toggle: (productId: string) => Promise<boolean>;
+  refresh: () => Promise<void>;
+  entries: WishlistEntry[];
 };
 
 const Ctx = createContext<Wish>(null!);
 
 export const WishlistProvider = ({ children }: { children: ReactNode }) => {
-  const [items, set] = useState<string[]>(() => load("wishlist", []));
-  const toggle = (slug: string) => {
-    const v = items.includes(slug)
-      ? items.filter((s) => s !== slug)
-      : [...items, slug];
-    set(v);
-    save("wishlist", v);
-  };
-  const has = (slug: string) => items.includes(slug);
-  return <Ctx.Provider value={{ items, toggle, has }}>{children}</Ctx.Provider>;
+  const { user } = useAuthUser();
+  const [map, setMap] = useState<WishlistMap>({});
+  const [loading, setLoading] = useState(true);
+  const [entries, setEntries] = useState<WishlistEntry[]>([]);
+
+  const loadEntries = useCallback(async () => {
+    if (!user?.id) {
+      setEntries([]);
+      setMap({});
+      return;
+    }
+    try {
+      const list = await fetchWishlistEntries();
+      setEntries(list);
+      const next: WishlistMap = {};
+      for (const entry of list) {
+        next[entry.product.id] = true;
+      }
+      setMap(next);
+    } catch (err) {
+      console.error("Failed to load wishlist entries", err);
+      throw err;
+    }
+  }, [user?.id]);
+
+  const refresh = useCallback(async () => {
+    await loadEntries();
+  }, [loadEntries]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function bootstrap() {
+      setLoading(true);
+      try {
+        await refresh();
+      } catch (err) {
+        if (!cancelled) {
+          console.error("Failed to refresh wishlist", err);
+          setMap({});
+          setEntries([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    bootstrap();
+    return () => {
+      cancelled = true;
+    };
+  }, [refresh]);
+
+  const items = useMemo(() => Object.keys(map), [map]);
+
+  const has = useCallback((productId: string) => Boolean(map[productId]), [map]);
+
+  const toggle = useCallback(async (productId: string) => {
+    let previous = false;
+    setMap((prev) => {
+      previous = Boolean(prev[productId]);
+      const next = { ...prev };
+      if (previous) {
+        delete next[productId];
+      } else {
+        next[productId] = true;
+      }
+      return next;
+    });
+
+    try {
+      const saved = await toggleWishlistItem(productId);
+      setMap((prev) => {
+        const next = { ...prev };
+        if (saved) {
+          next[productId] = true;
+        } else {
+          delete next[productId];
+        }
+        return next;
+      });
+      try {
+        await loadEntries();
+      } catch (err) {
+        console.error("Failed to refresh wishlist entries after toggle", err);
+      }
+      return saved;
+    } catch (err) {
+      setMap((prev) => {
+        const next = { ...prev };
+        if (previous) {
+          next[productId] = true;
+        } else {
+          delete next[productId];
+        }
+        return next;
+      });
+      throw err;
+    }
+  }, [loadEntries]);
+
+  const value = useMemo(
+    () => ({ items, loading, has, toggle, refresh, entries }),
+    [entries, has, items, loading, refresh, toggle]
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 };
 
 export const useWishlist = () => useContext(Ctx);

--- a/src/lib/commerce/products.ts
+++ b/src/lib/commerce/products.ts
@@ -1,27 +1,52 @@
-import { Product } from "./types";
+import { supabase } from '@/lib/supabaseClient';
+import type { Product } from './types';
 
-export const products: Product[] = [
-  {
-    slug: "turian-plush",
-    name: "Turian Plush",
-    price: 24,
-    image: "/Marketplace/Turianplushie.png",
-    description: "Cuddly plush of Turian.",
-  },
-  {
-    slug: "navatar-tee",
-    name: "Navatar Tee",
-    price: 18,
-    image: "/Marketplace/Turiantshirt.png",
-    description: "Soft cotton tee.",
-  },
-  {
-    slug: "sticker-pack",
-    name: "Sticker Pack",
-    price: 6,
-    image: "/Marketplace/Stickerpack.png",
-    description: "6 glossy stickers.",
-  },
-];
+export type ProductRecord = {
+  id: string;
+  slug: string;
+  title?: string | null;
+  description?: string | null;
+  price_cents?: number | null;
+  image_url?: string | null;
+};
 
-export const bySlug = (s: string) => products.find((p) => p.slug === s)!;
+export function mapProductRecord(row: ProductRecord): Product {
+  const price = typeof row.price_cents === 'number' ? row.price_cents / 100 : 0;
+  const image = row.image_url && row.image_url.length > 0 ? row.image_url : '';
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.title?.trim() || row.slug,
+    price,
+    image,
+    description: row.description?.trim() || undefined,
+  };
+}
+
+function ensureProduct(row: ProductRecord | null): Product | null {
+  if (!row) return null;
+  if (!row.id || !row.slug) return null;
+  return mapProductRecord(row);
+}
+
+export async function fetchProducts(): Promise<Product[]> {
+  const { data, error } = await supabase
+    .from('products')
+    .select('*')
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+  if (!data) return [];
+  return data.map(mapProductRecord);
+}
+
+export async function fetchProductBySlug(slug: string): Promise<Product | null> {
+  const { data, error } = await supabase
+    .from('products')
+    .select('*')
+    .eq('slug', slug)
+    .maybeSingle();
+
+  if (error) throw error;
+  return ensureProduct(data);
+}

--- a/src/lib/commerce/types.ts
+++ b/src/lib/commerce/types.ts
@@ -1,4 +1,5 @@
 export type Product = {
+  id: string;
   slug: string;
   name: string;
   price: number;

--- a/src/lib/navatar/stability.ts
+++ b/src/lib/navatar/stability.ts
@@ -128,12 +128,6 @@ export function normalizeSeed(seed: number | undefined): number | undefined {
   return Math.floor(seed);
 }
 
-function parseRemaining(header: string | null): number | null {
-  if (!header) return null;
-  const value = Number(header);
-  return Number.isFinite(value) ? value : null;
-}
-
 export interface StabilityGenerateOptions {
   prompt: string;
   negativePrompt?: string;
@@ -146,6 +140,7 @@ export interface StabilityGenerateOptions {
 export interface StabilityGenerateResult {
   blob: Blob;
   remaining?: number | null;
+  source: 'stability' | 'dicebear';
 }
 
 export async function generateWithStability({
@@ -174,31 +169,51 @@ export async function generateWithStability({
 
   let resp: Response;
   try {
-    resp = await fetch("/.netlify/functions/stability-generate", {
+    resp = await fetch("/.netlify/functions/generate-avatar", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
       signal,
     });
   } catch {
-    throw new StabilityError("Unable to reach Stability right now. Check your connection and try again.");
+    throw new StabilityError("Unable to reach the avatar generator right now. Check your connection and try again.");
   }
 
-  const remaining = parseRemaining(resp.headers.get("x-ratelimit-remaining"));
+  const data = await resp.json().catch(() => null);
 
-  if (!resp.ok) {
-    const err = await resp.json().catch(() => null);
-    const detail = typeof err === "object" && err
-      ? ("detail" in err ? String((err as any).detail) : "error" in err ? String((err as any).error) : null)
-      : null;
-
-    if (resp.status === 429 || (typeof remaining === "number" && remaining <= 0)) {
-      throw new RateLimitError(RATE_LIMIT_MESSAGE, remaining);
+  if (!resp.ok || !data) {
+    const detail = typeof data === "object" && data && "error" in data ? String((data as any).error) : null;
+    if (resp.status === 429 || resp.status === 402) {
+      throw new RateLimitError(RATE_LIMIT_MESSAGE, null);
     }
-
-    throw new StabilityError(detail || `HTTP ${resp.status}`, resp.status, remaining);
+    throw new StabilityError(detail || `HTTP ${resp.status}`, resp.status);
   }
 
-  const blob = await resp.blob();
-  return { blob, remaining };
+  const { imageBase64, mime, source, remaining } = data as {
+    imageBase64?: string;
+    mime?: string;
+    source?: string;
+    remaining?: number | null;
+  };
+
+  if (!imageBase64 || !mime) {
+    throw new StabilityError("Invalid image response from generator");
+  }
+
+  const blob = base64ToBlob(imageBase64, mime);
+  return {
+    blob,
+    remaining: typeof remaining === "number" ? remaining : undefined,
+    source: source === "dicebear" ? "dicebear" : "stability",
+  };
+}
+
+function base64ToBlob(base64: string, mime: string) {
+  const binary = atob(base64);
+  const length = binary.length;
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: mime });
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -299,19 +299,29 @@ export default function GenerateNavatarPage() {
     const seed = keepStyle && user?.id ? seedFromUserId(user.id) : undefined;
     setIsGenerating(true);
     try {
-      const { blob } = await generateWithStability({
+      const { blob, source } = await generateWithStability({
         prompt: finalPrompt,
         negativePrompt,
         seed,
         style: selectedStyle.id,
       });
 
-      const generatedFile = new File([blob], `navatar-${Date.now()}.png`, {
+      const extension = blob.type?.includes("webp")
+        ? "webp"
+        : blob.type?.includes("svg")
+          ? "svg"
+          : "png";
+      const generatedFile = new File([blob], `navatar-${Date.now()}.${extension}`, {
         type: blob.type || "image/png",
       });
 
       setFile(generatedFile);
-      toast({ text: "Navatar generated ✓", kind: "ok" });
+      const toastKind = source === "dicebear" ? "warn" : "ok";
+      const toastText =
+        source === "dicebear"
+          ? "Stability unavailable — DiceBear fallback used ✓"
+          : "Navatar generated ✓";
+      toast({ text: toastText, kind: toastKind });
     } catch (error) {
       console.error(error);
       if (error instanceof RateLimitError) {

--- a/src/routes/marketplace/index.tsx
+++ b/src/routes/marketplace/index.tsx
@@ -1,12 +1,46 @@
+import { useEffect, useState } from "react";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import ProductCard from "../../components/ProductCard";
-import { products } from "../../lib/commerce/products";
+import { fetchProducts } from "../../lib/commerce/products";
+import type { Product } from "../../lib/commerce/types";
 import { useCart } from "../../context/CartContext";
 import { useWishlist } from "../../context/WishlistContext";
 
 export default function Marketplace() {
   const { add } = useCart();
   const wishlist = useWishlist();
+  const [items, setItems] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const data = await fetchProducts();
+        if (!cancelled) {
+          setItems(data);
+          setError(null);
+        }
+      } catch (err) {
+        console.error("Failed to load marketplace products", err);
+        if (!cancelled) {
+          setItems([]);
+          setError("Unable to load marketplace products.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <section>
       <Breadcrumbs
@@ -16,18 +50,26 @@ export default function Marketplace() {
         ]}
       />
       <h1>Marketplace</h1>
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {products.map((p) => (
-          <ProductCard
-            key={p.slug}
-            product={{ ...p, saved: wishlist.has(p.slug) }}
-            onAddToCart={(item) => add(item)}
-            onToggleSave={(item) => wishlist.toggle(item.slug)}
-            showCartButton
-            showSaveButton
-          />
-        ))}
-      </div>
+      {loading ? (
+        <p>Loading products…</p>
+      ) : error ? (
+        <p className="text-red-700">{error}</p>
+      ) : items.length === 0 ? (
+        <p>No products available right now.</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map((p) => (
+            <ProductCard
+              key={p.id}
+              product={{ ...p, saved: wishlist.has(p.id) }}
+              onAddToCart={(item) => add(item)}
+              onToggleSave={(item) => wishlist.toggle(item.id)}
+              showCartButton
+              showSaveButton
+            />
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/src/routes/marketplace/product/[slug].tsx
+++ b/src/routes/marketplace/product/[slug].tsx
@@ -1,32 +1,81 @@
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import Breadcrumbs from "../../../components/Breadcrumbs";
 import AddToCart from "../../../components/commerce/AddToCart";
 import Price from "../../../components/commerce/Price";
 import WishlistButton from "../../../components/commerce/WishlistButton";
-import { bySlug } from "../../../lib/commerce/products";
+import { fetchProductBySlug } from "../../../lib/commerce/products";
+import type { Product } from "../../../lib/commerce/types";
 
 export default function ProductPage() {
   const { slug = "" } = useParams();
-  const p = bySlug(slug);
+  const [product, setProduct] = useState<Product | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const data = slug ? await fetchProductBySlug(slug) : null;
+        if (!cancelled) {
+          setProduct(data);
+          setError(data ? null : "Product not found.");
+        }
+      } catch (err) {
+        console.error("Failed to load product", err);
+        if (!cancelled) {
+          setProduct(null);
+          setError("Unable to load this product.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  if (loading) {
+    return (
+      <section>
+        <p>Loading product…</p>
+      </section>
+    );
+  }
+
+  if (error || !product) {
+    return (
+      <section>
+        <p>{error ?? "Product not found."}</p>
+      </section>
+    );
+  }
+
   return (
     <section>
       <Breadcrumbs
         items={[
           { label: "Home", href: "/" },
           { label: "Marketplace", href: "/marketplace" },
-          { label: p.name, href: `/marketplace/${p.slug}` },
+          { label: product.name, href: `/marketplace/${product.slug}` },
         ]}
       />
-      <h1>{p.name}</h1>
+      <h1>{product.name}</h1>
       <div className="card">
         <div className="img-wrap">
-          <img src={p.image} alt={p.name} />
+          <img src={product.image} alt={product.name} />
         </div>
         <p>
-          <Price amount={p.price} />
+          <Price amount={product.price} />
         </p>
-        <p>{p.description}</p>
-        <AddToCart product={p} /> <WishlistButton slug={p.slug} />
+        {product.description ? <p>{product.description}</p> : null}
+        <AddToCart product={product} /> <WishlistButton productId={product.id} />
       </div>
     </section>
   );

--- a/src/routes/marketplace/wishlist.tsx
+++ b/src/routes/marketplace/wishlist.tsx
@@ -1,13 +1,13 @@
 import Breadcrumbs from "../../components/Breadcrumbs";
 import ProductCard from "../../components/ProductCard";
-import { products } from "../../lib/commerce/products";
 import { useCart } from "../../context/CartContext";
 import { useWishlist } from "../../context/WishlistContext";
 
 export default function Wishlist() {
   const { add } = useCart();
-  const { items, toggle } = useWishlist();
-  const liked = products.filter((p) => items.includes(p.slug));
+  const { entries, toggle, loading } = useWishlist();
+  const hasItems = entries.length > 0;
+
   return (
     <section>
       <Breadcrumbs
@@ -18,14 +18,16 @@ export default function Wishlist() {
         ]}
       />
       <h1>Wishlist</h1>
-      {liked.length ? (
+      {loading ? (
+        <p>Loading wishlist…</p>
+      ) : hasItems ? (
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {liked.map((p) => (
+          {entries.map(({ product }) => (
             <ProductCard
-              key={p.slug}
-              product={{ ...p, saved: true }}
+              key={product.id}
+              product={{ ...product, saved: true }}
               onAddToCart={(item) => add(item)}
-              onToggleSave={(item) => toggle(item.slug)}
+              onToggleSave={(item) => toggle(item.id)}
               showCartButton
               showSaveButton
             />

--- a/src/services/wishlist.ts
+++ b/src/services/wishlist.ts
@@ -1,0 +1,93 @@
+import { supabase } from '@/lib/supabaseClient';
+import type { Product } from '@/lib/commerce/types';
+import { mapProductRecord, type ProductRecord } from '@/lib/commerce/products';
+
+export type WishlistMap = Record<string, boolean>;
+
+export type WishlistEntry = {
+  product: Product;
+  wishedAt: string;
+};
+
+export async function getWishlistMap(): Promise<WishlistMap> {
+  const { data: userRes } = await supabase.auth.getUser();
+  const user = userRes?.user;
+  if (!user) return {};
+
+  const { data, error } = await supabase
+    .from('wishlist_items')
+    .select('product_id');
+
+  if (error) throw error;
+  const map: WishlistMap = {};
+  for (const row of data ?? []) {
+    if (row?.product_id) {
+      map[row.product_id] = true;
+    }
+  }
+  return map;
+}
+
+export async function toggleWishlist(productId: string): Promise<boolean> {
+  const { data: userRes } = await supabase.auth.getUser();
+  const user = userRes?.user;
+  if (!user) {
+    throw new Error('not_signed_in');
+  }
+
+  const { data: existing, error: selectError } = await supabase
+    .from('wishlist_items')
+    .select('id')
+    .eq('product_id', productId)
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (selectError && selectError.code !== 'PGRST116') {
+    throw selectError;
+  }
+
+  if (existing) {
+    const { error } = await supabase
+      .from('wishlist_items')
+      .delete()
+      .eq('product_id', productId)
+      .eq('user_id', user.id);
+    if (error) throw error;
+    return false;
+  }
+
+  const { error } = await supabase
+    .from('wishlist_items')
+    .upsert(
+      { user_id: user.id, product_id: productId },
+      { onConflict: 'user_id,product_id' }
+    );
+  if (error) throw error;
+  return true;
+}
+
+export async function fetchWishlistEntries(): Promise<WishlistEntry[]> {
+  const { data: userRes } = await supabase.auth.getUser();
+  const user = userRes?.user;
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from('wishlist_items')
+    .select('created_at, product:products (*)')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+  const entries: WishlistEntry[] = [];
+  for (const row of data ?? []) {
+    const rawProduct = row?.product as ProductRecord | ProductRecord[] | null;
+    const productRecord = Array.isArray(rawProduct)
+      ? rawProduct[0] ?? null
+      : rawProduct;
+    if (!productRecord) continue;
+    const product = mapProductRecord(productRecord);
+    const createdAt = typeof row?.created_at === 'string' ? row.created_at : new Date().toISOString();
+    entries.push({ product, wishedAt: createdAt });
+  }
+  return entries;
+}


### PR DESCRIPTION
## Summary
- add a Netlify generate-avatar function that calls Stability first and falls back to DiceBear and wire the Navatar generator to it
- replace the local-storage wishlist with Supabase-backed helpers, update marketplace pages, and surface saved state in cards/buttons
- fetch marketplace products from Supabase so saved state matches real product ids and update Netlify config for the new function

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d3461202148329a96d90efcdb837a6