### PR TITLE
fix: correct JSON formatting and unify image generation across providers

### DIFF
--- a/netlify/functions/image-generate.ts
+++ b/netlify/functions/image-generate.ts
@@ -1,45 +1,43 @@
 import type { Handler } from "@netlify/functions";
 
-// Netlify (Node 20) has global fetch/Headers/FormData via undici.
+const JSON_HEADERS = { "Content-Type": "application/json" } as const;
+const ALLOWED_PROVIDERS = new Set(["openai", "stability", "huggingface", "deepai"] as const);
 
-const OPENAI_IMAGE_URL = "https://api.openai.com/v1/images/generations";
+type Provider = "openai" | "stability" | "huggingface" | "deepai";
 
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization",
-  "Access-Control-Allow-Methods": "POST,OPTIONS",
-} as const;
-
-type ImagePayload = {
+type ImageRequest = {
   prompt?: string;
-  model?: string;
-  size?: string;
-  quality?: string;
-  style?: string;
-  background?: string;
-  n?: number;
-  user?: string;
+  size?: string | number;
+  provider?: Provider;
+};
+
+export const config = {
+  maxDuration: 26,
 };
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod === "OPTIONS") {
-    return { statusCode: 204, headers: { ...CORS_HEADERS } };
+    return {
+      statusCode: 204,
+      headers: {
+        ...JSON_HEADERS,
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Allow-Methods": "POST,OPTIONS",
+      },
+      body: "",
+    };
   }
 
   if (event.httpMethod !== "POST") {
     return json(405, { error: "method_not_allowed" });
   }
 
-  const apiKey = process.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY_BEARER;
-  if (!apiKey) {
-    return json(500, { error: "missing_openai_key" });
-  }
-
-  let payload: ImagePayload;
+  let payload: ImageRequest;
   try {
-    payload = JSON.parse(event.body || "{}") as ImagePayload;
-  } catch (error) {
-    return json(400, { error: "invalid_json" });
+    payload = JSON.parse(event.body || "{}") as ImageRequest;
+  } catch (error: any) {
+    return json(400, { error: "invalid_json", detail: error?.message ?? String(error) });
   }
 
   const prompt = typeof payload.prompt === "string" ? payload.prompt.trim() : "";
@@ -47,92 +45,224 @@ export const handler: Handler = async (event) => {
     return json(400, { error: "prompt_required" });
   }
 
-  const model = normaliseString(payload.model) || "gpt-image-1";
-  const size = normaliseString(payload.size);
-  const quality = normaliseString(payload.quality);
-  const style = normaliseString(payload.style);
-  const background = normaliseString(payload.background);
-  const user = normaliseString(payload.user);
-  const n = normaliseCount(payload.n);
+  const requestedProvider = (payload.provider ?? "openai") as Provider;
+  if (!ALLOWED_PROVIDERS.has(requestedProvider)) {
+    return json(400, { error: "invalid_provider" });
+  }
 
-  const requestBody: Record<string, unknown> = {
-    model,
-    prompt,
-    response_format: "b64_json",
-  };
-
-  if (size) requestBody.size = size;
-  if (quality) requestBody.quality = quality;
-  if (style) requestBody.style = style;
-  if (background) requestBody.background = background;
-  if (user) requestBody.user = user;
-  if (n) requestBody.n = n;
-
-  const requestHeaders: Record<string, string> = {
-    "content-type": "application/json",
-    authorization: `Bearer ${apiKey}`,
-  };
+  const size = normaliseSize(payload.size);
 
   try {
-    const response = await fetch(OPENAI_IMAGE_URL, {
-      method: "POST",
-      headers: requestHeaders,
-      body: JSON.stringify(requestBody),
-    });
-
-    if (!response.ok) {
-      const detail = await response.text().catch(() => "");
-      return json(response.status, { error: "openai_error", detail: detail.slice(0, 10_000) });
-    }
-
-    const data = await response.json().catch(() => null);
-    if (!data || !Array.isArray(data?.data)) {
-      return json(502, { error: "invalid_openai_response" });
-    }
-
-    const images = data.data
-      .map((entry: any) => extractImage(entry))
-      .filter((url: string | null): url is string => typeof url === "string" && url.length > 0);
-
-    if (images.length === 0) {
-      return json(502, { error: "no_images_returned" });
-    }
-
-    return json(200, { images });
+    const imageUrl = await generateImage({ prompt, provider: requestedProvider, size });
+    return json(200, { imageUrl });
   } catch (error: any) {
-    return json(500, { error: "unexpected_error", detail: error?.message || String(error) });
+    console.error("Generation Error", error);
+    const message = error?.message ?? "unknown_error";
+    const status = typeof error?.statusCode === "number" ? error.statusCode : 500;
+    return json(status, { error: message });
   }
 };
+
+type GenerateInput = { prompt: string; provider: Provider; size: string };
+
+async function generateImage({ prompt, provider, size }: GenerateInput): Promise<string> {
+  switch (provider) {
+    case "openai":
+      return generateWithOpenAI(prompt, size);
+    case "stability":
+      return generateWithStability(prompt, size);
+    case "huggingface":
+      return generateWithHuggingFace(prompt);
+    case "deepai":
+      return generateWithDeepAI(prompt);
+    default:
+      throw new Error("unsupported_provider");
+  }
+}
+
+async function generateWithOpenAI(prompt: string, size: string): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw Object.assign(new Error("missing_openai_key"), { statusCode: 500 });
+  }
+
+  const response = await fetch("https://api.openai.com/v1/images/generations", {
+    method: "POST",
+    headers: {
+      ...JSON_HEADERS,
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ model: "gpt-image-1", prompt, size }),
+  });
+
+  if (!response.ok) {
+    const detail = await safeReadText(response);
+    throw Object.assign(new Error(parseError(detail)), { statusCode: response.status });
+  }
+
+  const data = await response.json().catch(() => null);
+  const url = data?.data?.[0]?.url;
+  if (typeof url !== "string" || !url) {
+    throw new Error("openai_no_image");
+  }
+
+  return url;
+}
+
+async function generateWithStability(prompt: string, size: string): Promise<string> {
+  const apiKey = process.env.STABILITY_API_KEY;
+  if (!apiKey) {
+    throw Object.assign(new Error("missing_stability_key"), { statusCode: 500 });
+  }
+
+  const { width, height } = sizeToDimensions(size);
+
+  const response = await fetch("https://api.stability.ai/v2beta/stable-image/generate/core", {
+    method: "POST",
+    headers: {
+      ...JSON_HEADERS,
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ prompt, width, height }),
+  });
+
+  if (!response.ok) {
+    const detail = await safeReadText(response);
+    throw Object.assign(new Error(parseError(detail)), { statusCode: response.status });
+  }
+
+  const data = await response.json().catch(() => null);
+  const url = data?.artifacts?.[0]?.url;
+  if (typeof url !== "string" || !url) {
+    throw new Error("stability_no_image");
+  }
+
+  return url;
+}
+
+async function generateWithHuggingFace(prompt: string): Promise<string> {
+  const apiKey = process.env.HUGGINGFACE_API_KEY;
+  const spaceUrl = process.env.HF_SPACE_URL;
+  if (!apiKey || !spaceUrl) {
+    throw Object.assign(new Error("missing_huggingface_key"), { statusCode: 500 });
+  }
+
+  const response = await fetch(spaceUrl, {
+    method: "POST",
+    headers: {
+      ...JSON_HEADERS,
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ inputs: prompt }),
+  });
+
+  if (!response.ok) {
+    const detail = await safeReadText(response);
+    throw Object.assign(new Error(parseError(detail)), { statusCode: response.status });
+  }
+
+  const buffer = await response.arrayBuffer();
+  return `data:image/png;base64,${Buffer.from(buffer).toString("base64")}`;
+}
+
+async function generateWithDeepAI(prompt: string): Promise<string> {
+  const apiKey = process.env.DEEPAI_API_KEY;
+  if (!apiKey) {
+    throw Object.assign(new Error("missing_deepai_key"), { statusCode: 500 });
+  }
+
+  const response = await fetch("https://api.deepai.org/api/text2img", {
+    method: "POST",
+    headers: {
+      ...JSON_HEADERS,
+      "api-key": apiKey,
+    },
+    body: JSON.stringify({ text: prompt }),
+  });
+
+  if (!response.ok) {
+    const detail = await safeReadText(response);
+    throw Object.assign(new Error(parseError(detail)), { statusCode: response.status });
+  }
+
+  const data = await response.json().catch(() => null);
+  const url = data?.output_url;
+  if (typeof url !== "string" || !url) {
+    throw new Error("deepai_no_image");
+  }
+
+  return url;
+}
 
 function json(statusCode: number, payload: unknown) {
   return {
     statusCode,
     headers: {
-      ...CORS_HEADERS,
-      "Content-Type": "application/json",
-      "Cache-Control": "no-store",
+      ...JSON_HEADERS,
+      "Access-Control-Allow-Origin": "*",
     },
     body: JSON.stringify(payload),
   };
 }
 
-function normaliseString(value: unknown) {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+function normaliseSize(value: string | number | undefined): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const clamped = clamp(Math.floor(value), 256, 2048);
+    return `${clamped}x${clamped}`;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim().toLowerCase();
+    const match = trimmed.match(/^(\d{2,4})x(\d{2,4})$/);
+    if (match) {
+      const width = clamp(Number(match[1]), 256, 2048);
+      const height = clamp(Number(match[2]), 256, 2048);
+      return `${width}x${height}`;
+    }
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric)) {
+      const clamped = clamp(Math.floor(numeric), 256, 2048);
+      return `${clamped}x${clamped}`;
+    }
+  }
+
+  return "1024x1024";
 }
 
-function normaliseCount(value: unknown) {
-  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
-  const clamped = Math.min(Math.max(Math.floor(value), 1), 4);
-  return clamped;
+function sizeToDimensions(size: string): { width: number; height: number } {
+  const [width, height] = size.split("x").map((part) => clamp(Number(part), 256, 2048));
+  return {
+    width: width || 1024,
+    height: height || 1024,
+  };
 }
 
-function extractImage(entry: any): string | null {
-  if (!entry || typeof entry !== "object") return null;
-  if (typeof entry.b64_json === "string" && entry.b64_json) {
-    return `data:image/png;base64,${entry.b64_json}`;
+function clamp(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "";
   }
-  if (typeof entry.url === "string" && entry.url) {
-    return entry.url;
+}
+
+function parseError(detail: string) {
+  if (!detail) return "generation_failed";
+  try {
+    const parsed = JSON.parse(detail);
+    if (parsed && typeof parsed === "object" && "error" in parsed) {
+      const error = (parsed as any).error;
+      if (typeof error === "string" && error) return error;
+      if (error && typeof error === "object" && typeof error.message === "string") {
+        return error.message;
+      }
+    }
+  } catch {
+    // ignore
   }
-  return null;
+  return detail.slice(0, 10_000);
 }

--- a/netlify/functions/stability-generate.ts
+++ b/netlify/functions/stability-generate.ts
@@ -1,106 +1,158 @@
 import type { Handler } from "@netlify/functions";
 
+const JSON_HEADERS = { "Content-Type": "application/json" } as const;
+
+export const config = {
+  maxDuration: 26,
+};
+
 export const handler: Handler = async (event) => {
-  try {
-    const API_KEY = process.env.STABILITY_API_KEY;
-    if (!API_KEY) {
-      return {
-        statusCode: 500,
-        body: JSON.stringify({ error: "Missing STABILITY_API_KEY" }),
-        headers: { "Content-Type": "application/json" },
-      };
-    }
-
-    const body = JSON.parse(event.body || "{}");
-    const { prompt, negativePrompt, seed, size } = body ?? {};
-    if (!prompt || typeof prompt !== "string") {
-      return {
-        statusCode: 400,
-        body: JSON.stringify({ error: "Missing prompt" }),
-        headers: { "Content-Type": "application/json" },
-      };
-    }
-
-    // Build multipart form-data (let fetch set the Content-Type+boundary)
-    const form = new FormData();
-    form.append("prompt", prompt);
-    form.append("output_format", "png");
-
-    if (negativePrompt && typeof negativePrompt === "string") {
-      form.append("negative_prompt", negativePrompt);
-    }
-
-    if (typeof seed === "number" && Number.isFinite(seed)) {
-      const clamped = Math.max(0, Math.min(0xffff_ffff, Math.floor(seed)));
-      form.append("seed", String(clamped));
-    }
-
-    let width: number | undefined;
-    let height: number | undefined;
-
-    if (size && typeof size === "string") {
-      const match = size.toLowerCase().split("x");
-      if (match.length === 2) {
-        const parsedWidth = Number(match[0]);
-        const parsedHeight = Number(match[1]);
-        if (Number.isFinite(parsedWidth) && Number.isFinite(parsedHeight)) {
-          width = Math.max(128, Math.min(2048, Math.floor(parsedWidth)));
-          height = Math.max(128, Math.min(2048, Math.floor(parsedHeight)));
-        }
-      }
-    }
-
-    if (!width || !height) {
-      width = 1024;
-      height = 1024;
-    }
-
-    form.append("width", String(width));
-    form.append("height", String(height));
-
-    const resp = await fetch(
-      "https://api.stability.ai/v2beta/stable-image/generate/core",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${API_KEY}`,
-          // IMPORTANT: Accept must be image/* or application/json
-          Accept: "image/*",
-        },
-        body: form,
-      }
-    );
-
-    const remaining = resp.headers.get("x-ratelimit-remaining");
-
-    if (!resp.ok) {
-      const errTxt = await resp.text().catch(() => "");
-      return {
-        statusCode: resp.status,
-        body: JSON.stringify({ error: "stability_error", detail: errTxt }),
-        headers: {
-          "Content-Type": "application/json",
-          ...(remaining ? { "x-ratelimit-remaining": remaining } : {}),
-        },
-      };
-    }
-
-    const buf = Buffer.from(await resp.arrayBuffer());
+  if (event.httpMethod === "OPTIONS") {
     return {
-      statusCode: 200,
+      statusCode: 204,
       headers: {
-        "Content-Type": "image/png",
-        "Cache-Control": "no-store",
-        ...(remaining ? { "x-ratelimit-remaining": remaining } : {}),
+        ...JSON_HEADERS,
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Allow-Methods": "POST,OPTIONS",
       },
-      body: buf.toString("base64"),
-      isBase64Encoded: true,
-    };
-  } catch (e: any) {
-    return {
-      statusCode: 500,
-      body: JSON.stringify({ error: "proxy_failure", detail: e?.message }),
-      headers: { "Content-Type": "application/json" },
+      body: "",
     };
   }
+
+  if (event.httpMethod !== "POST") {
+    return json(405, { error: "method_not_allowed" });
+  }
+
+  const apiKey = process.env.STABILITY_API_KEY;
+  if (!apiKey) {
+    return json(500, { error: "missing_stability_key" });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(event.body || "{}") as Record<string, unknown>;
+  } catch (error: any) {
+    return json(400, { error: "invalid_json", detail: error?.message ?? String(error) });
+  }
+
+  const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
+  if (!prompt) {
+    return json(400, { error: "prompt_required" });
+  }
+
+  const negativePrompt = typeof body.negativePrompt === "string" ? body.negativePrompt.trim() : undefined;
+  const stylePreset = typeof body.style === "string" ? body.style.trim() : undefined;
+  const size = typeof body.size === "string" ? body.size.trim().toLowerCase() : undefined;
+  const seed = normalizeSeed(body.seed);
+  const { width, height } = size ? parseSize(size) : { width: 1024, height: 1024 };
+
+  const requestPayload: Record<string, unknown> = {
+    prompt,
+    output_format: "png",
+    width,
+    height,
+  };
+
+  if (negativePrompt) requestPayload.negative_prompt = negativePrompt;
+  if (typeof seed === "number") requestPayload.seed = seed;
+  if (stylePreset) requestPayload.style_preset = stylePreset;
+
+  try {
+    const resp = await fetch("https://api.stability.ai/v2beta/stable-image/generate/core", {
+      method: "POST",
+      headers: {
+        ...JSON_HEADERS,
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+      body: JSON.stringify(requestPayload),
+    });
+
+    const remaining = resp.headers.get("x-ratelimit-remaining") ?? undefined;
+
+    if (!resp.ok) {
+      const detail = await safeReadText(resp);
+      return json(resp.status, { error: "stability_error", detail }, remaining);
+    }
+
+    const data = await resp.json().catch(() => null);
+    const artifact = data?.artifacts?.[0];
+    const b64 = typeof artifact?.base64 === "string" && artifact.base64
+      ? artifact.base64
+      : typeof artifact?.b64_json === "string" && artifact.b64_json
+      ? artifact.b64_json
+      : null;
+    const mime = typeof artifact?.mime === "string" && artifact.mime ? artifact.mime : "image/png";
+    const url = typeof artifact?.url === "string" ? artifact.url : null;
+
+    if (b64) {
+      return {
+        statusCode: 200,
+        headers: {
+          "Content-Type": mime,
+          "Cache-Control": "no-store",
+          "Access-Control-Allow-Origin": "*",
+          ...(remaining ? { "x-ratelimit-remaining": remaining } : {}),
+        },
+        body: b64,
+        isBase64Encoded: true,
+      };
+    }
+
+    if (url) {
+      return json(200, { url }, remaining);
+    }
+
+    return json(502, { error: "invalid_stability_response" }, remaining);
+  } catch (error: any) {
+    return json(500, { error: "proxy_failure", detail: error?.message ?? String(error) });
+  }
 };
+
+function json(statusCode: number, payload: unknown, remaining?: string) {
+  return {
+    statusCode,
+    headers: {
+      ...JSON_HEADERS,
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "no-store",
+      ...(remaining ? { "x-ratelimit-remaining": remaining } : {}),
+    },
+    body: JSON.stringify(payload),
+  };
+}
+
+function safeReadText(response: Response): Promise<string> {
+  return response.text().catch(() => "");
+}
+
+function normalizeSeed(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const normalized = Math.floor(value);
+  if (normalized < 0) return 0;
+  const max = 0xffff_ffff;
+  return normalized > max ? max : normalized;
+}
+
+function parseSize(value: string): { width: number; height: number } {
+  const match = value.match(/^(\d{2,4})x(\d{2,4})$/);
+  if (match) {
+    const width = clamp(Number(match[1]), 128, 2048);
+    const height = clamp(Number(match[2]), 128, 2048);
+    return { width, height };
+  }
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    const clamped = clamp(Math.floor(numeric), 128, 2048);
+    return { width: clamped, height: clamped };
+  }
+
+  return { width: 1024, height: 1024 };
+}
+
+function clamp(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/lib/image/generate.ts
+++ b/src/lib/image/generate.ts
@@ -1,92 +1,55 @@
-import { getSelectedProvider, haveDeepAI, haveStability } from './providers';
+import { getSelectedProvider, haveDeepAI, haveStability } from "./providers";
 
 type GenOpts = { prompt: string; size?: number };
 
-type ProviderName = 'deepai' | 'stability';
+type ProviderName = "deepai" | "stability";
 
 type GeneratedImage = { url: string; provider: ProviderName };
 
-async function generateWithDeepAI({ prompt, size = 1024 }: GenOpts): Promise<GeneratedImage> {
-  const key = import.meta.env.VITE_DEEPAI_API_KEY;
-  if (!key) throw new Error('deepai:key-missing');
+async function callImageFunction(provider: ProviderName, { prompt, size = 1024 }: GenOpts): Promise<GeneratedImage> {
+  const payload = {
+    provider,
+    prompt,
+    size: `${Math.max(256, Math.min(2048, Math.floor(size)))}x${Math.max(256, Math.min(2048, Math.floor(size)))}`,
+  };
 
-  const form = new FormData();
-  form.append('text', prompt);
-  form.append('grid_size', '1');
-  form.append('width', String(size));
-  form.append('height', String(size));
-
-  const res = await fetch('https://api.deepai.org/api/text2img', {
-    method: 'POST',
-    headers: { 'Api-Key': key },
-    body: form,
+  const response = await fetch("/.netlify/functions/image-generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
   });
 
-  if (!res.ok) {
-    const t = await res.text().catch(() => '');
-    throw new Error(`deepai:${res.status}:${t}`);
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const detail = typeof data?.error === "string" ? data.error : `http_${response.status}`;
+    throw new Error(`${provider}:${detail}`);
   }
 
-  const data = await res.json();
-  if (!data.output_url) throw new Error('deepai:no-output');
-  return { url: data.output_url as string, provider: 'deepai' };
-}
-
-async function generateWithStability({ prompt, size = 1024 }: GenOpts): Promise<GeneratedImage> {
-  const key = import.meta.env.VITE_STABILITY_API_KEY || import.meta.env.STABILITY_API_KEY;
-  if (!key) throw new Error('stability:key-missing');
-
-  const res = await fetch('https://api.stability.ai/v1/generation/stable-diffusion-v1-6/text-to-image', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${key}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body: JSON.stringify({
-      text_prompts: [{ text: prompt }],
-      width: size,
-      height: size,
-      cfg_scale: 7,
-      samples: 1,
-    }),
-  });
-
-  if (!res.ok) {
-    const t = await res.text().catch(() => '');
-    throw new Error(`stability:${res.status}:${t}`);
+  const imageUrl = typeof data?.imageUrl === "string" ? data.imageUrl : null;
+  if (!imageUrl) {
+    throw new Error(`${provider}:no-image`);
   }
 
-  const json = await res.json();
-  const b64: string | undefined = json?.artifacts?.[0]?.base64;
-  if (!b64) throw new Error('stability:no-output');
-
-  const binary = atob(b64);
-  const buffer = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i += 1) {
-    buffer[i] = binary.charCodeAt(i);
-  }
-  const blob = new Blob([buffer], { type: 'image/png' });
-  const url = URL.createObjectURL(blob);
-  return { url, provider: 'stability' };
+  return { url: imageUrl, provider };
 }
 
 export async function generateImage(opts: GenOpts): Promise<GeneratedImage> {
   const primary = getSelectedProvider();
-  const order: ProviderName[] = primary === 'deepai' ? ['deepai', 'stability'] : ['stability', 'deepai'];
+  const order: ProviderName[] = primary === "deepai" ? ["deepai", "stability"] : ["stability", "deepai"];
+  const available = order.filter((provider) => (provider === "deepai" ? haveDeepAI() : haveStability()));
 
-  for (const provider of order) {
+  if (available.length === 0) {
+    throw new Error("no-provider-available");
+  }
+
+  let lastError: unknown = null;
+  for (const provider of available) {
     try {
-      if (provider === 'deepai') {
-        if (!haveDeepAI()) throw new Error('deepai:key-missing');
-        return await generateWithDeepAI(opts);
-      }
-      if (!haveStability()) throw new Error('stability:key-missing');
-      return await generateWithStability(opts);
-    } catch (err) {
-      // Try the next provider in the order.
+      return await callImageFunction(provider, opts);
+    } catch (error) {
+      lastError = error;
     }
   }
 
-  throw new Error('no-provider-available');
+  throw lastError instanceof Error ? lastError : new Error("generation_failed");
 }


### PR DESCRIPTION
## Summary
- add a unified image generation Netlify function with provider-specific payloads and extended timeout
- normalize Stability proxy handling to accept JSON requests and return clearer error details
- route frontend image generation helpers through the consolidated Netlify endpoint

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e3b9b3a3348329be4049b79142396b