### PR TITLE
Fix wishlist and cart image URLs

### DIFF
--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -4,9 +4,9 @@ import Breadcrumbs from '../components/Breadcrumbs';
 import { useToast } from '../components/Toast';
 import ShareNavatar from '../components/ShareNavatar';
 import { saveDemoOrder } from '@/lib/marketplace';
-import { resolveProductImage, DEFAULT_PRODUCT_IMAGE } from '@/hooks/useProducts';
 import { logEvent } from '@/lib/activity';
 import { startCheckout } from '@/lib/checkout';
+import { resolveImageUrl } from '@/utils/resolveImageUrl';
 
 export default function CartPage() {
   const { items, inc, dec, remove, subtotal } = useCart();
@@ -40,7 +40,7 @@ export default function CartPage() {
       ) : (
         <div className="nv-card cart-card">
           {items.map((it) => {
-            const imageSrc = resolveProductImage(it.id, it.image);
+            const imageSrc = resolveImageUrl(it.image);
             return (
               <div key={it.id} className="cart-line">
                 <img
@@ -49,7 +49,7 @@ export default function CartPage() {
                   loading="lazy"
                   onError={(event) => {
                     event.currentTarget.onerror = null;
-                    event.currentTarget.src = DEFAULT_PRODUCT_IMAGE;
+                    event.currentTarget.src = resolveImageUrl(null);
                   }}
                 />
                 <div>

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -5,7 +5,8 @@ import '../../styles/marketplace.css';
 import { useToast } from '@/components/Toast';
 import { useAuthUser } from '@/lib/useAuthUser';
 import { fetchWishlist, removeFromWishlist, type ProductSummary } from '@/lib/wishlist';
-import { formatPrice, resolveProductImage, DEFAULT_PRODUCT_IMAGE } from '@/hooks/useProducts';
+import { formatPrice } from '@/hooks/useProducts';
+import { resolveImageUrl } from '@/utils/resolveImageUrl';
 import { cart } from '@/lib/cart';
 import { track } from '@/lib/analytics';
 
@@ -135,7 +136,7 @@ export default function MarketplaceWishlist() {
       ) : (
         <div className="mp-grid nv-card-grid" style={{ marginTop: '1.5rem' }}>
           {items.map((entry) => {
-            const imageSrc = resolveProductImage(entry.slug, entry.image_url ?? undefined);
+            const imageSrc = resolveImageUrl(entry.image_url);
             return (
               <article key={entry.id} className="mp-card nv-card">
                 <div className="mp-image nv-image">
@@ -145,7 +146,7 @@ export default function MarketplaceWishlist() {
                     loading="lazy"
                     onError={(event) => {
                       event.currentTarget.onerror = null;
-                      event.currentTarget.src = DEFAULT_PRODUCT_IMAGE;
+                      event.currentTarget.src = resolveImageUrl(null);
                     }}
                   />
                 </div>

--- a/src/utils/resolveImageUrl.ts
+++ b/src/utils/resolveImageUrl.ts
@@ -1,0 +1,38 @@
+/**
+ * Normalize product image URLs so relative, absolute, and storage-backed paths all work.
+ * No binary assets required — falls back to a tiny inline SVG placeholder.
+ */
+const PLACEHOLDER_DATA_URI =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(`
+    <svg xmlns="http://www.w3.org/2000/svg" width="640" height="480">
+      <rect width="100%" height="100%" fill="#eef1f5"/>
+      <g stroke="#c5cbd3" stroke-width="8" fill="none">
+        <circle cx="210" cy="180" r="40" />
+        <polyline points="160,360 280,260 360,320 460,240 520,300" />
+      </g>
+    </svg>
+  `);
+
+export function resolveImageUrl(raw?: string | null): string {
+  if (!raw) return PLACEHOLDER_DATA_URI;
+
+  const url = raw.trim();
+
+  if (!url) return PLACEHOLDER_DATA_URI;
+
+  // Already absolute (http/https) -> use as-is
+  if (/^https?:\/\//i.test(url)) return url;
+
+  // Supabase storage public object path (e.g. "product-art/foo.png")
+  // Build an absolute URL if we detect no leading slash and no protocol.
+  const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+  if (SUPABASE_URL && !url.startsWith('/')) {
+    return `${SUPABASE_URL.replace(/\/+$/, '')}/storage/v1/object/public/${url}`;
+  }
+
+  // Ensure leading slash for site-hosted assets (e.g. "images/merch/tee.jpg")
+  if (!url.startsWith('/')) return `/${url}`;
+
+  return url;
+}


### PR DESCRIPTION
## Summary
- add a shared resolveImageUrl helper that normalizes relative, absolute, and storage-based paths
- switch wishlist and cart pages to use the helper and fallback to the inline SVG placeholder when needed

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4daee5d80832991934cabaf1e3baf