### PR TITLE
Fix Supabase image resolution in cart and wishlist

### DIFF
--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabaseClient';
+import { resolveImageUrl, DEFAULT_IMAGE_URL } from '@/utils/resolveImageUrl';
 
 type ProductRecord = {
   slug: string;
@@ -16,7 +17,7 @@ export type Product = {
   description?: string;
 };
 
-export const DEFAULT_PRODUCT_IMAGE = '/Marketplace/placeholder.svg';
+export const DEFAULT_PRODUCT_IMAGE = DEFAULT_IMAGE_URL;
 
 export const FALLBACK_PRODUCTS: Product[] = [
   {
@@ -46,11 +47,11 @@ const fallbackMap = new Map(FALLBACK_PRODUCTS.map((product) => [product.slug, pr
 
 export function resolveProductImage(slug: string, imageUrl?: string | null) {
   if (imageUrl && imageUrl.trim().length > 0) {
-    return imageUrl;
+    return resolveImageUrl(imageUrl);
   }
   const fallback = fallbackMap.get(slug);
   if (fallback?.image_url) {
-    return fallback.image_url;
+    return resolveImageUrl(fallback.image_url);
   }
   return DEFAULT_PRODUCT_IMAGE;
 }

--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -5,6 +5,7 @@ import { useToast } from '../components/Toast';
 import ShareNavatar from '../components/ShareNavatar';
 import { saveDemoOrder } from '@/lib/marketplace';
 import { resolveProductImage, DEFAULT_PRODUCT_IMAGE } from '@/hooks/useProducts';
+import resolveImageUrl from '@/utils/resolveImageUrl';
 import { logEvent } from '@/lib/activity';
 import { startCheckout } from '@/lib/checkout';
 
@@ -40,7 +41,8 @@ export default function CartPage() {
       ) : (
         <div className="nv-card cart-card">
           {items.map((it) => {
-            const imageSrc = resolveProductImage(it.id, it.image);
+            const fallbackImage = resolveProductImage(it.id);
+            const imageSrc = resolveImageUrl(it.image.trim() ? it.image : fallbackImage);
             return (
               <div key={it.id} className="cart-line">
                 <img

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -6,6 +6,7 @@ import { useToast } from '@/components/Toast';
 import { useAuthUser } from '@/lib/useAuthUser';
 import { fetchWishlist, removeFromWishlist, type ProductSummary } from '@/lib/wishlist';
 import { formatPrice, resolveProductImage, DEFAULT_PRODUCT_IMAGE } from '@/hooks/useProducts';
+import resolveImageUrl from '@/utils/resolveImageUrl';
 import { cart } from '@/lib/cart';
 import { track } from '@/lib/analytics';
 
@@ -135,7 +136,8 @@ export default function MarketplaceWishlist() {
       ) : (
         <div className="mp-grid nv-card-grid" style={{ marginTop: '1.5rem' }}>
           {items.map((entry) => {
-            const imageSrc = resolveProductImage(entry.slug, entry.image_url ?? undefined);
+            const fallbackImage = resolveProductImage(entry.slug);
+            const imageSrc = resolveImageUrl(entry.image_url ?? fallbackImage);
             return (
               <article key={entry.id} className="mp-card nv-card">
                 <div className="mp-image nv-image">

--- a/src/utils/resolveImageUrl.ts
+++ b/src/utils/resolveImageUrl.ts
@@ -1,0 +1,19 @@
+export const DEFAULT_IMAGE_URL = '/Marketplace/placeholder.svg';
+
+export function resolveImageUrl(imagePath?: string | null): string {
+  if (!imagePath) return DEFAULT_IMAGE_URL;
+  const trimmed = imagePath.trim();
+  if (!trimmed) return DEFAULT_IMAGE_URL;
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://') || trimmed.startsWith('/')) {
+    return trimmed;
+  }
+
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL?.replace(/\/$/, '');
+  if (!supabaseUrl) return DEFAULT_IMAGE_URL;
+
+  const objectPath = trimmed.replace(/^\/+/, '');
+  return `${supabaseUrl}/storage/v1/object/public/${objectPath}`;
+}
+
+export default resolveImageUrl;


### PR DESCRIPTION
## Summary
- add a Supabase-aware resolveImageUrl helper to normalize product image paths and reuse the marketplace placeholder
- update product utilities to resolve fallback images through the helper
- ensure the cart and wishlist renderers use the helper so storage keys, absolute URLs, and missing images load correctly

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4cb65958c83299119db8aee6ebfcb