### PR TITLE
PostHog integration + products schema fix + safe seed

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "three": "^0.160.0",
     "workbox-window": "^7.1.0",
     "nprogress": "^0.2.0",
+    "posthog-js": "^2.8.0",
     "react-helmet-async": "^2.0.4",
     "zod": "^3.23.8"
   },

--- a/src/analytics/posthog.ts
+++ b/src/analytics/posthog.ts
@@ -1,0 +1,9 @@
+import posthog from 'posthog-js';
+
+export function track(event: string, props?: Record<string, any>) {
+  try {
+    if (posthog?.capture) {
+      posthog.capture(event, props);
+    }
+  } catch {}
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,24 +17,38 @@ import { supabase } from '@/lib/supabaseClient';
 import './runtime-logger';
 import { prefetchGlob, prefetchOnHover } from './lib/prefetch';
 import './boot/warmup';
+import { PostHogProvider } from 'posthog-js/react';
+
+const phKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
+const phHost = import.meta.env.VITE_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com';
 
 async function bootstrap() {
   const { data } = await supabase.auth.getSession();
   const initialSession = data.session ?? null;
 
+  // Ensure auth context wraps the entire app so Home gets updates immediately
+  const app = (
+    <AuthProvider initialSession={initialSession}>
+      <SkipLink />
+      <ToastProvider>
+        <OfflineBanner />
+        <BaseAuthProvider>
+          <App />
+        </BaseAuthProvider>
+      </ToastProvider>
+    </AuthProvider>
+  );
+
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-      {/* Ensure auth context wraps the entire app so Home gets updates immediately */}
-        <AuthProvider initialSession={initialSession}>
-          <SkipLink />
-          <ToastProvider>
-            <OfflineBanner />
-            <BaseAuthProvider>
-              <App />
-            </BaseAuthProvider>
-          </ToastProvider>
-        </AuthProvider>
-      </React.StrictMode>,
+      {phKey ? (
+        <PostHogProvider apiKey={phKey} options={{ api_host: phHost }}>
+          {app}
+        </PostHogProvider>
+      ) : (
+        app
+      )}
+    </React.StrictMode>,
   );
 }
 

--- a/supabase/migrations/20240924_rename_products_title_to_name.sql
+++ b/supabase/migrations/20240924_rename_products_title_to_name.sql
@@ -1,0 +1,17 @@
+-- Rename old column if it exists
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name   = 'products'
+      and column_name  = 'title'
+  ) then
+    alter table public.products rename column title to name;
+  end if;
+end $$;
+
+-- Ensure NOT NULL for name (matches prior constraint on title)
+alter table public.products
+  alter column name set not null;

--- a/supabase/seed/20240924_products_seed.sql
+++ b/supabase/seed/20240924_products_seed.sql
@@ -1,0 +1,11 @@
+insert into public.products (slug, name, price_cents, image_url, description, available)
+values
+  ('turian-plush', 'Turian Plush', 2400, '/images/merch/turian-plush.jpg', 'Soft plushy buddy.', true),
+  ('navatar-tee', 'Navatar Tee', 1800, '/images/merch/navatar-tee.jpg', 'Classic tee with Navatar print.', true),
+  ('sticker-pack', 'Sticker Pack', 600, '/images/merch/sticker-pack.jpg', 'Assorted Naturverse stickers.', true)
+on conflict (slug) do update
+set name        = excluded.name,
+    price_cents = excluded.price_cents,
+    image_url   = excluded.image_url,
+    description = excluded.description,
+    available   = excluded.available;


### PR DESCRIPTION
## Summary
- add the PostHog client dependency and wrap the app tree in a guarded PostHogProvider so analytics only initializes when keys exist
- introduce a safe `track` helper for PostHog events and keep the rest of the bootstrap logic intact
- supply a migration that renames `products.title` to `products.name` and a seed script that safely upserts the three demo products

## Testing
- npm run typecheck *(fails: missing `posthog-js` package because the npm registry is inaccessible in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d39e7a1b3c8329b0a1d7c5074a6a50