### PR TITLE
Fix OpenAI image generation payload

### DIFF
--- a/netlify/functions/image-openai.ts
+++ b/netlify/functions/image-openai.ts
@@ -53,7 +53,6 @@ export const handler: Handler = async (event) => {
   const requestPayload: Record<string, unknown> = {
     model,
     prompt,
-    response_format: "b64_json",
     size: `${size}x${size}`,
   };
 
@@ -62,12 +61,18 @@ export const handler: Handler = async (event) => {
   if (user) requestPayload.user = user;
 
   try {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      authorization: `Bearer ${apiKey}`,
+    };
+    const projectId = process.env.OPENAI_PROJECT_ID?.trim();
+    if (projectId) {
+      headers["OpenAI-Project"] = projectId;
+    }
+
     const response = await fetch(OPENAI_URL, {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${apiKey}`,
-      },
+      headers,
       body: JSON.stringify(requestPayload),
     });
 
@@ -88,8 +93,11 @@ export const handler: Handler = async (event) => {
     for (const entry of entries) {
       if (entry && typeof entry === "object") {
         if (typeof entry.b64_json === "string" && entry.b64_json.length > 0) {
+          const imageBase64 = entry.b64_json;
+          const imageUrl = `data:image/png;base64,${imageBase64}`;
           return respond(200, {
-            imageUrl: `data:image/png;base64,${entry.b64_json}`,
+            imageBase64,
+            imageUrl,
             provider: "openai",
           });
         }

--- a/src/lib/image/generate.ts
+++ b/src/lib/image/generate.ts
@@ -8,8 +8,9 @@ type GenerateRequest = {
 };
 
 type ImageResponse = {
-  imageUrl: string;
-  provider: Provider;
+  imageUrl?: string;
+  imageBase64?: string;
+  provider?: Provider;
 };
 
 export async function generateImage({ provider, prompt, size }: GenerateRequest): Promise<ImageResponse> {
@@ -25,12 +26,24 @@ export async function generateImage({ provider, prompt, size }: GenerateRequest)
     body: JSON.stringify(payload),
   });
 
-  if (!result || typeof result.imageUrl !== "string" || result.imageUrl.length === 0) {
+  if (!result) {
+    throw new Error("invalid_image_response");
+  }
+
+  const base64 = typeof result.imageBase64 === "string" && result.imageBase64.length > 0 ? result.imageBase64 : undefined;
+  const imageUrl =
+    typeof result.imageUrl === "string" && result.imageUrl.length > 0
+      ? result.imageUrl
+      : base64
+      ? `data:image/png;base64,${base64}`
+      : undefined;
+
+  if (!imageUrl) {
     throw new Error("invalid_image_response");
   }
 
   return {
-    imageUrl: result.imageUrl,
-    provider: result.provider ?? provider,
+    imageUrl,
+    provider: (result.provider as Provider | undefined) ?? provider,
   };
 }


### PR DESCRIPTION
## Summary
- remove the deprecated `response_format` parameter from the OpenAI image generation Netlify function and include the project header when available
- return both `imageBase64` and `imageUrl` from the OpenAI function so callers can consume raw base64 data
- allow the client helper to construct a data URL when an `imageBase64` payload is returned

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e62c4214e8832993794df0ea51333b