### PR TITLE
Lock wishlist to the signed-in user

### DIFF
--- a/netlify/functions/wishlist.ts
+++ b/netlify/functions/wishlist.ts
@@ -1,12 +1,100 @@
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
 
-const s = createClient(process.env.VITE_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const supabaseUrl = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-export const handler: Handler = async (e) => {
-  if(e.httpMethod!=='POST') return res({error:'method'},405);
-  const { device, type, id } = JSON.parse(e.body||'{}');
-  await s.from('wishlists').upsert({ device_id: device, thing_type: type, thing_id: id }, { onConflict:'device_id,thing_type,thing_id' });
-  return res({ ok:true });
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error('Supabase credentials are not configured');
+}
+
+const s = createClient(supabaseUrl, supabaseKey);
+
+type WishlistRequest = {
+  userId?: string;
+  product?: {
+    slug?: string;
+    name?: string;
+    price_cents?: number;
+    price?: number;
+    image_url?: string | null;
+  };
+  action?: 'add' | 'remove';
 };
-const res = (b:any, status=200)=>({statusCode:status,body:JSON.stringify(b)});
+
+const response = (body: unknown, status = 200) => ({ statusCode: status, body: JSON.stringify(body) });
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return response({ error: 'method' }, 405);
+  }
+
+  let payload: WishlistRequest;
+  try {
+    payload = JSON.parse(event.body || '{}');
+  } catch {
+    return response({ error: 'invalid_json' }, 400);
+  }
+
+  const normalizedUserId = typeof payload.userId === 'string' && payload.userId.trim().length > 0 ? payload.userId.trim() : '';
+  if (!normalizedUserId) {
+    return response({ error: 'userId required' }, 400);
+  }
+
+  const action = payload.action === 'remove' ? 'remove' : 'add';
+  const product = payload.product ?? {};
+  const slug = typeof product.slug === 'string' && product.slug.trim().length > 0 ? product.slug.trim() : '';
+
+  if (!slug) {
+    return response({ error: 'product.slug required' }, 400);
+  }
+
+  if (action === 'remove') {
+    const { error } = await s
+      .from('user_wishlist')
+      .delete()
+      .eq('user_id', normalizedUserId)
+      .eq('product_slug', slug);
+
+    if (error) {
+      return response({ error: error.message ?? 'Unable to update wishlist' }, 500);
+    }
+
+    return response({ ok: true, saved: false });
+  }
+
+  const name = typeof product.name === 'string' && product.name.trim().length > 0 ? product.name.trim() : '';
+  const imageUrl = typeof product.image_url === 'string' && product.image_url.trim().length > 0 ? product.image_url.trim() : null;
+
+  let priceCents: number | null = null;
+  if (typeof product.price_cents === 'number' && Number.isFinite(product.price_cents)) {
+    priceCents = Math.round(product.price_cents);
+  } else if (typeof product.price === 'number' && Number.isFinite(product.price)) {
+    priceCents = Math.round(product.price * 100);
+  }
+
+  if (!name) {
+    return response({ error: 'product.name required' }, 400);
+  }
+
+  if (priceCents == null) {
+    return response({ error: 'product.price_cents required' }, 400);
+  }
+
+  const { error } = await s.from('user_wishlist').insert({
+    user_id: normalizedUserId,
+    product_slug: slug,
+    product_name: name,
+    product_price_cents: priceCents,
+    product_image: imageUrl,
+  });
+
+  if (error) {
+    if ((error as any)?.code === '23505') {
+      return response({ ok: true, saved: true });
+    }
+    return response({ error: error.message ?? 'Unable to update wishlist' }, 500);
+  }
+
+  return response({ ok: true, saved: true });
+};

--- a/server/routes/marketplace.ts
+++ b/server/routes/marketplace.ts
@@ -57,41 +57,66 @@ router.post('/demo-order', async (req, res) => {
 router.post('/wishlist', async (req, res) => {
   try {
     const supabase = requireClient();
-    const { userId, itemId } = req.body ?? {};
+    const { userId, product } = req.body ?? {};
 
-    if (!itemId || typeof itemId !== 'string') {
-      return res.status(400).json({ error: 'itemId required' });
+    const normalizedUserId = typeof userId === 'string' && userId.trim().length > 0 ? userId.trim() : '';
+    if (!normalizedUserId) {
+      return res.status(400).json({ error: 'userId required' });
     }
 
-    const normalizedUserId = typeof userId === 'string' && userId.trim().length > 0 ? userId.trim() : null;
+    const slug = typeof product?.slug === 'string' && product.slug.trim().length > 0 ? product.slug.trim() : '';
+    const name = typeof product?.name === 'string' && product.name.trim().length > 0 ? product.name.trim() : '';
+    const imageUrl = typeof product?.image_url === 'string' && product.image_url.trim().length > 0 ? product.image_url.trim() : null;
 
-    const query = supabase
-      .from('wishlists')
+    let priceCents: number | null = null;
+    if (typeof product?.price_cents === 'number' && Number.isFinite(product.price_cents)) {
+      priceCents = Math.round(product.price_cents);
+    } else if (typeof product?.price === 'number' && Number.isFinite(product.price)) {
+      priceCents = Math.round(product.price * 100);
+    }
+
+    if (!slug) {
+      return res.status(400).json({ error: 'product.slug required' });
+    }
+    if (!name) {
+      return res.status(400).json({ error: 'product.name required' });
+    }
+    if (priceCents == null) {
+      return res.status(400).json({ error: 'product.price_cents required' });
+    }
+
+    const { data: existing, error: selectError } = await supabase
+      .from('user_wishlist')
       .select('id')
-      .eq('item_id', itemId)
-      .limit(1);
+      .eq('user_id', normalizedUserId)
+      .eq('product_slug', slug)
+      .maybeSingle();
 
-    if (normalizedUserId) {
-      query.eq('user_id', normalizedUserId);
-    } else {
-      query.is('user_id', null);
-    }
-
-    const { data: existing, error: selectError } = await query.maybeSingle();
     if (selectError && selectError.code !== 'PGRST116') {
       throw selectError;
     }
 
     if (existing?.id) {
-      await supabase.from('wishlists').delete().eq('id', existing.id);
+      const { error } = await supabase
+        .from('user_wishlist')
+        .delete()
+        .eq('id', existing.id);
+      if (error) throw error;
       return res.json({ ok: true, saved: false });
     }
 
-    const insertPayload: Record<string, unknown> = { item_id: itemId };
-    if (normalizedUserId) insertPayload.user_id = normalizedUserId;
+    const { error: insertError } = await supabase.from('user_wishlist').insert({
+      user_id: normalizedUserId,
+      product_slug: slug,
+      product_name: name,
+      product_price_cents: priceCents,
+      product_image: imageUrl,
+    });
 
-    const { error: insertError } = await supabase.from('wishlists').insert(insertPayload);
     if (insertError) {
+      if ((insertError as any)?.code === '23505') {
+        return res.json({ ok: true, saved: true });
+      }
       throw insertError;
     }
 

--- a/src/components/HeaderHeart.tsx
+++ b/src/components/HeaderHeart.tsx
@@ -1,35 +1,38 @@
 import { useEffect, useState } from 'react';
 
-const KEY = 'naturverse_wishlist_v1';
-const LEGACY_KEY = 'nv:wishlist';
-
-function readCount() {
-  if (typeof window === 'undefined') return 0;
-  try {
-    const raw = localStorage.getItem(KEY);
-    if (raw) {
-      const list = JSON.parse(raw) as unknown[];
-      return Array.isArray(list) ? list.length : 0;
-    }
-    const legacyRaw = localStorage.getItem(LEGACY_KEY);
-    if (legacyRaw) {
-      const list = JSON.parse(legacyRaw) as unknown[];
-      return Array.isArray(list) ? list.length : 0;
-    }
-  } catch {
-    return 0;
-  }
-  return 0;
-}
+import { countWishlist } from '@/features/wishlist/api';
 
 export default function HeaderHeart() {
-  const [count, setCount] = useState(() => readCount());
+  const [count, setCount] = useState<number>(0);
 
   useEffect(() => {
-    const update = () => setCount(readCount());
-    update();
-    window.addEventListener('wishlist:changed', update);
-    return () => window.removeEventListener('wishlist:changed', update);
+    let active = true;
+
+    const refresh = async () => {
+      try {
+        const value = await countWishlist();
+        if (active) setCount(value);
+      } catch {
+        if (active) setCount(0);
+      }
+    };
+
+    refresh();
+
+    const update = () => {
+      void refresh();
+    };
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('wishlist:changed', update);
+    }
+
+    return () => {
+      active = false;
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('wishlist:changed', update);
+      }
+    };
   }, []);
 
   return (

--- a/src/features/wishlist/api.ts
+++ b/src/features/wishlist/api.ts
@@ -1,0 +1,97 @@
+import type { User } from '@supabase/supabase-js';
+
+import { supabase } from '@/lib/supabaseClient';
+import type { Database } from '@/types/db';
+
+export type WishlistRow = Database['public']['Tables']['user_wishlist']['Row'];
+export type WishlistInsert = Database['public']['Tables']['user_wishlist']['Insert'];
+
+function notifyWishlistChanged() {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('wishlist:changed'));
+  }
+}
+
+export async function getCurrentUser(): Promise<User | null> {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error) throw error;
+  return user ?? null;
+}
+
+export async function listWishlist(): Promise<WishlistRow[]> {
+  const user = await getCurrentUser();
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from('user_wishlist')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('added_at', { ascending: false });
+
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function addToWishlist(params: {
+  slug: string;
+  name: string;
+  price_cents: number;
+  image_url?: string | null;
+}): Promise<WishlistRow | null> {
+  const user = await getCurrentUser();
+  if (!user) throw new Error('SIGN_IN_REQUIRED');
+
+  const payload: WishlistInsert = {
+    user_id: user.id,
+    product_slug: params.slug,
+    product_name: params.name,
+    product_price_cents: Math.round(params.price_cents),
+    product_image: params.image_url ?? null,
+  };
+
+  const { data, error } = await supabase
+    .from('user_wishlist')
+    .insert(payload)
+    .select('*')
+    .single();
+
+  if (error) {
+    if ((error as any)?.code === '23505') {
+      return null; // duplicate entry, treat as success
+    }
+    throw error;
+  }
+
+  notifyWishlistChanged();
+  return data;
+}
+
+export async function removeFromWishlist(slug: string): Promise<void> {
+  const user = await getCurrentUser();
+  if (!user) throw new Error('SIGN_IN_REQUIRED');
+
+  const { error } = await supabase
+    .from('user_wishlist')
+    .delete()
+    .eq('user_id', user.id)
+    .eq('product_slug', slug);
+
+  if (error) throw error;
+  notifyWishlistChanged();
+}
+
+export async function countWishlist(): Promise<number> {
+  const user = await getCurrentUser();
+  if (!user) return 0;
+
+  const { count, error } = await supabase
+    .from('user_wishlist')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', user.id);
+
+  if (error) throw error;
+  return count ?? 0;
+}

--- a/src/pages/marketplace/[slug].tsx
+++ b/src/pages/marketplace/[slug].tsx
@@ -6,7 +6,7 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 import './../../styles/marketplace.css';
 import { useToast } from '@/components/Toast';
 import { useAuthUser } from '@/lib/useAuthUser';
-import { addToWishlist, getWishlist, removeFromWishlist } from '@/services/wishlist';
+import { addToWishlist, listWishlist, removeFromWishlist } from '@/features/wishlist/api';
 import type { MarketProduct, WishlistItem } from '@/types/market';
 import { fetchProducts, FALLBACK_PRODUCTS, formatPrice, type Product } from '@/hooks/useProducts';
 import { track } from '@/lib/analytics';
@@ -63,7 +63,7 @@ export default function ProductPage() {
     setLoadingWishlist(true);
     setPending(false);
 
-    getWishlist()
+    listWishlist()
       .then((items) => {
         if (active) setWishlist(items);
       })
@@ -92,9 +92,7 @@ export default function ProductPage() {
 
   const priceLabel = product ? formatPrice(product.price_cents) : '';
   const priceValue = product ? product.price_cents / 100 : 0;
-  const inWishlist = marketProduct
-    ? wishlist.some((item) => item.product_name === marketProduct.name)
-    : false;
+  const inWishlist = slug ? wishlist.some((item) => item.product_slug === slug) : false;
 
   const onToggleWishlist = async () => {
     if (!user) {
@@ -104,20 +102,44 @@ export default function ProductPage() {
     if (!marketProduct) return;
     try {
       setPending(true);
-      const existing = wishlist.find((item) => item.product_name === marketProduct.name);
+      const productSlug = marketProduct.id;
+      const existing = wishlist.find((item) => item.product_slug === productSlug);
 
       if (existing) {
-        await removeFromWishlist(existing.id, marketProduct.name);
-        setWishlist((prev) => prev.filter((item) => item.id !== existing.id));
+        await removeFromWishlist(productSlug);
+        setWishlist((prev) => prev.filter((item) => item.product_slug !== productSlug));
         toast({ text: 'Removed from wishlist', kind: 'warn' });
-        track('wishlist_remove', { slug: marketProduct.id, name: marketProduct.name });
+        track('wishlist_remove', { slug: productSlug, name: marketProduct.name });
       } else {
-        const created = await addToWishlist(marketProduct);
-        setWishlist((prev) => [created, ...prev]);
+        const priceCents =
+          typeof product?.price_cents === 'number'
+            ? product.price_cents
+            : marketProduct.price != null
+            ? Math.round(marketProduct.price * 100)
+            : 0;
+
+        const created = await addToWishlist({
+          slug: productSlug,
+          name: marketProduct.name,
+          price_cents: priceCents,
+          image_url: product?.image_url ?? marketProduct.image,
+        });
+
+        if (created) {
+          setWishlist((prev) => [created, ...prev.filter((item) => item.product_slug !== productSlug)]);
+        } else {
+          const latest = await listWishlist();
+          setWishlist(latest);
+        }
+
         toast({ text: 'Added to wishlist', kind: 'ok' });
-        track('wishlist_add', { slug: marketProduct.id, name: marketProduct.name });
+        track('wishlist_add', { slug: productSlug, name: marketProduct.name });
       }
     } catch (error) {
+      if (error instanceof Error && error.message === 'SIGN_IN_REQUIRED') {
+        toast({ text: 'Sign in to use your wishlist.', kind: 'warn' });
+        return;
+      }
       const message = error instanceof Error ? error.message : 'Could not update wishlist';
       toast({ text: message, kind: 'err' });
     } finally {

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -8,7 +8,7 @@ import '../../styles/marketplace.css';
 import { useToast } from '@/components/Toast';
 import { useAuthUser } from '@/lib/useAuthUser';
 import { fetchProducts, FALLBACK_PRODUCTS, formatPrice, type Product } from '@/hooks/useProducts';
-import { addToWishlist, getWishlist, removeFromWishlist } from '@/services/wishlist';
+import { addToWishlist, listWishlist, removeFromWishlist } from '@/features/wishlist/api';
 import { track } from '@/lib/analytics';
 import type { MarketProduct, WishlistItem } from '@/types/market';
 
@@ -65,7 +65,7 @@ export default function MarketplaceShop() {
     }
 
     setLoadingWishlist(true);
-    getWishlist()
+    listWishlist()
       .then((items) => {
         if (active) setWishlist(items);
       })
@@ -84,7 +84,7 @@ export default function MarketplaceShop() {
     };
   }, [user, authLoading]);
 
-  const wishlistNames = useMemo(() => new Set(wishlist.map((item) => item.product_name)), [wishlist]);
+  const wishlistSlugs = useMemo(() => new Set(wishlist.map((item) => item.product_slug)), [wishlist]);
 
   const cards = useMemo<ProductCard[]>(
     () =>
@@ -113,27 +113,45 @@ export default function MarketplaceShop() {
       return;
     }
 
-    try {
-      setPendingId(card.product.slug);
+    const slug = card.product.slug;
 
-      const existing = wishlist.find((item) => item.product_name === card.marketProduct.name);
+    try {
+      setPendingId(slug);
+
+      const existing = wishlist.find((item) => item.product_slug === slug);
 
       if (existing) {
-        await removeFromWishlist(existing.id, card.marketProduct.name);
-        setWishlist((prev) => prev.filter((item) => item.id !== existing.id));
+        await removeFromWishlist(slug);
+        setWishlist((prev) => prev.filter((item) => item.product_slug !== slug));
         toast({ text: 'Removed from wishlist', kind: 'warn' });
-        track('wishlist_remove', { slug: card.product.slug, name: card.product.name });
+        track('wishlist_remove', { slug, name: card.product.name });
       } else {
-        const created = await addToWishlist(card.marketProduct);
-        setWishlist((prev) => [created, ...prev]);
+        const created = await addToWishlist({
+          slug,
+          name: card.product.name,
+          price_cents: card.product.price_cents,
+          image_url: card.product.image_url,
+        });
+
+        if (created) {
+          setWishlist((prev) => [created, ...prev.filter((item) => item.product_slug !== slug)]);
+        } else {
+          const latest = await listWishlist();
+          setWishlist(latest);
+        }
+
         toast({ text: 'Added to wishlist', kind: 'ok' });
-        track('wishlist_add', { slug: card.product.slug, name: card.product.name });
+        track('wishlist_add', { slug, name: card.product.name });
       }
     } catch (error) {
+      if (error instanceof Error && error.message === 'SIGN_IN_REQUIRED') {
+        toast({ text: 'Sign in to use your wishlist.', kind: 'warn' });
+        return;
+      }
       const message = error instanceof Error ? error.message : 'Could not update wishlist';
       toast({ text: message, kind: 'err' });
     } finally {
-      setPendingId((prev) => (prev === card.product.slug ? null : prev));
+      setPendingId((prev) => (prev === slug ? null : prev));
     }
   };
 
@@ -171,9 +189,9 @@ export default function MarketplaceShop() {
               className="btn-secondary w-full"
               disabled={(loadingWishlist && !wishlist.length) || pendingId === card.product.slug || loadingProducts}
               onClick={() => void toggleWishlist(card)}
-              aria-pressed={wishlistNames.has(card.marketProduct.name)}
+              aria-pressed={wishlistSlugs.has(card.marketProduct.id)}
             >
-              {wishlistNames.has(card.marketProduct.name) ? 'In Wishlist' : 'Add to Wishlist'}
+              {wishlistSlugs.has(card.marketProduct.id) ? 'In Wishlist' : 'Add to Wishlist'}
             </button>
           </article>
         ))}

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -4,7 +4,7 @@ import MarketTabs from '../../components/MarketTabs';
 import '../../styles/marketplace.css';
 import { useToast } from '@/components/Toast';
 import { useAuthUser } from '@/lib/useAuthUser';
-import { getWishlist, removeFromWishlist } from '@/services/wishlist';
+import { listWishlist, removeFromWishlist } from '@/features/wishlist/api';
 import type { WishlistItem } from '@/types/market';
 import { fetchProducts, FALLBACK_PRODUCTS, formatPrice, type Product } from '@/hooks/useProducts';
 import { cart } from '@/lib/cart';
@@ -64,7 +64,7 @@ export default function MarketplaceWishlist() {
     setPendingId(null);
     setItems([]);
 
-    getWishlist()
+    listWishlist()
       .then((data) => {
         if (active) setItems(data);
       })
@@ -84,10 +84,10 @@ export default function MarketplaceWishlist() {
     };
   }, [user, authLoading]);
 
-  const productsByName = useMemo(() => {
+  const productsBySlug = useMemo(() => {
     const map = new Map<string, Product>();
     for (const product of catalog) {
-      map.set(product.name, product);
+      map.set(product.slug, product);
     }
     return map;
   }, [catalog]);
@@ -95,13 +95,13 @@ export default function MarketplaceWishlist() {
   const derived = useMemo<WishlistProductMeta[]>(
     () =>
       items.map((item) => {
-        const product = productsByName.get(item.product_name);
-        const priceCents = product?.price_cents ?? (typeof item.product_price === 'number' ? Math.round(item.product_price * 100) : null);
+        const product = productsBySlug.get(item.product_slug);
+        const priceCents = product?.price_cents ?? item.product_price_cents;
         const image = item.product_image ?? product?.image_url ?? null;
-        const href = product ? `/marketplace/${product.slug}` : undefined;
+        const href = product ? `/marketplace/${product.slug}` : `/marketplace/${item.product_slug}`;
         return { item, product, image, priceCents, href };
       }),
-    [items, productsByName]
+    [items, productsBySlug]
   );
 
   const handleRemove = async (entry: WishlistProductMeta) => {
@@ -111,11 +111,15 @@ export default function MarketplaceWishlist() {
     }
     try {
       setPendingId(entry.item.id);
-      await removeFromWishlist(entry.item.id, entry.item.product_name);
-      setItems((prev) => prev.filter((item) => item.id !== entry.item.id));
+      await removeFromWishlist(entry.item.product_slug);
+      setItems((prev) => prev.filter((item) => item.product_slug !== entry.item.product_slug));
       toast({ text: 'Removed from wishlist', kind: 'warn' });
-      track('wishlist_remove', { name: entry.item.product_name });
+      track('wishlist_remove', { slug: entry.item.product_slug, name: entry.item.product_name });
     } catch (err) {
+      if (err instanceof Error && err.message === 'SIGN_IN_REQUIRED') {
+        toast({ text: 'Sign in to update your wishlist.', kind: 'warn' });
+        return;
+      }
       const message = err instanceof Error ? err.message : 'Could not update wishlist';
       toast({ text: message, kind: 'err' });
     } finally {

--- a/src/services/wishlist.ts
+++ b/src/services/wishlist.ts
@@ -1,77 +1,10 @@
-import { supabase } from '@/lib/supabaseClient';
-import type { MarketProduct, WishlistItem } from '@/types/market';
+export {
+  getCurrentUser,
+  listWishlist,
+  addToWishlist,
+  removeFromWishlist,
+  countWishlist,
+  type WishlistRow,
+} from '@/features/wishlist/api';
 
-const WISHLIST_KEY = 'naturverse_wishlist_v1';
-const LEGACY_KEY = 'nv:wishlist';
-
-const readCache = () => {
-  if (typeof window === 'undefined') return [] as string[];
-  try {
-    const raw = localStorage.getItem(WISHLIST_KEY) ?? localStorage.getItem(LEGACY_KEY);
-    if (!raw) return [];
-    const value = JSON.parse(raw) as unknown;
-    return Array.isArray(value) ? (value as string[]) : [];
-  } catch {
-    return [];
-  }
-};
-
-const writeCache = (items: string[]) => {
-  if (typeof window === 'undefined') return;
-  localStorage.setItem(WISHLIST_KEY, JSON.stringify(items));
-  window.dispatchEvent(new Event('wishlist:changed'));
-};
-
-function toDbRow(product: MarketProduct, userId: string) {
-  return {
-    user_id: userId,
-    product_name: product.name,
-    product_price: product.price ?? null,
-    product_image: product.image ?? null,
-  };
-}
-
-export async function getWishlist(): Promise<WishlistItem[]> {
-  const { data, error } = await supabase.from('wishlist').select('*').order('added_at', { ascending: false });
-  if (error) throw error;
-  const items = (data ?? []) as WishlistItem[];
-  writeCache(items.map((item) => item.product_name));
-  return items;
-}
-
-export async function addToWishlist(product: MarketProduct): Promise<WishlistItem> {
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-
-  if (authError) throw authError;
-  if (!user) throw new Error('Please sign in to use your wishlist.');
-
-  const { data, error } = await supabase
-    .from('wishlist')
-    .insert([toDbRow(product, user.id)])
-    .select('*')
-    .single();
-
-  if (error) throw error;
-  const item = data as WishlistItem;
-  const cache = readCache();
-  if (!cache.includes(item.product_name)) {
-    writeCache([...cache, item.product_name]);
-  } else {
-    writeCache(cache);
-  }
-  return item;
-}
-
-export async function removeFromWishlist(itemId: string, productName?: string) {
-  const { error } = await supabase.from('wishlist').delete().eq('id', itemId);
-  if (error) throw error;
-  if (productName) {
-    const cache = readCache();
-    writeCache(cache.filter((name) => name !== productName));
-  } else {
-    writeCache(readCache());
-  }
-}
+export { listWishlist as getWishlist } from '@/features/wishlist/api';

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -94,20 +94,26 @@ export type Database = {
         };
         Update: Partial<Database['public']['Tables']['orders_demo']['Insert']>;
       };
-      wishlists: {
+      user_wishlist: {
         Row: {
           id: string;
-          user_id: string | null;
-          item_id: string;
-          created_at: string;
+          user_id: string;
+          product_slug: string;
+          product_name: string;
+          product_price_cents: number;
+          product_image: string | null;
+          added_at: string;
         };
         Insert: {
           id?: string;
-          user_id?: string | null;
-          item_id: string;
-          created_at?: string;
+          user_id: string;
+          product_slug: string;
+          product_name: string;
+          product_price_cents: number;
+          product_image?: string | null;
+          added_at?: string;
         };
-        Update: Partial<Database['public']['Tables']['wishlists']['Insert']>;
+        Update: Partial<Database['public']['Tables']['user_wishlist']['Insert']>;
       };
       events: {
         Row: {

--- a/src/types/market.ts
+++ b/src/types/market.ts
@@ -1,3 +1,5 @@
+import type { Database } from './db';
+
 export type MarketProduct = {
   id: string;
   name: string;
@@ -5,11 +7,4 @@ export type MarketProduct = {
   image?: string;
 };
 
-export type WishlistItem = {
-  id: string;
-  user_id: string;
-  product_name: string;
-  product_price: number | null;
-  product_image: string | null;
-  added_at: string;
-};
+export type WishlistItem = Database['public']['Tables']['user_wishlist']['Row'];

--- a/src/types/posthog.d.ts
+++ b/src/types/posthog.d.ts
@@ -1,0 +1,8 @@
+declare module 'posthog-js' {
+  const posthog: any;
+  export default posthog;
+}
+
+declare module 'posthog-js/react' {
+  export const PostHogProvider: any;
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -290,13 +290,24 @@ create table if not exists public.orders_demo (
   created_at timestamptz not null default now()
 );
 
-create table if not exists public.wishlists (
+create table if not exists public.user_wishlist (
   id uuid primary key default gen_random_uuid(),
-  user_id uuid references auth.users(id) on delete cascade,
-  item_id text not null,
-  created_at timestamptz not null default now(),
-  unique (user_id, item_id)
+  user_id uuid not null references auth.users(id) on delete cascade,
+  product_slug text not null,
+  product_name text not null,
+  product_price_cents integer not null,
+  product_image text,
+  added_at timestamptz not null default now()
 );
+
+create unique index if not exists user_wishlist_user_product_unique
+  on public.user_wishlist (user_id, product_slug);
+
+create index if not exists user_wishlist_user_idx
+  on public.user_wishlist (user_id);
+
+create index if not exists user_wishlist_added_at_idx
+  on public.user_wishlist (added_at desc);
 
 create table if not exists public.events (
   id uuid primary key default gen_random_uuid(),
@@ -307,7 +318,7 @@ create table if not exists public.events (
 );
 
 alter table public.orders_demo enable row level security;
-alter table public.wishlists enable row level security;
+alter table public.user_wishlist enable row level security;
 alter table public.events enable row level security;
 
 do $$ begin
@@ -315,9 +326,17 @@ do $$ begin
     create policy orders_demo_insert_self on public.orders_demo
       for insert to authenticated with check (user_id = auth.uid());
   end if;
-  if not exists (select 1 from pg_policies where policyname='wishlists_self') then
-    create policy wishlists_self on public.wishlists
-      for all to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
+  if not exists (select 1 from pg_policies where policyname='user_wishlist_select_own') then
+    create policy user_wishlist_select_own on public.user_wishlist
+      for select to authenticated using (user_id = auth.uid());
+  end if;
+  if not exists (select 1 from pg_policies where policyname='user_wishlist_insert_own') then
+    create policy user_wishlist_insert_own on public.user_wishlist
+      for insert to authenticated with check (user_id = auth.uid());
+  end if;
+  if not exists (select 1 from pg_policies where policyname='user_wishlist_delete_own') then
+    create policy user_wishlist_delete_own on public.user_wishlist
+      for delete to authenticated using (user_id = auth.uid());
   end if;
   if not exists (select 1 from pg_policies where policyname='events_self_insert') then
     create policy events_self_insert on public.events

--- a/supabase/sql/2025-full-schema.sql
+++ b/supabase/sql/2025-full-schema.sql
@@ -235,13 +235,24 @@ create table if not exists public.orders_demo (
   created_at timestamptz not null default now()
 );
 
-create table if not exists public.wishlists (
+create table if not exists public.user_wishlist (
   id uuid primary key default gen_random_uuid(),
-  user_id uuid references auth.users(id) on delete cascade,
-  item_id text not null,
-  created_at timestamptz not null default now(),
-  unique (user_id, item_id)
+  user_id uuid not null references auth.users(id) on delete cascade,
+  product_slug text not null,
+  product_name text not null,
+  product_price_cents integer not null,
+  product_image text,
+  added_at timestamptz not null default now()
 );
+
+create unique index if not exists user_wishlist_user_product_unique
+  on public.user_wishlist (user_id, product_slug);
+
+create index if not exists user_wishlist_user_idx
+  on public.user_wishlist (user_id);
+
+create index if not exists user_wishlist_added_at_idx
+  on public.user_wishlist (added_at desc);
 
 create table if not exists public.events (
   id uuid primary key default gen_random_uuid(),
@@ -252,14 +263,20 @@ create table if not exists public.events (
 );
 
 alter table public.orders_demo enable row level security;
-alter table public.wishlists enable row level security;
+alter table public.user_wishlist enable row level security;
 alter table public.events enable row level security;
 
 create policy orders_demo_insert_self on public.orders_demo
   for insert to authenticated with check (user_id = auth.uid());
 
-create policy wishlists_self on public.wishlists
-  for all to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
+create policy user_wishlist_select_own on public.user_wishlist
+  for select to authenticated using (user_id = auth.uid());
+
+create policy user_wishlist_insert_own on public.user_wishlist
+  for insert to authenticated with check (user_id = auth.uid());
+
+create policy user_wishlist_delete_own on public.user_wishlist
+  for delete to authenticated using (user_id = auth.uid());
 
 create policy events_self_insert on public.events
   for insert to authenticated with check (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- add the `user_wishlist` table definition with RLS policies, unique constraint, and indexes
- add a shared wishlist API that always scopes queries by the authenticated user and dispatches UI updates
- update marketplace pages, header badge, and server/serverless handlers to use the new per-user wishlist endpoints

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d3cbd0ba448329beb731733ac592d7