### PR TITLE
Integrate persistent user wishlist support

### DIFF
--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,6 +1,7 @@
 import { supabase } from '@/lib/supabaseClient';
 
 export type Product = {
+  id: string;
   slug: string;
   name: string;
   price_cents: number;
@@ -10,6 +11,7 @@ export type Product = {
 
 export const FALLBACK_PRODUCTS: Product[] = [
   {
+    id: 'turian-plush',
     slug: 'turian-plush',
     name: 'Turian Plush',
     price_cents: 2400,
@@ -17,6 +19,7 @@ export const FALLBACK_PRODUCTS: Product[] = [
     description: 'Soft plushy buddy.',
   },
   {
+    id: 'navatar-tee',
     slug: 'navatar-tee',
     name: 'Navatar Tee',
     price_cents: 1800,
@@ -24,6 +27,7 @@ export const FALLBACK_PRODUCTS: Product[] = [
     description: 'Classic tee with Navatar print.',
   },
   {
+    id: 'sticker-pack',
     slug: 'sticker-pack',
     name: 'Sticker Pack',
     price_cents: 600,
@@ -38,7 +42,7 @@ export async function fetchProducts(): Promise<Product[]> {
   try {
     const { data, error } = await supabase
       .from('products')
-      .select('slug,name,price_cents,image_url,description')
+      .select('id,slug,name,price_cents,image_url,description')
       .eq('active', true)
       .order('name');
     if (error) throw error;

--- a/src/lib/fixtures.ts
+++ b/src/lib/fixtures.ts
@@ -79,7 +79,7 @@ export const sampleProducts: ProductRow[] = [
 export const sampleWishlist: WishlistRow[] = [
   {
     id: 'w1',
-    owner_id: 'u1',
+    user_id: 'u1',
     product_id: 'p2',
     created_at: new Date().toISOString(),
   },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,7 +56,7 @@ export type ProductRow = {
 
 export type WishlistRow = {
   id: string;
-  owner_id: string;
+  user_id: string;
   product_id: string;
   created_at: string;
 };

--- a/src/pages/marketplace/[slug].tsx
+++ b/src/pages/marketplace/[slug].tsx
@@ -84,6 +84,7 @@ export default function ProductPage() {
     if (!product) return null;
     return {
       id: product.slug,
+      productId: product.id,
       name: product.name,
       price: product.price_cents / 100,
       image: product.image_url,
@@ -93,7 +94,13 @@ export default function ProductPage() {
   const priceLabel = product ? formatPrice(product.price_cents) : '';
   const priceValue = product ? product.price_cents / 100 : 0;
   const inWishlist = marketProduct
-    ? wishlist.some((item) => item.product_name === marketProduct.name)
+    ? wishlist.some((item) => {
+        if (marketProduct.productId && item.product_id === marketProduct.productId) {
+          return true;
+        }
+        const slug = item.product?.slug;
+        return slug ? slug === marketProduct.id : false;
+      })
     : false;
 
   const onToggleWishlist = async () => {
@@ -104,10 +111,16 @@ export default function ProductPage() {
     if (!marketProduct) return;
     try {
       setPending(true);
-      const existing = wishlist.find((item) => item.product_name === marketProduct.name);
+      const existing = wishlist.find((item) => {
+        if (marketProduct.productId && item.product_id === marketProduct.productId) {
+          return true;
+        }
+        const slug = item.product?.slug;
+        return slug ? slug === marketProduct.id : false;
+      });
 
       if (existing) {
-        await removeFromWishlist(existing.id, marketProduct.name);
+        await removeFromWishlist(existing.id, marketProduct.id);
         setWishlist((prev) => prev.filter((item) => item.id !== existing.id));
         toast({ text: 'Removed from wishlist', kind: 'warn' });
         track('wishlist_remove', { slug: marketProduct.id, name: marketProduct.name });

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -84,7 +84,15 @@ export default function MarketplaceShop() {
     };
   }, [user, authLoading]);
 
-  const wishlistNames = useMemo(() => new Set(wishlist.map((item) => item.product_name)), [wishlist]);
+  const wishlistKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const item of wishlist) {
+      if (item.product_id) keys.add(item.product_id);
+      const slug = item.product?.slug;
+      if (slug) keys.add(slug);
+    }
+    return keys;
+  }, [wishlist]);
 
   const cards = useMemo<ProductCard[]>(
     () =>
@@ -92,6 +100,7 @@ export default function MarketplaceShop() {
         const price = product.price_cents / 100;
         const marketProduct: MarketProduct = {
           id: product.slug,
+          productId: product.id,
           name: product.name,
           price,
           image: product.image_url,
@@ -116,10 +125,16 @@ export default function MarketplaceShop() {
     try {
       setPendingId(card.product.slug);
 
-      const existing = wishlist.find((item) => item.product_name === card.marketProduct.name);
+      const existing = wishlist.find((item) => {
+        if (card.marketProduct.productId && item.product_id === card.marketProduct.productId) {
+          return true;
+        }
+        const slug = item.product?.slug;
+        return slug ? slug === card.marketProduct.id : false;
+      });
 
       if (existing) {
-        await removeFromWishlist(existing.id, card.marketProduct.name);
+        await removeFromWishlist(existing.id, card.marketProduct.id);
         setWishlist((prev) => prev.filter((item) => item.id !== existing.id));
         toast({ text: 'Removed from wishlist', kind: 'warn' });
         track('wishlist_remove', { slug: card.product.slug, name: card.product.name });
@@ -171,9 +186,9 @@ export default function MarketplaceShop() {
               className="btn-secondary w-full"
               disabled={(loadingWishlist && !wishlist.length) || pendingId === card.product.slug || loadingProducts}
               onClick={() => void toggleWishlist(card)}
-              aria-pressed={wishlistNames.has(card.marketProduct.name)}
+              aria-pressed={wishlistKeys.has(card.marketProduct.productId ?? card.marketProduct.id)}
             >
-              {wishlistNames.has(card.marketProduct.name) ? 'In Wishlist' : 'Add to Wishlist'}
+              {wishlistKeys.has(card.marketProduct.productId ?? card.marketProduct.id) ? 'In Wishlist' : 'Add to Wishlist'}
             </button>
           </article>
         ))}

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -13,9 +13,11 @@ import { track } from '@/lib/analytics';
 interface WishlistProductMeta {
   item: WishlistItem;
   product?: Product;
+  title: string;
   image: string | null;
   priceCents: number | null;
   href?: string;
+  slug?: string;
 }
 
 export default function MarketplaceWishlist() {
@@ -84,10 +86,18 @@ export default function MarketplaceWishlist() {
     };
   }, [user, authLoading]);
 
-  const productsByName = useMemo(() => {
+  const productsById = useMemo(() => {
     const map = new Map<string, Product>();
     for (const product of catalog) {
-      map.set(product.name, product);
+      map.set(product.id, product);
+    }
+    return map;
+  }, [catalog]);
+
+  const productsBySlug = useMemo(() => {
+    const map = new Map<string, Product>();
+    for (const product of catalog) {
+      map.set(product.slug, product);
     }
     return map;
   }, [catalog]);
@@ -95,13 +105,22 @@ export default function MarketplaceWishlist() {
   const derived = useMemo<WishlistProductMeta[]>(
     () =>
       items.map((item) => {
-        const product = productsByName.get(item.product_name);
-        const priceCents = product?.price_cents ?? (typeof item.product_price === 'number' ? Math.round(item.product_price * 100) : null);
-        const image = item.product_image ?? product?.image_url ?? null;
-        const href = product ? `/marketplace/${product.slug}` : undefined;
-        return { item, product, image, priceCents, href };
+        const supabaseProduct = item.product;
+        const product =
+          productsById.get(item.product_id) ?? (supabaseProduct?.slug ? productsBySlug.get(supabaseProduct.slug) : undefined);
+        const title = supabaseProduct?.name ?? product?.name ?? 'Saved item';
+        const priceCents =
+          typeof product?.price_cents === 'number'
+            ? product.price_cents
+            : typeof supabaseProduct?.price_cents === 'number'
+            ? supabaseProduct.price_cents
+            : null;
+        const image = supabaseProduct?.image_url ?? product?.image_url ?? null;
+        const slug = product?.slug ?? supabaseProduct?.slug;
+        const href = slug ? `/marketplace/${slug}` : undefined;
+        return { item, product, title, image, priceCents, href, slug };
       }),
-    [items, productsByName]
+    [items, productsById, productsBySlug]
   );
 
   const handleRemove = async (entry: WishlistProductMeta) => {
@@ -111,10 +130,10 @@ export default function MarketplaceWishlist() {
     }
     try {
       setPendingId(entry.item.id);
-      await removeFromWishlist(entry.item.id, entry.item.product_name);
+      await removeFromWishlist(entry.item.id, entry.slug);
       setItems((prev) => prev.filter((item) => item.id !== entry.item.id));
       toast({ text: 'Removed from wishlist', kind: 'warn' });
-      track('wishlist_remove', { name: entry.item.product_name });
+      track('wishlist_remove', { name: entry.title });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Could not update wishlist';
       toast({ text: message, kind: 'err' });
@@ -164,9 +183,9 @@ export default function MarketplaceWishlist() {
           {derived.map((entry) => (
             <article key={entry.item.id} className="mp-card nv-card">
               <div className="mp-image nv-image">
-                {entry.image ? <img src={entry.image} alt={entry.item.product_name} loading="lazy" /> : null}
+                {entry.image ? <img src={entry.image} alt={entry.title} loading="lazy" /> : null}
               </div>
-              <h3>{entry.href ? <Link to={entry.href}>{entry.item.product_name}</Link> : entry.item.product_name}</h3>
+              <h3>{entry.href ? <Link to={entry.href}>{entry.title}</Link> : entry.title}</h3>
               {entry.priceCents != null ? <p className="price">{formatPrice(entry.priceCents)}</p> : null}
               <div className="wishlist-actions">
                 <button className="btn-secondary" onClick={() => handleRemove(entry)} disabled={pendingId === entry.item.id}>

--- a/src/services/wishlist.ts
+++ b/src/services/wishlist.ts
@@ -4,6 +4,20 @@ import type { MarketProduct, WishlistItem } from '@/types/market';
 const WISHLIST_KEY = 'naturverse_wishlist_v1';
 const LEGACY_KEY = 'nv:wishlist';
 
+const WISHLIST_SELECT = `
+  id,
+  user_id,
+  product_id,
+  created_at,
+  product:products (
+    id,
+    slug,
+    name,
+    price_cents,
+    image_url
+  )
+`;
+
 const readCache = () => {
   if (typeof window === 'undefined') return [] as string[];
   try {
@@ -18,24 +32,24 @@ const readCache = () => {
 
 const writeCache = (items: string[]) => {
   if (typeof window === 'undefined') return;
-  localStorage.setItem(WISHLIST_KEY, JSON.stringify(items));
+  const unique = Array.from(new Set(items.filter((item) => typeof item === 'string' && item.length > 0)));
+  localStorage.setItem(WISHLIST_KEY, JSON.stringify(unique));
   window.dispatchEvent(new Event('wishlist:changed'));
 };
 
-function toDbRow(product: MarketProduct, userId: string) {
-  return {
-    user_id: userId,
-    product_name: product.name,
-    product_price: product.price ?? null,
-    product_image: product.image ?? null,
-  };
-}
+const extractSlugs = (items: WishlistItem[]) =>
+  items
+    .map((item) => item.product?.slug)
+    .filter((slug): slug is string => typeof slug === 'string' && slug.length > 0);
 
 export async function getWishlist(): Promise<WishlistItem[]> {
-  const { data, error } = await supabase.from('wishlist').select('*').order('added_at', { ascending: false });
+  const { data, error } = await supabase
+    .from('user_wishlist')
+    .select(WISHLIST_SELECT)
+    .order('created_at', { ascending: false });
   if (error) throw error;
   const items = (data ?? []) as WishlistItem[];
-  writeCache(items.map((item) => item.product_name));
+  writeCache(extractSlugs(items));
   return items;
 }
 
@@ -48,29 +62,34 @@ export async function addToWishlist(product: MarketProduct): Promise<WishlistIte
   if (authError) throw authError;
   if (!user) throw new Error('Please sign in to use your wishlist.');
 
+  const productId = product.productId;
+  if (!productId) {
+    throw new Error('Product not available yet.');
+  }
+
   const { data, error } = await supabase
-    .from('wishlist')
-    .insert([toDbRow(product, user.id)])
-    .select('*')
+    .from('user_wishlist')
+    .insert([{ user_id: user.id, product_id: productId }])
+    .select(WISHLIST_SELECT)
     .single();
 
   if (error) throw error;
   const item = data as WishlistItem;
   const cache = readCache();
-  if (!cache.includes(item.product_name)) {
-    writeCache([...cache, item.product_name]);
+  if (!cache.includes(product.id)) {
+    writeCache([...cache, product.id]);
   } else {
     writeCache(cache);
   }
   return item;
 }
 
-export async function removeFromWishlist(itemId: string, productName?: string) {
-  const { error } = await supabase.from('wishlist').delete().eq('id', itemId);
+export async function removeFromWishlist(itemId: string, productSlug?: string) {
+  const { error } = await supabase.from('user_wishlist').delete().eq('id', itemId);
   if (error) throw error;
-  if (productName) {
+  if (productSlug) {
     const cache = readCache();
-    writeCache(cache.filter((name) => name !== productName));
+    writeCache(cache.filter((slug) => slug !== productSlug));
   } else {
     writeCache(readCache());
   }

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -94,20 +94,20 @@ export type Database = {
         };
         Update: Partial<Database['public']['Tables']['orders_demo']['Insert']>;
       };
-      wishlists: {
+      user_wishlist: {
         Row: {
           id: string;
-          user_id: string | null;
-          item_id: string;
+          user_id: string;
+          product_id: string;
           created_at: string;
         };
         Insert: {
           id?: string;
-          user_id?: string | null;
-          item_id: string;
+          user_id: string;
+          product_id: string;
           created_at?: string;
         };
-        Update: Partial<Database['public']['Tables']['wishlists']['Insert']>;
+        Update: Partial<Database['public']['Tables']['user_wishlist']['Insert']>;
       };
       events: {
         Row: {

--- a/src/types/market.ts
+++ b/src/types/market.ts
@@ -1,15 +1,29 @@
 export type MarketProduct = {
+  /**
+   * Public slug used across the marketplace UI.
+   */
   id: string;
+  /**
+   * Backing Supabase product identifier used for persistence.
+   */
+  productId?: string;
   name: string;
   price?: number;
   image?: string;
 };
 
+export type WishlistProduct = {
+  id: string;
+  slug: string;
+  name: string;
+  price_cents: number | null;
+  image_url: string | null;
+};
+
 export type WishlistItem = {
   id: string;
   user_id: string;
-  product_name: string;
-  product_price: number | null;
-  product_image: string | null;
-  added_at: string;
+  product_id: string;
+  created_at: string;
+  product: WishlistProduct | null;
 };

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -298,6 +298,14 @@ create table if not exists public.wishlists (
   unique (user_id, item_id)
 );
 
+create table if not exists public.user_wishlist (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade,
+  product_id uuid references public.products(id) on delete cascade,
+  created_at timestamptz default timezone('utc'::text, now()),
+  unique (user_id, product_id)
+);
+
 create table if not exists public.events (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users(id) on delete cascade,
@@ -308,6 +316,7 @@ create table if not exists public.events (
 
 alter table public.orders_demo enable row level security;
 alter table public.wishlists enable row level security;
+alter table public.user_wishlist enable row level security;
 alter table public.events enable row level security;
 
 do $$ begin
@@ -318,6 +327,10 @@ do $$ begin
   if not exists (select 1 from pg_policies where policyname='wishlists_self') then
     create policy wishlists_self on public.wishlists
       for all to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
+  end if;
+  if not exists (select 1 from pg_policies where policyname='user_wishlist_self') then
+    create policy user_wishlist_self on public.user_wishlist
+      for all to authenticated using (auth.uid() = user_id) with check (auth.uid() = user_id);
   end if;
   if not exists (select 1 from pg_policies where policyname='events_self_insert') then
     create policy events_self_insert on public.events

--- a/supabase/sql/2025-full-schema.sql
+++ b/supabase/sql/2025-full-schema.sql
@@ -243,6 +243,14 @@ create table if not exists public.wishlists (
   unique (user_id, item_id)
 );
 
+create table if not exists public.user_wishlist (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade,
+  product_id uuid references public.products(id) on delete cascade,
+  created_at timestamptz default timezone('utc'::text, now()),
+  unique (user_id, product_id)
+);
+
 create table if not exists public.events (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users(id) on delete cascade,
@@ -253,6 +261,7 @@ create table if not exists public.events (
 
 alter table public.orders_demo enable row level security;
 alter table public.wishlists enable row level security;
+alter table public.user_wishlist enable row level security;
 alter table public.events enable row level security;
 
 create policy orders_demo_insert_self on public.orders_demo
@@ -260,6 +269,9 @@ create policy orders_demo_insert_self on public.orders_demo
 
 create policy wishlists_self on public.wishlists
   for all to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create policy user_wishlist_self on public.user_wishlist
+  for all to authenticated using (auth.uid() = user_id) with check (auth.uid() = user_id);
 
 create policy events_self_insert on public.events
   for insert to authenticated with check (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- extend marketplace product data to include Supabase product ids and expose them throughout the React views
- rework wishlist services and pages to use the new `user_wishlist` table, joining product metadata and syncing the slug-based cache
- add the `user_wishlist` table plus RLS policy to the Supabase schema and generated database types

## Testing
- npm run typecheck *(fails: missing @types/node because npm install is blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c0913e3c832998131a87d35af620