### PR TITLE
Add JSON post helper for image generation

### DIFF
--- a/src/lib/image/generate.ts
+++ b/src/lib/image/generate.ts
@@ -1,10 +1,11 @@
-import { jsonFetch } from "../jsonFetch";
+import { jsonPost } from "../jsonPost";
 import { providerEndpoint, type Provider } from "./providers";
 
 type GenerateRequest = {
   provider: Provider;
   prompt: string;
   size?: number;
+  model?: string;
 };
 
 type ImageResponse = {
@@ -12,18 +13,17 @@ type ImageResponse = {
   provider: Provider;
 };
 
-export async function generateImage({ provider, prompt, size }: GenerateRequest): Promise<ImageResponse> {
+export async function generateImage({ provider, prompt, size, model }: GenerateRequest): Promise<ImageResponse> {
   const endpoint = providerEndpoint(provider);
   const payload: Record<string, unknown> = { prompt };
   if (typeof size === "number" && Number.isFinite(size)) {
     payload.size = size;
   }
+  if (typeof model === "string" && model.trim().length > 0) {
+    payload.model = model.trim();
+  }
 
-  const result = await jsonFetch<ImageResponse>(endpoint, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
+  const result = await jsonPost<ImageResponse>(endpoint, payload);
 
   if (!result || typeof result.imageUrl !== "string" || result.imageUrl.length === 0) {
     throw new Error("invalid_image_response");

--- a/src/lib/jsonPost.ts
+++ b/src/lib/jsonPost.ts
@@ -1,0 +1,31 @@
+export async function jsonPost<T = unknown>(
+  url: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  let data: any = null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = null;
+    }
+  }
+
+  if (!response.ok) {
+    const detail =
+      (data && (data.details || data.error)) || text || `HTTP ${response.status}`;
+    throw new Error(typeof detail === "string" ? detail : "Request failed");
+  }
+
+  return data as T;
+}

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -70,27 +70,17 @@ export default function DescribeAndGeneratePage() {
         size,
       });
       setUsedProvider(used);
-      setPreviewUrl(imageUrl);
 
-      try {
-        const response = await fetch(imageUrl);
-        const blob = await response.blob();
-        const file = new File([blob], `navatar-${Date.now()}.png`, {
-          type: blob.type || "image/png",
-        });
-        const localUrl = URL.createObjectURL(blob);
-        setGeneratedFile(file);
-        setObjectUrl(localUrl);
-        setPreviewUrl(localUrl);
-        void logEvent("avatar.created", { method: "generate", provider: used, size });
-      } catch (err) {
-        console.error(err);
-        setPreviewUrl(imageUrl);
-        toast({
-          text: "Generation succeeded, but we couldn't prepare the image for saving.",
-          kind: "err",
-        });
-      }
+      const response = await fetch(imageUrl);
+      const blob = await response.blob();
+      const file = new File([blob], `navatar-${Date.now()}.png`, {
+        type: blob.type || "image/png",
+      });
+      const localUrl = URL.createObjectURL(file);
+      setGeneratedFile(file);
+      setObjectUrl(localUrl);
+      setPreviewUrl(localUrl);
+      void logEvent("avatar.created", { method: "generate", provider: used, size });
     } catch (e) {
       console.error(e);
       const message = e instanceof Error ? e.message : "Generation failed.";


### PR DESCRIPTION
## Summary
- add a shared `jsonPost` helper for sending JSON POST requests
- update the image generation client to use the helper and accept optional models
- simplify the navatar generator flow by always materialising the generated image as a downloadable file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ef056eba9083299dd072329fcd946c