### PR TITLE
Refactor navatar generator with dedicated provider functions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,9 @@
   included_files = []
   external_node_modules = []
 
+[functions."*"]
+  timeout = 26
+
 # SPA routing
 [[redirects]]
   from = "/*"

--- a/netlify/functions/deepai-generate.ts
+++ b/netlify/functions/deepai-generate.ts
@@ -1,0 +1,65 @@
+import type { Handler } from "@netlify/functions";
+
+function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+    "Access-Control-Allow-Headers": "content-type,authorization",
+  };
+}
+
+function json(body: any, status = 200) {
+  return {
+    statusCode: status,
+    headers: { "Content-Type": "application/json", ...corsHeaders() },
+    body: JSON.stringify(body),
+  };
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return json({}, 204);
+
+  try {
+    const API_KEY = process.env.DEEPAI_API_KEY || "";
+    if (!API_KEY) return json({ ok: false, error: "missing_deepai_key" }, 500);
+
+    const { prompt = "" }: { prompt?: string } = JSON.parse(event.body || "{}");
+    if (!prompt) return json({ ok: false, error: "missing_prompt" }, 400);
+
+    const res = await fetch("https://api.deepai.org/api/text2img", {
+      method: "POST",
+      headers: {
+        "api-key": API_KEY,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({ text: prompt }).toString(),
+    });
+
+    if (!res.ok) {
+      let raw = "";
+      try {
+        raw = await res.text();
+      } catch (error) {
+        console.error("Failed to read DeepAI error response", error);
+      }
+      const tag =
+        res.status === 402 || res.status === 429
+          ? "deepai_quota"
+          : res.status >= 500
+            ? "deepai_5xx"
+            : "deepai_error";
+      return json({ ok: false, error: tag, detail: raw }, 502);
+    }
+
+    const data = (await res.json()) as { output_url?: string };
+    if (!data.output_url) return json({ ok: false, error: "deepai_bad_response" }, 502);
+
+    const imgRes = await fetch(data.output_url);
+    const buf = Buffer.from(await imgRes.arrayBuffer());
+    return json({ ok: true, provider: "deepai", image: `data:image/png;base64,${buf.toString("base64")}` });
+  } catch (e: any) {
+    const msg = String(e?.message || e || "");
+    const tag = /timeout|504/i.test(msg) ? "timeout_504" : "deepai_exception";
+    return json({ ok: false, error: tag, detail: msg }, 502);
+  }
+};

--- a/netlify/functions/hf-generate.ts
+++ b/netlify/functions/hf-generate.ts
@@ -1,0 +1,83 @@
+import type { Handler } from "@netlify/functions";
+
+function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+    "Access-Control-Allow-Headers": "content-type,authorization",
+  };
+}
+
+function json(body: any, status = 200) {
+  return {
+    statusCode: status,
+    headers: { "Content-Type": "application/json", ...corsHeaders() },
+    body: JSON.stringify(body),
+  };
+}
+
+function clamp(n: number, lo: number, hi: number) {
+  return Math.max(lo, Math.min(hi, Math.floor(n)));
+}
+
+function parseSize(s?: string) {
+  const size = (s || "1024x1024").toLowerCase();
+  const [w, h] = size.split("x").map(Number);
+  return {
+    width: clamp(w || 1024, 256, 2048),
+    height: clamp(h || 1024, 256, 2048),
+  };
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return json({}, 204);
+
+  try {
+    const API_KEY =
+      process.env.HUGGINGFACE_API_KEY || process.env.HF_API_TOKEN || "";
+    const MODEL = process.env.HF_MODEL_ID || "black-forest-labs/FLUX.1-dev";
+    if (!API_KEY) return json({ ok: false, error: "missing_hf_key" }, 500);
+
+    const { prompt = "", size }: { prompt?: string; size?: string } = JSON.parse(
+      event.body || "{}",
+    );
+    if (!prompt) return json({ ok: false, error: "missing_prompt" }, 400);
+
+    const { width, height } = parseSize(size);
+    const res = await fetch(`https://api-inference.huggingface.co/models/${MODEL}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        "Content-Type": "application/json",
+        Accept: "image/png",
+      },
+      body: JSON.stringify({
+        inputs: prompt,
+        parameters: { width, height, guidance_scale: 5, num_inference_steps: 28 },
+      }),
+    });
+
+    if (!res.ok) {
+      let raw = "";
+      try {
+        raw = await res.text();
+      } catch (error) {
+        console.error("Failed to read HF error response", error);
+      }
+      const tag =
+        res.status === 402 || res.status === 429
+          ? "hf_quota"
+          : res.status >= 500
+            ? "hf_5xx"
+            : "hf_error";
+      return json({ ok: false, error: tag, detail: raw }, 502);
+    }
+
+    const buf = Buffer.from(await res.arrayBuffer());
+    return json({ ok: true, provider: "huggingface", image: `data:image/png;base64,${buf.toString("base64")}` });
+  } catch (e: any) {
+    const msg = String(e?.message || e || "");
+    const tag = /timeout|504/i.test(msg) ? "timeout_504" : "hf_exception";
+    return json({ ok: false, error: tag, detail: msg }, 502);
+  }
+};

--- a/netlify/functions/multavatar-generate.ts
+++ b/netlify/functions/multavatar-generate.ts
@@ -1,0 +1,35 @@
+import type { Handler } from "@netlify/functions";
+
+function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+    "Access-Control-Allow-Headers": "content-type,authorization",
+  };
+}
+
+function json(body: any, status = 200) {
+  return {
+    statusCode: status,
+    headers: { "Content-Type": "application/json", ...corsHeaders() },
+    body: JSON.stringify(body),
+  };
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return json({}, 204);
+
+  try {
+    const { seed = "navatar" }: { seed?: string } = JSON.parse(event.body || "{}");
+
+    const url = `https://api.multiavatar.com/${encodeURIComponent(seed)}.png`;
+    const res = await fetch(url, { headers: { Accept: "image/png" } });
+    if (!res.ok)
+      return json({ ok: false, error: "basic_error", detail: await res.text().catch(() => "") }, 502);
+
+    const buf = Buffer.from(await res.arrayBuffer());
+    return json({ ok: true, provider: "basic", image: `data:image/png;base64,${buf.toString("base64")}` });
+  } catch (e: any) {
+    return json({ ok: false, error: "basic_exception", detail: String(e?.message || e || "") }, 502);
+  }
+};

--- a/netlify/functions/openai-generate.ts
+++ b/netlify/functions/openai-generate.ts
@@ -1,0 +1,81 @@
+import type { Handler } from "@netlify/functions";
+
+function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+    "Access-Control-Allow-Headers": "content-type,authorization",
+  };
+}
+
+function json(body: any, status = 200) {
+  return {
+    statusCode: status,
+    headers: { "Content-Type": "application/json", ...corsHeaders() },
+    body: JSON.stringify(body),
+  };
+}
+
+function clampSize(size: string | undefined) {
+  const s = (size || "1024x1024").toLowerCase();
+  const [w, h] = s
+    .split("x")
+    .map((n) => Math.max(256, Math.min(2048, Math.floor(Number(n) || 1024))));
+  return `${w}x${h}`;
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return json({}, 204);
+
+  try {
+    const API_KEY = process.env.OPENAI_API_KEY || "";
+    if (!API_KEY) return json({ ok: false, error: "missing_openai_key" }, 500);
+
+    const { prompt = "", size }: { prompt?: string; size?: string } = JSON.parse(
+      event.body || "{}",
+    );
+    if (!prompt || typeof prompt !== "string")
+      return json({ ok: false, error: "missing_prompt" }, 400);
+
+    const finalSize = clampSize(size);
+    const resp = await fetch("https://api.openai.com/v1/images/generations", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: "gpt-image-1", prompt, size: finalSize }),
+    });
+
+    if (!resp.ok) {
+      let raw = "";
+      try {
+        raw = await resp.text();
+      } catch (error) {
+        console.error("Failed to read OpenAI error response", error);
+      }
+      const code = resp.status;
+      const tag =
+        code === 400
+          ? "openai_400"
+          : code === 401
+            ? "openai_401"
+            : code === 429
+              ? "openai_quota"
+              : code >= 500
+                ? "openai_5xx"
+                : "openai_error";
+      return json({ ok: false, error: tag, detail: raw }, 502);
+    }
+
+    const data = (await resp.json()) as { data?: { b64_json: string }[] };
+    const b64 = data?.data?.[0]?.b64_json;
+    if (!b64) return json({ ok: false, error: "openai_bad_response" }, 502);
+
+    return json({ ok: true, provider: "openai", image: `data:image/png;base64,${b64}` });
+  } catch (err: any) {
+    const msg = String(err?.message || err || "");
+    const tag = /504|timeout/i.test(msg) ? "timeout_504" : "openai_exception";
+    return json({ ok: false, error: tag, detail: msg }, 502);
+  }
+};

--- a/src/lib/req.ts
+++ b/src/lib/req.ts
@@ -1,0 +1,14 @@
+export async function postJSON(url: string, body: any) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+  try {
+    return { ok: res.ok, status: res.status, json: JSON.parse(text) };
+  } catch {
+    return { ok: res.ok, status: res.status, json: { ok: false, error: "bad_json", detail: text } };
+  }
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -1,200 +1,154 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import Breadcrumbs from "../../components/Breadcrumbs";
-import NavatarCard from "../../components/NavatarCard";
-import BackToMyNavatar from "../../components/BackToMyNavatar";
-import NavatarTabs from "../../components/NavatarTabs";
-import { uploadNavatar } from "../../lib/navatar";
-import { setActiveNavatarId } from "../../lib/localNavatar";
-import { useToast } from "../../components/Toast";
-import { generateImage } from "@/lib/image/generate";
-import {
-  getSelectedProvider,
-  setSelectedProvider,
-  type Provider,
-  haveDeepAI,
-  haveStability,
-} from "@/lib/image/providers";
-import { logEvent } from "@/lib/activity";
-import "../../styles/navatar.css";
+import { useState } from "react";
+import { postJSON } from "../../lib/req";
+import "../../styles/ui.css";
 
-const SIZE_OPTIONS = [512, 1024, 2048] as const;
+type Provider = "openai" | "huggingface" | "deepai" | "basic";
 
-export default function DescribeAndGeneratePage() {
-  const toast = useToast();
-  const nav = useNavigate();
-  const [provider, setProvider] = useState<Provider>(getSelectedProvider());
-  const [prompt, setPrompt] = useState("");
-  const [size, setSize] = useState<number>(1024);
-  const [name, setName] = useState("");
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [generatedFile, setGeneratedFile] = useState<File | null>(null);
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
-  const [usedProvider, setUsedProvider] = useState<Provider | null>(null);
+const PROVIDERS: { key: Provider; label: string; endpoint: string }[] = [
+  {
+    key: "openai",
+    label: "OpenAI",
+    endpoint: "/.netlify/functions/openai-generate",
+  },
+  {
+    key: "huggingface",
+    label: "Hugging Face",
+    endpoint: "/.netlify/functions/hf-generate",
+  },
+  {
+    key: "deepai",
+    label: "DeepAI",
+    endpoint: "/.netlify/functions/deepai-generate",
+  },
+  {
+    key: "basic",
+    label: "Basic (Avatar)",
+    endpoint: "/.netlify/functions/multavatar-generate",
+  },
+];
 
-  useEffect(() => {
-    setSelectedProvider(provider);
-  }, [provider]);
+export default function GeneratePage() {
+  const [provider, setProvider] = useState<Provider>("openai");
+  const [prompt, setPrompt] = useState<string>(
+    "Cartoon action hero frog with a cape",
+  );
+  const [seed, setSeed] = useState<string>("turtle-hero");
+  const [size, setSize] = useState<string>("1024x1024");
+  const [loading, setLoading] = useState(false);
+  const [image, setImage] = useState<string>("");
+  const [err, setErr] = useState<string>("");
 
-  useEffect(() => {
-    return () => {
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-      }
-    };
-  }, [objectUrl]);
+  const onGenerate = async () => {
+    setErr("");
+    setImage("");
+    setLoading(true);
+    const ep = PROVIDERS.find((p) => p.key === provider)!.endpoint;
+    const payload = provider === "basic" ? { seed } : { prompt, size };
+    const { json } = await postJSON(ep, payload);
+    setLoading(false);
 
-  async function onGenerate() {
-    if (!prompt.trim()) {
-      toast({ text: "Enter a description first.", kind: "warn" });
+    if (json?.ok && json?.image) {
+      setImage(json.image);
       return;
     }
-
-    if (objectUrl) {
-      URL.revokeObjectURL(objectUrl);
-      setObjectUrl(null);
-    }
-
-    setIsGenerating(true);
-    setGeneratedFile(null);
-    setPreviewUrl(null);
-    setUsedProvider(null);
-
-    try {
-      const { url, provider: used } = await generateImage({ prompt: prompt.trim(), size });
-      setUsedProvider(used);
-
-      try {
-        const response = await fetch(url);
-        const blob = await response.blob();
-        const file = new File([blob], `navatar-${Date.now()}.png`, {
-          type: blob.type || "image/png",
-        });
-        const localUrl = URL.createObjectURL(blob);
-        setGeneratedFile(file);
-        setObjectUrl(localUrl);
-        setPreviewUrl(localUrl);
-        void logEvent("avatar.created", { method: "generate", provider: used, size });
-      } catch (err) {
-        console.error(err);
-        setPreviewUrl(url);
-        toast({
-          text: "Generation succeeded, but we couldn't prepare the image for saving.",
-          kind: "err",
-        });
-      }
-    } catch (e) {
-      console.error(e);
-      toast({ text: "Generation failed. Check API keys or try the other provider.", kind: "err" });
-    } finally {
-      setIsGenerating(false);
-    }
-  }
-
-  async function onSave(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    if (isSaving) return;
-
-    if (!generatedFile) {
-      toast({ text: "Generate an image first.", kind: "err" });
-      return;
-    }
-
-    setIsSaving(true);
-    try {
-      const row = await uploadNavatar(generatedFile, name || undefined);
-      setActiveNavatarId(row.id);
-      toast({ text: "Saved ✓", kind: "ok" });
-      const methodProvider = usedProvider ?? provider;
-      void logEvent("avatar.saved", { method: "generate", provider: methodProvider, id: row.id });
-      nav("/navatar");
-    } catch (error) {
-      console.error(error);
-      toast({ text: "Save failed", kind: "err" });
-    } finally {
-      setIsSaving(false);
-    }
-  }
-
-  const canSave = Boolean(generatedFile) && !isSaving;
-  const cardTitle = name.trim() || "My Navatar";
+    setErr(humanError(json?.error || "unknown_error"));
+  };
 
   return (
-    <main className="page-pad mx-auto max-w-4xl p-4">
-      <div className="bcRow">
-        <Breadcrumbs
-          items={[{ href: "/", label: "Home" }, { href: "/navatar", label: "Navatar" }, { label: "Describe & Generate" }]}
-        />
-      </div>
-      <h1 className="pageTitle mt-6 mb-12">Describe &amp; Generate</h1>
-      <BackToMyNavatar />
-      <NavatarTabs context="subpage" />
-      <form
-        onSubmit={onSave}
-        style={{ maxWidth: 520, margin: "16px auto", display: "grid", justifyItems: "center", gap: 12 }}
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: "1.25rem" }}>
+      <h1
+        style={{
+          fontSize: "2.25rem",
+          fontWeight: 800,
+          color: "#1f2937",
+          marginBottom: "1rem",
+        }}
       >
-        <div className="row" style={{ marginBottom: "0.75rem", width: "100%", alignItems: "center" }}>
-          <label style={{ marginRight: 8 }}>Provider</label>
-          <select
-            value={provider}
-            onChange={(e) => setProvider(e.target.value as Provider)}
-            disabled={isGenerating || isSaving}
+        Describe &amp; Generate
+      </h1>
+
+      <div className="pills" style={{ marginBottom: ".75rem" }}>
+        {PROVIDERS.map((p) => (
+          <button
+            key={p.key}
+            className={`pill ${provider === p.key ? "active" : ""}`}
+            onClick={() => setProvider(p.key)}
           >
-            <option value="deepai" disabled={!haveDeepAI()}>
-              DeepAI
-            </option>
-            <option value="stability" disabled={!haveStability()}>
-              Stability
-            </option>
-          </select>
-          <small style={{ marginLeft: 8 }}>
-            Primary is your selection; it auto-falls back to the other if needed.
-          </small>
-        </div>
+            {p.label}
+          </button>
+        ))}
+      </div>
 
-        <textarea
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          placeholder="Describe your Navatar…"
-          rows={3}
-          style={{ width: "100%", marginBottom: "0.5rem" }}
-          disabled={isGenerating || isSaving}
-        />
-        <div style={{ marginBottom: "0.75rem", width: "100%" }}>
-          <label>Size</label>{" "}
-          <select value={size} onChange={(e) => setSize(Number(e.target.value))} disabled={isGenerating || isSaving}>
-            {SIZE_OPTIONS.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
+      {provider === "basic" ? (
+        <>
+          <input
+            className="input"
+            placeholder="Seed / Name (e.g., turtle-hero)"
+            value={seed}
+            onChange={(e) => setSeed(e.target.value)}
+          />
+          <div className="hint">Uses Multiavatar by seed.</div>
+        </>
+      ) : (
+        <>
+          <textarea
+            className="textarea"
+            rows={3}
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="Describe your Navatar..."
+          />
+          <div style={{ display: "flex", gap: ".5rem", marginTop: ".5rem" }}>
+            {["512x512", "1024x1024", "2048x2048"].map((s) => (
+              <button
+                key={s}
+                className={`pill ${size === s ? "active" : ""}`}
+                onClick={() => setSize(s)}
+              >
+                {s.split("x")[0]}
+              </button>
             ))}
-          </select>
-        </div>
-
-        <button className="btn-primary" type="button" onClick={onGenerate} disabled={isGenerating || isSaving}>
-          {isGenerating ? "Generating…" : "Generate"}
-        </button>
-
-        <NavatarCard src={previewUrl ?? undefined} title={cardTitle} />
-
-        <input
-          style={{ display: "block", width: "100%" }}
-          placeholder="Name (optional)"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          disabled={isSaving}
-        />
-        <button className="pill pill--active" type="submit" style={{ marginTop: 8 }} disabled={!canSave}>
-          {isSaving ? "Saving…" : "Save"}
-        </button>
-      </form>
-      {previewUrl && usedProvider && (
-        <p className="center" style={{ opacity: 0.8 }}>
-          Generated with {usedProvider === "deepai" ? "DeepAI" : "Stability AI"}.
-        </p>
+          </div>
+          <div className="hint">Format: WIDTHxHEIGHT (e.g., 1024x1024)</div>
+        </>
       )}
-    </main>
+
+      <div style={{ marginTop: "1rem" }}>
+        <button className="btn-primary" disabled={loading} onClick={onGenerate}>
+          {loading ? "Generating..." : "Generate"}
+        </button>
+      </div>
+
+      <div className="result-card">
+        {image ? (
+          <img alt="Navatar" src={image} />
+        ) : (
+          <div style={{ color: "#94a3b8", fontWeight: 700 }}>My Navatar</div>
+        )}
+      </div>
+
+      {err ? <div className="error">Generation failed: {err}</div> : null}
+    </div>
   );
+}
+
+function humanError(tag: string) {
+  switch (tag) {
+    case "missing_prompt":
+      return "Please enter a prompt.";
+    case "openai_400":
+      return "OpenAI rejected the request (400).";
+    case "openai_401":
+      return "OpenAI key is invalid.";
+    case "openai_quota":
+      return "OpenAI quota is exhausted.";
+    case "hf_quota":
+      return "Hugging Face quota is exhausted.";
+    case "deepai_quota":
+      return "DeepAI credits are exhausted.";
+    case "timeout_504":
+      return "Provider took too long (504). Try a smaller size.";
+    default:
+      return tag.replace(/_/g, " ");
+  }
 }

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -1,0 +1,90 @@
+/* Pills */
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pill {
+  padding: 0.6rem 1rem;
+  border-radius: 9999px;
+  font-weight: 700;
+  background: #eaf0ff;
+  color: #2a4bff;
+  border: 2px solid #cfe0ff;
+  cursor: pointer;
+}
+
+.pill.active {
+  background: #2a4bff;
+  color: #ffffff;
+  border-color: #2a4bff;
+}
+
+.pill:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Inputs */
+.input,
+.textarea {
+  width: 100%;
+  border: 2px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  font-size: 1rem;
+  background: #ffffff;
+  color: #111827;
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin-top: 0.25rem;
+}
+
+/* Button (blue / white text) */
+.btn-primary {
+  width: 100%;
+  border: none;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  background: #1e5bff;
+  color: #ffffff;
+  font-weight: 800;
+  font-size: 1.05rem;
+  box-shadow: 0 10px 25px rgba(30, 91, 255, 0.25);
+}
+
+.btn-primary:hover {
+  filter: brightness(1.05);
+}
+
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Result card */
+.result-card {
+  margin-top: 1rem;
+  border-radius: 16px;
+  background: #f5f7fb;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 320px;
+}
+
+.result-card img {
+  max-width: 100%;
+  border-radius: 12px;
+}
+
+.error {
+  color: #b91c1c;
+  font-weight: 700;
+  margin-top: 0.75rem;
+}


### PR DESCRIPTION
## Summary
- add dedicated Netlify functions for OpenAI, Hugging Face, DeepAI, and Multiavatar with consistent JSON responses and CORS headers
- rebuild the Navatar generator page around provider pills, unified styling, and human-readable error messaging
- introduce shared UI styles, a JSON POST helper, and extend the Netlify function timeout for longer image generations

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e3b3a726e883298d4fba88f75c0080