### PR TITLE
Use wishlist view for product images

### DIFF
--- a/src/lib/wishlist.ts
+++ b/src/lib/wishlist.ts
@@ -109,10 +109,10 @@ export async function fetchWishlist(): Promise<ProductSummary[]> {
   if (!userId) return [];
 
   const { data, error } = await supabase
-    .from('user_wishlist')
-    .select('created_at, products:product_id (id, slug, name, price_cents, image_url)')
+    .from('user_wishlist_view')
+    .select('id, slug, name, price_cents, image_url')
     .eq('user_id', userId)
-    .order('created_at', { ascending: false });
+    .order('added_at', { ascending: false });
 
   if (error) {
     console.error('wishlist fetch error', error);
@@ -121,15 +121,13 @@ export async function fetchWishlist(): Promise<ProductSummary[]> {
 
   return (data ?? [])
     .map((row) => {
-      const raw = (row as { products?: ProductSummary | ProductSummary[] | null }).products;
-      const product = Array.isArray(raw) ? raw[0] ?? null : raw ?? null;
-      if (!product) return null;
+      if (!row || !row.slug) return null;
       return {
-        id: product.id,
-        slug: product.slug,
-        name: product.name,
-        price_cents: product.price_cents ?? 0,
-        image_url: product.image_url ?? null,
+        id: row.id,
+        slug: row.slug,
+        name: row.name ?? 'Unknown product',
+        price_cents: row.price_cents ?? 0,
+        image_url: row.image_url ?? null,
       } satisfies ProductSummary;
     })
     .filter((item): item is ProductSummary => !!item);

--- a/src/pages/marketplace/wishlist.tsx
+++ b/src/pages/marketplace/wishlist.tsx
@@ -5,9 +5,21 @@ import '../../styles/marketplace.css';
 import { useToast } from '@/components/Toast';
 import { useAuthUser } from '@/lib/useAuthUser';
 import { fetchWishlist, removeFromWishlist, type ProductSummary } from '@/lib/wishlist';
-import { formatPrice, resolveProductImage, DEFAULT_PRODUCT_IMAGE } from '@/hooks/useProducts';
+import { formatPrice, DEFAULT_PRODUCT_IMAGE } from '@/hooks/useProducts';
 import { cart } from '@/lib/cart';
 import { track } from '@/lib/analytics';
+
+function resolveWishlistImage(src?: string | null) {
+  if (!src || src.trim().length === 0) {
+    return DEFAULT_PRODUCT_IMAGE;
+  }
+
+  if (/^https?:\/\//i.test(src)) {
+    return src;
+  }
+
+  return src.startsWith('/') ? src : `/${src}`;
+}
 
 export default function MarketplaceWishlist() {
   const [items, setItems] = useState<ProductSummary[]>([]);
@@ -135,7 +147,7 @@ export default function MarketplaceWishlist() {
       ) : (
         <div className="mp-grid nv-card-grid" style={{ marginTop: '1.5rem' }}>
           {items.map((entry) => {
-            const imageSrc = resolveProductImage(entry.slug, entry.image_url ?? undefined);
+            const imageSrc = resolveWishlistImage(entry.image_url);
             return (
               <article key={entry.id} className="mp-card nv-card">
                 <div className="mp-image nv-image">


### PR DESCRIPTION
## Summary
- load wishlist entries from the new `user_wishlist_view` so image URLs are returned with each row
- normalize wishlist image URLs in the UI to handle absolute, relative, and missing sources before rendering

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4ded3b4b08329ac50453f8ca5d7bb