### PR TITLE
Add provider selection and Netlify avatar generator

### DIFF
--- a/netlify/functions/navatar-generate.ts
+++ b/netlify/functions/navatar-generate.ts
@@ -1,0 +1,178 @@
+import type { Handler } from "@netlify/functions";
+
+const json = (status: number, body: unknown) => ({
+  statusCode: status,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(body),
+});
+
+type Provider = "auto" | "openai" | "stability" | "deepai" | "huggingface" | "multiavatar";
+
+type ProviderResult = { dataUrl: string; provider: Exclude<Provider, "auto"> };
+
+const DEFAULT_SIZE = 1024;
+
+const normalizeSize = (value: unknown): number => {
+  if (typeof value !== "number" || Number.isNaN(value)) return DEFAULT_SIZE;
+  return Math.min(Math.max(Math.round(value), 256), 2048);
+};
+
+async function callOpenAI(prompt: string, size: number): Promise<ProviderResult> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error("OPENAI_API_KEY missing");
+  const resolved = size >= 1024 ? "1024x1024" : size >= 512 ? "512x512" : "256x256";
+  const response = await fetch("https://api.openai.com/v1/images/generations", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+      ...(process.env.OPENAI_PROJECT_ID ? { "OpenAI-Project": process.env.OPENAI_PROJECT_ID } : {}),
+    },
+    body: JSON.stringify({
+      model: "gpt-image-1",
+      prompt,
+      size: resolved,
+      response_format: "b64_json",
+    }),
+  });
+  if (!response.ok) throw new Error(`openai ${response.status}`);
+  const data: any = await response.json();
+  const b64 = data?.data?.[0]?.b64_json;
+  if (!b64) throw new Error("openai invalid response");
+  return { dataUrl: `data:image/png;base64,${b64}`, provider: "openai" };
+}
+
+async function callStability(prompt: string, size: number): Promise<ProviderResult> {
+  const apiKey = process.env.STABILITY_API_KEY;
+  if (!apiKey) throw new Error("STABILITY_API_KEY missing");
+  const dim = Math.min(Math.max(Math.round(size), 256), 1024);
+  const response = await fetch(
+    "https://api.stability.ai/v1/generation/stable-diffusion-v1-6/text-to-image",
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        cfg_scale: 7,
+        height: dim,
+        width: dim,
+        samples: 1,
+        steps: 30,
+        text_prompts: [{ text: prompt }],
+      }),
+    },
+  );
+  if (!response.ok) throw new Error(`stability ${response.status}`);
+  const data: any = await response.json();
+  const art = data?.artifacts?.[0]?.base64;
+  if (!art) throw new Error("stability invalid response");
+  return { dataUrl: `data:image/png;base64,${art}`, provider: "stability" };
+}
+
+async function callDeepAI(prompt: string, size: number): Promise<ProviderResult> {
+  const apiKey = process.env.DEPAI_API_KEY ?? process.env.DEEPAI_API_KEY;
+  if (!apiKey) throw new Error("DEEPAI_API_KEY missing");
+  const response = await fetch("https://api.deepai.org/api/text2img", {
+    method: "POST",
+    headers: { "api-key": apiKey, "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ text: prompt, width: String(size), height: String(size) }),
+  });
+  if (!response.ok) throw new Error(`deepai ${response.status}`);
+  const data: any = await response.json();
+  if (!data?.output_url) throw new Error("deepai invalid response");
+  const imageResponse = await fetch(data.output_url);
+  if (!imageResponse.ok) throw new Error(`deepai image ${imageResponse.status}`);
+  const buffer = Buffer.from(await imageResponse.arrayBuffer());
+  return { dataUrl: `data:image/jpeg;base64,${buffer.toString("base64")}`, provider: "deepai" };
+}
+
+async function callHuggingFace(prompt: string): Promise<ProviderResult> {
+  const apiKey = process.env.HF_API_TOKEN;
+  if (!apiKey) throw new Error("HF_API_TOKEN missing");
+  const model = process.env.HF_MODEL_ID ?? "runwayml/stable-diffusion-v1-5";
+  const response = await fetch(
+    `https://api-inference.huggingface.co/models/${encodeURIComponent(model)}`,
+    {
+      method: "POST",
+      headers: { authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
+      body: JSON.stringify({ inputs: prompt }),
+    },
+  );
+  if (!response.ok) throw new Error(`hf ${response.status}`);
+  const buffer = Buffer.from(await response.arrayBuffer());
+  return { dataUrl: `data:image/png;base64,${buffer.toString("base64")}`, provider: "huggingface" };
+}
+
+async function callMultiavatar(seed: string): Promise<ProviderResult> {
+  const response = await fetch(`https://api.multiavatar.com/${encodeURIComponent(seed)}.svg`);
+  if (!response.ok) throw new Error(`multiavatar ${response.status}`);
+  const svg = await response.text();
+  return {
+    dataUrl: `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`,
+    provider: "multiavatar",
+  };
+}
+
+async function tryAuto(prompt: string, size: number): Promise<ProviderResult> {
+  const steps: Array<[Exclude<Provider, "auto">, () => Promise<ProviderResult>]> = [
+    ["openai", () => callOpenAI(prompt, size)],
+    ["stability", () => callStability(prompt, size)],
+    ["deepai", () => callDeepAI(prompt, size)],
+    ["huggingface", () => callHuggingFace(prompt)],
+    ["multiavatar", () => callMultiavatar(prompt.slice(0, 60) || "naturverse")],
+  ];
+  const errors: string[] = [];
+  for (const [provider, step] of steps) {
+    try {
+      return await step();
+    } catch (error: any) {
+      errors.push(`${provider}: ${error?.message ?? error}`);
+    }
+  }
+  throw new Error(`All providers failed: ${errors.join(" | ")}`);
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return json(405, { error: "Method not allowed" });
+  }
+  try {
+    const { prompt, provider, size }: { prompt?: string; provider?: Provider; size?: number } =
+      JSON.parse(event.body ?? "{}");
+    if (!prompt) {
+      return json(400, { error: "prompt required" });
+    }
+
+    const selected: Provider = provider ?? "auto";
+    const normalizedSize = normalizeSize(size);
+    let result: ProviderResult;
+
+    switch (selected) {
+      case "openai":
+        result = await callOpenAI(prompt, normalizedSize);
+        break;
+      case "stability":
+        result = await callStability(prompt, normalizedSize);
+        break;
+      case "deepai":
+        result = await callDeepAI(prompt, normalizedSize);
+        break;
+      case "huggingface":
+        result = await callHuggingFace(prompt);
+        break;
+      case "multiavatar":
+        result = await callMultiavatar(prompt);
+        break;
+      case "auto":
+      default:
+        result = await tryAuto(prompt, normalizedSize);
+        break;
+    }
+
+    return json(200, { ok: true, dataUrl: result.dataUrl, provider: result.provider });
+  } catch (error: any) {
+    return json(200, { ok: false, error: error?.message ?? "failed" });
+  }
+};

--- a/src/lib/navatar/providerPref.ts
+++ b/src/lib/navatar/providerPref.ts
@@ -1,0 +1,29 @@
+export type Provider =
+  | "auto"
+  | "openai"
+  | "stability"
+  | "deepai"
+  | "huggingface"
+  | "multiavatar";
+
+const KEY = "nv.navatar.provider";
+
+export const getProviderPref = (): Provider => {
+  if (typeof localStorage === "undefined") return "auto";
+  const stored = localStorage.getItem(KEY) as Provider | null;
+  return stored ?? "auto";
+};
+
+export const setProviderPref = (provider: Provider) => {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(KEY, provider);
+};
+
+export const PROVIDER_LABEL: Record<Provider, string> = {
+  auto: "Auto (OpenAI → Stability → DeepAI → HF → Basic)",
+  openai: "OpenAI",
+  stability: "Stability",
+  deepai: "DeepAI",
+  huggingface: "Hugging Face",
+  multiavatar: "Basic (Multiavatar)",
+};

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ChangeEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import NavatarCard from "../../components/NavatarCard";
@@ -7,14 +7,12 @@ import NavatarTabs from "../../components/NavatarTabs";
 import { uploadNavatar } from "../../lib/navatar";
 import { setActiveNavatarId } from "../../lib/localNavatar";
 import { useToast } from "../../components/Toast";
-import { generateImage } from "@/lib/image/generate";
 import {
-  getSelectedProvider,
-  setSelectedProvider,
+  getProviderPref,
+  setProviderPref,
+  PROVIDER_LABEL,
   type Provider,
-  haveDeepAI,
-  haveStability,
-} from "@/lib/image/providers";
+} from "@/lib/navatar/providerPref";
 import { logEvent } from "@/lib/activity";
 import "../../styles/navatar.css";
 
@@ -23,7 +21,7 @@ const SIZE_OPTIONS = [512, 1024, 2048] as const;
 export default function DescribeAndGeneratePage() {
   const toast = useToast();
   const nav = useNavigate();
-  const [provider, setProvider] = useState<Provider>(getSelectedProvider());
+  const [provider, setProvider] = useState<Provider>("auto");
   const [prompt, setPrompt] = useState("");
   const [size, setSize] = useState<number>(1024);
   const [name, setName] = useState("");
@@ -35,8 +33,14 @@ export default function DescribeAndGeneratePage() {
   const [usedProvider, setUsedProvider] = useState<Provider | null>(null);
 
   useEffect(() => {
-    setSelectedProvider(provider);
-  }, [provider]);
+    setProvider(getProviderPref());
+  }, []);
+
+  const handleProviderChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value as Provider;
+    setProvider(value);
+    setProviderPref(value);
+  };
 
   useEffect(() => {
     return () => {
@@ -63,23 +67,38 @@ export default function DescribeAndGeneratePage() {
     setUsedProvider(null);
 
     try {
-      const { url, provider: used } = await generateImage({ prompt: prompt.trim(), size });
-      setUsedProvider(used);
+      const response = await fetch("/.netlify/functions/navatar-generate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt: prompt.trim(), provider, size }),
+      });
+      const data: { ok?: boolean; dataUrl?: string; error?: string; provider?: Provider } = await response.json();
+      if (!data?.ok || !data.dataUrl) {
+        toast({
+          text: `Generation failed: ${data?.error ?? "Unknown error"}. Try another provider.`,
+          kind: "err",
+        });
+        return;
+      }
+
+      const resolvedProvider = (data.provider ?? provider) as Provider;
+      setUsedProvider(resolvedProvider);
 
       try {
-        const response = await fetch(url);
+        const response = await fetch(data.dataUrl);
         const blob = await response.blob();
         const file = new File([blob], `navatar-${Date.now()}.png`, {
-          type: blob.type || "image/png",
+          type:
+            blob.type || (data.dataUrl.startsWith("data:image/svg+xml") ? "image/svg+xml" : "image/png"),
         });
         const localUrl = URL.createObjectURL(blob);
         setGeneratedFile(file);
         setObjectUrl(localUrl);
         setPreviewUrl(localUrl);
-        void logEvent("avatar.created", { method: "generate", provider: used, size });
+        void logEvent("avatar.created", { method: "generate", provider: resolvedProvider, size });
       } catch (err) {
         console.error(err);
-        setPreviewUrl(url);
+        setPreviewUrl(data.dataUrl);
         toast({
           text: "Generation succeeded, but we couldn't prepare the image for saving.",
           kind: "err",
@@ -87,7 +106,7 @@ export default function DescribeAndGeneratePage() {
       }
     } catch (e) {
       console.error(e);
-      toast({ text: "Generation failed. Check API keys or try the other provider.", kind: "err" });
+      toast({ text: "Generation failed. Check API keys or try another provider.", kind: "err" });
     } finally {
       setIsGenerating(false);
     }
@@ -135,24 +154,18 @@ export default function DescribeAndGeneratePage() {
         onSubmit={onSave}
         style={{ maxWidth: 520, margin: "16px auto", display: "grid", justifyItems: "center", gap: 12 }}
       >
-        <div className="row" style={{ marginBottom: "0.75rem", width: "100%", alignItems: "center" }}>
-          <label style={{ marginRight: 8 }}>Provider</label>
-          <select
-            value={provider}
-            onChange={(e) => setProvider(e.target.value as Provider)}
-            disabled={isGenerating || isSaving}
-          >
-            <option value="deepai" disabled={!haveDeepAI()}>
-              DeepAI
-            </option>
-            <option value="stability" disabled={!haveStability()}>
-              Stability
-            </option>
+        <label className="field" style={{ width: "100%" }}>
+          <span className="label">Provider</span>
+          <select value={provider} onChange={handleProviderChange} disabled={isGenerating || isSaving}>
+            {(
+              ["auto", "openai", "stability", "deepai", "huggingface", "multiavatar"] as Provider[]
+            ).map((option) => (
+              <option key={option} value={option}>
+                {PROVIDER_LABEL[option]}
+              </option>
+            ))}
           </select>
-          <small style={{ marginLeft: 8 }}>
-            Primary is your selection; it auto-falls back to the other if needed.
-          </small>
-        </div>
+        </label>
 
         <textarea
           value={prompt}
@@ -192,7 +205,7 @@ export default function DescribeAndGeneratePage() {
       </form>
       {previewUrl && usedProvider && (
         <p className="center" style={{ opacity: 0.8 }}>
-          Generated with {usedProvider === "deepai" ? "DeepAI" : "Stability AI"}.
+          Generated with {PROVIDER_LABEL[usedProvider] ?? usedProvider}.
         </p>
       )}
     </main>


### PR DESCRIPTION
## Summary
- add a Netlify function that proxies Navatar generation across OpenAI, Stability, DeepAI, Hugging Face, and Multiavatar with automatic fallback
- persist the preferred Navatar provider in localStorage with friendly labels for the dropdown
- update the Describe & Generate page to call the Netlify function, expose the provider selector, and keep logging/upload flows unchanged

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5fbbdf1f08329a54e87a91c1a0e4a