### PR TITLE
Add provider picker with DeepAI and auto fallback

### DIFF
--- a/src/lib/imageProviders.ts
+++ b/src/lib/imageProviders.ts
@@ -1,0 +1,144 @@
+import {
+  RateLimitError,
+  StabilityError,
+  generateWithStability,
+  normalizeSeed,
+} from "@/lib/navatar/stability";
+
+export type GenOptions = {
+  prompt: string;
+  negativePrompt?: string;
+  seed?: number | string;
+  size?: number; // px edge
+  style?: string;
+  signal?: AbortSignal;
+};
+
+export type Provider = "auto" | "deepai" | "stability" | "dicebear";
+
+export type ProviderResult = {
+  blob: Blob;
+  provider: Exclude<Provider, "auto">;
+  remaining?: number | null;
+};
+
+const toBlob = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Fetch failed: ${res.status}`);
+  }
+  return await res.blob();
+};
+
+async function callDeepAI({ prompt, negativePrompt, size = 1024 }: GenOptions): Promise<ProviderResult> {
+  const key = import.meta.env.VITE_DEEPAI_API_KEY as string | undefined;
+  if (!key) {
+    throw new Error("DeepAI not configured");
+  }
+
+  const promptParts = [prompt];
+  if (negativePrompt?.trim()) {
+    promptParts.push(`Avoid: ${negativePrompt.trim()}`);
+  }
+
+  const res = await fetch("https://api.deepai.org/api/text2img", {
+    method: "POST",
+    headers: { "api-key": key },
+    body: new URLSearchParams({
+      text: promptParts.filter(Boolean).join("\n"),
+      width: String(size),
+      height: String(size),
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`DeepAI error ${res.status}`);
+  }
+
+  const json = await res.json();
+  const url: string | undefined =
+    typeof json?.output_url === "string"
+      ? json.output_url
+      : Array.isArray(json?.output_url)
+        ? json.output_url[0]
+        : undefined;
+  if (!url) {
+    throw new Error("DeepAI did not return output_url");
+  }
+
+  const blob = await toBlob(url);
+  return { blob, provider: "deepai" };
+}
+
+async function callStability({
+  prompt,
+  negativePrompt,
+  seed,
+  style,
+  signal,
+}: GenOptions): Promise<ProviderResult> {
+  const numericSeed = typeof seed === "string" ? Number(seed) : seed;
+  const normalizedSeed = normalizeSeed(
+    typeof numericSeed === "number" && Number.isFinite(numericSeed) ? numericSeed : undefined,
+  );
+
+  const { blob, remaining } = await generateWithStability({
+    prompt,
+    negativePrompt,
+    seed: normalizedSeed,
+    style,
+    signal,
+  });
+
+  return { blob, provider: "stability", remaining };
+}
+
+async function callDiceBear({ seed, size = 1024 }: GenOptions): Promise<ProviderResult> {
+  const resolvedSeed =
+    typeof seed === "string"
+      ? seed
+      : typeof seed === "number" && Number.isFinite(seed)
+        ? String(seed)
+        : typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : Math.random().toString(36).slice(2, 10);
+  const url = `https://api.dicebear.com/7.x/adventurer/png?seed=${encodeURIComponent(
+    resolvedSeed,
+  )}&size=${size}&backgroundColor=transparent`;
+
+  const blob = await toBlob(url);
+  return { blob, provider: "dicebear" };
+}
+
+export async function generateWithProvider(
+  provider: Provider,
+  opts: GenOptions,
+): Promise<ProviderResult> {
+  if (provider === "deepai") {
+    return await callDeepAI(opts);
+  }
+  if (provider === "stability") {
+    return await callStability(opts);
+  }
+  if (provider === "dicebear") {
+    return await callDiceBear(opts);
+  }
+
+  try {
+    return await callDeepAI(opts);
+  } catch (error) {
+    console.warn("DeepAI failed, falling back", error);
+  }
+
+  try {
+    return await callStability(opts);
+  } catch (error) {
+    if (error instanceof RateLimitError || error instanceof StabilityError) {
+      console.warn("Stability unavailable, falling back to DiceBear", error);
+    } else {
+      console.warn("Stability failed, falling back", error);
+    }
+  }
+
+  return await callDiceBear(opts);
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -14,19 +14,32 @@ import { logEvent } from "@/lib/activity";
 import { flags } from "@/lib/featureFlags";
 import {
   DEFAULT_STYLE_ID,
-  RATE_LIMIT_MESSAGE,
   RateLimitError,
   STYLE_PRESETS,
   StabilityError,
   buildNegativePrompt,
   buildPrompt,
-  generateWithStability,
   seedFromUserId,
 } from "../../lib/navatar/stability";
+import { generateWithProvider, type Provider as ImageProvider } from "@/lib/imageProviders";
 import "../../styles/navatar.css";
 
 type GeneratorMode = "stability" | "dicebear";
 type DicebearBackgroundSelection = "none" | "solid" | "gradientLinear" | "gradientRadial";
+type AiProvider = Exclude<ImageProvider, "dicebear">;
+
+function providerDisplayName(value: ImageProvider): string {
+  switch (value) {
+    case "deepai":
+      return "DeepAI";
+    case "stability":
+      return "Stability AI";
+    case "dicebear":
+      return "DiceBear";
+    default:
+      return "Auto";
+  }
+}
 
 const DICEBEAR_STYLE_OPTIONS: { value: DicebearStyle; label: string }[] = [
   { value: "adventurer", label: "Adventurer" },
@@ -93,7 +106,10 @@ function seedFromPrompt(raw: string): string {
 }
 
 export default function GenerateNavatarPage() {
-  const [mode, setMode] = useState<GeneratorMode>("stability");
+  const stabilityEnabled = flags.stability;
+  const [mode, setMode] = useState<GeneratorMode>(stabilityEnabled ? "stability" : "dicebear");
+  const [provider, setProvider] = useState<ImageProvider>(stabilityEnabled ? "auto" : "dicebear");
+  const [lastAiProvider, setLastAiProvider] = useState<AiProvider>("auto");
   const [prompt, setPrompt] = useState("");
   const [styleId, setStyleId] = useState(DEFAULT_STYLE_ID);
   const [extraNegativePrompt, setExtraNegativePrompt] = useState("");
@@ -211,17 +227,55 @@ export default function GenerateNavatarPage() {
     ]
   );
 
-  const stabilityEnabled = flags.stability;
   const currentMode = !stabilityEnabled && mode === "stability" ? "dicebear" : mode;
   const previewUrl = currentMode === "stability" ? stabilityPreviewUrl : dicebearPreviewUrl;
   const isDicebear = currentMode === "dicebear";
   const isStability = stabilityEnabled && currentMode === "stability";
+  const providerButtonLabel =
+    provider === "auto"
+      ? "Generate (Auto fallback)"
+      : provider === "deepai"
+        ? "Generate with DeepAI"
+        : provider === "stability"
+          ? "Generate with Stability AI"
+          : "Generate";
+  const providerFooterText =
+    provider === "deepai"
+      ? "Powered by DeepAI — experimental photoreal and art models."
+      : provider === "auto"
+        ? "Auto tries DeepAI, then Stability AI, then DiceBear so you always get an image."
+        : "Powered by Stability AI (Stable Image Core) – square 512×512 art.";
 
   useEffect(() => {
-    if (!stabilityEnabled && mode === "stability") {
-      setMode("dicebear");
+    if (!stabilityEnabled) {
+      if (mode === "stability") {
+        setMode("dicebear");
+      }
+      if (provider !== "dicebear") {
+        setProvider("dicebear");
+      }
     }
-  }, [mode, stabilityEnabled]);
+  }, [mode, provider, stabilityEnabled]);
+
+  useEffect(() => {
+    if (provider === "dicebear" && mode !== "dicebear") {
+      setMode("dicebear");
+    } else if (provider !== "dicebear" && mode !== "stability") {
+      setMode("stability");
+    }
+  }, [provider, mode]);
+
+  useEffect(() => {
+    if (provider !== "dicebear" && provider !== lastAiProvider) {
+      setLastAiProvider(provider as AiProvider);
+    }
+  }, [provider, lastAiProvider]);
+
+  useEffect(() => {
+    if (provider !== "stability" && stabilityRemaining != null) {
+      setStabilityRemaining(null);
+    }
+  }, [provider, stabilityRemaining]);
 
   const canSave = isDicebear ? !isSaving : Boolean(file) && !isGenerating && !isSaving;
   const saveLabel = isSaving ? "Saving…" : isStability && isGenerating ? "Generating…" : "Save";
@@ -327,22 +381,28 @@ export default function GenerateNavatarPage() {
     const seed = keepStyle && user?.id ? seedFromUserId(user.id) : undefined;
     setIsGenerating(true);
     try {
-      const { blob, remaining } = await generateWithStability({
+      const generation = await generateWithProvider(provider, {
         prompt: finalPrompt,
         negativePrompt,
         seed,
         style: selectedStyle.id,
       });
-      setStabilityRemaining(typeof remaining === "number" ? remaining : null);
 
-      const generatedFile = new File([blob], `navatar-${Date.now()}.png`, {
-        type: blob.type || "image/png",
+      setStabilityRemaining(
+        generation.provider === "stability" && typeof generation.remaining === "number"
+          ? generation.remaining
+          : null,
+      );
+
+      const generatedFile = new File([generation.blob], `navatar-${Date.now()}.png`, {
+        type: generation.blob.type || "image/png",
       });
 
       setFile(generatedFile);
-      toast({ text: "Navatar generated ✓", kind: "ok" });
+      const providerName = providerDisplayName(generation.provider);
+      toast({ text: `Navatar generated via ${providerName} ✓`, kind: "ok" });
       void logEvent("avatar.created", {
-        method: "stability",
+        method: generation.provider,
         style: selectedStyle.id,
         onBrand,
         keepStyle,
@@ -358,7 +418,7 @@ export default function GenerateNavatarPage() {
           setDicebearSeed(seedFromPrompt(trimmedPrompt || prompt));
           setDicebearSeedTouched(true);
         }
-        setMode("dicebear");
+        setProvider("dicebear");
         toast({ text: "AI credits low — switched to Free (DiceBear).", kind: "warn" });
       } else if (error instanceof Error) {
         toast({ text: error.message, kind: "err" });
@@ -396,7 +456,10 @@ export default function GenerateNavatarPage() {
             <button
               type="button"
               className={`pill${isStability ? " pill--active" : ""}`}
-              onClick={() => setMode("stability")}
+              onClick={() => {
+                setMode("stability");
+                setProvider(lastAiProvider);
+              }}
               aria-pressed={isStability}
             >
               AI (Stability)
@@ -405,7 +468,7 @@ export default function GenerateNavatarPage() {
           <button
             type="button"
             className={`pill${isDicebear ? " pill--active" : ""}`}
-            onClick={() => setMode("dicebear")}
+            onClick={() => setProvider("dicebear")}
             aria-pressed={isDicebear}
           >
             Free (DiceBear)
@@ -614,6 +677,31 @@ export default function GenerateNavatarPage() {
                 disabled={isGenerating || isSaving}
               />
             </div>
+            <div className="navatar-field">
+              <label htmlFor="navatar-provider">Provider</label>
+              <select
+                id="navatar-provider"
+                className="navatar-style-select"
+                value={provider}
+                onChange={(e) => {
+                  const next = e.target.value as ImageProvider;
+                  if (next === "dicebear") {
+                    setProvider("dicebear");
+                    return;
+                  }
+                  setProvider(next);
+                }}
+                disabled={isGenerating || isSaving}
+              >
+                <option value="auto">Auto (DeepAI → Stability → DiceBear)</option>
+                <option value="deepai">DeepAI</option>
+                <option value="stability">Stability AI</option>
+                <option value="dicebear">DiceBear (switch to Free)</option>
+              </select>
+              <small style={{ color: "#1e3a8a" }}>
+                Auto tries DeepAI, then Stability, then DiceBear if others fail.
+              </small>
+            </div>
             <label className="navatar-toggle" htmlFor="navatar-brand-style">
               <input
                 id="navatar-brand-style"
@@ -692,7 +780,7 @@ export default function GenerateNavatarPage() {
               onClick={handleGenerate}
               disabled={isGenerating || isSaving}
             >
-              {isGenerating ? "Generating…" : "Generate with Stability AI"}
+              {isGenerating ? "Generating…" : providerButtonLabel}
             </button>
             <input
               type="file"
@@ -715,7 +803,7 @@ export default function GenerateNavatarPage() {
       </form>
       <p className="center" style={{ opacity: 0.8 }}>
         {isStability
-          ? "Powered by Stability AI (Stable Image Core) – square 512×512 art."
+          ? providerFooterText
           : "Powered by DiceBear avatars — saved straight to your Supabase storage."}
       </p>
     </main>


### PR DESCRIPTION
## Summary
- add shared image provider helpers to call DeepAI, Stability AI, and DiceBear with automatic fallbacks
- extend the Navatar generator page with a provider dropdown, synced state, and updated messaging
- route generation through the new helper so auto mode and DeepAI responses feed the existing upload flow

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5337a2ea4832987ec97a89e108e93