### PR TITLE
Ensure marketplace wishlist and cart images fallback

### DIFF
--- a/public/Marketplace/placeholder.svg
+++ b/public/Marketplace/placeholder.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320" role="img" aria-label="Product image placeholder">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f4f6fb" />
+      <stop offset="100%" stop-color="#e5e9f2" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="320" fill="url(#grad)" rx="24" ry="24" />
+  <g fill="none" stroke="#b5bed1" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M88 214l48-64 44 52 32-44 20 28" />
+    <circle cx="116" cy="112" r="28" />
+  </g>
+</svg>

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,5 +1,13 @@
 import { supabase } from '@/lib/supabaseClient';
 
+type ProductRecord = {
+  slug: string;
+  name: string;
+  price_cents: number;
+  image_url: string | null;
+  description?: string | null;
+};
+
 export type Product = {
   slug: string;
   name: string;
@@ -7,6 +15,8 @@ export type Product = {
   image_url: string;
   description?: string;
 };
+
+export const DEFAULT_PRODUCT_IMAGE = '/Marketplace/placeholder.svg';
 
 export const FALLBACK_PRODUCTS: Product[] = [
   {
@@ -34,6 +44,17 @@ export const FALLBACK_PRODUCTS: Product[] = [
 
 const fallbackMap = new Map(FALLBACK_PRODUCTS.map((product) => [product.slug, product] as const));
 
+export function resolveProductImage(slug: string, imageUrl?: string | null) {
+  if (imageUrl && imageUrl.trim().length > 0) {
+    return imageUrl;
+  }
+  const fallback = fallbackMap.get(slug);
+  if (fallback?.image_url) {
+    return fallback.image_url;
+  }
+  return DEFAULT_PRODUCT_IMAGE;
+}
+
 export async function fetchProducts(): Promise<Product[]> {
   try {
     const { data, error } = await supabase
@@ -42,13 +63,16 @@ export async function fetchProducts(): Promise<Product[]> {
       .eq('active', true)
       .order('name');
     if (error) throw error;
-    const products = (data ?? []) as Product[];
+    const products = (data ?? []) as ProductRecord[];
     if (!products.length) {
       return FALLBACK_PRODUCTS;
     }
     return products.map((product) => ({
-      ...product,
-      image_url: product.image_url || fallbackMap.get(product.slug)?.image_url || '/Marketplace/Turianplushie.png',
+      slug: product.slug,
+      name: product.name,
+      price_cents: product.price_cents,
+      image_url: resolveProductImage(product.slug, product.image_url ?? undefined),
+      description: product.description ?? undefined,
     }));
   } catch (error) {
     if (import.meta.env.DEV) {

--- a/src/lib/cart.tsx
+++ b/src/lib/cart.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { supabase } from "./supabaseClient";
 import type { Product } from "@/hooks/useProducts";
-import { findFallbackProduct } from "@/hooks/useProducts";
+import { findFallbackProduct, resolveProductImage } from "@/hooks/useProducts";
 
 export type CartItem = { id: string; name: string; price: number; image: string; qty: number };
 type Saved = Record<string, true>;
@@ -90,8 +90,10 @@ const resolveCartItem = (slug: string, qty: number, meta?: CartProductMeta): Car
       : fallback
       ? fallback.price_cents / 100
       : 0;
-  const image =
-    meta?.image ?? meta?.image_url ?? (fallback ? fallback.image_url : "");
+  const image = resolveProductImage(
+    slug,
+    meta?.image ?? meta?.image_url ?? meta?.product?.image_url ?? fallback?.image_url
+  );
   const name = meta?.name ?? fallback?.name ?? slug;
   return { id: slug, name, price, image, qty: sanitizeQty(qty) };
 };

--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -4,6 +4,7 @@ import Breadcrumbs from '../components/Breadcrumbs';
 import { useToast } from '../components/Toast';
 import ShareNavatar from '../components/ShareNavatar';
 import { saveDemoOrder } from '@/lib/marketplace';
+import { resolveProductImage, DEFAULT_PRODUCT_IMAGE } from '@/hooks/useProducts';
 import { logEvent } from '@/lib/activity';
 import { startCheckout } from '@/lib/checkout';
 
@@ -38,30 +39,41 @@ export default function CartPage() {
         <p>Your cart is empty.</p>
       ) : (
         <div className="nv-card cart-card">
-          {items.map((it) => (
-            <div key={it.id} className="cart-line">
-              <img src={it.image} alt="" />
-              <div>
-                <div className="title">{it.name}</div>
-                <div className="meta price">${it.price.toFixed(2)}</div>
-                <div className="qty-group">
-                  <div className="qty">
-                    <button onClick={() => dec(it.id)} aria-label="Decrease quantity">
-                      −
-                    </button>
-                    <input type="number" value={it.qty} readOnly aria-label="Quantity" />
-                    <button onClick={() => inc(it.id)} aria-label="Increase quantity">
-                      +
+          {items.map((it) => {
+            const imageSrc = resolveProductImage(it.id, it.image);
+            return (
+              <div key={it.id} className="cart-line">
+                <img
+                  src={imageSrc}
+                  alt={it.name}
+                  loading="lazy"
+                  onError={(event) => {
+                    event.currentTarget.onerror = null;
+                    event.currentTarget.src = DEFAULT_PRODUCT_IMAGE;
+                  }}
+                />
+                <div>
+                  <div className="title">{it.name}</div>
+                  <div className="meta price">${it.price.toFixed(2)}</div>
+                  <div className="qty-group">
+                    <div className="qty">
+                      <button onClick={() => dec(it.id)} aria-label="Decrease quantity">
+                        −
+                      </button>
+                      <input type="number" value={it.qty} readOnly aria-label="Quantity" />
+                      <button onClick={() => inc(it.id)} aria-label="Increase quantity">
+                        +
+                      </button>
+                    </div>
+                    <button className="btn-danger" onClick={() => remove(it.id)}>
+                      Remove
                     </button>
                   </div>
-                  <button className="btn-danger" onClick={() => remove(it.id)}>
-                    Remove
-                  </button>
                 </div>
+                <div className="meta price">${(it.qty * it.price).toFixed(2)}</div>
               </div>
-              <div className="meta price">${(it.qty * it.price).toFixed(2)}</div>
-            </div>
-          ))}
+            );
+          })}
           <hr />
           <div className="subtotal-row subtotal">
             <strong className="label">Subtotal</strong>

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -5,7 +5,7 @@ import '../../styles/marketplace.css';
 import { useToast } from '@/components/Toast';
 import { useAuthUser } from '@/lib/useAuthUser';
 import { fetchWishlist, removeFromWishlist, type ProductSummary } from '@/lib/wishlist';
-import { formatPrice } from '@/hooks/useProducts';
+import { formatPrice, resolveProductImage, DEFAULT_PRODUCT_IMAGE } from '@/hooks/useProducts';
 import { cart } from '@/lib/cart';
 import { track } from '@/lib/analytics';
 
@@ -134,29 +134,40 @@ export default function MarketplaceWishlist() {
         </p>
       ) : (
         <div className="mp-grid nv-card-grid" style={{ marginTop: '1.5rem' }}>
-          {items.map((entry) => (
-            <article key={entry.id} className="mp-card nv-card">
-              <div className="mp-image nv-image">
-                {entry.image_url ? <img src={entry.image_url} alt={entry.name} loading="lazy" /> : null}
-              </div>
-              <h3>
-                <Link to={`/marketplace/${entry.slug}`}>{entry.name}</Link>
-              </h3>
-              <p className="price">{formatPrice(entry.price_cents)}</p>
-              <div className="wishlist-actions">
-                <button className="btn-secondary" onClick={() => void handleRemove(entry)} disabled={pendingSlug === entry.slug}>
-                  Remove
-                </button>
-                <button
-                  className="btn-primary"
-                  onClick={() => void handleMoveToCart(entry)}
-                  disabled={pendingSlug === entry.slug}
-                >
-                  Move to cart
-                </button>
-              </div>
-            </article>
-          ))}
+          {items.map((entry) => {
+            const imageSrc = resolveProductImage(entry.slug, entry.image_url ?? undefined);
+            return (
+              <article key={entry.id} className="mp-card nv-card">
+                <div className="mp-image nv-image">
+                  <img
+                    src={imageSrc}
+                    alt={entry.name}
+                    loading="lazy"
+                    onError={(event) => {
+                      event.currentTarget.onerror = null;
+                      event.currentTarget.src = DEFAULT_PRODUCT_IMAGE;
+                    }}
+                  />
+                </div>
+                <h3>
+                  <Link to={`/marketplace/${entry.slug}`}>{entry.name}</Link>
+                </h3>
+                <p className="price">{formatPrice(entry.price_cents)}</p>
+                <div className="wishlist-actions">
+                  <button className="btn-secondary" onClick={() => void handleRemove(entry)} disabled={pendingSlug === entry.slug}>
+                    Remove
+                  </button>
+                  <button
+                    className="btn-primary"
+                    onClick={() => void handleMoveToCart(entry)}
+                    disabled={pendingSlug === entry.slug}
+                  >
+                    Move to cart
+                  </button>
+                </div>
+              </article>
+            );
+          })}
         </div>
       )}
     </main>


### PR DESCRIPTION
## Summary
- add a reusable helper to resolve product images with a local placeholder fallback
- ensure cart and wishlist UIs always render product imagery and recover from broken URLs
- add a simple SVG placeholder asset used when product imagery is missing

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4b7a032ec8329876cb221f1c901a6