### PR TITLE
Wire marketplace wishlist to Supabase

### DIFF
--- a/src/lib/marketplace.ts
+++ b/src/lib/marketplace.ts
@@ -26,28 +26,3 @@ export async function saveDemoOrder(items: DemoLineItem[]) {
   return resp.json() as Promise<{ ok: boolean; order?: { id: string } }>;
 }
 
-export async function toggleWishlistItem(itemId: string) {
-  const { data } = await supabase.auth.getUser();
-  const userId = data.user?.id ?? null;
-
-  const resp = await fetch('/api/marketplace/wishlist', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ itemId, userId }),
-  });
-
-  if (!resp.ok) {
-    const err = await resp.json().catch(() => null);
-    const message = typeof err?.error === 'string' ? err.error : 'Unable to update wishlist';
-    throw new Error(message);
-  }
-
-  return resp.json() as Promise<{ ok: boolean; saved: boolean }>;
-}
-
-export async function fetchWishlistIds(): Promise<string[]> {
-  const { data, error } = await supabase.from('wishlists').select('item_id');
-  if (error) throw error;
-
-  return (data ?? []).map((row) => row.item_id as string).filter(Boolean);
-}

--- a/src/pages/marketplace/[slug].tsx
+++ b/src/pages/marketplace/[slug].tsx
@@ -4,7 +4,7 @@ import AddToCartButton from "../../components/AddToCartButton";
 import SaveButton from "../../components/SaveButton";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import "./../../styles/marketplace.css";
-import { fetchWishlistIds, toggleWishlistItem } from "@/lib/marketplace";
+import { getWishlistIds, toggleWishlist as toggleWishlistService } from "@/services/wishlist";
 import { useToast } from "@/components/Toast";
 import { useAuthUser } from "@/lib/useAuthUser";
 
@@ -19,15 +19,16 @@ export default function ProductPage(){
   const p = MAP[slug];
   const toast = useToast();
   const { user } = useAuthUser();
-  const [wishlist, setWishlist] = useState<string[]>([]);
+  const [wishlist, setWishlist] = useState<Set<string>>(() => new Set());
   const [loadingWishlist, setLoadingWishlist] = useState(true);
+  const [busy, setBusy] = useState(false);
 
   useEffect(() => {
     let active = true;
     (async () => {
       try {
-        const ids = await fetchWishlistIds();
-        if (active) setWishlist(ids);
+        const ids = await getWishlistIds();
+        if (active) setWishlist(new Set(ids));
       } catch (error) {
         if (import.meta.env.DEV) console.warn(error);
       } finally {
@@ -41,7 +42,7 @@ export default function ProductPage(){
 
   if (!p) return null;
 
-  const inWishlist = wishlist.includes(p.id);
+  const inWishlist = wishlist.has(p.id);
 
   const onToggleWishlist = async () => {
     if (!user) {
@@ -49,17 +50,27 @@ export default function ProductPage(){
       return;
     }
     try {
-      const { saved } = await toggleWishlistItem(p.id);
+      setBusy(true);
+      const saved = await toggleWishlistService(p.id);
       setWishlist((prev) => {
         const next = new Set(prev);
         if (saved) next.add(p.id);
         else next.delete(p.id);
-        return Array.from(next);
+        return next;
       });
       toast({ text: saved ? "Added to wishlist" : "Removed from wishlist", kind: saved ? "ok" : "warn" });
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Could not update wishlist";
-      toast({ text: message, kind: "err" });
+      const message =
+        error instanceof Error
+          ? error.message === "not_signed_in"
+            ? "Sign in to use your wishlist."
+            : error.message === "product_not_found"
+              ? "Product unavailable."
+              : error.message
+          : "Could not update wishlist";
+      toast({ text: message, kind: error instanceof Error && error.message === "not_signed_in" ? "warn" : "err" });
+    } finally {
+      setBusy(false);
     }
   };
   return (
@@ -78,12 +89,12 @@ export default function ProductPage(){
         </div>
         <button
           className="btn-secondary w-full"
-          disabled={loadingWishlist && !wishlist.length}
+          disabled={busy || (loadingWishlist && wishlist.size === 0)}
           onClick={onToggleWishlist}
           aria-pressed={inWishlist}
           style={{ marginTop: "1rem" }}
         >
-          {inWishlist ? "In Wishlist" : "Add to Wishlist"}
+          {inWishlist ? "Saved" : "Add to Wishlist"}
         </button>
       </article>
     </main>

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -5,7 +5,7 @@ import AddToCartButton from "../../components/AddToCartButton";
 import SaveButton from "../../components/SaveButton";
 import "../../styles/_cards.css";
 import "../../styles/marketplace.css";
-import { toggleWishlistItem, fetchWishlistIds } from "@/lib/marketplace";
+import { getWishlistIds, toggleWishlist as toggleWishlistService } from "@/services/wishlist";
 import { useToast } from "@/components/Toast";
 import { useAuthUser } from "@/lib/useAuthUser";
 
@@ -16,8 +16,9 @@ const PRODUCTS = [
 ];
 
 export default function MarketplaceShop() {
-  const [wishlist, setWishlist] = useState<string[]>([]);
+  const [wishlist, setWishlist] = useState<Set<string>>(() => new Set());
   const [loadingWishlist, setLoadingWishlist] = useState(true);
+  const [busyIds, setBusyIds] = useState<Set<string>>(() => new Set());
   const toast = useToast();
   const { user } = useAuthUser();
 
@@ -25,8 +26,8 @@ export default function MarketplaceShop() {
     let active = true;
     (async () => {
       try {
-        const ids = await fetchWishlistIds();
-        if (active) setWishlist(ids);
+        const ids = await getWishlistIds();
+        if (active) setWishlist(new Set(ids));
       } catch (error) {
         if (import.meta.env.DEV) {
           console.warn("wishlist", error);
@@ -40,24 +41,42 @@ export default function MarketplaceShop() {
     };
   }, []);
 
-  const toggleWishlist = async (itemId: string) => {
+  const handleToggleWishlist = async (itemId: string) => {
     if (!user) {
       toast({ text: "Sign in to use your wishlist.", kind: "warn" });
       return;
     }
 
     try {
-      const { saved } = await toggleWishlistItem(itemId);
+      setBusyIds((prev) => {
+        const next = new Set(prev);
+        next.add(itemId);
+        return next;
+      });
+      const saved = await toggleWishlistService(itemId);
       setWishlist((prev) => {
-        const set = new Set(prev);
-        if (saved) set.add(itemId);
-        else set.delete(itemId);
-        return Array.from(set);
+        const next = new Set(prev);
+        if (saved) next.add(itemId);
+        else next.delete(itemId);
+        return next;
       });
       toast({ text: saved ? "Added to wishlist" : "Removed from wishlist", kind: saved ? "ok" : "warn" });
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Could not update wishlist";
-      toast({ text: message, kind: "err" });
+      const message =
+        error instanceof Error
+          ? error.message === "not_signed_in"
+            ? "Sign in to use your wishlist."
+            : error.message === "product_not_found"
+              ? "Product unavailable."
+              : error.message
+          : "Could not update wishlist";
+      toast({ text: message, kind: error instanceof Error && error.message === "not_signed_in" ? "warn" : "err" });
+    } finally {
+      setBusyIds((prev) => {
+        const next = new Set(prev);
+        next.delete(itemId);
+        return next;
+      });
     }
   };
 
@@ -73,27 +92,33 @@ export default function MarketplaceShop() {
       <MarketTabs />
 
       <div className="mp-grid nv-card-grid">
-        {PRODUCTS.map(p => (
-          <article key={p.id} className="mp-card nv-card">
-            <div className="mp-image nv-image">
-              <img src={p.image} alt={p.name} loading="lazy" />
-            </div>
-            <h3><Link to={p.href}>{p.name}</Link></h3>
-            <p className="price">${p.price.toFixed(2)}</p>
-            <div className="actions">
-              <AddToCartButton id={p.id} name={p.name} price={p.price} image={p.image} />
-              <SaveButton id={`product:${p.id}`} kind="product" title={p.name} href={p.href} />
-            </div>
-            <button
-              className="btn-secondary w-full"
-              disabled={loadingWishlist && !wishlist.length}
-              onClick={() => toggleWishlist(p.id)}
-              aria-pressed={wishlist.includes(p.id)}
-            >
-              {wishlist.includes(p.id) ? "In Wishlist" : "Add to Wishlist"}
-            </button>
-          </article>
-        ))}
+        {PRODUCTS.map((p) => {
+          const isSaved = wishlist.has(p.id);
+          const isBusy = busyIds.has(p.id);
+          return (
+            <article key={p.id} className="mp-card nv-card">
+              <div className="mp-image nv-image">
+                <img src={p.image} alt={p.name} loading="lazy" />
+              </div>
+              <h3>
+                <Link to={p.href}>{p.name}</Link>
+              </h3>
+              <p className="price">${p.price.toFixed(2)}</p>
+              <div className="actions">
+                <AddToCartButton id={p.id} name={p.name} price={p.price} image={p.image} />
+                <SaveButton id={`product:${p.id}`} kind="product" title={p.name} href={p.href} />
+              </div>
+              <button
+                className="btn-secondary w-full"
+                disabled={isBusy || (loadingWishlist && wishlist.size === 0)}
+                onClick={() => handleToggleWishlist(p.id)}
+                aria-pressed={isSaved}
+              >
+                {isSaved ? "Saved" : "Add to Wishlist"}
+              </button>
+            </article>
+          );
+        })}
       </div>
       <p style={{ textAlign: "center", marginTop: "1.5rem", opacity: 0.8 }}>
         More products unlock as we hit funding goals.

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -1,20 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import MarketTabs from "../../components/MarketTabs";
 import "../../styles/marketplace.css";
-import { fetchWishlistIds, toggleWishlistItem } from "@/lib/marketplace";
+import { listWishlistProducts, toggleWishlist as toggleWishlistService, type WishlistProduct } from "@/services/wishlist";
 import { useToast } from "@/components/Toast";
 import { useAuthUser } from "@/lib/useAuthUser";
 
-const LOOKUP: Record<string, { name: string; image: string; href: string; price: number }> = {
-  "turian-plush": { name: "Turian Plush", image: "/Marketplace/Turianplushie.png", href: "/marketplace/turian-plush", price: 24 },
-  "navatar-tee": { name: "Navatar Tee", image: "/Marketplace/Turiantshirt.png", href: "/marketplace/navatar-tee", price: 18 },
-  stickers: { name: "Sticker Pack", image: "/Marketplace/Stickerpack.png", href: "/marketplace/stickers", price: 6 },
-};
+function formatPrice(cents: number | null | undefined) {
+  if (typeof cents !== "number") return "";
+  return `$${(cents / 100).toFixed(2)}`;
+}
 
 export default function MarketplaceWishlist() {
-  const [items, setItems] = useState<string[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [items, setItems] = useState<WishlistProduct[] | null>(null);
+  const [removing, setRemoving] = useState<Set<string>>(() => new Set());
   const toast = useToast();
   const { user } = useAuthUser();
 
@@ -22,12 +21,11 @@ export default function MarketplaceWishlist() {
     let active = true;
     (async () => {
       try {
-        const ids = await fetchWishlistIds();
-        if (active) setItems(ids);
+        const products = await listWishlistProducts();
+        if (active) setItems(products);
       } catch (error) {
         if (import.meta.env.DEV) console.warn(error);
-      } finally {
-        if (active) setLoading(false);
+        if (active) setItems([]);
       }
     })();
     return () => {
@@ -35,23 +33,45 @@ export default function MarketplaceWishlist() {
     };
   }, []);
 
-  const products = useMemo(() => items.map((id) => ({ id, data: LOOKUP[id] })).filter((p) => p.data), [items]);
-
-  const handleRemove = async (id: string) => {
+  const handleRemove = async (slug: string) => {
     if (!user) {
       toast({ text: "Sign in to update your wishlist.", kind: "warn" });
       return;
     }
+
+    setRemoving((prev) => {
+      const next = new Set(prev);
+      next.add(slug);
+      return next;
+    });
+
     try {
-      const { saved } = await toggleWishlistItem(id);
+      const saved = await toggleWishlistService(slug);
       if (!saved) {
-        setItems((prev) => prev.filter((x) => x !== id));
+        setItems((prev) => (prev ?? []).filter((item) => item.slug !== slug));
+        toast({ text: "Removed from wishlist", kind: "warn" });
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Could not update wishlist";
-      toast({ text: message, kind: "err" });
+      const message =
+        error instanceof Error
+          ? error.message === "not_signed_in"
+            ? "Sign in to update your wishlist."
+            : error.message === "product_not_found"
+              ? "Product unavailable."
+              : error.message
+          : "Could not update wishlist";
+      toast({ text: message, kind: error instanceof Error && error.message === "not_signed_in" ? "warn" : "err" });
+    } finally {
+      setRemoving((prev) => {
+        const next = new Set(prev);
+        next.delete(slug);
+        return next;
+      });
     }
   };
+
+  const isLoading = items === null;
+  const hasItems = Array.isArray(items) && items.length > 0;
 
   return (
     <main className="container">
@@ -64,28 +84,33 @@ export default function MarketplaceWishlist() {
 
       <MarketTabs />
 
-      {loading ? (
+      {isLoading ? (
         <p style={{ textAlign: "center", marginTop: "1.5rem" }}>Loading wishlist…</p>
-      ) : products.length === 0 ? (
+      ) : !hasItems ? (
         <p style={{ textAlign: "center", marginTop: "1.5rem" }}>
           No saved items yet. More products unlock as we hit funding goals.
         </p>
       ) : (
         <div className="mp-grid nv-card-grid" style={{ marginTop: "1.5rem" }}>
-          {products.map(({ id, data }) => (
-            <article key={id} className="mp-card nv-card">
-              <div className="mp-image nv-image">
-                <img src={data.image} alt={data.name} loading="lazy" />
-              </div>
-              <h3>
-                <Link to={data.href}>{data.name}</Link>
-              </h3>
-              <p className="price">${data.price.toFixed(2)}</p>
-              <button className="btn-secondary" onClick={() => handleRemove(id)}>
-                Remove from Wishlist
-              </button>
-            </article>
-          ))}
+          {items.map((product) => {
+            const disabled = removing.has(product.slug);
+            return (
+              <article key={product.id} className="mp-card nv-card">
+                <div className="mp-image nv-image">
+                  <img src={product.image_url} alt={product.title} loading="lazy" />
+                </div>
+                <h3>
+                  <Link to={`/marketplace/${product.slug}`}>{product.title}</Link>
+                </h3>
+                {product.price_cents != null && (
+                  <p className="price">{formatPrice(product.price_cents)}</p>
+                )}
+                <button className="btn-secondary" onClick={() => handleRemove(product.slug)} disabled={disabled}>
+                  {disabled ? "Removing…" : "Remove from Wishlist"}
+                </button>
+              </article>
+            );
+          })}
         </div>
       )}
     </main>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,3 +8,4 @@ export * from '../lib/queries';
 export * from '../lib/xp';
 export * from '../lib/quizzes';
 export * from '../lib/feedback';
+export * from './wishlist';

--- a/src/services/wishlist.ts
+++ b/src/services/wishlist.ts
@@ -1,0 +1,92 @@
+import { supabase } from '@/lib/supabaseClient';
+
+export async function getWishlistIds(): Promise<Set<string>> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return new Set();
+
+  const { data, error } = await supabase
+    .from('wishlist_items')
+    .select('product:products(slug)')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+  const slugs = (data ?? [])
+    .map((row: any) => row?.product?.slug as string | undefined)
+    .filter((slug): slug is string => Boolean(slug));
+
+  return new Set(slugs);
+}
+
+export async function toggleWishlist(productSlug: string): Promise<boolean> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('not_signed_in');
+
+  const { data: product, error: productError } = await supabase
+    .from('products')
+    .select('id')
+    .eq('slug', productSlug)
+    .maybeSingle();
+
+  if (productError) throw productError;
+  if (!product?.id) throw new Error('product_not_found');
+
+  const productId = product.id as string;
+
+  const { data, error } = await supabase
+    .from('wishlist_items')
+    .select('id')
+    .eq('user_id', user.id)
+    .eq('product_id', productId)
+    .maybeSingle();
+
+  if (error) throw error;
+
+  if (data?.id) {
+    const { error: deleteError } = await supabase
+      .from('wishlist_items')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('product_id', productId);
+    if (deleteError) throw deleteError;
+    return false;
+  }
+
+  const { error: insertError } = await supabase
+    .from('wishlist_items')
+    .insert({ user_id: user.id, product_id: productId });
+
+  if (insertError) throw insertError;
+  return true;
+}
+
+export type WishlistProduct = {
+  id: string;
+  slug: string;
+  title: string;
+  price_cents: number;
+  image_url: string;
+};
+
+export async function listWishlistProducts(): Promise<WishlistProduct[]> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from('wishlist_items')
+    .select('product:products(id, slug, title, price_cents, image_url)')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+
+  return (data ?? [])
+    .map((row: any) => row?.product)
+    .filter((product): product is WishlistProduct => Boolean(product?.id && product?.slug));
+}


### PR DESCRIPTION
## Summary
- add a Supabase-backed wishlist service for querying, toggling, and listing saved products
- connect marketplace product views to the service so wishlist state loads, updates, and disables buttons appropriately
- expose the wishlist helpers through the shared services entry point

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d34cba5224832983f466979952e0cc