### PR TITLE
Fix image generation provider defaults and error handling

### DIFF
--- a/netlify/functions/openai-image.ts
+++ b/netlify/functions/openai-image.ts
@@ -39,8 +39,8 @@ export const handler: Handler = async (event) => {
       body: JSON.stringify({
         model: "gpt-image-1",
         prompt,
+        // OpenAI Images no longer accepts response_format; default returns b64_json.
         size,
-        response_format: "b64_json",
       }),
     });
 
@@ -50,13 +50,22 @@ export const handler: Handler = async (event) => {
     }
 
     const data = await response.json();
-    const base64 = data?.data?.[0]?.b64_json;
+    const entries = Array.isArray(data?.data) ? data.data : [];
 
-    if (!base64) {
-      return withCors({ ok: false, error: "OpenAI: empty image" }, 502);
+    for (const entry of entries) {
+      if (entry && typeof entry === "object") {
+        const b64 = (entry as any).b64_json;
+        const url = (entry as any).url;
+        if (typeof b64 === "string") {
+          return withCors({ ok: true, image_base64: `data:image/png;base64,${b64}` });
+        }
+        if (typeof url === "string") {
+          return withCors({ ok: true, image_url: url });
+        }
+      }
     }
 
-    return withCors({ ok: true, image_base64: `data:image/png;base64,${base64}` });
+    return withCors({ ok: false, error: "OpenAI: empty image" }, 502);
   } catch (error: any) {
     return withCors({ ok: false, error: error?.message || "OpenAI handler error" }, 500);
   }

--- a/netlify/functions/stability-image.ts
+++ b/netlify/functions/stability-image.ts
@@ -1,6 +1,9 @@
 import type { Handler } from "@netlify/functions";
 import { preflight, withCors } from "./_utils/cors";
 
+// v1-6 often 404s now. SDXL works on current accounts, override via STABILITY_ENGINE.
+const DEFAULT_ENGINE = process.env.STABILITY_ENGINE || "sdxl-1024-v1-0";
+
 export const handler: Handler = async (event) => {
   if (event.httpMethod === "OPTIONS") {
     return preflight();
@@ -23,6 +26,7 @@ export const handler: Handler = async (event) => {
   }
 
   const prompt = typeof payload.prompt === "string" ? payload.prompt : "";
+  const engine = normaliseString(payload.model) || DEFAULT_ENGINE;
   const width = normaliseNumber(payload.width, 512);
   const height = normaliseNumber(payload.height, 512);
   const steps = normaliseNumber(payload.steps, 30);
@@ -33,24 +37,21 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    const response = await fetch(
-      "https://api.stability.ai/v1/generation/stable-diffusion-v1-6/text-to-image",
-      {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${apiKey}`,
-          "content-type": "application/json",
-          accept: "application/json",
-        },
-        body: JSON.stringify({
-          height,
-          width,
-          steps,
-          cfg_scale: cfgScale,
-          text_prompts: [{ text: prompt }],
-        }),
+    const response = await fetch(`https://api.stability.ai/v1/generation/${engine}/text-to-image`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        "content-type": "application/json",
+        accept: "application/json",
       },
-    );
+      body: JSON.stringify({
+        height,
+        width,
+        steps,
+        cfg_scale: cfgScale,
+        text_prompts: [{ text: prompt }],
+      }),
+    });
 
     if (!response.ok) {
       const text = await response.text();
@@ -81,4 +82,14 @@ function normaliseNumber(value: unknown, fallback: number) {
     }
   }
   return fallback;
+}
+
+function normaliseString(value: unknown) {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return "";
 }

--- a/src/pages/navatar/generate.tsx
+++ b/src/pages/navatar/generate.tsx
@@ -37,7 +37,8 @@ export default function NavatarGenerate() {
       });
       setImg(out);
     } catch (error: any) {
-      setErr(error?.message || "Generation failed");
+      const message = typeof error?.message === "string" ? error.message.trim() : "";
+      setErr(message || `Generation failed with ${provider.toUpperCase()}. Try a different provider or size.`);
     } finally {
       setBusy(false);
     }


### PR DESCRIPTION
## Summary
- remove the deprecated OpenAI image response_format flag and accept either base64 or URL results
- switch the Stability image function to default to the SDXL engine while still allowing overrides
- show a clearer provider-specific error message in the Navatar generator UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fc2f4efb888329b803e6204b23469f