### PR TITLE
Add Supabase-backed wishlist persistence

### DIFF
--- a/src/lib/marketplace.ts
+++ b/src/lib/marketplace.ts
@@ -26,28 +26,4 @@ export async function saveDemoOrder(items: DemoLineItem[]) {
   return resp.json() as Promise<{ ok: boolean; order?: { id: string } }>;
 }
 
-export async function toggleWishlistItem(itemId: string) {
-  const { data } = await supabase.auth.getUser();
-  const userId = data.user?.id ?? null;
-
-  const resp = await fetch('/api/marketplace/wishlist', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ itemId, userId }),
-  });
-
-  if (!resp.ok) {
-    const err = await resp.json().catch(() => null);
-    const message = typeof err?.error === 'string' ? err.error : 'Unable to update wishlist';
-    throw new Error(message);
-  }
-
-  return resp.json() as Promise<{ ok: boolean; saved: boolean }>;
-}
-
-export async function fetchWishlistIds(): Promise<string[]> {
-  const { data, error } = await supabase.from('wishlists').select('item_id');
-  if (error) throw error;
-
-  return (data ?? []).map((row) => row.item_id as string).filter(Boolean);
-}
+// Wishlist helpers moved to src/services/wishlist.ts

--- a/src/pages/marketplace/[slug].tsx
+++ b/src/pages/marketplace/[slug].tsx
@@ -4,44 +4,68 @@ import AddToCartButton from "../../components/AddToCartButton";
 import SaveButton from "../../components/SaveButton";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import "./../../styles/marketplace.css";
-import { fetchWishlistIds, toggleWishlistItem } from "@/lib/marketplace";
 import { useToast } from "@/components/Toast";
 import { useAuthUser } from "@/lib/useAuthUser";
+import { addToWishlist, getWishlist, removeFromWishlist } from "@/services/wishlist";
+import type { MarketProduct, WishlistItem } from "@/types/market";
 
-const MAP:any = {
-  "turian-plush": { id:"turian-plush", name:"Turian Plush", price:24, image:"/Marketplace/Turianplushie.png", blurb:"Cuddly plush of Turian." },
-  "navatar-tee":  { id:"navatar-tee",  name:"Navatar Tee",  price:18, image:"/Marketplace/Turiantshirt.png",  blurb:"Soft tee with Navatar." },
-  "stickers":     { id:"stickers",     name:"Sticker Pack", price:6,  image:"/Marketplace/Stickerpack.png", blurb:"Six vinyl stickers." },
+type ProductDetail = MarketProduct & { price: number; image: string; blurb: string };
+
+const MAP: Record<string, ProductDetail> = {
+  "turian-plush": { id: "turian-plush", name: "Turian Plush", price: 24, image: "/Marketplace/Turianplushie.png", blurb: "Cuddly plush of Turian." },
+  "navatar-tee": { id: "navatar-tee", name: "Navatar Tee", price: 18, image: "/Marketplace/Turiantshirt.png", blurb: "Soft tee with Navatar." },
+  "stickers": { id: "stickers", name: "Sticker Pack", price: 6, image: "/Marketplace/Stickerpack.png", blurb: "Six vinyl stickers." },
 };
 
 export default function ProductPage(){
   const { slug="" } = useParams();
   const p = MAP[slug];
   const toast = useToast();
-  const { user } = useAuthUser();
-  const [wishlist, setWishlist] = useState<string[]>([]);
+  const { user, loading: authLoading } = useAuthUser();
+  const [wishlist, setWishlist] = useState<WishlistItem[]>([]);
   const [loadingWishlist, setLoadingWishlist] = useState(true);
+  const [pending, setPending] = useState(false);
 
   useEffect(() => {
     let active = true;
-    (async () => {
-      try {
-        const ids = await fetchWishlistIds();
-        if (active) setWishlist(ids);
-      } catch (error) {
+    if (authLoading) {
+      return () => {
+        active = false;
+      };
+    }
+
+    if (!user) {
+      setWishlist([]);
+      setPending(false);
+      setLoadingWishlist(false);
+      return () => {
+        active = false;
+      };
+    }
+
+    setLoadingWishlist(true);
+    setPending(false);
+
+    getWishlist()
+      .then((items) => {
+        if (active) setWishlist(items);
+      })
+      .catch((error) => {
         if (import.meta.env.DEV) console.warn(error);
-      } finally {
+        if (active) setWishlist([]);
+      })
+      .finally(() => {
         if (active) setLoadingWishlist(false);
-      }
-    })();
+      });
+
     return () => {
       active = false;
     };
-  }, []);
+  }, [user, authLoading]);
 
   if (!p) return null;
 
-  const inWishlist = wishlist.includes(p.id);
+  const inWishlist = wishlist.some((item) => item.product_name === p.name);
 
   const onToggleWishlist = async () => {
     if (!user) {
@@ -49,17 +73,23 @@ export default function ProductPage(){
       return;
     }
     try {
-      const { saved } = await toggleWishlistItem(p.id);
-      setWishlist((prev) => {
-        const next = new Set(prev);
-        if (saved) next.add(p.id);
-        else next.delete(p.id);
-        return Array.from(next);
-      });
-      toast({ text: saved ? "Added to wishlist" : "Removed from wishlist", kind: saved ? "ok" : "warn" });
+      setPending(true);
+      const existing = wishlist.find((item) => item.product_name === p.name);
+
+      if (existing) {
+        await removeFromWishlist(existing.id);
+        setWishlist((prev) => prev.filter((item) => item.id !== existing.id));
+        toast({ text: "Removed from wishlist", kind: "warn" });
+      } else {
+        const created = await addToWishlist(p);
+        setWishlist((prev) => [created, ...prev]);
+        toast({ text: "Added to wishlist", kind: "ok" });
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : "Could not update wishlist";
       toast({ text: message, kind: "err" });
+    } finally {
+      setPending(false);
     }
   };
   return (
@@ -78,7 +108,7 @@ export default function ProductPage(){
         </div>
         <button
           className="btn-secondary w-full"
-          disabled={loadingWishlist && !wishlist.length}
+          disabled={(loadingWishlist && !wishlist.length) || pending}
           onClick={onToggleWishlist}
           aria-pressed={inWishlist}
           style={{ marginTop: "1rem" }}

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -1,63 +1,93 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import MarketTabs from "../../components/MarketTabs";
 import AddToCartButton from "../../components/AddToCartButton";
 import SaveButton from "../../components/SaveButton";
 import "../../styles/_cards.css";
 import "../../styles/marketplace.css";
-import { toggleWishlistItem, fetchWishlistIds } from "@/lib/marketplace";
 import { useToast } from "@/components/Toast";
 import { useAuthUser } from "@/lib/useAuthUser";
+import { addToWishlist, getWishlist, removeFromWishlist } from "@/services/wishlist";
+import type { MarketProduct, WishlistItem } from "@/types/market";
 
-const PRODUCTS = [
-  { id:"turian-plush", name:"Turian Plush", price:24, image:"/Marketplace/Turianplushie.png", href:"/marketplace/turian-plush" },
-  { id:"navatar-tee",  name:"Navatar Tee",  price:18, image:"/Marketplace/Turiantshirt.png",  href:"/marketplace/navatar-tee" },
-  { id:"stickers",     name:"Sticker Pack", price:6,  image:"/Marketplace/Stickerpack.png", href:"/marketplace/stickers" },
+type ProductCardData = MarketProduct & { price: number; image: string; href: string };
+
+const PRODUCTS: ProductCardData[] = [
+  { id: "turian-plush", name: "Turian Plush", price: 24, image: "/Marketplace/Turianplushie.png", href: "/marketplace/turian-plush" },
+  { id: "navatar-tee", name: "Navatar Tee", price: 18, image: "/Marketplace/Turiantshirt.png", href: "/marketplace/navatar-tee" },
+  { id: "stickers", name: "Sticker Pack", price: 6, image: "/Marketplace/Stickerpack.png", href: "/marketplace/stickers" },
 ];
 
 export default function MarketplaceShop() {
-  const [wishlist, setWishlist] = useState<string[]>([]);
+  const [wishlist, setWishlist] = useState<WishlistItem[]>([]);
   const [loadingWishlist, setLoadingWishlist] = useState(true);
+  const [pendingId, setPendingId] = useState<string | null>(null);
   const toast = useToast();
-  const { user } = useAuthUser();
+  const { user, loading: authLoading } = useAuthUser();
+
+  const wishlistNames = useMemo(() => new Set(wishlist.map((item) => item.product_name)), [wishlist]);
 
   useEffect(() => {
     let active = true;
-    (async () => {
-      try {
-        const ids = await fetchWishlistIds();
-        if (active) setWishlist(ids);
-      } catch (error) {
+    if (authLoading) {
+      return () => {
+        active = false;
+      };
+    }
+
+    if (!user) {
+      setWishlist([]);
+      setLoadingWishlist(false);
+      return () => {
+        active = false;
+      };
+    }
+
+    setLoadingWishlist(true);
+    getWishlist()
+      .then((items) => {
+        if (active) setWishlist(items);
+      })
+      .catch((error) => {
         if (import.meta.env.DEV) {
           console.warn("wishlist", error);
         }
-      } finally {
+        if (active) setWishlist([]);
+      })
+      .finally(() => {
         if (active) setLoadingWishlist(false);
-      }
-    })();
+      });
+
     return () => {
       active = false;
     };
-  }, []);
+  }, [user, authLoading]);
 
-  const toggleWishlist = async (itemId: string) => {
+  const toggleWishlist = async (product: ProductCardData) => {
     if (!user) {
       toast({ text: "Sign in to use your wishlist.", kind: "warn" });
       return;
     }
 
     try {
-      const { saved } = await toggleWishlistItem(itemId);
-      setWishlist((prev) => {
-        const set = new Set(prev);
-        if (saved) set.add(itemId);
-        else set.delete(itemId);
-        return Array.from(set);
-      });
-      toast({ text: saved ? "Added to wishlist" : "Removed from wishlist", kind: saved ? "ok" : "warn" });
+      setPendingId(product.id);
+
+      const existing = wishlist.find((item) => item.product_name === product.name);
+
+      if (existing) {
+        await removeFromWishlist(existing.id);
+        setWishlist((prev) => prev.filter((item) => item.id !== existing.id));
+        toast({ text: "Removed from wishlist", kind: "warn" });
+      } else {
+        const created = await addToWishlist(product);
+        setWishlist((prev) => [created, ...prev]);
+        toast({ text: "Added to wishlist", kind: "ok" });
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : "Could not update wishlist";
       toast({ text: message, kind: "err" });
+    } finally {
+      setPendingId((prev) => (prev === product.id ? null : prev));
     }
   };
 
@@ -86,11 +116,11 @@ export default function MarketplaceShop() {
             </div>
             <button
               className="btn-secondary w-full"
-              disabled={loadingWishlist && !wishlist.length}
-              onClick={() => toggleWishlist(p.id)}
-              aria-pressed={wishlist.includes(p.id)}
+              disabled={(loadingWishlist && !wishlist.length) || pendingId === p.id}
+              onClick={() => toggleWishlist(p)}
+              aria-pressed={wishlistNames.has(p.name)}
             >
-              {wishlist.includes(p.id) ? "In Wishlist" : "Add to Wishlist"}
+              {wishlistNames.has(p.name) ? "In Wishlist" : "Add to Wishlist"}
             </button>
           </article>
         ))}

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -2,54 +2,107 @@ import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import MarketTabs from "../../components/MarketTabs";
 import "../../styles/marketplace.css";
-import { fetchWishlistIds, toggleWishlistItem } from "@/lib/marketplace";
 import { useToast } from "@/components/Toast";
 import { useAuthUser } from "@/lib/useAuthUser";
+import { getWishlist, removeFromWishlist } from "@/services/wishlist";
+import type { WishlistItem } from "@/types/market";
 
-const LOOKUP: Record<string, { name: string; image: string; href: string; price: number }> = {
+type LookupEntry = { name: string; image: string; href: string; price: number };
+
+const LOOKUP: Record<string, LookupEntry> = {
   "turian-plush": { name: "Turian Plush", image: "/Marketplace/Turianplushie.png", href: "/marketplace/turian-plush", price: 24 },
   "navatar-tee": { name: "Navatar Tee", image: "/Marketplace/Turiantshirt.png", href: "/marketplace/navatar-tee", price: 18 },
   stickers: { name: "Sticker Pack", image: "/Marketplace/Stickerpack.png", href: "/marketplace/stickers", price: 6 },
 };
 
+const LOOKUP_BY_NAME: Record<string, LookupEntry & { id: string }> = Object.entries(LOOKUP).reduce(
+  (acc, [id, data]) => {
+    acc[data.name] = { ...data, id };
+    return acc;
+  },
+  {} as Record<string, LookupEntry & { id: string }>
+);
+
 export default function MarketplaceWishlist() {
-  const [items, setItems] = useState<string[]>([]);
+  const [items, setItems] = useState<WishlistItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
   const toast = useToast();
-  const { user } = useAuthUser();
+  const { user, loading: authLoading } = useAuthUser();
 
   useEffect(() => {
     let active = true;
-    (async () => {
-      try {
-        const ids = await fetchWishlistIds();
-        if (active) setItems(ids);
-      } catch (error) {
-        if (import.meta.env.DEV) console.warn(error);
-      } finally {
+    if (authLoading) {
+      return () => {
+        active = false;
+      };
+    }
+
+    if (!user) {
+      setItems([]);
+      setError(null);
+      setPendingId(null);
+      setLoading(false);
+      return () => {
+        active = false;
+      };
+    }
+
+    setLoading(true);
+    setError(null);
+    setPendingId(null);
+    setItems([]);
+
+    getWishlist()
+      .then((data) => {
+        if (active) setItems(data);
+      })
+      .catch((err) => {
+        if (import.meta.env.DEV) console.warn(err);
+        if (active) {
+          setItems([]);
+          setError(err instanceof Error ? err.message : "Could not load wishlist");
+        }
+      })
+      .finally(() => {
         if (active) setLoading(false);
-      }
-    })();
+      });
+
     return () => {
       active = false;
     };
-  }, []);
+  }, [user, authLoading]);
 
-  const products = useMemo(() => items.map((id) => ({ id, data: LOOKUP[id] })).filter((p) => p.data), [items]);
+  const products = useMemo(
+    () =>
+      items.map((item) => {
+        const meta = LOOKUP_BY_NAME[item.product_name];
+        return {
+          item,
+          meta,
+          image: item.product_image ?? meta?.image ?? null,
+          price: item.product_price ?? meta?.price ?? null,
+        };
+      }),
+    [items]
+  );
 
-  const handleRemove = async (id: string) => {
+  const handleRemove = async (entry: WishlistItem) => {
     if (!user) {
       toast({ text: "Sign in to update your wishlist.", kind: "warn" });
       return;
     }
     try {
-      const { saved } = await toggleWishlistItem(id);
-      if (!saved) {
-        setItems((prev) => prev.filter((x) => x !== id));
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Could not update wishlist";
+      setPendingId(entry.id);
+      await removeFromWishlist(entry.id);
+      setItems((prev) => prev.filter((item) => item.id !== entry.id));
+      toast({ text: "Removed from wishlist", kind: "warn" });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Could not update wishlist";
       toast({ text: message, kind: "err" });
+    } finally {
+      setPendingId((prev) => (prev === entry.id ? null : prev));
     }
   };
 
@@ -66,22 +119,30 @@ export default function MarketplaceWishlist() {
 
       {loading ? (
         <p style={{ textAlign: "center", marginTop: "1.5rem" }}>Loading wishlist…</p>
+      ) : !user ? (
+        <p style={{ textAlign: "center", marginTop: "1.5rem" }}>Sign in to view your wishlist.</p>
+      ) : error ? (
+        <p style={{ textAlign: "center", marginTop: "1.5rem" }}>{error}</p>
       ) : products.length === 0 ? (
         <p style={{ textAlign: "center", marginTop: "1.5rem" }}>
           No saved items yet. More products unlock as we hit funding goals.
         </p>
       ) : (
         <div className="mp-grid nv-card-grid" style={{ marginTop: "1.5rem" }}>
-          {products.map(({ id, data }) => (
-            <article key={id} className="mp-card nv-card">
+          {products.map(({ item, meta, image, price }) => (
+            <article key={item.id} className="mp-card nv-card">
               <div className="mp-image nv-image">
-                <img src={data.image} alt={data.name} loading="lazy" />
+                {image ? <img src={image} alt={item.product_name} loading="lazy" /> : null}
               </div>
               <h3>
-                <Link to={data.href}>{data.name}</Link>
+                {meta ? <Link to={meta.href}>{item.product_name}</Link> : item.product_name}
               </h3>
-              <p className="price">${data.price.toFixed(2)}</p>
-              <button className="btn-secondary" onClick={() => handleRemove(id)}>
+              {price != null ? <p className="price">${Number(price).toFixed(2)}</p> : null}
+              <button
+                className="btn-secondary"
+                onClick={() => handleRemove(item)}
+                disabled={pendingId === item.id}
+              >
                 Remove from Wishlist
               </button>
             </article>

--- a/src/services/wishlist.ts
+++ b/src/services/wishlist.ts
@@ -1,0 +1,41 @@
+import { supabase } from '@/lib/supabaseClient';
+import type { MarketProduct, WishlistItem } from '@/types/market';
+
+function toDbRow(product: MarketProduct, userId: string) {
+  return {
+    user_id: userId,
+    product_name: product.name,
+    product_price: product.price ?? null,
+    product_image: product.image ?? null,
+  };
+}
+
+export async function getWishlist(): Promise<WishlistItem[]> {
+  const { data, error } = await supabase.from('wishlist').select('*').order('added_at', { ascending: false });
+  if (error) throw error;
+  return (data ?? []) as WishlistItem[];
+}
+
+export async function addToWishlist(product: MarketProduct): Promise<WishlistItem> {
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError) throw authError;
+  if (!user) throw new Error('Please sign in to use your wishlist.');
+
+  const { data, error } = await supabase
+    .from('wishlist')
+    .insert([toDbRow(product, user.id)])
+    .select('*')
+    .single();
+
+  if (error) throw error;
+  return data as WishlistItem;
+}
+
+export async function removeFromWishlist(itemId: string) {
+  const { error } = await supabase.from('wishlist').delete().eq('id', itemId);
+  if (error) throw error;
+}

--- a/src/types/market.ts
+++ b/src/types/market.ts
@@ -1,0 +1,15 @@
+export type MarketProduct = {
+  id: string;
+  name: string;
+  price?: number;
+  image?: string;
+};
+
+export type WishlistItem = {
+  id: string;
+  user_id: string;
+  product_name: string;
+  product_price: number | null;
+  product_image: string | null;
+  added_at: string;
+};


### PR DESCRIPTION
## Summary
- add wishlist data types and Supabase service helpers for marketplace products
- update marketplace listing and product detail views to load and toggle wishlist items via Supabase
- render Supabase-backed wishlist entries with removal controls on the wishlist page

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d362cfea2c832981fe1d50481fb81c