### PR TITLE
Add Supabase marketplace API helpers

### DIFF
--- a/src/lib/marketplaceApi.ts
+++ b/src/lib/marketplaceApi.ts
@@ -1,0 +1,178 @@
+import { supabase } from '@/lib/supabaseClient';
+
+type SupabaseProductRow = {
+  id: string;
+  slug: string;
+  name: string;
+  price_cents: number | null;
+  image_url: string | null;
+};
+
+type WishlistQueryRow = {
+  id: string;
+  created_at: string;
+  products: SupabaseProductRow | SupabaseProductRow[] | null;
+};
+
+type CartQueryRow = {
+  id: string;
+  qty: number | null;
+  products: SupabaseProductRow | SupabaseProductRow[] | null;
+};
+
+// -------------- Wishlist --------------
+
+export async function addToWishlist(productId: string) {
+  const { data, error } = await supabase
+    .from('user_wishlist')
+    .insert({ product_id: productId })
+    .select('id')
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function removeFromWishlist(wishlistRowId: string) {
+  const { error } = await supabase
+    .from('user_wishlist')
+    .delete()
+    .eq('id', wishlistRowId);
+
+  if (error) throw error;
+}
+
+export type WishlistItem = {
+  wishlist_id: string;
+  product_id: string;
+  name: string;
+  price_cents: number;
+  image_url: string | null;
+  slug: string;
+  created_at: string;
+};
+
+export async function getWishlist(): Promise<WishlistItem[]> {
+  const { data, error } = await supabase
+    .from('user_wishlist')
+    .select(
+      `
+        id,
+        created_at,
+        products:product_id (
+          id,
+          slug,
+          name,
+          price_cents,
+          image_url
+        )
+      `
+    )
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+
+  const rows = (data ?? []) as WishlistQueryRow[];
+
+  return rows.flatMap((row) => {
+    const product = Array.isArray(row.products)
+      ? row.products[0] ?? null
+      : row.products;
+
+    if (!product) return [];
+
+    return [
+      {
+        wishlist_id: row.id,
+        product_id: product.id,
+        slug: product.slug,
+        name: product.name,
+        price_cents: product.price_cents ?? 0,
+        image_url: product.image_url ?? null,
+        created_at: row.created_at,
+      },
+    ];
+  });
+}
+
+// -------------- Cart (server table version) --------------
+
+export type CartLine = {
+  cart_item_id: string;
+  product_id: string;
+  qty: number;
+  name: string;
+  price_cents: number;
+  image_url: string | null;
+  slug: string;
+};
+
+export async function getCart(): Promise<CartLine[]> {
+  const { data, error } = await supabase
+    .from('cart_items')
+    .select(
+      `
+        id,
+        qty,
+        products:product_id (
+          id,
+          slug,
+          name,
+          price_cents,
+          image_url
+        )
+      `
+    )
+    .order('id', { ascending: true });
+
+  if (error) throw error;
+
+  const rows = (data ?? []) as CartQueryRow[];
+
+  return rows.flatMap((row) => {
+    const product = Array.isArray(row.products)
+      ? row.products[0] ?? null
+      : row.products;
+
+    if (!product) return [];
+
+    return [
+      {
+        cart_item_id: row.id,
+        product_id: product.id,
+        qty: typeof row.qty === 'number' ? row.qty : 1,
+        slug: product.slug,
+        name: product.name,
+        price_cents: product.price_cents ?? 0,
+        image_url: product.image_url ?? null,
+      },
+    ];
+  });
+}
+
+export async function addToCart(productId: string, qty = 1) {
+  const { data, error } = await supabase
+    .from('cart_items')
+    .insert({ product_id: productId, qty })
+    .select('id')
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function updateCartQty(cartItemId: string, qty: number) {
+  const { error } = await supabase
+    .from('cart_items')
+    .update({ qty })
+    .eq('id', cartItemId);
+  if (error) throw error;
+}
+
+export async function removeFromCart(cartItemId: string) {
+  const { error } = await supabase
+    .from('cart_items')
+    .delete()
+    .eq('id', cartItemId);
+  if (error) throw error;
+}

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -4,13 +4,13 @@ import MarketTabs from '../../components/MarketTabs';
 import '../../styles/marketplace.css';
 import { useToast } from '@/components/Toast';
 import { useAuthUser } from '@/lib/useAuthUser';
-import { fetchWishlist, removeFromWishlist, type ProductSummary } from '@/lib/wishlist';
+import { getWishlist, removeFromWishlist as removeWishlistRow, type WishlistItem } from '@/lib/marketplaceApi';
 import { formatPrice, resolveProductImage, DEFAULT_PRODUCT_IMAGE } from '@/hooks/useProducts';
 import { cart } from '@/lib/cart';
 import { track } from '@/lib/analytics';
 
 export default function MarketplaceWishlist() {
-  const [items, setItems] = useState<ProductSummary[]>([]);
+  const [items, setItems] = useState<WishlistItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pendingSlug, setPendingSlug] = useState<string | null>(null);
@@ -40,7 +40,7 @@ export default function MarketplaceWishlist() {
     setPendingSlug(null);
     setItems([]);
 
-    fetchWishlist()
+    getWishlist()
       .then((data) => {
         if (active) setItems(data);
       })
@@ -61,7 +61,7 @@ export default function MarketplaceWishlist() {
   }, [user, authLoading]);
 
   const removeWishlistEntry = async (
-    entry: ProductSummary,
+    entry: WishlistItem,
     options: { message: string; toastKind: 'ok' | 'warn' | 'err'; trackEvent: string; trackExtra?: Record<string, unknown>; onSuccess?: () => void }
   ) => {
     if (!user) {
@@ -70,34 +70,32 @@ export default function MarketplaceWishlist() {
     }
     try {
       setPendingSlug(entry.slug);
-      const res = await removeFromWishlist(entry.slug);
-      if (!res.ok) {
-        const message =
-          res.reason === 'auth'
-            ? 'Sign in to update your wishlist.'
-            : 'Could not update wishlist';
-        toast({ text: message, kind: res.reason === 'db' ? 'err' : 'warn' });
-        if (res.reason === 'auth') {
-          setItems([]);
-        }
-        return;
-      }
+      await removeWishlistRow(entry.wishlist_id);
       setItems((prev) => prev.filter((item) => item.slug !== entry.slug));
       options.onSuccess?.();
       toast({ text: options.message, kind: options.toastKind });
       track(options.trackEvent, { slug: entry.slug, name: entry.name, ...options.trackExtra });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Could not update wishlist';
-      toast({ text: message, kind: 'err' });
+      const code =
+        typeof err === 'object' && err && 'code' in err && typeof (err as { code?: unknown }).code === 'string'
+          ? ((err as { code: string }).code ?? '')
+          : '';
+      if (code === 'PGRST301' || code === 'PGRST302') {
+        toast({ text: 'Sign in to update your wishlist.', kind: 'warn' });
+        setItems([]);
+      } else {
+        const message = err instanceof Error ? err.message : 'Could not update wishlist';
+        toast({ text: message, kind: 'err' });
+      }
     } finally {
       setPendingSlug((prev) => (prev === entry.slug ? null : prev));
     }
   };
 
-  const handleRemove = (entry: ProductSummary) =>
+  const handleRemove = (entry: WishlistItem) =>
     removeWishlistEntry(entry, { message: 'Removed from wishlist', toastKind: 'warn', trackEvent: 'wishlist_remove' });
 
-  const handleMoveToCart = (entry: ProductSummary) =>
+  const handleMoveToCart = (entry: WishlistItem) =>
     removeWishlistEntry(entry, {
       message: 'Moved to cart',
       toastKind: 'ok',
@@ -137,7 +135,7 @@ export default function MarketplaceWishlist() {
           {items.map((entry) => {
             const imageSrc = resolveProductImage(entry.slug, entry.image_url ?? undefined);
             return (
-              <article key={entry.id} className="mp-card nv-card">
+              <article key={entry.wishlist_id} className="mp-card nv-card">
                 <div className="mp-image nv-image">
                   <img
                     src={imageSrc}


### PR DESCRIPTION
## Summary
- add Supabase marketplace API helpers that join related product data for wishlist and cart rows
- update the marketplace wishlist page to use the new helpers and surface image URLs from Supabase joins
- improve wishlist removal error handling to prompt for sign-in when Supabase indicates an auth issue

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4c4a00d188329bd1ecb325039c309