### PR TITLE
Fix wishlist flow with Supabase upsert and product joins

### DIFF
--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,6 +1,7 @@
 import { supabase } from '@/lib/supabaseClient';
 
 export type Product = {
+  id: string;
   slug: string;
   name: string;
   price_cents: number;
@@ -10,6 +11,7 @@ export type Product = {
 
 export const FALLBACK_PRODUCTS: Product[] = [
   {
+    id: 'turian-plush',
     slug: 'turian-plush',
     name: 'Turian Plush',
     price_cents: 2400,
@@ -17,6 +19,7 @@ export const FALLBACK_PRODUCTS: Product[] = [
     description: 'Soft plushy buddy.',
   },
   {
+    id: 'navatar-tee',
     slug: 'navatar-tee',
     name: 'Navatar Tee',
     price_cents: 1800,
@@ -24,6 +27,7 @@ export const FALLBACK_PRODUCTS: Product[] = [
     description: 'Classic tee with Navatar print.',
   },
   {
+    id: 'sticker-pack',
     slug: 'sticker-pack',
     name: 'Sticker Pack',
     price_cents: 600,
@@ -38,7 +42,7 @@ export async function fetchProducts(): Promise<Product[]> {
   try {
     const { data, error } = await supabase
       .from('products')
-      .select('slug,name,price_cents,image_url,description')
+      .select('id,slug,name,price_cents,image_url,description')
       .eq('active', true)
       .order('name');
     if (error) throw error;
@@ -48,6 +52,7 @@ export async function fetchProducts(): Promise<Product[]> {
     }
     return products.map((product) => ({
       ...product,
+      id: product.id || product.slug,
       image_url: product.image_url || fallbackMap.get(product.slug)?.image_url || '/Marketplace/Turianplushie.png',
     }));
   } catch (error) {

--- a/src/pages/marketplace/[slug].tsx
+++ b/src/pages/marketplace/[slug].tsx
@@ -83,7 +83,8 @@ export default function ProductPage() {
   const marketProduct = useMemo<MarketProduct | null>(() => {
     if (!product) return null;
     return {
-      id: product.slug,
+      id: product.id,
+      slug: product.slug,
       name: product.name,
       price: product.price_cents / 100,
       image: product.image_url,
@@ -93,7 +94,7 @@ export default function ProductPage() {
   const priceLabel = product ? formatPrice(product.price_cents) : '';
   const priceValue = product ? product.price_cents / 100 : 0;
   const inWishlist = marketProduct
-    ? wishlist.some((item) => item.product_name === marketProduct.name)
+    ? wishlist.some((item) => (item.product?.slug ?? item.product_id) === marketProduct.slug)
     : false;
 
   const onToggleWishlist = async () => {
@@ -104,18 +105,20 @@ export default function ProductPage() {
     if (!marketProduct) return;
     try {
       setPending(true);
-      const existing = wishlist.find((item) => item.product_name === marketProduct.name);
+      const existing = wishlist.find(
+        (item) => (item.product?.slug ?? item.product_id) === marketProduct.slug,
+      );
 
       if (existing) {
-        await removeFromWishlist(existing.id, marketProduct.name);
+        await removeFromWishlist(existing.id, marketProduct.slug, existing.product_id);
         setWishlist((prev) => prev.filter((item) => item.id !== existing.id));
         toast({ text: 'Removed from wishlist', kind: 'warn' });
-        track('wishlist_remove', { slug: marketProduct.id, name: marketProduct.name });
+        track('wishlist_remove', { slug: marketProduct.slug, name: marketProduct.name });
       } else {
         const created = await addToWishlist(marketProduct);
         setWishlist((prev) => [created, ...prev]);
         toast({ text: 'Added to wishlist', kind: 'ok' });
-        track('wishlist_add', { slug: marketProduct.id, name: marketProduct.name });
+        track('wishlist_add', { slug: marketProduct.slug, name: marketProduct.name });
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Could not update wishlist';
@@ -143,12 +146,17 @@ export default function ProductPage() {
           {marketProduct && (
             <div className="nv-cta">
               <AddToCartButton
-                id={marketProduct.id}
+                id={marketProduct.slug}
                 name={marketProduct.name}
                 price={priceValue}
                 image={marketProduct.image ?? ''}
               />
-              <SaveButton id={`product:${marketProduct.id}`} kind="product" title={marketProduct.name} href={`/marketplace/${marketProduct.id}`} />
+              <SaveButton
+                id={`product:${marketProduct.slug}`}
+                kind="product"
+                title={marketProduct.name}
+                href={`/marketplace/${marketProduct.slug}`}
+              />
             </div>
           )}
           <button

--- a/src/pages/marketplace/index.tsx
+++ b/src/pages/marketplace/index.tsx
@@ -84,14 +84,18 @@ export default function MarketplaceShop() {
     };
   }, [user, authLoading]);
 
-  const wishlistNames = useMemo(() => new Set(wishlist.map((item) => item.product_name)), [wishlist]);
+  const wishlistSlugs = useMemo(
+    () => new Set(wishlist.map((item) => item.product?.slug ?? item.product_id)),
+    [wishlist],
+  );
 
   const cards = useMemo<ProductCard[]>(
     () =>
       catalog.map((product) => {
         const price = product.price_cents / 100;
         const marketProduct: MarketProduct = {
-          id: product.slug,
+          id: product.id,
+          slug: product.slug,
           name: product.name,
           price,
           image: product.image_url,
@@ -116,10 +120,13 @@ export default function MarketplaceShop() {
     try {
       setPendingId(card.product.slug);
 
-      const existing = wishlist.find((item) => item.product_name === card.marketProduct.name);
+      const slug = card.marketProduct.slug;
+      const existing = wishlist.find(
+        (item) => (item.product?.slug ?? item.product_id) === slug,
+      );
 
       if (existing) {
-        await removeFromWishlist(existing.id, card.marketProduct.name);
+        await removeFromWishlist(existing.id, slug, existing.product_id);
         setWishlist((prev) => prev.filter((item) => item.id !== existing.id));
         toast({ text: 'Removed from wishlist', kind: 'warn' });
         track('wishlist_remove', { slug: card.product.slug, name: card.product.name });
@@ -160,20 +167,25 @@ export default function MarketplaceShop() {
             <p className="price">{card.priceLabel}</p>
             <div className="actions">
               <AddToCartButton
-                id={card.marketProduct.id}
+                id={card.product.slug}
                 name={card.marketProduct.name}
                 price={card.price}
                 image={card.marketProduct.image ?? ''}
               />
-              <SaveButton id={`product:${card.marketProduct.id}`} kind="product" title={card.marketProduct.name} href={card.href} />
+              <SaveButton
+                id={`product:${card.marketProduct.slug}`}
+                kind="product"
+                title={card.marketProduct.name}
+                href={card.href}
+              />
             </div>
             <button
               className="btn-secondary w-full"
               disabled={(loadingWishlist && !wishlist.length) || pendingId === card.product.slug || loadingProducts}
               onClick={() => void toggleWishlist(card)}
-              aria-pressed={wishlistNames.has(card.marketProduct.name)}
+              aria-pressed={wishlistSlugs.has(card.marketProduct.slug)}
             >
-              {wishlistNames.has(card.marketProduct.name) ? 'In Wishlist' : 'Add to Wishlist'}
+              {wishlistSlugs.has(card.marketProduct.slug) ? 'In Wishlist' : 'Add to Wishlist'}
             </button>
           </article>
         ))}

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -12,7 +12,9 @@ import { track } from '@/lib/analytics';
 
 interface WishlistProductMeta {
   item: WishlistItem;
-  product?: Product;
+  product: Product | null;
+  slug: string | null;
+  name: string;
   image: string | null;
   priceCents: number | null;
   href?: string;
@@ -84,10 +86,10 @@ export default function MarketplaceWishlist() {
     };
   }, [user, authLoading]);
 
-  const productsByName = useMemo(() => {
+  const productsBySlug = useMemo(() => {
     const map = new Map<string, Product>();
     for (const product of catalog) {
-      map.set(product.name, product);
+      map.set(product.slug, product);
     }
     return map;
   }, [catalog]);
@@ -95,13 +97,15 @@ export default function MarketplaceWishlist() {
   const derived = useMemo<WishlistProductMeta[]>(
     () =>
       items.map((item) => {
-        const product = productsByName.get(item.product_name);
-        const priceCents = product?.price_cents ?? (typeof item.product_price === 'number' ? Math.round(item.product_price * 100) : null);
-        const image = item.product_image ?? product?.image_url ?? null;
-        const href = product ? `/marketplace/${product.slug}` : undefined;
-        return { item, product, image, priceCents, href };
+        const slug = item.product?.slug ?? null;
+        const product = slug ? productsBySlug.get(slug) ?? null : null;
+        const priceCents = product?.price_cents ?? item.product?.price_cents ?? null;
+        const image = item.product?.image_url ?? product?.image_url ?? null;
+        const href = slug ? `/marketplace/${slug}` : undefined;
+        const name = item.product?.name ?? product?.name ?? 'Saved item';
+        return { item, product, slug, name, image, priceCents, href };
       }),
-    [items, productsByName]
+    [items, productsBySlug]
   );
 
   const handleRemove = async (entry: WishlistProductMeta) => {
@@ -111,10 +115,10 @@ export default function MarketplaceWishlist() {
     }
     try {
       setPendingId(entry.item.id);
-      await removeFromWishlist(entry.item.id, entry.item.product_name);
+      await removeFromWishlist(entry.item.id, entry.slug ?? undefined, entry.item.product_id);
       setItems((prev) => prev.filter((item) => item.id !== entry.item.id));
       toast({ text: 'Removed from wishlist', kind: 'warn' });
-      track('wishlist_remove', { name: entry.item.product_name });
+      track('wishlist_remove', { name: entry.name, slug: entry.slug ?? entry.item.product_id });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Could not update wishlist';
       toast({ text: message, kind: 'err' });
@@ -164,9 +168,9 @@ export default function MarketplaceWishlist() {
           {derived.map((entry) => (
             <article key={entry.item.id} className="mp-card nv-card">
               <div className="mp-image nv-image">
-                {entry.image ? <img src={entry.image} alt={entry.item.product_name} loading="lazy" /> : null}
+                {entry.image ? <img src={entry.image} alt={entry.name} loading="lazy" /> : null}
               </div>
-              <h3>{entry.href ? <Link to={entry.href}>{entry.item.product_name}</Link> : entry.item.product_name}</h3>
+              <h3>{entry.href ? <Link to={entry.href}>{entry.name}</Link> : entry.name}</h3>
               {entry.priceCents != null ? <p className="price">{formatPrice(entry.priceCents)}</p> : null}
               <div className="wishlist-actions">
                 <button className="btn-secondary" onClick={() => handleRemove(entry)} disabled={pendingId === entry.item.id}>

--- a/src/services/wishlist.ts
+++ b/src/services/wishlist.ts
@@ -22,20 +22,16 @@ const writeCache = (items: string[]) => {
   window.dispatchEvent(new Event('wishlist:changed'));
 };
 
-function toDbRow(product: MarketProduct, userId: string) {
-  return {
-    user_id: userId,
-    product_name: product.name,
-    product_price: product.price ?? null,
-    product_image: product.image ?? null,
-  };
-}
+const cacheKeyForItem = (item: WishlistItem) => item.product?.slug ?? item.product_id;
 
 export async function getWishlist(): Promise<WishlistItem[]> {
-  const { data, error } = await supabase.from('wishlist').select('*').order('added_at', { ascending: false });
+  const { data, error } = await supabase
+    .from('user_wishlist')
+    .select('id,user_id,product_id,created_at,product:products(id,slug,name,price_cents,image_url)')
+    .order('created_at', { ascending: false });
   if (error) throw error;
-  const items = (data ?? []) as WishlistItem[];
-  writeCache(items.map((item) => item.product_name));
+  const items = ((data ?? []) as unknown) as WishlistItem[];
+  writeCache(items.map(cacheKeyForItem));
   return items;
 }
 
@@ -49,29 +45,34 @@ export async function addToWishlist(product: MarketProduct): Promise<WishlistIte
   if (!user) throw new Error('Please sign in to use your wishlist.');
 
   const { data, error } = await supabase
-    .from('wishlist')
-    .insert([toDbRow(product, user.id)])
-    .select('*')
+    .from('user_wishlist')
+    .upsert([{ user_id: user.id, product_id: product.id }], {
+      onConflict: 'user_id,product_id',
+      ignoreDuplicates: true,
+    })
+    .select('id,user_id,product_id,created_at,product:products(id,slug,name,price_cents,image_url)')
     .single();
 
   if (error) throw error;
-  const item = data as WishlistItem;
+  const item = (data as unknown) as WishlistItem;
   const cache = readCache();
-  if (!cache.includes(item.product_name)) {
-    writeCache([...cache, item.product_name]);
+  const key = cacheKeyForItem(item) || product.slug || product.id;
+  if (!cache.includes(key)) {
+    writeCache([key, ...cache]);
   } else {
     writeCache(cache);
   }
   return item;
 }
 
-export async function removeFromWishlist(itemId: string, productName?: string) {
-  const { error } = await supabase.from('wishlist').delete().eq('id', itemId);
+export async function removeFromWishlist(itemId: string, productSlug?: string, productId?: string) {
+  const { error } = await supabase.from('user_wishlist').delete().eq('id', itemId);
   if (error) throw error;
-  if (productName) {
-    const cache = readCache();
-    writeCache(cache.filter((name) => name !== productName));
+  const cache = readCache();
+  if (productSlug || productId) {
+    const next = cache.filter((value) => value !== productSlug && value !== productId);
+    writeCache(next);
   } else {
-    writeCache(readCache());
+    writeCache(cache);
   }
 }

--- a/src/types/market.ts
+++ b/src/types/market.ts
@@ -1,5 +1,6 @@
 export type MarketProduct = {
   id: string;
+  slug: string;
   name: string;
   price?: number;
   image?: string;
@@ -8,8 +9,13 @@ export type MarketProduct = {
 export type WishlistItem = {
   id: string;
   user_id: string;
-  product_name: string;
-  product_price: number | null;
-  product_image: string | null;
-  added_at: string;
+  product_id: string;
+  created_at: string;
+  product: {
+    id: string;
+    slug: string;
+    name: string;
+    price_cents: number;
+    image_url: string | null;
+  } | null;
 };


### PR DESCRIPTION
## Summary
- update the wishlist service to query Supabase `user_wishlist`, join product data, and use upsert with cache updates
- adjust marketplace product pages to key wishlist state by product slug/id and keep controls responsive after failures
- add product IDs to the Supabase product hook and wishlist typings so UI components receive joined product metadata

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4ae8811748329a965e442bfc8fa31