### PR TITLE
Add Supabase-backed wishlist save and display

### DIFF
--- a/server/routes/marketplace.ts
+++ b/server/routes/marketplace.ts
@@ -57,18 +57,25 @@ router.post('/demo-order', async (req, res) => {
 router.post('/wishlist', async (req, res) => {
   try {
     const supabase = requireClient();
-    const { userId, itemId } = req.body ?? {};
-
-    if (!itemId || typeof itemId !== 'string') {
-      return res.status(400).json({ error: 'itemId required' });
-    }
+    const { userId, itemId: legacyItemId, item } = req.body ?? {};
 
     const normalizedUserId = typeof userId === 'string' && userId.trim().length > 0 ? userId.trim() : null;
+
+    const normalizedItemId =
+      typeof legacyItemId === 'string' && legacyItemId.trim().length > 0
+        ? legacyItemId.trim()
+        : typeof item?.id === 'string' && item.id.trim().length > 0
+          ? item.id.trim()
+          : null;
+
+    if (!normalizedItemId) {
+      return res.status(400).json({ error: 'itemId required' });
+    }
 
     const query = supabase
       .from('wishlists')
       .select('id')
-      .eq('item_id', itemId)
+      .eq('item_id', normalizedItemId)
       .limit(1);
 
     if (normalizedUserId) {
@@ -84,18 +91,41 @@ router.post('/wishlist', async (req, res) => {
 
     if (existing?.id) {
       await supabase.from('wishlists').delete().eq('id', existing.id);
-      return res.json({ ok: true, saved: false });
+      return res.json({ ok: true, saved: false, id: existing.id });
     }
 
-    const insertPayload: Record<string, unknown> = { item_id: itemId };
+    const productName = typeof item?.name === 'string' ? item.name.trim() : '';
+    if (!productName) {
+      return res.status(400).json({ error: 'product name required' });
+    }
+
+    const insertPayload: Record<string, unknown> = {
+      item_id: normalizedItemId,
+      product_name: productName,
+    };
+
+    if (typeof item?.price === 'number' && Number.isFinite(item.price)) {
+      insertPayload.product_price = item.price;
+    }
+    if (typeof item?.image === 'string' && item.image.trim().length > 0) {
+      insertPayload.product_image = item.image.trim();
+    }
+    if (typeof item?.href === 'string' && item.href.trim().length > 0) {
+      insertPayload.product_href = item.href.trim();
+    }
     if (normalizedUserId) insertPayload.user_id = normalizedUserId;
 
-    const { error: insertError } = await supabase.from('wishlists').insert(insertPayload);
+    const { data: inserted, error: insertError } = await supabase
+      .from('wishlists')
+      .insert(insertPayload)
+      .select('id, item_id, product_name, product_price, product_image, product_href, added_at, created_at')
+      .single();
+
     if (insertError) {
       throw insertError;
     }
 
-    return res.json({ ok: true, saved: true });
+    return res.json({ ok: true, saved: true, item: inserted });
   } catch (error: any) {
     const message = error?.message ?? 'Unable to update wishlist';
     return res.status(500).json({ error: message });

--- a/src/lib/marketplace.ts
+++ b/src/lib/marketplace.ts
@@ -26,14 +26,33 @@ export async function saveDemoOrder(items: DemoLineItem[]) {
   return resp.json() as Promise<{ ok: boolean; order?: { id: string } }>;
 }
 
-export async function toggleWishlistItem(itemId: string) {
+export type WishlistProductPayload = {
+  id: string;
+  name: string;
+  price?: number;
+  image?: string;
+  href?: string;
+};
+
+export type WishlistRow = {
+  id: string;
+  item_id: string;
+  product_name: string;
+  product_price: number | string | null;
+  product_image: string | null;
+  product_href: string | null;
+  added_at: string | null;
+  created_at: string | null;
+};
+
+export async function toggleWishlistItem(item: WishlistProductPayload) {
   const { data } = await supabase.auth.getUser();
   const userId = data.user?.id ?? null;
 
   const resp = await fetch('/api/marketplace/wishlist', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ itemId, userId }),
+    body: JSON.stringify({ item, userId }),
   });
 
   if (!resp.ok) {
@@ -42,12 +61,44 @@ export async function toggleWishlistItem(itemId: string) {
     throw new Error(message);
   }
 
-  return resp.json() as Promise<{ ok: boolean; saved: boolean }>;
+  return resp.json() as Promise<{ ok: boolean; saved: boolean; item?: WishlistRow; id?: string }>;
 }
 
-export async function fetchWishlistIds(): Promise<string[]> {
-  const { data, error } = await supabase.from('wishlists').select('item_id');
+export type WishlistItem = {
+  id: string;
+  itemId: string;
+  name: string;
+  price: number | null;
+  image: string | null;
+  href: string | null;
+  addedAt: string | null;
+};
+
+export async function fetchWishlistItems(): Promise<WishlistItem[]> {
+  const { data, error } = await supabase
+    .from('wishlists')
+    .select('id, item_id, product_name, product_price, product_image, product_href, added_at, created_at')
+    .order('added_at', { ascending: false })
+    .order('created_at', { ascending: false });
   if (error) throw error;
 
-  return (data ?? []).map((row) => row.item_id as string).filter(Boolean);
+  return (data ?? []).map((row) => {
+    let price: number | null = null;
+    if (typeof row.product_price === 'number') {
+      price = row.product_price;
+    } else if (typeof row.product_price === 'string') {
+      const parsed = Number(row.product_price);
+      price = Number.isFinite(parsed) ? parsed : null;
+    }
+
+    return {
+      id: row.id,
+      itemId: row.item_id,
+      name: row.product_name || row.item_id,
+      price,
+      image: row.product_image ?? null,
+      href: row.product_href ?? null,
+      addedAt: row.added_at ?? row.created_at ?? null,
+    };
+  });
 }

--- a/src/pages/marketplace/[slug].tsx
+++ b/src/pages/marketplace/[slug].tsx
@@ -4,7 +4,7 @@ import AddToCartButton from "../../components/AddToCartButton";
 import SaveButton from "../../components/SaveButton";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import "./../../styles/marketplace.css";
-import { fetchWishlistIds, toggleWishlistItem } from "@/lib/marketplace";
+import { fetchWishlistItems, toggleWishlistItem, type WishlistItem } from "@/lib/marketplace";
 import { useToast } from "@/components/Toast";
 import { useAuthUser } from "@/lib/useAuthUser";
 
@@ -18,18 +18,32 @@ export default function ProductPage(){
   const { slug="" } = useParams();
   const p = MAP[slug];
   const toast = useToast();
-  const { user } = useAuthUser();
-  const [wishlist, setWishlist] = useState<string[]>([]);
+  const { user, loading: authLoading } = useAuthUser();
+  const [wishlist, setWishlist] = useState<WishlistItem[]>([]);
   const [loadingWishlist, setLoadingWishlist] = useState(true);
 
   useEffect(() => {
     let active = true;
+    if (!user) {
+      if (!authLoading) {
+        setWishlist([]);
+        setLoadingWishlist(false);
+      } else {
+        setLoadingWishlist(true);
+      }
+      return () => {
+        active = false;
+      };
+    }
+
     (async () => {
       try {
-        const ids = await fetchWishlistIds();
-        if (active) setWishlist(ids);
+        setLoadingWishlist(true);
+        const items = await fetchWishlistItems();
+        if (active) setWishlist(items);
       } catch (error) {
         if (import.meta.env.DEV) console.warn(error);
+        if (active) setWishlist([]);
       } finally {
         if (active) setLoadingWishlist(false);
       }
@@ -37,11 +51,11 @@ export default function ProductPage(){
     return () => {
       active = false;
     };
-  }, []);
+  }, [user, authLoading]);
 
   if (!p) return null;
 
-  const inWishlist = wishlist.includes(p.id);
+  const inWishlist = wishlist.some((item) => item.itemId === p.id);
 
   const onToggleWishlist = async () => {
     if (!user) {
@@ -49,12 +63,41 @@ export default function ProductPage(){
       return;
     }
     try {
-      const { saved } = await toggleWishlistItem(p.id);
+      const { saved, item } = await toggleWishlistItem({
+        id: p.id,
+        name: p.name,
+        price: p.price,
+        image: p.image,
+        href: `/marketplace/${p.id}`,
+      });
       setWishlist((prev) => {
-        const next = new Set(prev);
-        if (saved) next.add(p.id);
-        else next.delete(p.id);
-        return Array.from(next);
+        if (saved && item) {
+          let price: number | null = null;
+          if (typeof item.product_price === "number") {
+            price = item.product_price;
+          } else if (typeof item.product_price === "string") {
+            const parsed = Number(item.product_price);
+            price = Number.isFinite(parsed) ? parsed : null;
+          }
+
+          const map = new Map(prev.map((entry) => [entry.itemId, entry] as const));
+          map.set(item.item_id, {
+            id: item.id,
+            itemId: item.item_id,
+            name: item.product_name,
+            price,
+            image: item.product_image ?? null,
+            href: item.product_href ?? null,
+            addedAt: item.added_at ?? item.created_at ?? null,
+          });
+          return Array.from(map.values());
+        }
+
+        if (!saved) {
+          return prev.filter((entry) => entry.itemId !== p.id);
+        }
+
+        return prev;
       });
       toast({ text: saved ? "Added to wishlist" : "Removed from wishlist", kind: saved ? "ok" : "warn" });
     } catch (error) {

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -5,7 +5,7 @@ import AddToCartButton from "../../components/AddToCartButton";
 import SaveButton from "../../components/SaveButton";
 import "../../styles/_cards.css";
 import "../../styles/marketplace.css";
-import { toggleWishlistItem, fetchWishlistIds } from "@/lib/marketplace";
+import { toggleWishlistItem, fetchWishlistItems, type WishlistItem } from "@/lib/marketplace";
 import { useToast } from "@/components/Toast";
 import { useAuthUser } from "@/lib/useAuthUser";
 
@@ -16,21 +16,32 @@ const PRODUCTS = [
 ];
 
 export default function MarketplaceShop() {
-  const [wishlist, setWishlist] = useState<string[]>([]);
+  const [wishlist, setWishlist] = useState<WishlistItem[]>([]);
   const [loadingWishlist, setLoadingWishlist] = useState(true);
   const toast = useToast();
   const { user } = useAuthUser();
 
   useEffect(() => {
     let active = true;
+
+    if (!user) {
+      setWishlist([]);
+      setLoadingWishlist(false);
+      return () => {
+        active = false;
+      };
+    }
+
     (async () => {
       try {
-        const ids = await fetchWishlistIds();
-        if (active) setWishlist(ids);
+        setLoadingWishlist(true);
+        const items = await fetchWishlistItems();
+        if (active) setWishlist(items);
       } catch (error) {
         if (import.meta.env.DEV) {
           console.warn("wishlist", error);
         }
+        if (active) setWishlist([]);
       } finally {
         if (active) setLoadingWishlist(false);
       }
@@ -38,21 +49,54 @@ export default function MarketplaceShop() {
     return () => {
       active = false;
     };
-  }, []);
+  }, [user]);
 
-  const toggleWishlist = async (itemId: string) => {
+  const toggleWishlist = async (product: (typeof PRODUCTS)[number]) => {
     if (!user) {
       toast({ text: "Sign in to use your wishlist.", kind: "warn" });
       return;
     }
 
     try {
-      const { saved } = await toggleWishlistItem(itemId);
+      const { saved, item } = await toggleWishlistItem({
+        id: product.id,
+        name: product.name,
+        price: product.price,
+        image: product.image,
+        href: product.href,
+      });
       setWishlist((prev) => {
-        const set = new Set(prev);
-        if (saved) set.add(itemId);
-        else set.delete(itemId);
-        return Array.from(set);
+        if (saved && item) {
+          const map = new Map(prev.map((entry) => [entry.itemId, entry] as const));
+          let price: number | null = null;
+          if (typeof item.product_price === "number") {
+            price = item.product_price;
+          } else if (typeof item.product_price === "string") {
+            const parsed = Number(item.product_price);
+            price = Number.isFinite(parsed) ? parsed : null;
+          }
+
+          map.set(item.item_id, {
+            id: item.id,
+            itemId: item.item_id,
+            name: item.product_name,
+            price,
+            image: item.product_image ?? null,
+            href: item.product_href ?? null,
+            addedAt: item.added_at ?? item.created_at ?? null,
+          });
+          return Array.from(map.values()).sort((a, b) => {
+            const left = a.addedAt ? new Date(a.addedAt).getTime() : 0;
+            const right = b.addedAt ? new Date(b.addedAt).getTime() : 0;
+            return right - left;
+          });
+        }
+
+        if (!saved) {
+          return prev.filter((entry) => entry.itemId !== product.id);
+        }
+
+        return prev;
       });
       toast({ text: saved ? "Added to wishlist" : "Removed from wishlist", kind: saved ? "ok" : "warn" });
     } catch (error) {
@@ -87,10 +131,10 @@ export default function MarketplaceShop() {
             <button
               className="btn-secondary w-full"
               disabled={loadingWishlist && !wishlist.length}
-              onClick={() => toggleWishlist(p.id)}
-              aria-pressed={wishlist.includes(p.id)}
+              onClick={() => toggleWishlist(p)}
+              aria-pressed={wishlist.some((entry) => entry.itemId === p.id)}
             >
-              {wishlist.includes(p.id) ? "In Wishlist" : "Add to Wishlist"}
+              {wishlist.some((entry) => entry.itemId === p.id) ? "In Wishlist" : "Add to Wishlist"}
             </button>
           </article>
         ))}

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -1,31 +1,40 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import MarketTabs from "../../components/MarketTabs";
 import "../../styles/marketplace.css";
-import { fetchWishlistIds, toggleWishlistItem } from "@/lib/marketplace";
+import { fetchWishlistItems, toggleWishlistItem, type WishlistItem } from "@/lib/marketplace";
 import { useToast } from "@/components/Toast";
 import { useAuthUser } from "@/lib/useAuthUser";
 
-const LOOKUP: Record<string, { name: string; image: string; href: string; price: number }> = {
-  "turian-plush": { name: "Turian Plush", image: "/Marketplace/Turianplushie.png", href: "/marketplace/turian-plush", price: 24 },
-  "navatar-tee": { name: "Navatar Tee", image: "/Marketplace/Turiantshirt.png", href: "/marketplace/navatar-tee", price: 18 },
-  stickers: { name: "Sticker Pack", image: "/Marketplace/Stickerpack.png", href: "/marketplace/stickers", price: 6 },
-};
-
 export default function MarketplaceWishlist() {
-  const [items, setItems] = useState<string[]>([]);
+  const [items, setItems] = useState<WishlistItem[]>([]);
   const [loading, setLoading] = useState(true);
   const toast = useToast();
-  const { user } = useAuthUser();
+  const { user, loading: authLoading } = useAuthUser();
 
   useEffect(() => {
     let active = true;
+
+    if (!user) {
+      if (!authLoading) {
+        setItems([]);
+        setLoading(false);
+      } else {
+        setLoading(true);
+      }
+      return () => {
+        active = false;
+      };
+    }
+
     (async () => {
       try {
-        const ids = await fetchWishlistIds();
-        if (active) setItems(ids);
+        setLoading(true);
+        const data = await fetchWishlistItems();
+        if (active) setItems(data);
       } catch (error) {
         if (import.meta.env.DEV) console.warn(error);
+        if (active) setItems([]);
       } finally {
         if (active) setLoading(false);
       }
@@ -33,19 +42,23 @@ export default function MarketplaceWishlist() {
     return () => {
       active = false;
     };
-  }, []);
+  }, [user, authLoading]);
 
-  const products = useMemo(() => items.map((id) => ({ id, data: LOOKUP[id] })).filter((p) => p.data), [items]);
-
-  const handleRemove = async (id: string) => {
+  const handleRemove = async (item: WishlistItem) => {
     if (!user) {
       toast({ text: "Sign in to update your wishlist.", kind: "warn" });
       return;
     }
     try {
-      const { saved } = await toggleWishlistItem(id);
+      const { saved } = await toggleWishlistItem({
+        id: item.itemId,
+        name: item.name,
+        price: item.price ?? undefined,
+        image: item.image ?? undefined,
+        href: item.href ?? undefined,
+      });
       if (!saved) {
-        setItems((prev) => prev.filter((x) => x !== id));
+        setItems((prev) => prev.filter((x) => x.itemId !== item.itemId));
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : "Could not update wishlist";
@@ -64,24 +77,58 @@ export default function MarketplaceWishlist() {
 
       <MarketTabs />
 
-      {loading ? (
+      {!authLoading && !user ? (
+        <p style={{ textAlign: "center", marginTop: "1.5rem" }}>
+          Please sign in to view your wishlist.
+        </p>
+      ) : loading ? (
         <p style={{ textAlign: "center", marginTop: "1.5rem" }}>Loading wishlist…</p>
-      ) : products.length === 0 ? (
+      ) : items.length === 0 ? (
         <p style={{ textAlign: "center", marginTop: "1.5rem" }}>
           No saved items yet. More products unlock as we hit funding goals.
         </p>
       ) : (
         <div className="mp-grid nv-card-grid" style={{ marginTop: "1.5rem" }}>
-          {products.map(({ id, data }) => (
-            <article key={id} className="mp-card nv-card">
+          {items.map((item) => (
+            <article key={item.id} className="mp-card nv-card">
               <div className="mp-image nv-image">
-                <img src={data.image} alt={data.name} loading="lazy" />
+                {item.image ? (
+                  <img src={item.image} alt={item.name} loading="lazy" />
+                ) : (
+                  <div
+                    style={{
+                      alignItems: "center",
+                      display: "flex",
+                      justifyContent: "center",
+                      height: "100%",
+                      width: "100%",
+                      fontSize: "0.875rem",
+                      opacity: 0.7,
+                    }}
+                  >
+                    No image
+                  </div>
+                )}
               </div>
               <h3>
-                <Link to={data.href}>{data.name}</Link>
+                <Link to={item.href ?? `/marketplace/${item.itemId}`}>{item.name}</Link>
               </h3>
-              <p className="price">${data.price.toFixed(2)}</p>
-              <button className="btn-secondary" onClick={() => handleRemove(id)}>
+              {typeof item.price === "number" ? (
+                <p className="price">${item.price.toFixed(2)}</p>
+              ) : (
+                <p className="price">Price unavailable</p>
+              )}
+              {(() => {
+                if (!item.addedAt) return null;
+                const parsed = new Date(item.addedAt);
+                if (Number.isNaN(parsed.getTime())) return null;
+                return (
+                  <small style={{ display: "block", marginBottom: "0.75rem" }}>
+                    Added on {parsed.toLocaleDateString()}
+                  </small>
+                );
+              })()}
+              <button className="btn-secondary" onClick={() => handleRemove(item)}>
                 Remove from Wishlist
               </button>
             </article>

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -99,12 +99,22 @@ export type Database = {
           id: string;
           user_id: string | null;
           item_id: string;
+          product_name: string;
+          product_price: number | string | null;
+          product_image: string | null;
+          product_href: string | null;
+          added_at: string | null;
           created_at: string;
         };
         Insert: {
           id?: string;
           user_id?: string | null;
           item_id: string;
+          product_name: string;
+          product_price?: number | string | null;
+          product_image?: string | null;
+          product_href?: string | null;
+          added_at?: string | null;
           created_at?: string;
         };
         Update: Partial<Database['public']['Tables']['wishlists']['Insert']>;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -294,6 +294,11 @@ create table if not exists public.wishlists (
   id uuid primary key default gen_random_uuid(),
   user_id uuid references auth.users(id) on delete cascade,
   item_id text not null,
+  product_name text not null,
+  product_price numeric,
+  product_image text,
+  product_href text,
+  added_at timestamptz not null default now(),
   created_at timestamptz not null default now(),
   unique (user_id, item_id)
 );

--- a/supabase/sql/2025-full-schema.sql
+++ b/supabase/sql/2025-full-schema.sql
@@ -239,6 +239,11 @@ create table if not exists public.wishlists (
   id uuid primary key default gen_random_uuid(),
   user_id uuid references auth.users(id) on delete cascade,
   item_id text not null,
+  product_name text not null,
+  product_price numeric,
+  product_image text,
+  product_href text,
+  added_at timestamptz not null default now(),
   created_at timestamptz not null default now(),
   unique (user_id, item_id)
 );


### PR DESCRIPTION
## Summary
- store wishlist product metadata in Supabase and expose it via the marketplace API
- refresh marketplace pages to use the richer wishlist payload for saving and rendering
- extend Supabase schema/types for wishlist rows and show sign-in guidance in the wishlist UI

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d35acd8f4c8329a8234a296643ede2