### PR TITLE
Fix Netlify timeout object syntax

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,8 +9,11 @@
 [functions]
   node_bundler = "esbuild"
   directory = "netlify/functions"
-  included_files = []
+  included_files = ["netlify/functions/**"]
   external_node_modules = []
+
+  [functions."*"]
+    timeout = 26
 
 # SPA routing
 [[redirects]]


### PR DESCRIPTION
## Summary
- ensure the Netlify functions configuration uses an object table for the global timeout setting
- retain existing bundler configuration while adding an include glob for function assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3eeb05694832994015b91a091d035