### PR TITLE
Normalize headers usage across providers (OpenAI, Stability, HuggingFace, DeepAI)

### DIFF
--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -55,15 +55,17 @@ export const handler: Handler = async (event) => {
     const negativePrompt = NEGATIVE;
     const effectiveSeed = keepSeed ? clampSeed(seed) : undefined;
 
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${API_KEY}`,
+      "Content-Type": "application/json",
+      Accept: "image/png",
+    };
+
     const res = await fetch(
       `https://api-inference.huggingface.co/models/${HF_MODEL}`,
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${API_KEY}`,
-          "Content-Type": "application/json",
-          Accept: "image/png",
-        },
+        headers,
         body: JSON.stringify({
           inputs: finalPrompt,
           parameters: {

--- a/netlify/functions/generate-navatar.ts
+++ b/netlify/functions/generate-navatar.ts
@@ -25,13 +25,15 @@ export const handler: Handler = async (event) => {
   }
 
   try {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      Accept: "image/png",
+    };
+
     const response = await fetch(API_URL, {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-        Accept: "image/png",
-      },
+      headers,
       body: JSON.stringify({
         prompt,
         output_format: "png",

--- a/netlify/functions/image-generate.ts
+++ b/netlify/functions/image-generate.ts
@@ -68,7 +68,7 @@ export const handler: Handler = async (event) => {
   if (user) requestBody.user = user;
   if (n) requestBody.n = n;
 
-  const requestHeaders: Record<string, string> = {
+  const headers: Record<string, string> = {
     "content-type": "application/json",
     authorization: `Bearer ${apiKey}`,
   };
@@ -76,7 +76,7 @@ export const handler: Handler = async (event) => {
   try {
     const response = await fetch(OPENAI_IMAGE_URL, {
       method: "POST",
-      headers: requestHeaders,
+      headers,
       body: JSON.stringify(requestBody),
     });
 

--- a/netlify/functions/stability-generate.ts
+++ b/netlify/functions/stability-generate.ts
@@ -58,15 +58,17 @@ export const handler: Handler = async (event) => {
     form.append("width", String(width));
     form.append("height", String(height));
 
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${API_KEY}`,
+      // IMPORTANT: Accept must be image/* or application/json
+      Accept: "image/*",
+    };
+
     const resp = await fetch(
       "https://api.stability.ai/v2beta/stable-image/generate/core",
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${API_KEY}`,
-          // IMPORTANT: Accept must be image/* or application/json
-          Accept: "image/*",
-        },
+        headers,
         body: form,
       }
     );


### PR DESCRIPTION
## Summary
- replace inline header initialization in Hugging Face, Stability, OpenAI image, and navatar functions with plain object header maps
- ensure each function now shares a consistent Record<string, string> header shape without relying on the Headers constructor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d611b600748329ab6953fda2a9d283